### PR TITLE
Refactor defer-close with error handling

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/0xsoniclabs/sonic/cmd/sonicd/metrics"
 	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/config/flags"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/version"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/console/prompt"
@@ -202,11 +203,11 @@ func initApp() {
 		return nil
 	}
 
-	app.After = func(ctx *cli.Context) error {
+	app.After = func(ctx *cli.Context) (err error) {
 		debug.Exit()
-		prompt.Stdin.Close() // Resets terminal mode.
-
-		return nil
+		// Close will resets terminal mode.
+		caution.CloseAndReportError(&err, prompt.Stdin, "failed to reset terminal input")
+		return err
 	}
 }
 

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -12,7 +12,6 @@ import (
 	"github.com/0xsoniclabs/sonic/cmd/sonicd/metrics"
 	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/config/flags"
-	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/version"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/console/prompt"
@@ -203,11 +202,13 @@ func initApp() {
 		return nil
 	}
 
-	app.After = func(ctx *cli.Context) (err error) {
+	app.After = func(ctx *cli.Context) error {
 		debug.Exit()
 		// Close will resets terminal mode.
-		caution.CloseAndReportError(&err, prompt.Stdin, "failed to reset terminal input")
-		return err
+		if err := prompt.Stdin.Close(); err != nil {
+			return fmt.Errorf("failed to reset terminal input")
+		}
+		return nil
 	}
 }
 

--- a/cmd/sonictool/app/chain.go
+++ b/cmd/sonictool/app/chain.go
@@ -3,11 +3,13 @@ package app
 import (
 	"compress/gzip"
 	"fmt"
-	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/chain"
 	"github.com/0xsoniclabs/sonic/config/flags"
@@ -16,12 +18,12 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-func exportEvents(ctx *cli.Context) error {
+func exportEvents(ctx *cli.Context) (err error) {
 	if len(ctx.Args()) < 1 {
 		return fmt.Errorf("this command requires an argument - the output file")
 	}
 
-	fn := ctx.Args().First()
+	filename := ctx.Args().First()
 
 	dataDir := ctx.GlobalString(flags.DataDirFlag.Name)
 	if dataDir == "" {
@@ -29,16 +31,18 @@ func exportEvents(ctx *cli.Context) error {
 	}
 
 	// Open the file handle and potentially wrap with a gzip stream
-	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	fileHandler, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err
 	}
-	defer fh.Close()
+	defer caution.CloseAndReportError(&err, fileHandler, fmt.Sprintf("failed to close file %v", filename))
 
-	var writer io.Writer = fh
-	if strings.HasSuffix(fn, ".gz") {
+	var writer io.Writer = fileHandler
+	if strings.HasSuffix(filename, ".gz") {
 		writer = gzip.NewWriter(writer)
-		defer writer.(*gzip.Writer).Close()
+		defer caution.CloseAndReportError(&err,
+			writer.(*gzip.Writer),
+			fmt.Sprintf("failed to close gzip writer for file %v", filename))
 	}
 
 	from := idx.Epoch(1)
@@ -64,7 +68,7 @@ func exportEvents(ctx *cli.Context) error {
 		ArchiveCache: ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
 	}
 
-	log.Info("Exporting events to file", "file", fn)
+	log.Info("Exporting events to file", "file", filename)
 	err = chain.ExportEvents(gdbParams, writer, from, to)
 	if err != nil {
 		return fmt.Errorf("export error: %w", err)

--- a/cmd/sonictool/app/cli.go
+++ b/cmd/sonictool/app/cli.go
@@ -65,14 +65,14 @@ func remoteConsole(ctx *cli.Context) (err error) {
 
 	if script := ctx.String(ExecFlag.Name); script != "" {
 		console.Evaluate(script)
-		return
+		return nil
 	}
 
 	// Otherwise print the welcome screen and enter interactive mode
 	console.Welcome()
 	console.Interactive()
 
-	return
+	return nil
 }
 
 // makeConsolePreloads retrieves the absolute paths for the console JavaScript

--- a/cmd/sonictool/app/cli.go
+++ b/cmd/sonictool/app/cli.go
@@ -2,11 +2,13 @@ package app
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/0xsoniclabs/sonic/config/flags"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/rpc"
 	"gopkg.in/urfave/cli.v1"
-	"strings"
 )
 
 var (
@@ -27,7 +29,7 @@ var (
 
 // remoteConsole will connect to a remote opera instance, attaching a JavaScript
 // console to it.
-func remoteConsole(ctx *cli.Context) error {
+func remoteConsole(ctx *cli.Context) (err error) {
 	// Attach to a remotely running opera instance and start the JavaScript console
 	endpoint := ctx.Args().First()
 	if endpoint == "" {
@@ -57,18 +59,20 @@ func remoteConsole(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to start the JavaScript console: %v", err)
 	}
-	defer console.Stop(false)
+	defer caution.ExecuteAndReportError(&err,
+		func() error { return console.Stop(false) },
+		"failed to stop the JavaScript console")
 
 	if script := ctx.String(ExecFlag.Name); script != "" {
 		console.Evaluate(script)
-		return nil
+		return
 	}
 
 	// Otherwise print the welcome screen and enter interactive mode
 	console.Welcome()
 	console.Interactive()
 
-	return nil
+	return
 }
 
 // makeConsolePreloads retrieves the absolute paths for the console JavaScript

--- a/cmd/sonictool/app/compact.go
+++ b/cmd/sonictool/app/compact.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/config/flags"
 	"github.com/0xsoniclabs/sonic/integration"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/utils/dbutil"
 	"github.com/0xsoniclabs/sonic/utils/dbutil/compactdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
@@ -38,13 +39,13 @@ func compactDbs(ctx *cli.Context) error {
 	return nil
 }
 
-func compactDB(name string, producer kvdb.DBProducer) error {
+func compactDB(name string, producer kvdb.DBProducer) (err error) {
 	db, err := producer.OpenDB(name)
 	if err != nil {
 		log.Error("Cannot open db or db does not exists", "db", name)
 		return err
 	}
-	defer db.Close()
+	defer caution.CloseAndReportError(&err, db, "failed to close db")
 
 	log.Info("Stats before compaction", "db", name)
 	showDbStats(db)

--- a/cmd/sonictool/app/config.go
+++ b/cmd/sonictool/app/config.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"fmt"
-	"github.com/0xsoniclabs/sonic/config"
-	"gopkg.in/urfave/cli.v1"
 	"os"
+
+	"github.com/0xsoniclabs/sonic/config"
+	"github.com/0xsoniclabs/sonic/utils/caution"
+	"gopkg.in/urfave/cli.v1"
 )
 
 func checkConfig(ctx *cli.Context) error {
@@ -17,7 +19,7 @@ func checkConfig(ctx *cli.Context) error {
 }
 
 // dumpConfig is the dumpconfig command.
-func dumpConfig(ctx *cli.Context) error {
+func dumpConfig(ctx *cli.Context) (err error) {
 	cfg, err := config.MakeAllConfigs(ctx)
 	if err != nil {
 		return err
@@ -35,10 +37,12 @@ func dumpConfig(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		defer dump.Close()
+		defer caution.CloseAndReportError(&err, dump, "failed to close config file")
 	}
-	dump.WriteString(comment)
-	dump.Write(out)
-
-	return nil
+	_, err = dump.WriteString(comment)
+	if err != nil {
+		return err
+	}
+	_, err = dump.Write(out)
+	return err
 }

--- a/cmd/sonictool/app/export_genesis.go
+++ b/cmd/sonictool/app/export_genesis.go
@@ -3,17 +3,19 @@ package app
 import (
 	"context"
 	"fmt"
-	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
-	"github.com/0xsoniclabs/sonic/cmd/sonictool/genesis"
-	"github.com/0xsoniclabs/sonic/config/flags"
-	"github.com/0xsoniclabs/sonic/integration"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-	"gopkg.in/urfave/cli.v1"
 	"os"
 	"os/signal"
 	"path"
 	"path/filepath"
 	"syscall"
+
+	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
+	"github.com/0xsoniclabs/sonic/cmd/sonictool/genesis"
+	"github.com/0xsoniclabs/sonic/config/flags"
+	"github.com/0xsoniclabs/sonic/integration"
+	"github.com/0xsoniclabs/sonic/utils/caution"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"gopkg.in/urfave/cli.v1"
 )
 
 func exportGenesis(ctx *cli.Context) error {
@@ -45,7 +47,7 @@ func exportGenesis(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to make DB producer: %v", err)
 	}
-	defer dbs.Close()
+	defer caution.CloseAndReportError(&err, dbs, "failed to close DB producer")
 
 	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
 		Dbs:           dbs,
@@ -58,17 +60,18 @@ func exportGenesis(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	defer gdb.Close()
+	defer caution.CloseAndReportError(&err, gdb, "failed to close Gossip DB")
 
-	fh, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+	fileHandler, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err
 	}
-	defer fh.Close()
+	defer caution.CloseAndReportError(&err, fileHandler, fmt.Sprintf("failed to close file %v", fileName))
 
 	tmpPath := path.Join(dataDir, "tmp-genesis-export")
 	_ = os.RemoveAll(tmpPath)
-	defer os.RemoveAll(tmpPath)
+	defer caution.ExecuteAndReportError(&err, func() error { return os.RemoveAll(tmpPath) },
+		"failed to remove tmp genesis export dir")
 
-	return genesis.ExportGenesis(cancelCtx, gdb, !forValidatorMode, fh, tmpPath)
+	return genesis.ExportGenesis(cancelCtx, gdb, !forValidatorMode, fileHandler, tmpPath)
 }

--- a/cmd/sonictool/app/sign_genesis.go
+++ b/cmd/sonictool/app/sign_genesis.go
@@ -1,12 +1,15 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/genesis"
 	ogenesis "github.com/0xsoniclabs/sonic/opera/genesis"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
+	"github.com/0xsoniclabs/sonic/utils"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/utils/prompt"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
@@ -57,18 +60,19 @@ func signGenesis(ctx *cli.Context) error {
 	return nil
 }
 
-func getGenesisHeaderHashes(genesisFile string) (ogenesis.Header, ogenesis.Hashes, error) {
+func getGenesisHeaderHashes(genesisFile string) (header ogenesis.Header, genesisHashes ogenesis.Hashes, err error) {
 	genesisReader, err := os.Open(genesisFile)
+	// note, genesisStore closes the reader, no need to defer close it here
 	if err != nil {
-		return ogenesis.Header{}, nil, fmt.Errorf("failed to open the genesis file: %w", err)
+		return ogenesis.Header{}, nil, fmt.Errorf("failed to open genesis file: %w", err)
 	}
-	defer genesisReader.Close()
 
 	genesisStore, genesisHashes, err := genesisstore.OpenGenesisStore(genesisReader)
 	if err != nil {
-		return ogenesis.Header{}, nil, fmt.Errorf("failed to read genesis file: %w", err)
+		return ogenesis.Header{}, nil, errors.Join(
+			fmt.Errorf("failed to read genesis file: %w", err),
+			utils.AnnotateIfError(genesisReader.Close(), "failed to close the genesis file"))
 	}
-	defer genesisStore.Close()
-
+	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")
 	return genesisStore.Header(), genesisHashes, nil
 }

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -1,11 +1,13 @@
 package chain
 
 import (
-	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
-	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"io"
 	"path/filepath"
 	"time"
+
+	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
+	"github.com/0xsoniclabs/sonic/utils/caution"
+	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -30,7 +32,7 @@ func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, from, to idx.Epo
 	if err != nil {
 		return err
 	}
-	defer dbs.Close()
+	defer caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 
 	// Fill the rest of the params
 	gdbParams.Dbs = dbs
@@ -40,7 +42,7 @@ func ExportEvents(gdbParams db.GossipDbParameters, w io.Writer, from, to idx.Epo
 	if err != nil {
 		return err
 	}
-	defer gdb.Close()
+	defer caution.CloseAndReportError(&err, gdb, "failed to close gossip db")
 
 	// Write header and version
 	_, err = w.Write(append(eventsFileHeader, eventsFileVersion...))

--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/gossip/emitter"
 	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/utils/ioread"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -85,7 +86,7 @@ func checkEventsFileHeader(reader io.Reader) error {
 	return nil
 }
 
-func importEventsFile(srv *gossip.Service, fn string) error {
+func importEventsFile(srv *gossip.Service, filename string) (err error) {
 	// Watch for Ctrl-C while the import is running.
 	// If a signal is received, the import will stop.
 	interrupt := make(chan os.Signal, 1)
@@ -93,18 +94,18 @@ func importEventsFile(srv *gossip.Service, fn string) error {
 	defer signal.Stop(interrupt)
 
 	// Open the file handle and potentially unwrap the gzip stream
-	fh, err := os.Open(fn)
+	fileHandle, err := os.Open(filename)
 	if err != nil {
 		return err
 	}
-	defer fh.Close()
+	defer caution.CloseAndReportError(&err, fileHandle, "failed to close file")
 
-	var reader io.Reader = fh
-	if strings.HasSuffix(fn, ".gz") {
+	var reader io.Reader = fileHandle
+	if strings.HasSuffix(filename, ".gz") {
 		if reader, err = gzip.NewReader(reader); err != nil {
 			return err
 		}
-		defer reader.(*gzip.Reader).Close()
+		defer caution.CloseAndReportError(&err, reader.(*gzip.Reader), "failed to close gzip reader")
 	}
 
 	// Check file version and header
@@ -173,7 +174,7 @@ func importEventsFile(srv *gossip.Service, fn string) error {
 		events++
 	}
 	srv.WaitBlockEnd()
-	log.Info("Events import is finished", "file", fn, "last", last.String(), "imported", events, "txs", txs, "elapsed", common.PrettyDuration(time.Since(start)))
+	log.Info("Events import is finished", "file", filename, "last", last.String(), "imported", events, "txs", txs, "elapsed", common.PrettyDuration(time.Since(start)))
 
 	return nil
 }

--- a/cmd/sonictool/check/archive.go
+++ b/cmd/sonictool/check/archive.go
@@ -8,6 +8,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	carmen "github.com/0xsoniclabs/carmen/go/state"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
@@ -33,13 +34,13 @@ func CheckArchiveStateDb(ctx context.Context, dataDir string, cacheRatio cachesc
 	return nil
 }
 
-func checkArchiveBlockRoots(dataDir string, cacheRatio cachescale.Func) error {
+func checkArchiveBlockRoots(dataDir string, cacheRatio cachescale.Func) (err error) {
 	gdb, dbs, err := createGdb(dataDir, cacheRatio, carmen.S5Archive, false)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create gdb and db producer: %w", err)
 	}
-	defer gdb.Close()
-	defer dbs.Close()
+	defer caution.CloseAndReportError(&err, gdb, "failed to close gossip db")
+	defer caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 
 	invalidBlocks := 0
 	lastBlockIdx := gdb.GetLatestBlockIndex()

--- a/cmd/sonictool/check/live.go
+++ b/cmd/sonictool/check/live.go
@@ -8,6 +8,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	carmen "github.com/0xsoniclabs/carmen/go/state"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 	"github.com/ethereum/go-ethereum/log"
@@ -32,13 +33,13 @@ func CheckLiveStateDb(ctx context.Context, dataDir string, cacheRatio cachescale
 	return nil
 }
 
-func checkLiveBlockRoot(dataDir string, cacheRatio cachescale.Func) error {
+func checkLiveBlockRoot(dataDir string, cacheRatio cachescale.Func) (err error) {
 	gdb, dbs, err := createGdb(dataDir, cacheRatio, carmen.NoArchive, true)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create gdb and db producer: %w", err)
 	}
-	defer gdb.Close()
-	defer dbs.Close()
+	defer caution.CloseAndReportError(&err, gdb, "failed to close gossip db")
+	defer caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 
 	lastBlockIdx := gdb.GetLatestBlockIndex()
 	lastBlock := gdb.GetBlock(lastBlockIdx)

--- a/cmd/sonictool/db/heal.go
+++ b/cmd/sonictool/db/heal.go
@@ -2,10 +2,14 @@ package db
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/integration"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/Fantom-foundation/lachesis-base/abft"
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -16,26 +20,24 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/syndtr/goleveldb/leveldb/opt"
-	"strings"
-	"time"
 )
 
-func HealChaindata(chaindataDir string, cacheRatio cachescale.Func, cfg *config.Config, lastCarmenBlock idx.Block) (idx.Block, error) {
+func HealChaindata(chaindataDir string, cacheRatio cachescale.Func, cfg *config.Config, lastCarmenBlock idx.Block) (lastBlockId idx.Block, err error) {
 	producer := &DummyScopedProducer{integration.GetRawDbProducer(chaindataDir, integration.DBCacheConfig{
 		Cache:   cacheRatio.U64(480 * opt.MiB),
 		Fdlimit: makeDatabaseHandles(),
 	})}
-	defer producer.Close()
+	defer caution.CloseAndReportError(&err, producer, "failed to close db producer")
 
 	log.Info("Healing gossip db...")
-	epochState, lastBlock, err := healGossipDb(producer, cfg.OperaStore, lastCarmenBlock)
+	epochState, lastBlockId, err := healGossipDb(producer, cfg.OperaStore, lastCarmenBlock)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to heal gossip db: %w", err)
 	}
 
 	log.Info("Removing epoch DBs - will be recreated on next start")
 	if err = dropAllEpochDbs(producer); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to drop epoch DBs: %w", err)
 	}
 
 	log.Info("Recreating consensus database")
@@ -63,11 +65,11 @@ func HealChaindata(chaindataDir string, cacheRatio cachescale.Func, cfg *config.
 	}
 
 	log.Info("Clearing DBs dirty flags")
-	if err := clearDirtyFlags(producer); err != nil {
-		return 0, fmt.Errorf("failed to write clean FlushID: %w", err)
+	if err = clearDirtyFlags(producer); err != nil {
+		return 0, fmt.Errorf("failed to clear dirty flags: %w", err)
 	}
 
-	return lastBlock, nil
+	return lastBlockId, nil
 }
 
 // healGossipDb reverts the gossip database into state, into which can be reverted carmen
@@ -78,7 +80,7 @@ func healGossipDb(producer kvdb.FlushableDBProducer, cfg gossip.StoreConfig, las
 	if err != nil {
 		return nil, 0, err
 	}
-	defer gdb.Close()
+	defer caution.CloseAndReportError(&err, gdb, "failed to close gossip db")
 
 	// find the last closed epoch with the state available
 	epochIdx, blockState, epochState := getLastEpochWithState(gdb, lastCarmenBlock)

--- a/cmd/sonictool/genesis/signature.go
+++ b/cmd/sonictool/genesis/signature.go
@@ -110,8 +110,7 @@ func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file
 		return fmt.Errorf("failed to write signature to genesis file: %w", err)
 	}
 	_, err = writer.Flush()
-	utils.AnnotateIfError(err, "failed to flush genesis file:")
-	return err
+	return utils.AnnotateIfError(err, "failed to flush genesis file:")
 }
 
 // TypedDataAndHash is a helper function that calculates a hash for typed data conforming to EIP-712.

--- a/cmd/sonictool/genesis/signature.go
+++ b/cmd/sonictool/genesis/signature.go
@@ -2,13 +2,16 @@ package genesis
 
 import (
 	"fmt"
-	"github.com/0xsoniclabs/sonic/opera/genesis"
-	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"io"
 	"os"
 	"sort"
+
+	"github.com/0xsoniclabs/sonic/opera/genesis"
+	"github.com/0xsoniclabs/sonic/utils"
+	"github.com/0xsoniclabs/sonic/utils/caution"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
 func GetGenesisMetadata(header genesis.Header, genesisHashes genesis.Hashes) ([]byte, string, error) {
@@ -80,32 +83,34 @@ func CheckGenesisSignature(hash []byte, signature []byte) error {
 	return fmt.Errorf("genesis signature does not match any trusted signer (signer: %x)", address)
 }
 
-func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file string) error {
+func WriteSignatureIntoGenesisFile(header genesis.Header, signature []byte, file string) (err error) {
 	out, err := os.OpenFile(file, os.O_RDWR, os.ModePerm) // avoid using O_APPEND for correct seek positions
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open genesis file: %w", err)
 	}
 	_, err = out.Seek(0, io.SeekEnd)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to seek genesis file: %w", err)
 	}
-	defer out.Close()
+	defer caution.CloseAndReportError(&err, out, "failed to close genesis file")
 
 	tmpDir, err := os.MkdirTemp("", "signing-genesis-tmp")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer caution.ExecuteAndReportError(&err, func() error { return os.RemoveAll(tmpDir) },
+		"failed to remove temporary directory")
 
 	writer := newUnitWriter(out)
-	if err := writer.Start(header, "signature", tmpDir); err != nil {
-		return err
+	if err = writer.Start(header, "signature", tmpDir); err != nil {
+		return fmt.Errorf("failed to write start to genesis file: %w", err)
 	}
 	_, err = writer.Write(signature)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write signature to genesis file: %w", err)
 	}
 	_, err = writer.Flush()
+	utils.AnnotateIfError(err, "failed to flush genesis file:")
 	return err
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/gossip/emitter"
 	"github.com/0xsoniclabs/sonic/integration"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/utils/memory"
 	"github.com/0xsoniclabs/sonic/vecmt"
 )
@@ -81,12 +82,12 @@ func (c *Config) AppConfigs() integration.Configs {
 	}
 }
 
-func loadAllConfigs(file string, cfg *Config) error {
+func loadAllConfigs(file string, cfg *Config) (err error) {
 	f, err := os.Open(file)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open config file %s: %w", file, err)
 	}
-	defer f.Close()
+	defer caution.CloseAndReportError(&err, f, "failed to close config file")
 
 	err = TomlSettings.NewDecoder(bufio.NewReader(f)).Decode(cfg)
 	// Add file name to errors that have a line number.
@@ -94,12 +95,11 @@ func loadAllConfigs(file string, cfg *Config) error {
 		err = errors.New(file + ", " + err.Error())
 	}
 	if err != nil {
-
 		return fmt.Errorf("TOML config file error: %v.\n"+
 			"Use 'dumpconfig' command to get an example config file.\n"+
 			"If node was recently upgraded and a previous network config file is used, then check updates for the config file.", err)
 	}
-	return err
+	return nil
 }
 
 func setBootnodes(ctx *cli.Context, urls []string, cfg *node.Config) {

--- a/debug/api.go
+++ b/debug/api.go
@@ -22,6 +22,7 @@ package debug
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/user"
@@ -31,6 +32,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -60,8 +62,9 @@ func (h *HandlerT) StartCPUProfile(file string) error {
 		return err
 	}
 	if err := pprof.StartCPUProfile(f); err != nil {
-		f.Close()
-		return err
+		return errors.Join(
+			fmt.Errorf("failed to start CPU: %w", err),
+			utils.AnnotateIfError(f.Close(), "failed to close CPU profile file"))
 	}
 	h.cpuW = f
 	h.cpuFile = file
@@ -78,7 +81,9 @@ func (h *HandlerT) StopCPUProfile() error {
 		return errors.New("CPU profiling not in progress")
 	}
 	log.Info("Done writing CPU profile", "dump", h.cpuFile)
-	h.cpuW.Close()
+	if err := h.cpuW.Close(); err != nil {
+		return fmt.Errorf("failed to close CPU profile file: %w", err)
+	}
 	h.cpuW = nil
 	h.cpuFile = ""
 	return nil

--- a/debug/trace.go
+++ b/debug/trace.go
@@ -21,9 +21,11 @@ package debug
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"runtime/trace"
 
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -39,8 +41,9 @@ func (h *HandlerT) StartGoTrace(file string) error {
 		return err
 	}
 	if err := trace.Start(f); err != nil {
-		f.Close()
-		return err
+		return errors.Join(
+			fmt.Errorf("failed to start Go trace: %w", err),
+			utils.AnnotateIfError(f.Close(), "failed to close trace file"))
 	}
 	h.traceW = f
 	h.traceFile = file
@@ -57,7 +60,9 @@ func (h *HandlerT) StopGoTrace() error {
 		return errors.New("trace not in progress")
 	}
 	log.Info("Done writing Go trace", "dump", h.traceFile)
-	h.traceW.Close()
+	if err := h.traceW.Close(); err != nil {
+		return err
+	}
 	h.traceW = nil
 	h.traceFile = ""
 	return nil

--- a/evmcore/tx_journal.go
+++ b/evmcore/tx_journal.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -148,10 +149,9 @@ func (journal *txJournal) rotate(all map[common.Address]types.Transactions) erro
 	for _, txs := range all {
 		for _, tx := range txs {
 			if err = rlp.Encode(replacement, tx); err != nil {
-				if closeErr := replacement.Close(); closeErr != nil {
-					return errors.Join(closeErr, fmt.Errorf("failed to close journal file: %w", closeErr))
-				}
-				return err
+				return errors.Join(
+					fmt.Errorf("failed to encode transaction: %w", err),
+					utils.AnnotateIfError(replacement.Close(), "failed to close journal file:"))
 			}
 		}
 		journaled += len(txs)

--- a/evmcore/tx_journal.go
+++ b/evmcore/tx_journal.go
@@ -18,9 +18,11 @@ package evmcore
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -56,7 +58,7 @@ func newTxJournal(path string) *txJournal {
 
 // load parses a transaction journal dump from disk, loading its contents into
 // the specified pool.
-func (journal *txJournal) load(add func([]*types.Transaction) []error) error {
+func (journal *txJournal) load(add func([]*types.Transaction) []error) (err error) {
 	// Skip the parsing if the journal file doesn't exist at all
 	if _, err := os.Stat(journal.path); os.IsNotExist(err) {
 		return nil
@@ -64,9 +66,9 @@ func (journal *txJournal) load(add func([]*types.Transaction) []error) error {
 	// Open the journal for loading any past transactions
 	input, err := os.Open(journal.path)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to open transaction journal: %w", err)
 	}
-	defer input.Close()
+	defer caution.CloseAndReportError(&err, input, "Failed to close transaction journal")
 
 	// Temporarily discard any journal additions (don't double add on load)
 	journal.writer = new(devNull)
@@ -146,13 +148,17 @@ func (journal *txJournal) rotate(all map[common.Address]types.Transactions) erro
 	for _, txs := range all {
 		for _, tx := range txs {
 			if err = rlp.Encode(replacement, tx); err != nil {
-				replacement.Close()
+				if closeErr := replacement.Close(); closeErr != nil {
+					return errors.Join(closeErr, fmt.Errorf("failed to close journal file: %w", closeErr))
+				}
 				return err
 			}
 		}
 		journaled += len(txs)
 	}
-	replacement.Close()
+	if err := replacement.Close(); err != nil {
+		return fmt.Errorf("failed to close journal file: %w", err)
+	}
 
 	// Replace the live journal with the newly generated one
 	if err = os.Rename(journal.path+".new", journal.path); err != nil {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -429,7 +429,9 @@ func (pool *TxPool) Stop() {
 	pool.wg.Wait()
 
 	if pool.journal != nil {
-		pool.journal.close()
+		if err := pool.journal.close(); err != nil {
+			log.Warn("Failed to close transaction journal:", err)
+		}
 	}
 	log.Info("Transaction pool stopped")
 }

--- a/gossip/evmstore/statedb.go
+++ b/gossip/evmstore/statedb.go
@@ -2,14 +2,16 @@ package evmstore
 
 import (
 	"fmt"
+	"math/big"
+
 	cc "github.com/0xsoniclabs/carmen/go/common"
 	carmen "github.com/0xsoniclabs/carmen/go/state"
 	_ "github.com/0xsoniclabs/carmen/go/state/gostate"
 	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
-	"math/big"
 )
 
 // GetLiveStateDb obtains StateDB for block processing - the live writable state
@@ -71,7 +73,7 @@ func (s *Store) CheckLiveStateHash(blockNum idx.Block, root hash.Hash) error {
 }
 
 // CheckArchiveStateHash returns if the hash of the given archive StateDB hash matches
-func (s *Store) CheckArchiveStateHash(blockNum idx.Block, root hash.Hash) error {
+func (s *Store) CheckArchiveStateHash(blockNum idx.Block, root hash.Hash) (err error) {
 	if s.carmenState == nil {
 		return fmt.Errorf("unable to get live state - EvmStore is not open")
 	}
@@ -79,7 +81,7 @@ func (s *Store) CheckArchiveStateHash(blockNum idx.Block, root hash.Hash) error 
 	if err != nil {
 		return fmt.Errorf("unable to get archive state: %w", err)
 	}
-	defer archiveState.Close()
+	defer caution.CloseAndReportError(&err, archiveState, "failed to close archive state")
 
 	stateHash, err := archiveState.GetHash()
 	if err != nil {

--- a/gossip/evmstore/statedb_import.go
+++ b/gossip/evmstore/statedb_import.go
@@ -14,6 +14,7 @@ import (
 	carmen "github.com/0xsoniclabs/carmen/go/state"
 	"github.com/0xsoniclabs/sonic/opera/genesis"
 	"github.com/0xsoniclabs/sonic/utils/adapters/kvdb2ethdb"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/nokeyiserr"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/pebble"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
@@ -99,22 +100,23 @@ func (s *Store) ExportArchiveWorldState(ctx context.Context, out io.Writer) erro
 	return nil
 }
 
-func (s *Store) ImportLegacyEvmData(evmItems genesis.EvmItems, blockNum uint64, root common.Hash) error {
-	if err := s.Open(); err != nil {
-		return fmt.Errorf("failed to open EvmStore for legacy EVM data import; %v", err)
+func (s *Store) ImportLegacyEvmData(evmItems genesis.EvmItems, blockNum uint64, root common.Hash) (err error) {
+	if err = s.Open(); err != nil {
+		return fmt.Errorf("failed to open EvmStore for legacy EVM data import; %w", err)
 	}
-	defer s.Close()
+	defer caution.CloseAndReportError(&err, s, "failed to close EvmStore after legacy EVM data import")
 
 	carmenDir, err := os.MkdirTemp(s.parameters.Directory, "opera-tmp-import-legacy-genesis")
 	if err != nil {
-		panic(fmt.Errorf("failed to create temporary dir for legacy EVM data import: %v", err))
+		panic(fmt.Errorf("failed to create temporary dir for legacy EVM data import: %w", err))
 	}
-	defer os.RemoveAll(carmenDir)
+	defer caution.ExecuteAndReportError(&err, func() error { return os.RemoveAll(carmenDir) },
+		"failed to remove temporary directory for legacy EVM data import")
 
 	s.Log.Info("Unpacking legacy EVM data into a temporary directory", "dir", carmenDir)
 	db, err := pebble.New(carmenDir, 1024, 100, nil, nil)
 	if err != nil {
-		panic(fmt.Errorf("failed to open temporary database for legacy EVM data import: %v", err))
+		panic(fmt.Errorf("failed to open temporary database for legacy EVM data import: %w", err))
 	}
 	evmItems.ForEach(func(key, value []byte) bool {
 		err := db.Put(key, value)
@@ -142,26 +144,26 @@ func (s *Store) ImportLegacyEvmData(evmItems genesis.EvmItems, blockNum uint64, 
 	tdb := triedb.NewDatabase(chaindb, &triedb.Config{Preimages: false, IsVerkle: false})
 	t, err := trie.NewStateTrie(trie.StateTrieID(root), tdb)
 	if err != nil {
-		return fmt.Errorf("failed to open trie; %v", err)
+		return fmt.Errorf("failed to open trie; %w", err)
 	}
 	preimages := table.New(db, []byte("secure-key-"))
 
 	accIter, err := t.NodeIterator(nil)
 	if err != nil {
-		return fmt.Errorf("failed to open accounts iterator; %v", err)
+		return fmt.Errorf("failed to open accounts iterator; %w", err)
 	}
 	for accIter.Next(true) {
 		if accIter.Leaf() {
 
 			addressBytes, err := preimages.Get(accIter.LeafKey())
 			if err != nil || addressBytes == nil {
-				return fmt.Errorf("missing preimage for account address hash %v; %v", accIter.LeafKey(), err)
+				return fmt.Errorf("missing preimage for account address hash %v; %w", accIter.LeafKey(), err)
 			}
 			address := cc.Address(common.BytesToAddress(addressBytes))
 
 			var acc types.StateAccount
 			if err := rlp.DecodeBytes(accIter.LeafBlob(), &acc); err != nil {
-				return fmt.Errorf("invalid account encountered during traversal; %v", err)
+				return fmt.Errorf("invalid account encountered during traversal; %w", err)
 			}
 
 			bulk.CreateAccount(address)
@@ -179,23 +181,23 @@ func (s *Store) ImportLegacyEvmData(evmItems genesis.EvmItems, blockNum uint64, 
 			if acc.Root != types.EmptyRootHash {
 				storageTrie, err := trie.NewStateTrie(trie.StateTrieID(acc.Root), tdb)
 				if err != nil {
-					return fmt.Errorf("failed to open storage trie for account %v; %v", address, err)
+					return fmt.Errorf("failed to open storage trie for account %v; %w", address, err)
 				}
 				storageIt, err := storageTrie.NodeIterator(nil)
 				if err != nil {
-					return fmt.Errorf("failed to open storage iterator for account %v; %v", address, err)
+					return fmt.Errorf("failed to open storage iterator for account %v; %w", address, err)
 				}
 				for storageIt.Next(true) {
 					if storageIt.Leaf() {
 						keyBytes, err := preimages.Get(storageIt.LeafKey())
 						if err != nil || keyBytes == nil {
-							return fmt.Errorf("missing preimage for storage key hash %v; %v", storageIt.LeafKey(), err)
+							return fmt.Errorf("missing preimage for storage key hash %v; %w", storageIt.LeafKey(), err)
 						}
 						key := cc.Key(common.BytesToHash(keyBytes))
 
 						_, valueBytes, _, err := rlp.Split(storageIt.LeafBlob())
 						if err != nil {
-							return fmt.Errorf("failed to decode storage; %v", err)
+							return fmt.Errorf("failed to decode storage; %w", err)
 						}
 						value := cc.Value(common.BytesToHash(valueBytes))
 
@@ -207,7 +209,7 @@ func (s *Store) ImportLegacyEvmData(evmItems genesis.EvmItems, blockNum uint64, 
 					}
 				}
 				if storageIt.Error() != nil {
-					return fmt.Errorf("failed to iterate storage trie of account %v; %v", address, storageIt.Error())
+					return fmt.Errorf("failed to iterate storage trie of account %v; %w", address, storageIt.Error())
 				}
 			}
 
@@ -218,7 +220,7 @@ func (s *Store) ImportLegacyEvmData(evmItems genesis.EvmItems, blockNum uint64, 
 		}
 	}
 	if accIter.Error() != nil {
-		return fmt.Errorf("failed to iterate accounts trie; %v", accIter.Error())
+		return fmt.Errorf("failed to iterate accounts trie; %w", accIter.Error())
 	}
 
 	if err := bulk.Close(); err != nil {

--- a/gossip/evmstore/statedb_verify.go
+++ b/gossip/evmstore/statedb_verify.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	carmen "github.com/0xsoniclabs/carmen/go/state"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -53,12 +54,12 @@ func (s *Store) VerifyWorldState(expectedBlockNum uint64, expectedHash common.Ha
 	return nil
 }
 
-func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expectedHash common.Hash) error {
+func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expectedHash common.Hash) (err error) {
 	liveState, err := carmen.NewState(params)
 	if err != nil {
 		return fmt.Errorf("failed to open carmen live state in %s: %w", params.Directory, err)
 	}
-	defer liveState.Close()
+	defer caution.CloseAndReportError(&err, liveState, "failed to close carmen live state")
 	if err := checkStateHash(liveState, expectedHash); err != nil {
 		return fmt.Errorf("live state check failed; %w", err)
 	}
@@ -78,7 +79,7 @@ func verifyLastState(params carmen.Parameters, expectedBlockNum uint64, expected
 	if err != nil {
 		return fmt.Errorf("failed to get carmen archive state; %w", err)
 	}
-	defer archiveState.Close()
+	defer caution.CloseAndReportError(&err, archiveState, "failed to close carmen archive state")
 	if err := checkStateHash(archiveState, expectedHash); err != nil {
 		return fmt.Errorf("archive state check failed; %w", err)
 	}

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/utils/adapters/vecmt2dagidx"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/vecmt"
 	"github.com/Fantom-foundation/lachesis-base/abft"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -81,9 +82,9 @@ func makeEngine(chaindataDir string, cfg Configs) (*abft.Lachesis, *vecmt.Index,
 	}
 	defer func() {
 		if err != nil {
-			gdb.Close()
-			cdb.Close()
-			dbs.Close()
+			caution.CloseAndReportError(&err, gdb, "failed to close gossip store")
+			caution.CloseAndReportError(&err, cdb, "failed to close lachesis store")
+			caution.CloseAndReportError(&err, dbs, "failed to close db producer")
 		}
 	}()
 

--- a/integration/db.go
+++ b/integration/db.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/0xsoniclabs/sonic/gossip"
+	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/utils/dbutil/dbcounter"
 	"github.com/0xsoniclabs/sonic/utils/dbutil/threads"
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -60,7 +61,7 @@ func isEmpty(dir string) bool {
 	if err != nil {
 		return true
 	}
-	defer f.Close()
+	defer caution.CloseAndReportError(&err, f, "failed to close dir")
 	_, err = f.Readdirnames(1)
 	return err == io.EOF
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -72,12 +72,10 @@ func isPortFree(host string, port int) bool {
 	if err != nil {
 		return false
 	}
-	err = listener.Close()
-	if err != nil {
-		fmt.Printf("failed to close port %d: %v\n", port, err)
+	if err = listener.Close(); err != nil {
+		panic(fmt.Errorf("failed to close listener:%w", err))
 	}
-	// if the port reports errors while closing, do not consider it free
-	return err == nil
+	return true
 }
 
 func getFreePort() (int, error) {

--- a/topicsdb/search_parallel.go
+++ b/topicsdb/search_parallel.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type logHandler func(rec *logrec) (gonext bool, err error)
@@ -117,5 +118,7 @@ func (tt *index) scanPatternVariant(pos uint8, variant common.Hash, start uint64
 			break
 		}
 	}
-	onMatched(nil)
+	if _, err := onMatched(nil); err != nil {
+		log.Warn("searchParallel", "err", err)
+	}
 }

--- a/topicsdb/search_parallel.go
+++ b/topicsdb/search_parallel.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 type logHandler func(rec *logrec) (gonext bool, err error)
@@ -118,7 +117,5 @@ func (tt *index) scanPatternVariant(pos uint8, variant common.Hash, start uint64
 			break
 		}
 	}
-	if _, err := onMatched(nil); err != nil {
-		log.Warn("searchParallel", "err", err)
-	}
+	_, _ = onMatched(nil)
 }

--- a/utils/annotateError.go
+++ b/utils/annotateError.go
@@ -1,0 +1,11 @@
+package utils
+
+import "fmt"
+
+// AnnotateIfError adds a message to an error, if the error is not nil.
+func AnnotateIfError(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}

--- a/utils/annotateError_test.go
+++ b/utils/annotateError_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotateIfError_PropagatesNil(t *testing.T) {
+	if AnnotateIfError(nil, "message") != nil {
+		t.Error("AnnotateIfError should return nil when err is nil")
+	}
+}
+
+func TestAnnotateIfError_AddsContextToError(t *testing.T) {
+	err := fmt.Errorf("someError")
+	errWithContext := AnnotateIfError(err, "message")
+	require.ErrorContains(t, errWithContext, "message: someError")
+}

--- a/utils/caution/caution_test.go
+++ b/utils/caution/caution_test.go
@@ -43,7 +43,7 @@ func (c *closeMe) Close() error {
 	return c.err
 }
 
-func TestCloseAndReportError_(t *testing.T) {
+func TestCloseAndReportError_AddsMessageToError(t *testing.T) {
 	file := &closeMe{}
 	var err error
 	CloseAndReportError(&err, file, "message")

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -5,13 +5,23 @@ import (
 	"io"
 	"os"
 	"path"
+
+	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
 // Check if errlock is written
 func Check() error {
-	locked, reason, eLockPath, _ := read(datadir)
+	locked, reason, eLockPath, err := read(datadir)
+	if err != nil {
+		return fmt.Errorf("Node isn't allowed to start due to an error reading"+
+			" the lock file %s.\n Please fix the issue. Error message:\n%w",
+			eLockPath, err)
+	}
+
 	if locked {
-		return fmt.Errorf("Node isn't allowed to start due to a previous error. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, reason)
+		return fmt.Errorf("Node isn't allowed to start due to a previous error."+
+			" Please fix the issue and then delete file \"%s\". Error message:\n%s",
+			eLockPath, reason)
 	}
 	return nil
 }
@@ -28,7 +38,9 @@ func SetDefaultDatadir(dir string) {
 // Permanent error
 func Permanent(err error) {
 	eLockPath, _ := write(datadir, err.Error())
-	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix the issue and then delete file \"%s\". Error message:\n%s", eLockPath, err.Error()))
+	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix"+
+		" the issue and then delete file \"%s\". Error message:\n%s",
+		eLockPath, err.Error()))
 }
 
 func readAll(reader io.Reader, max int) ([]byte, error) {
@@ -47,20 +59,21 @@ func readAll(reader io.Reader, max int) ([]byte, error) {
 }
 
 // read errlock file
-func read(dir string) (bool, string, string, error) {
-	eLockPath := path.Join(dir, "errlock")
+func read(dir string) (locked bool, reason string, eLockPath string, err error) {
+	eLockPath = path.Join(dir, "errlock")
 
 	data, err := os.Open(eLockPath)
 	if err != nil {
-		return false, "", eLockPath, err
+		// if file doesn't exist, directory is not locked and it is not an error
+		return false, "", eLockPath, nil
 	}
-	defer data.Close()
+	defer caution.CloseAndReportError(&err, data, "Failed to close errlock file")
 
 	// read no more than N bytes
 	maxFileLen := 5000
 	eLockBytes, err := readAll(data, maxFileLen)
 	if err != nil {
-		return true, "", eLockPath, err
+		return true, "", eLockPath, fmt.Errorf("failed to read lock file %v: %w", eLockPath, err)
 	}
 	return true, string(eLockBytes), eLockPath, nil
 }

--- a/valkeystore/encryption/io.go
+++ b/valkeystore/encryption/io.go
@@ -1,8 +1,12 @@
 package encryption
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/0xsoniclabs/sonic/utils"
 )
 
 func writeTemporaryKeyFile(file string, content []byte) (string, error) {
@@ -10,19 +14,22 @@ func writeTemporaryKeyFile(file string, content []byte) (string, error) {
 	// in case it is not present yet.
 	const dirPerm = 0700
 	if err := os.MkdirAll(filepath.Dir(file), dirPerm); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create keystore directory: %w", err)
 	}
 	// Atomic write: create a temporary hidden file first
 	// then move it into place. TempFile assigns mode 0600.
 	f, err := os.CreateTemp(filepath.Dir(file), "."+filepath.Base(file)+".tmp")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to create temporary key file: %w", err)
 	}
-	if _, err := f.Write(content); err != nil {
-		f.Close()
-		os.Remove(f.Name())
-		return "", err
+
+	if _, err = f.Write(content); err != nil {
+		return "", errors.Join(
+			fmt.Errorf("failed to write key file: %w", err),
+			utils.AnnotateIfError(f.Close(), "failed to close key file"),
+			utils.AnnotateIfError(os.Remove(f.Name()), "failed to remove temporary key file"),
+		)
 	}
-	f.Close()
-	return f.Name(), nil
+
+	return f.Name(), f.Close()
 }


### PR DESCRIPTION
This PR contributes to https://github.com/Fantom-foundation/sonic-admin/issues/90

This PR adds real life use cases of both functions, provided the caution package to properly handler errors in case of `defer` and `close`. 

This PR fixes some of the unhandled errors reported by the external audit. Most (if not all) of them are from either `defer close` patterns or similar cleanups or unhandled close errors.

Test list to verify we don't have double closes (or other errors) and panic now because error is no longer ignored:
- [x] make test
- [x] Norma test
    - demonet/static.yml
    - demonet/dynamic.yml
- [x] change scope and test study: https://docs.google.com/spreadsheets/d/1wma9IgKtWAePlPet0XdyoSQPRv5mU9tZspshbcd6jAc/edit?usp=sharing

original discussions: https://github.com/Fantom-foundation/Sonic/pull/378
