### PR TITLE
Replace best-effort port probing with OS selected port numbers

### DIFF
--- a/cmd/sonicd/app/app.go
+++ b/cmd/sonicd/app/app.go
@@ -2,10 +2,33 @@ package app
 
 import (
 	"os"
+
+	"gopkg.in/urfave/cli.v1"
 )
 
+// Run starts sonicd with the regular command line arguments.
 func Run() error {
-	initApp()
+	return RunWithArgs(os.Args, nil)
+}
+
+// RunWithArgs starts sonicd with the given command line arguments.
+// An optional httpPortAnnouncement channel can be provided to announce the HTTP port
+// used by the HTTP server of the started sonicd node. The channel is closed when the
+// when the process stops.
+func RunWithArgs(
+	args []string,
+	httpPortAnnouncement chan<- string,
+) error {
+	app := initApp()
 	initAppHelp()
-	return app.Run(os.Args)
+
+	// If present, inject the http port announcement channel into the action.
+	if httpPortAnnouncement != nil {
+		defer close(httpPortAnnouncement)
+		app.Action = func(ctx *cli.Context) error {
+			return lachesisMainInternal(ctx, httpPortAnnouncement)
+		}
+	}
+
+	return app.Run(args)
 }

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -64,7 +64,7 @@ func (tt *testcli) readConfig() {
 func init() {
 	// Run the app if we've been exec'd as "opera-test" in exec().
 	reexec.Register("opera-test", func() {
-		initApp()
+		app := initApp()
 		initAppHelp()
 		if err := app.Run(os.Args); err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
We experience flaky tests due to the selection of port numbers in integration tests that have already been used by other processes on the system. This change fixes this by allowing the OS to assign any free port number.

**Background**
When passing the port number 0 through the CLI to the `sonicd` client, an arbitrary free port is assigned to server sockets (for the P2P service and the web service). This code change is using this mechanism to avoid port collisions.

However, to inform the integration test infrastructure about the selected port, a back-channel needed to be added. Through this `sonicd` instances are able to inform the test infrastructure about the selected service port.

**Detail**
While working on this PR it was discovered that the HTTP and WebSocket traffic can be channeled over the same server socket -- which is the default when no alternative socket is defined on the command line. Thus, the http-port and the ws-port got combined.