### PR TITLE
Introduce BigMin / BigMax utils

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1349,7 +1349,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		// if the transaction has been mined, compute the effective gas price
 		if baseFee != nil && blockHash != (common.Hash{}) {
 			// price = min(tip, gasFeeCap - baseFee) + baseFee
-			price := math.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
+			price := utils.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
 			result.GasPrice = (*hexutil.Big)(price)
 		} else {
 			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())

--- a/ethapi/transaction_args.go
+++ b/ethapi/transaction_args.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/0xsoniclabs/sonic/gossip/gasprice"
+	"github.com/0xsoniclabs/sonic/utils"
 )
 
 // TransactionArgs represents the arguments to construct a new transaction
@@ -221,7 +222,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 			// Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
 			gasPrice = new(big.Int)
 			if gasFeeCap.BitLen() > 0 || gasTipCap.BitLen() > 0 {
-				gasPrice = math.BigMin(new(big.Int).Add(gasTipCap, baseFee), gasFeeCap)
+				gasPrice = utils.BigMin(new(big.Int).Add(gasTipCap, baseFee), gasFeeCap)
 			}
 		}
 	}

--- a/utils/big.go
+++ b/utils/big.go
@@ -1,0 +1,35 @@
+package utils
+
+import "math/big"
+
+// BigMin returns the smaller of the provided big.Ints.
+// None of the arguments must be nil. If no arguments
+// are provided, nil is returned.
+func BigMin(values ...*big.Int) *big.Int {
+	if len(values) == 0 {
+		return nil
+	}
+	res := values[0]
+	for _, b := range values[1:] {
+		if res.Cmp(b) > 0 {
+			res = b
+		}
+	}
+	return res
+}
+
+// BigMax returns the largest of the provided big.Ints.
+// None of the arguments must be nil. If no arguments
+// are provided, nil is returned.
+func BigMax(values ...*big.Int) *big.Int {
+	if len(values) == 0 {
+		return nil
+	}
+	res := values[0]
+	for _, b := range values[1:] {
+		if res.Cmp(b) < 0 {
+			res = b
+		}
+	}
+	return res
+}

--- a/utils/big.go
+++ b/utils/big.go
@@ -2,7 +2,7 @@ package utils
 
 import "math/big"
 
-// BigMin returns the smaller of the provided big.Ints.
+// BigMin returns the smallest of the provided big.Ints.
 // None of the arguments must be nil. If no arguments
 // are provided, nil is returned.
 func BigMin(values ...*big.Int) *big.Int {

--- a/utils/big_test.go
+++ b/utils/big_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+func TestBigMin_WithoutArgumentsReturnsNil(t *testing.T) {
+	if BigMin() != nil {
+		t.Error("BigMin() did not return nil")
+	}
+}
+
+func TestBigMin_ReturnsTheMinimum(t *testing.T) {
+	tests := [][]int{
+		{0},
+		{0, 1},
+		{1, 0},
+		{1, 1},
+		{1, 2, 3, 4, 5},
+		{5, 4, 3, 2, 1},
+	}
+
+	for _, test := range tests {
+		min := math.MaxInt
+		args := make([]*big.Int, len(test))
+		for i, v := range test {
+			args[i] = big.NewInt(int64(v))
+			if v < min {
+				min = v
+			}
+		}
+		got := int(BigMin(args...).Int64())
+		if got != min {
+			t.Errorf("BigMin(%v) = %d; want %d", test, got, min)
+		}
+	}
+}
+
+func TestBigMin_ReturnsThePointerToTheMinimum(t *testing.T) {
+	a := big.NewInt(1)
+	b := big.NewInt(2)
+	if BigMin(a, b) != a {
+		t.Error("BigMin(1, 2) did not return the pointer to the minimum")
+	}
+	if BigMin(b, a) != a {
+		t.Error("BigMin(2, 1) did not return the pointer to the minimum")
+	}
+}
+
+func TestBigMax_WithoutArgumentsReturnsNil(t *testing.T) {
+	if BigMax() != nil {
+		t.Error("BigMax() did not return nil")
+	}
+}
+
+func TestBigMax_ReturnsTheMaximum(t *testing.T) {
+	tests := [][]int{
+		{0},
+		{0, 1},
+		{1, 0},
+		{1, 1},
+		{1, 2, 3, 4, 5},
+		{5, 4, 3, 2, 1},
+	}
+
+	for _, test := range tests {
+		max := -1
+		args := make([]*big.Int, len(test))
+		for i, v := range test {
+			args[i] = big.NewInt(int64(v))
+			if v > max {
+				max = v
+			}
+		}
+		got := int(BigMax(args...).Int64())
+		if got != max {
+			t.Errorf("BigMax(%v) = %d; want %d", test, got, max)
+		}
+	}
+}
+
+func TestBigMax_ReturnsThePointerToTheMaximum(t *testing.T) {
+	a := big.NewInt(1)
+	b := big.NewInt(2)
+	if BigMax(a, b) != b {
+		t.Error("BigMin(1, 2) did not return the pointer to the minimum")
+	}
+	if BigMax(b, a) != b {
+		t.Error("BigMin(2, 1) did not return the pointer to the minimum")
+	}
+}


### PR DESCRIPTION
In geth 1.15 the former `math.BigMin` and `math.BigMax` utility functions got removed by this [PR](https://github.com/ethereum/go-ethereum/commit/a5fe7353c) due to its name-space collision with the standard-libary `math` module. The suggested replacement is to inline the min/max decision.

However, this results in weakened readability, as seen in #24. By inlining the code, the intention of computing the maximum or minimum of two integers is harder to derive. Also, mixing up the argument order or a `< 0` for a `> 0` for the result of the `Cmp()` function is an easy mistake (as has happened to the author of #24). 

To counter that, this PR introduces generalized replacements for these functions in the `utils` module to retain readability.