### PR TITLE
Update Github Actions workflows

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -12,22 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure private dependencies
-        uses: extractions/netrc@v1
-        with:
-          machine: github.com
-          username: git
-          password: ${{ secrets.ACCESS_TOKEN }}
-
       - name: Golang dependency
         uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
-
-      - name: Run unit tests
-        env:
-          GOPRIVATE: github.com/Fantom-foundation
-        run: go test -v ./...
+          go-version: '1.23'
 
       - name: Build
         run: make
@@ -35,5 +23,5 @@ jobs:
       - name: Release
         uses: ncipollo/release-action@v1
         with:
+          draft: true # create release as a draft
           artifacts: "./build/sonicd,./build/sonictool"
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-    - '*'
+    - 'v+([0-9]).+([0-9]).+([0-9])' # example: v2.0.12 (rc intentionally excluded)
 
 jobs:
   release:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,6 +1,7 @@
 name: Check build
 
-on: [push]
+on:
+  push:
 
 jobs:
   check-build:
@@ -9,27 +10,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure private dependencies
-        uses: extractions/netrc@v1
-        with:
-          machine: github.com
-          username: git
-          password: ${{ secrets.ACCESS_TOKEN }}
-
       - name: Golang dependency
         uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Static lints
-        env:
-          GOPRIVATE: github.com/Fantom-foundation
         run: make lint
-
-      - name: Run unit tests
-        env:
-          GOPRIVATE: github.com/Fantom-foundation
-        run: go test ./... --count 0 
 
       - name: Build
         run: make


### PR DESCRIPTION
* GITHUB_TOKEN is not needed to do a release (when running in the same repo) (currently is release [failing](https://github.com/0xsoniclabs/sonic/actions/runs/13198761118/job/36845805842#step:7:18) because of invalid token)
* No private repositories are in dependencies anymore - removing ACCESS_TOKEN/GOPRIVATE
* Upgrade Go in workflow to 1.23
* Removed disabled unit tests (already set to run 0-times, because moved out from github)