### PR TITLE
Accept stop calls for profiler and tracer if never started

### DIFF
--- a/debug/api.go
+++ b/debug/api.go
@@ -78,7 +78,7 @@ func (h *HandlerT) StopCPUProfile() error {
 	defer h.mu.Unlock()
 	pprof.StopCPUProfile()
 	if h.cpuW == nil {
-		return errors.New("CPU profiling not in progress")
+		return nil
 	}
 	log.Info("Done writing CPU profile", "dump", h.cpuFile)
 	if err := h.cpuW.Close(); err != nil {

--- a/debug/trace.go
+++ b/debug/trace.go
@@ -57,7 +57,7 @@ func (h *HandlerT) StopGoTrace() error {
 	defer h.mu.Unlock()
 	trace.Stop()
 	if h.traceW == nil {
-		return errors.New("trace not in progress")
+		return nil
 	}
 	log.Info("Done writing Go trace", "dump", h.traceFile)
 	if err := h.traceW.Close(); err != nil {


### PR DESCRIPTION
The CPU profiler and tracer failed to support stop calls in cases where they have not been started before. This caused the production of an error log message for sub-commands not starting them.

This PR fixes this by ignoring stop calls if the respective background service was not started before.

Fixes #16 