### PR TITLE
Remove code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Golang files:
-*.go @jmpike @thaarok @HerbertJordan @jenikd


### PR DESCRIPTION
This PR removes the code-owner file since reviews from code owners are no longer enforced.

The general established development process on this and other sonic repositories does not include code owners. Instead contributors are required to select proper reviewers depending on the addressed feature. The definition of a static set of reviewers through an owner file is adding unnecessary noise (and sometimes delay) to the development process. Thus, this mechanism should be eliminated.