### PR TITLE
Add Allegro hard fork flag

### DIFF
--- a/opera/legacy_serialization.go
+++ b/opera/legacy_serialization.go
@@ -96,6 +96,9 @@ func (u Upgrades) EncodeRLP(w io.Writer) error {
 	if u.Sonic {
 		bitmap.V |= sonicBit
 	}
+	if u.Allegro {
+		bitmap.V |= allegroBit
+	}
 	return rlp.Encode(w, &bitmap)
 }
 
@@ -112,6 +115,7 @@ func (u *Upgrades) DecodeRLP(s *rlp.Stream) error {
 	u.London = (bitmap.V & londonBit) != 0
 	u.Llr = (bitmap.V & llrBit) != 0
 	u.Sonic = (bitmap.V & sonicBit) != 0
+	u.Allegro = (bitmap.V & allegroBit) != 0
 	return nil
 }
 

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	ethparams "github.com/ethereum/go-ethereum/params"
 
-	"github.com/0xsoniclabs/tosca/go/geth_adapter"
-	"github.com/0xsoniclabs/tosca/go/interpreter/lfvm"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera/contracts/evmwriter"
+	"github.com/0xsoniclabs/tosca/go/geth_adapter"
+	"github.com/0xsoniclabs/tosca/go/interpreter/lfvm"
 )
 
 const (
@@ -25,6 +25,7 @@ const (
 	londonBit              = 1 << 1
 	llrBit                 = 1 << 2
 	sonicBit               = 1 << 3
+	allegroBit             = 1 << 4
 
 	defaultMaxBlockGas          = 1_000_000_000
 	defaultTargetGasRate        = 15_000_000 // 15 MGas/s
@@ -208,10 +209,14 @@ type BlocksRules struct {
 }
 
 type Upgrades struct {
+	// -- Fantom Chain --
 	Berlin bool
 	London bool
 	Llr    bool
-	Sonic  bool
+
+	// -- Sonic Chain --
+	Sonic   bool // < launch version of the Sonic chain
+	Allegro bool // < first hard fork of the Sonic chain
 }
 
 type UpgradeHeight struct {


### PR DESCRIPTION
This PR introduces a hard fork flag to the network rules for the next sonic network hard fork.

The existing code base indicates hard forks through boolean flags in a struct. Although it would be cleaner to replace this flag-based representation by an enumeration type, such that invalid flag combinations are automatically excluded, such a change is difficult to realize in a backward compatible way. Thus, the new hard fork flag is added following the preexisting infrastructure.

Some existing tests got generalized to cover the unit-testing of the encoding and decoding of the new flag.