### PR TITLE
Update version handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ sonicd:
 	GIT_TAG=`echo $(call get_git_tag)` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/config.GitCommit=$${GIT_COMMIT} \
-				        -X github.com/0xsoniclabs/sonic/config.GitDate=$${GIT_DATE} \
-						-X github.com/0xsoniclabs/sonic/version.Version=$${GIT_TAG}" \
+	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/version.gitCommit=$${GIT_COMMIT} \
+				        -X github.com/0xsoniclabs/sonic/version.gitDate=$${GIT_DATE} \
+						-X github.com/0xsoniclabs/sonic/version.codeVersion=$${GIT_TAG}" \
 	    -o build/sonicd \
 	    ./cmd/sonicd && \
 	    ./build/sonicd version
@@ -22,9 +22,9 @@ sonictool:
 	GIT_TAG=`echo  $(call get_git_tag)` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/config.GitCommit=$${GIT_COMMIT} \
-				        -X github.com/0xsoniclabs/sonic/config.GitDate=$${GIT_DATE} \
-						-X github.com/0xsoniclabs/sonic/version.Version=$${GIT_TAG}" \
+	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/version.gitCommit=$${GIT_COMMIT} \
+				        -X github.com/0xsoniclabs/sonic/version.gitDate=$${GIT_DATE} \
+						-X github.com/0xsoniclabs/sonic/version.codeVersion=$${GIT_TAG}" \
 	    -o build/sonictool \
 	    ./cmd/sonictool && \
 	    ./build/sonictool --version
@@ -91,10 +91,14 @@ define get_git_tag
         DIRTY_STATE=$$(git status --porcelain 2>/dev/null); \
         FINAL_TAG=$${GIT_TAG}; \
         if [ "$${COMMITS_SINCE}" -ne 0 ]; then \
-            FINAL_TAG=$${FINAL_TAG}-dev; \
+            FINAL_TAG="$${FINAL_TAG}:dev"; \
+        else \
+            FINAL_TAG="$${FINAL_TAG}:"; \
         fi; \
         if [ -n "$${DIRTY_STATE}" ]; then \
-            FINAL_TAG=$${FINAL_TAG}-dirty; \
+            FINAL_TAG="$${FINAL_TAG}:dirty"; \
+        else \
+            FINAL_TAG="$${FINAL_TAG}:"; \
         fi; \
         echo "$${FINAL_TAG}"
     )

--- a/cmd/sonicd/app/fake_test.go
+++ b/cmd/sonicd/app/fake_test.go
@@ -1,20 +1,21 @@
 package app
 
 import (
-	"github.com/0xsoniclabs/sonic/config"
-	"github.com/0xsoniclabs/sonic/version"
-	"github.com/ethereum/go-ethereum/crypto"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/0xsoniclabs/sonic/config"
+	"github.com/0xsoniclabs/sonic/version"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
 	"github.com/0xsoniclabs/sonic/inter/validatorpk"
 )
 
 const (
-	ipcAPIs  = "abft:1.0 admin:1.0 dag:1.0 debug:1.0 ftm:1.0 net:1.0 personal:1.0 rpc:1.0 trace:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs = "abft:1.0 admin:1.0 dag:1.0 debug:1.0 ftm:1.0 net:1.0 personal:1.0 rpc:1.0 trace:1.0 txpool:1.0 web3:1.0"
 )
 
 func TestFakeNetFlag_NonValidator(t *testing.T) {
@@ -30,7 +31,7 @@ func TestFakeNetFlag_NonValidator(t *testing.T) {
 	cli.SetTemplateFunc("goos", func() string { return runtime.GOOS })
 	cli.SetTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	cli.SetTemplateFunc("gover", runtime.Version)
-	cli.SetTemplateFunc("version", func() string { return version.VersionWithCommit("", "") })
+	cli.SetTemplateFunc("version", func() string { return version.String() })
 	cli.SetTemplateFunc("niltime", genesisStart)
 	cli.SetTemplateFunc("apis", func() string { return ipcAPIs })
 	cli.ExpectExit()
@@ -60,7 +61,7 @@ func TestFakeNetFlag_Validator(t *testing.T) {
 	cli.SetTemplateFunc("goos", func() string { return runtime.GOOS })
 	cli.SetTemplateFunc("goarch", func() string { return runtime.GOARCH })
 	cli.SetTemplateFunc("gover", runtime.Version)
-	cli.SetTemplateFunc("version", func() string { return version.VersionWithCommit("", "") })
+	cli.SetTemplateFunc("version", func() string { return version.String() })
 	cli.SetTemplateFunc("niltime", genesisStart)
 	cli.SetTemplateFunc("apis", func() string { return ipcAPIs })
 	cli.ExpectExit()

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -173,7 +173,7 @@ func initApp() {
 	app = cli.NewApp()
 	app.Name = "sonicd"
 	app.Usage = "the Sonic network client"
-	app.Version = version.VersionWithCommit(config.GitCommit, config.GitDate)
+	app.Version = version.StringWithCommit()
 	app.Action = lachesisMain
 	app.HideVersion = true // we have a command to print the version
 	app.Commands = []cli.Command{

--- a/cmd/sonicd/app/misccmd.go
+++ b/cmd/sonicd/app/misccmd.go
@@ -28,12 +28,12 @@ The output of this command is supposed to be machine-readable.
 
 func versionAction(ctx *cli.Context) error {
 	fmt.Println(config.ClientIdentifier)
-	fmt.Println("Version:", version.Version)
-	if config.GitCommit != "" {
-		fmt.Println("Git Commit:", config.GitCommit)
+	fmt.Println("Version:", version.String())
+	if commit := version.GitCommit(); commit != "" {
+		fmt.Println("Git Commit:", commit)
 	}
-	if config.GitDate != "" {
-		fmt.Println("Git Commit Date:", config.GitDate)
+	if date := version.GitDate(); date != "" {
+		fmt.Println("Git Commit Date:", date)
 	}
 	fmt.Println("Architecture:", runtime.GOARCH)
 	fmt.Println("Protocol Versions:", gossip.ProtocolVersions)

--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"sort"
 
-	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/config/flags"
 	"github.com/0xsoniclabs/sonic/version"
 	"gopkg.in/urfave/cli.v1"
@@ -14,7 +13,7 @@ func Run() error {
 	app := cli.NewApp()
 	app.Name = "sonictool"
 	app.Usage = "the Sonic management tool"
-	app.Version = version.VersionWithCommit(config.GitCommit, config.GitDate)
+	app.Version = version.StringWithCommit()
 	app.Flags = []cli.Flag{
 		flags.DataDirFlag,
 		flags.CacheFlag,

--- a/config/config.go
+++ b/config/config.go
@@ -39,12 +39,6 @@ const (
 	ClientIdentifier = "Sonic"
 )
 
-var (
-	// Git SHA1 commit hash of the release (set via linker flags).
-	GitCommit = ""
-	GitDate   = ""
-)
-
 // These settings ensure that TOML keys use the same names as Go struct fields.
 var TomlSettings = toml.Config{
 	NormFieldName: func(rt reflect.Type, key string) string {
@@ -359,7 +353,7 @@ func MakeAllConfigs(ctx *cli.Context) (*Config, error) {
 func DefaultNodeConfig() node.Config {
 	cfg := NodeDefaultConfig
 	cfg.Name = ClientIdentifier
-	cfg.Version = version.VersionWithCommit(GitCommit, GitDate)
+	cfg.Version = version.StringWithCommit()
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "ftm", "dag", "abft", "web3")
 	cfg.WSModules = append(cfg.WSModules, "eth", "ftm", "dag", "abft", "web3")
 	cfg.IPCPath = "sonic.ipc"

--- a/gossip/blockproc/verwatcher/version_number.go
+++ b/gossip/blockproc/verwatcher/version_number.go
@@ -1,0 +1,38 @@
+package verwatcher
+
+import "github.com/0xsoniclabs/sonic/version"
+
+type versionNumber uint64
+
+func getVersionNumber() versionNumber {
+	return toVersionNumber(version.Get())
+}
+
+func toVersionNumber(version version.Version) versionNumber {
+	// A released version is a higher version number than a development version.
+	released := 0
+	if version.IsRelease() {
+		// By using 256 for a released version we have the option to introduce
+		// pre-release version support in the future if needed.
+		released = 256
+	}
+
+	return versionNumber(
+		uint64(version.Major)<<48 |
+			uint64(version.Minor)<<32 |
+			uint64(version.Patch)<<16 |
+			uint64(released),
+	)
+}
+
+func (v versionNumber) String() string {
+	version := version.Version{
+		Major: int(v>>48) & 0xffff,
+		Minor: int(v>>32) & 0xffff,
+		Patch: int(v>>16) & 0xffff,
+	}
+	if v&0xffff < 256 {
+		version.Meta = "pre"
+	}
+	return version.String()
+}

--- a/gossip/blockproc/verwatcher/version_number_test.go
+++ b/gossip/blockproc/verwatcher/version_number_test.go
@@ -1,0 +1,66 @@
+package verwatcher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionNumber_AreOrderedFollowingSemanticVersioningRules(t *testing.T) {
+	versions := []version.Version{}
+	for major := range []int{0, 1, 2, 3} {
+		for minor := range []int{0, 1, 2, 3} {
+			for patch := range []int{0, 1, 2, 3} {
+				version := version.Version{Major: major, Minor: minor, Patch: patch, Meta: "pre"}
+				versions = append(versions, version)
+				version.Meta = ""
+				versions = append(versions, version)
+			}
+		}
+	}
+
+	for i := range len(versions) - 1 {
+		if toVersionNumber(versions[i]) > toVersionNumber(versions[i+1]) {
+			t.Errorf("%s > %s", versions[i], versions[i+1])
+		}
+	}
+}
+
+func TestVersionNumber_toVersionNumber_AnyMetaTagIsTreatedEquivalent(t *testing.T) {
+	version1 := version.Version{Meta: "alpha"}
+	version2 := version.Version{Meta: "beta"}
+	require.Equal(t, toVersionNumber(version1), toVersionNumber(version2))
+}
+
+func TestVersionNumber_ReleasesAreHigherThanVersionsWithMetaData(t *testing.T) {
+	release := version.Version{}
+	prerelease := version.Version{Meta: "some-meta"}
+	require.Less(t, toVersionNumber(prerelease), toVersionNumber(release))
+}
+
+func TestVersionNumber_PrintedInHumanReadableFormat(t *testing.T) {
+	tests := map[versionNumber]string{
+		0:                "v0.0.0-pre",
+		0x0001 << 48:     "v1.0.0-pre",
+		0x0001 << 32:     "v0.1.0-pre",
+		0x0001 << 16:     "v0.0.1-pre",
+		1:                "v0.0.0-pre",
+		255:              "v0.0.0-pre",
+		256:              "v0.0.0",
+		257:              "v0.0.0",
+		0x0001<<48 | 256: "v1.0.0",
+		0x0001<<32 | 256: "v0.1.0",
+		0x0001<<16 | 256: "v0.0.1",
+	}
+
+	for v, want := range tests {
+		if got := v.String(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		if got := fmt.Sprintf("%v", v); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}
+}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -82,7 +82,7 @@ func consensusCallbackBeginBlockFn(
 	txIndex bool,
 	feed *ServiceFeed,
 	emitters *[]*emitter.Emitter,
-	verWatcher *verwatcher.VerWarcher,
+	verWatcher *verwatcher.VersionWatcher,
 	bootstrapping *bool,
 ) lachesis.BeginBlockFn {
 	return func(cBlock *lachesis.Block) lachesis.BlockCallbacks {

--- a/gossip/emitter/config.go
+++ b/gossip/emitter/config.go
@@ -57,7 +57,7 @@ type Config struct {
 // DefaultConfig returns the default configurations for the events emitter.
 func DefaultConfig() Config {
 	return Config{
-		VersionToPublish: version.Version,
+		VersionToPublish: version.String(),
 
 		EmitIntervals: EmitIntervals{
 			Min:                        150 * time.Millisecond,

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -120,7 +120,7 @@ type Service struct {
 	uniqueEventIDs      uniqueID
 
 	// version watcher
-	verWatcher *verwatcher.VerWarcher
+	verWatcher *verwatcher.VersionWatcher
 
 	blockProcWg        sync.WaitGroup
 	blockProcTasks     *workers.Workers

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,68 +1,57 @@
 package version
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-type testcase struct {
-	vMajor, vMinor, vPatch uint16
-	result                 uint64
-	str                    string
-}
-
-func TestAsBigInt(t *testing.T) {
-	require := require.New(t)
-
-	prev := testcase{0, 0, 0, 0, "0.0.0"}
-	for _, next := range []testcase{
-		{0, 0, 1, 1, "0.0.1"},
-		{0, 0, 2, 2, "0.0.2"},
-		{0, 1, 0, 1000000, "0.1.0"},
-		{0, 1, math.MaxUint16, 1065535, "0.1.65535"},
-		{1, 0, 0, 1000000000000, "1.0.0"},
-		{1, 0, math.MaxUint16, 1000000065535, "1.0.65535"},
-		{1, 1, 0, 1000001000000, "1.1.0"},
-		{2, 9, 9, 2000009000009, "2.9.9"},
-		{3, 1, 0, 3000001000000, "3.1.0"},
-		{math.MaxUint16, math.MaxUint16, math.MaxUint16, 65535065535065535, "65535.65535.65535"},
-	} {
-		a := ToU64(prev.vMajor, prev.vMinor, prev.vPatch)
-		b := ToU64(next.vMajor, next.vMinor, next.vPatch)
-		require.Equal(a, prev.result)
-		require.Equal(b, next.result)
-		require.Equal(U64ToString(a), prev.str)
-		require.Equal(U64ToString(b), next.str)
-		require.Greater(b, a)
-		prev = next
-	}
-}
-
 func TestVersion_parseVersion(t *testing.T) {
 	require := require.New(t)
 
-	tests := map[string]struct {
-		major int
-		minor int
-		patch int
-		meta  string
-	}{
-		"v1.2.3":                       {major: 1, minor: 2, patch: 3},
-		"v1.2.3-alpha":                 {major: 1, minor: 2, patch: 3, meta: "alpha"},
-		"v1.2.3-alpha-dirty":           {major: 1, minor: 2, patch: 3, meta: "alpha-dirty"},
-		"some-non.stan-dard.12tag":     {},
-		"!`@#$%^&*()_{}|:<>?[]\\;',./": {},
-		"myTestTag":                    {},
+	tests := map[string]Version{
+		"":                          {Major: versionMajor, Minor: versionMinor, Meta: "dev"},
+		"::":                        {Major: versionMajor, Minor: versionMinor, Meta: "dev"},
+		"v1.2.3::":                  {Major: 1, Minor: 2, Patch: 3},
+		"v1.2.3::dirty":             {Major: 1, Minor: 2, Patch: 3, Dirty: true},
+		"v1.2.3:dev:dirty":          {Major: 1, Minor: 3, Meta: "dev"},
+		"v1.2.3-rc1::":              {Major: 1, Minor: 2, Patch: 3, Meta: "rc1"},
+		"v1.2.3-rc1-beta-12::":      {Major: 1, Minor: 2, Patch: 3, Meta: "rc1-beta-12"},
+		"v17.1258.3478-rc52-beta::": {Major: 17, Minor: 1258, Patch: 3478, Meta: "rc52-beta"},
 	}
 
 	for tag, want := range tests {
-		testVMajor, testVMinor, testVPatch, testVMeta := parseVersion(tag)
+		version, err := parseVersion(tag)
+		require.NoError(err, "failed to parse version")
+		require.Equal(want, version, "version mismatch")
+	}
+}
 
-		require.Equal(want.major, testVMajor, "major version mismatch")
-		require.Equal(want.minor, testVMinor, "minor version mismatch")
-		require.Equal(want.patch, testVPatch, "patch version mismatch")
-		require.Equal(want.meta, testVMeta, "meta version mismatch")
+func TestVersion_parseVersion_shouldFailInvalidVersionString(t *testing.T) {
+	require := require.New(t)
+
+	tests := []string{
+		// missing or too many parts
+		"v1.2.3",
+		"v1.2.3:",
+		"v1.2.3:::",
+
+		// invalid version parts
+		"some-non.stan-#.12tag::",
+		"!`@#$%^&*()_{}|<>?[]\\;',./::",
+
+		// invalid meta part
+		"v1.2.3-ü::",
+
+		// invalid dev part
+		"v1.2.3:dev-:",
+
+		// invalid dirty part
+		"v1.2.3::dirty-",
+	}
+
+	for _, tag := range tests {
+		_, err := parseVersion(tag)
+		require.Error(err, "expected parsing to fail")
 	}
 }


### PR DESCRIPTION
This PR introduces a few suggested changes to #6:
- the version string created in the `Makefile` is validated and parsed by a regex, improving resilience
- the version string created in the `Makefile` uses ":" instead of "-" to separate the version from the dirty and dev parameters to avoid mixing up meta strings with these flags
- the `Version` string was made private
- a `Version` struct allowing to access the parsed version information was added
- the version number features required by the `versionWatcher` (fixed a speller issue) got moved to the respective package
- the version number is now sorting pre-releases and releases into the right order
- the git commit and date values are now also tracked by the `version` package instead of the `config` package
- the git commit and date are now package private

Also, if a development version is detected, a minor version number one higher than the last tag is used. This is to fix the problem that a version `v2.3.4-dev` is considered less than a version `v2.3.4`. Thus, if the tag is `v2.3.4` and the build has extra commits, the version number `v2.4.0-dev` is used.