### PR TITLE
Fix sonic version commit and version date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ sonicd:
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE}" \
+	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/config.GitCommit=$${GIT_COMMIT} -X github.com/0xsoniclabs/sonic/config.GitDate=$${GIT_DATE}" \
 	    -o build/sonicd \
 	    ./cmd/sonicd
 
@@ -17,7 +17,7 @@ sonictool:
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/Fantom-foundation/go-opera/config.GitCommit=$${GIT_COMMIT} -X github.com/Fantom-foundation/go-opera/config.GitDate=$${GIT_DATE}" \
+	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/config.GitCommit=$${GIT_COMMIT} -X github.com/0xsoniclabs/sonic/config.GitDate=$${GIT_DATE}" \
 	    -o build/sonictool \
 	    ./cmd/sonictool
 


### PR DESCRIPTION
This PR corrects the variable names which hold commit id and commit date. The variables are used by `sonicd version` command. Due to incorrect name, currently git commit and date are not visible when run the command.