### PR TITLE
Get current version from git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GOPROXY ?= "https://proxy.golang.org,direct"
 sonicd:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
-	GIT_TAG=`git tag --points-at HEAD` && \
+	GIT_TAG=`git tag --points-at HEAD | head -n 1` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
 	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \
@@ -18,6 +18,7 @@ sonicd:
 sonictool:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
+	GIT_TAG=`git tag --points-at HEAD | head -n 1` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
 	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: sonicd sonictool
 
 GOPROXY ?= "https://proxy.golang.org,direct"
 .PHONY: sonicd sonictool
-
 sonicd:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
@@ -15,7 +14,7 @@ sonicd:
 						-X github.com/0xsoniclabs/sonic/version.Version=$${GIT_TAG}" \
 	    -o build/sonicd \
 	    ./cmd/sonicd && \
-		./build/sonicd version
+	    ./build/sonicd version
 
 sonictool:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
@@ -28,7 +27,7 @@ sonictool:
 						-X github.com/0xsoniclabs/sonic/version.Version=$${GIT_TAG}" \
 	    -o build/sonictool \
 	    ./cmd/sonictool && \
-		./build/sonictool --version
+	    ./build/sonictool --version
 
 TAG ?= "latest"
 .PHONY: sonic-image

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ GOPROXY ?= "https://proxy.golang.org,direct"
 sonicd:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
+	GIT_TAG=`git tag --points-at HEAD` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE}" \
+	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \
+				        -X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE} \
+						-X github.com/Fantom-foundation/go-opera/version.GitTag=$${GIT_TAG}" \
 	    -o build/sonicd \
 	    ./cmd/sonicd
 
@@ -17,7 +20,9 @@ sonictool:
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE}" \
+	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} \
+						-X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE} \
+						-X github.com/Fantom-foundation/go-opera/version.GitTag=$${GIT_TAG}" \
 	    -o build/sonictool \
 	    ./cmd/sonictool
 

--- a/cmd/sonicd/app/misccmd.go
+++ b/cmd/sonicd/app/misccmd.go
@@ -28,7 +28,7 @@ The output of this command is supposed to be machine-readable.
 
 func versionAction(ctx *cli.Context) error {
 	fmt.Println(config.ClientIdentifier)
-	fmt.Println("Version:", version.VersionWithMeta)
+	fmt.Println("Version:", version.Version)
 	if config.GitCommit != "" {
 		fmt.Println("Git Commit:", config.GitCommit)
 	}

--- a/gossip/emitter/config.go
+++ b/gossip/emitter/config.go
@@ -57,7 +57,7 @@ type Config struct {
 // DefaultConfig returns the default configurations for the events emitter.
 func DefaultConfig() Config {
 	return Config{
-		VersionToPublish: version.VersionWithMeta,
+		VersionToPublish: version.Version,
 
 		EmitIntervals: EmitIntervals{
 			Min:                        150 * time.Millisecond,

--- a/version/version.go
+++ b/version/version.go
@@ -2,7 +2,6 @@ package version
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 )
@@ -12,7 +11,7 @@ var (
 	versionMajor = 0  // Major version component of the current release
 	versionMinor = 0  // Minor version component of the current release
 	versionPatch = 0  // Patch version component of the current release
-	versionMeta  = "" // Version metadata to append to the version string
+	versionMeta  = "" // Meta information of the current release
 )
 
 // Version holds the textual version string.
@@ -23,7 +22,11 @@ var Version = func() string {
 	}
 	parseVersion()
 	// remove the leading "v" and possible leading white spaces
-	return strings.Split(GitTag, "v")[1]
+	tag := strings.Split(GitTag, "v")
+	if len(tag) > 1 {
+		return tag[1]
+	}
+	return GitTag
 }()
 
 // parseVersion parses the GitTag into major, minor, patch, and meta components.
@@ -34,10 +37,12 @@ func parseVersion() {
 	// Parse major, minor, and patch
 	versionMajor = parseVersionComponent(versionParts, 0, true)
 	versionMinor = parseVersionComponent(versionParts, 1, false)
-	versionPatch = parseVersionComponent(strings.Split(versionParts[2], "-"), 0, false)
-
+	if len(versionParts) > 2 {
+		dashSplits := strings.Split(versionParts[2], "-")
+		versionPatch = parseVersionComponent(dashSplits, 0, false)
+	}
 	// Parse meta if available
-	if len(parts) > 1 {
+	if (versionMajor != 0 || versionMinor != 0 || versionPatch != 0) && len(parts) > 1 {
 		versionMeta = parts[1]
 	}
 }
@@ -56,7 +61,6 @@ func parseVersionComponent(parts []string, index int, stripPrefix bool) int {
 
 	value, err := strconv.Atoi(component)
 	if err != nil {
-		log.Printf("Failed to parse version component %q: %v", component, err)
 		return 0
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -6,45 +6,39 @@ import (
 	"strings"
 )
 
+// Version holds the textual version string.
 var (
-	GitTag       = "" // Git tag of this release
-	versionMajor = 0  // Major version component of the current release
-	versionMinor = 0  // Minor version component of the current release
-	versionPatch = 0  // Patch version component of the current release
-	versionMeta  = "" // Meta information of the current release
+	Version      = ""
+	versionMajor = 0
+	versionMinor = 0
+	versionPatch = 0
+	// versionMeta  = "" // not used for now
 )
 
-// Version holds the textual version string.
-var Version = func() string {
+func init() {
 	// in case of no tag or small/irregular tag, return it as is
-	if len(GitTag) < 2 {
-		return GitTag
+	if len(Version) >= 2 {
+		versionMajor, versionMinor, versionPatch, _ = parseVersion(Version)
 	}
-	parseVersion()
-	// remove the leading "v" and possible leading white spaces
-	tag := strings.Split(GitTag, "v")
-	if len(tag) > 1 {
-		return tag[1]
-	}
-	return GitTag
-}()
+}
 
 // parseVersion parses the GitTag into major, minor, patch, and meta components.
-func parseVersion() {
-	parts := strings.SplitN(GitTag, "-", 2)
+func parseVersion(gitTag string) (vMajor, vMinor, vPatch int, vMeta string) {
+	parts := strings.SplitN(gitTag, "-", 2)
 	versionParts := strings.Split(parts[0], ".")
 
 	// Parse major, minor, and patch
-	versionMajor = parseVersionComponent(versionParts, 0, true)
-	versionMinor = parseVersionComponent(versionParts, 1, false)
+	vMajor = parseVersionComponent(versionParts, 0, true)
+	vMinor = parseVersionComponent(versionParts, 1, false)
 	if len(versionParts) > 2 {
 		dashSplits := strings.Split(versionParts[2], "-")
-		versionPatch = parseVersionComponent(dashSplits, 0, false)
+		vPatch = parseVersionComponent(dashSplits, 0, false)
 	}
 	// Parse meta if available
-	if (versionMajor != 0 || versionMinor != 0 || versionPatch != 0) && len(parts) > 1 {
-		versionMeta = parts[1]
+	if (vMajor != 0 || vMinor != 0 || vPatch != 0) && len(parts) > 1 {
+		vMeta = parts[1]
 	}
+	return
 }
 
 // parseVersionComponent parses and returns a specific version component.
@@ -68,11 +62,11 @@ func parseVersionComponent(parts []string, index int, stripPrefix bool) int {
 }
 
 func VersionWithCommit(gitCommit, gitDate string) string {
-	vsn := GitTag
+	vsn := Version
 	if len(gitCommit) >= 8 {
 		vsn += "-" + gitCommit[:8]
 	}
-	if (strings.Split(GitTag, "-")[0] != "") && (gitDate != "") {
+	if (strings.Split(Version, "-")[0] != "") && (gitDate != "") {
 		vsn += "-" + gitDate
 	}
 	return vsn

--- a/version/version.go
+++ b/version/version.go
@@ -2,46 +2,84 @@ package version
 
 import (
 	"fmt"
+	"log"
+	"strconv"
+	"strings"
 )
 
-const (
-	VersionMajor = 2     // Major version component of the current release
-	VersionMinor = 0     // Minor version component of the current release
-	VersionPatch = 2     // Patch version component of the current release
-	VersionMeta  = "dev" // Version metadata to append to the version string
+var (
+	GitTag       = "" // Git tag of this release
+	versionMajor = 0  // Major version component of the current release
+	versionMinor = 0  // Minor version component of the current release
+	versionPatch = 0  // Patch version component of the current release
+	versionMeta  = "" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.
 var Version = func() string {
-	return fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)
+	// in case of no tag or small/irregular tag, return it as is
+	if len(GitTag) < 2 {
+		return GitTag
+	}
+	parseVersion()
+	// remove the leading "v" and possible leading white spaces
+	return strings.Split(GitTag, "v")[1]
 }()
 
-// VersionWithMeta holds the textual version string including the metadata.
-var VersionWithMeta = func() string {
-	v := Version
-	if VersionMeta != "" {
-		v += "-" + VersionMeta
+// parseVersion parses the GitTag into major, minor, patch, and meta components.
+func parseVersion() {
+	parts := strings.SplitN(GitTag, "-", 2)
+	versionParts := strings.Split(parts[0], ".")
+
+	// Parse major, minor, and patch
+	versionMajor = parseVersionComponent(versionParts, 0, true)
+	versionMinor = parseVersionComponent(versionParts, 1, false)
+	versionPatch = parseVersionComponent(strings.Split(versionParts[2], "-"), 0, false)
+
+	// Parse meta if available
+	if len(parts) > 1 {
+		versionMeta = parts[1]
 	}
-	return v
-}()
+}
+
+// parseVersionComponent parses and returns a specific version component.
+// If `stripPrefix` is true, it strips the leading "v" from the major version.
+func parseVersionComponent(parts []string, index int, stripPrefix bool) int {
+	if len(parts) <= index {
+		return 0
+	}
+
+	component := parts[index]
+	if stripPrefix {
+		component = strings.TrimPrefix(component, "v")
+	}
+
+	value, err := strconv.Atoi(component)
+	if err != nil {
+		log.Printf("Failed to parse version component %q: %v", component, err)
+		return 0
+	}
+
+	return value
+}
 
 func VersionWithCommit(gitCommit, gitDate string) string {
-	vsn := VersionWithMeta
+	vsn := GitTag
 	if len(gitCommit) >= 8 {
 		vsn += "-" + gitCommit[:8]
 	}
-	if (VersionMeta != "stable") && (gitDate != "") {
+	if (strings.Split(GitTag, "-")[0] != "") && (gitDate != "") {
 		vsn += "-" + gitDate
 	}
 	return vsn
 }
 
 func AsString() string {
-	return ToString(uint16(VersionMajor), uint16(VersionMinor), uint16(VersionPatch))
+	return ToString(uint16(versionMajor), uint16(versionMinor), uint16(versionPatch))
 }
 
 func AsU64() uint64 {
-	return ToU64(uint16(VersionMajor), uint16(VersionMinor), uint16(VersionPatch))
+	return ToU64(uint16(versionMajor), uint16(versionMinor), uint16(versionPatch))
 }
 
 func ToU64(vMajor, vMinor, vPatch uint16) uint64 {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -39,3 +39,39 @@ func TestAsBigInt(t *testing.T) {
 		prev = next
 	}
 }
+
+func TestVersion_parseVersion(t *testing.T) {
+	require := require.New(t)
+
+	tests := map[string]struct {
+		major int
+		minor int
+		patch int
+		meta  string
+	}{
+		"v1.2.3":                        {major: 1, minor: 2, patch: 3},
+		"v1.2.3-alpha":                  {major: 1, minor: 2, patch: 3, meta: "alpha"},
+		"v1.2.3-alpha-dirty":            {major: 1, minor: 2, patch: 3, meta: "alpha-dirty"},
+		"some-non.stan-dard.12tag":      {},
+		"!`@#$%^&*()_+{}|:<>?[]\\;',./": {},
+		"myTestTag":                     {},
+	}
+
+	originalGitTag := GitTag
+	for tag, want := range tests {
+		versionMajor = 0
+		versionMinor = 0
+		versionPatch = 0
+		versionMeta = ""
+
+		GitTag = tag
+		parseVersion()
+
+		require.Equal(want.major, versionMajor, "major version mismatch")
+		require.Equal(want.minor, versionMinor, "minor version mismatch")
+		require.Equal(want.patch, versionPatch, "patch version mismatch")
+		require.Equal(want.meta, versionMeta, "meta version mismatch")
+	}
+
+	GitTag = originalGitTag
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -49,29 +49,20 @@ func TestVersion_parseVersion(t *testing.T) {
 		patch int
 		meta  string
 	}{
-		"v1.2.3":                        {major: 1, minor: 2, patch: 3},
-		"v1.2.3-alpha":                  {major: 1, minor: 2, patch: 3, meta: "alpha"},
-		"v1.2.3-alpha-dirty":            {major: 1, minor: 2, patch: 3, meta: "alpha-dirty"},
-		"some-non.stan-dard.12tag":      {},
-		"!`@#$%^&*()_+{}|:<>?[]\\;',./": {},
-		"myTestTag":                     {},
+		"v1.2.3":                       {major: 1, minor: 2, patch: 3},
+		"v1.2.3-alpha":                 {major: 1, minor: 2, patch: 3, meta: "alpha"},
+		"v1.2.3-alpha-dirty":           {major: 1, minor: 2, patch: 3, meta: "alpha-dirty"},
+		"some-non.stan-dard.12tag":     {},
+		"!`@#$%^&*()_{}|:<>?[]\\;',./": {},
+		"myTestTag":                    {},
 	}
 
-	originalGitTag := GitTag
 	for tag, want := range tests {
-		versionMajor = 0
-		versionMinor = 0
-		versionPatch = 0
-		versionMeta = ""
+		testVMajor, testVMinor, testVPatch, testVMeta := parseVersion(tag)
 
-		GitTag = tag
-		parseVersion()
-
-		require.Equal(want.major, versionMajor, "major version mismatch")
-		require.Equal(want.minor, versionMinor, "minor version mismatch")
-		require.Equal(want.patch, versionPatch, "patch version mismatch")
-		require.Equal(want.meta, versionMeta, "meta version mismatch")
+		require.Equal(want.major, testVMajor, "major version mismatch")
+		require.Equal(want.minor, testVMinor, "minor version mismatch")
+		require.Equal(want.patch, testVPatch, "patch version mismatch")
+		require.Equal(want.meta, testVMeta, "meta version mismatch")
 	}
-
-	GitTag = originalGitTag
 }


### PR DESCRIPTION
This PR adds a mechanism that uses the git tag (if any) as release version. Hence preventing the task to update both the version file as well as the release tag in git. It also should check if there have been any commits since the last label, and if the build is a dirty build (aka has uncommitted changes)

the git tag is "v2.0.1" => Major=2, Minor=0, Patch=1, Meta=""
the git tag is "v2.0.1-rc1" => Major=2, Minor=0, Patch=1, Meta="rc1"
the git tag is "v2.0.1" but there are extra commits on top: => Major=2, Minor=0, Patch=1, Meta="dev"
the git tag is "v2.0.1-rc1" with extra commits on top => Major=2, Minor=0, Patch=1, Meta="rc1-dev"
there is no git tag (e.g. development) => handle like "v0.0.0" with extra commits on top
if there are uncommitted changes, the suffix "-dirty" will be added