### PR TITLE
Add implementation of a BLS library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/status-im/keycard-go v0.3.2
 	github.com/stretchr/testify v1.9.0
+	github.com/supranational/blst v0.3.14
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tyler-smith/go-bip39 v1.1.0
 	go.uber.org/mock v0.4.0
@@ -110,7 +111,6 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
-	github.com/supranational/blst v0.3.13 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/urfave/cli/v2 v2.27.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/supranational/blst v0.3.13 h1:AYeSxdOMacwu7FBmpfloBz5pbFXDmJL33RuwnKtmTjk=
 github.com/supranational/blst v0.3.13/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.14 h1:xNMoHRJOTwMn63ip6qoWJ2Ymgvj7E2b9jY2FAwY+qRo=
+github.com/supranational/blst v0.3.14/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZb78yU=

--- a/scc/bls/bls.go
+++ b/scc/bls/bls.go
@@ -1,0 +1,252 @@
+// This package provides convenience wrappers around the blst library to
+// generate BLS12-381 keys, sign messages, and verify signatures. The package
+// is designed to be simple to use and to provide a high-level API to work with
+// BLS12-381 keys and signatures.
+//
+// The blst (pronounced "Blast") library is a high-performance BLS12-381 library
+// that provides a low-level API to work with BLS12-381 keys and signatures. The
+// library is written in C and provides Go bindings to use the library from Go
+// code. The blst library is designed to be fast and secure, and is suitable for
+// production use.
+//
+// When compiling the Go bindings of the blst library, native C code is
+// implicitly compiled using Go's CGO tool. On most systems, this should work
+// transparent. However, on older CPU architectures, certain optimizations may
+// cause the compiled code to crash with a SIGILL signal. This is a known issue
+// with the blst library, as reported here:
+//
+// Issue https://github.com/bnb-chain/bsc/issues/1521
+//
+// If you encounter an error like the this
+//
+//	> Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md
+//
+// you can work around the issue by setting the CGO_CFLAGS environment variable
+// to disable the optimizations that cause the crash.
+//
+//	> export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+//	> export CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
+//
+// Example uses of the API are demonstrated in the unit tests of the package.
+package bls
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	blst "github.com/supranational/blst/bindings/go"
+)
+
+// PrivateKey represents a BLS12-381 private key.
+type PrivateKey struct {
+	secretKey blst.SecretKey
+}
+
+// PublicKey represents a BLS12-381 public key.
+type PublicKey struct {
+	publicKey blst.P1Affine
+}
+
+// Signature represents a BLS12-381 signature.
+type Signature struct {
+	sign blst.P2Affine
+}
+
+// --- Private Keys -----------------------------------------------------------
+
+// NewPrivateKey creates a new BLS12-381 private key. The resulting keys are
+// cryptographically secure and can be used for production purposes.
+func NewPrivateKey() PrivateKey {
+	var inputKeyMaterial [32]byte
+	// crypto/rand.Read is cryptographically secure, guaranteed to never fail
+	_, _ = rand.Read(inputKeyMaterial[:])
+	return newPrivateKey(inputKeyMaterial)
+}
+
+// NewPrivateKeyForTests creates a new BLS12-381 private key using the provided
+// key material. The first 32 bytes of the material is used, the rest is ignored.
+// The security of the resulting key depends on the quality of the key material.
+// This function may be used in tests to generate deterministic keys. Use
+// NewPrivateKey() for production purposes.
+func NewPrivateKeyForTests(keyMaterial ...byte) PrivateKey {
+	var material [32]byte
+	copy(material[:], keyMaterial)
+	return newPrivateKey(material)
+}
+
+// newPrivateKey is a helper function that creates a new private key using the
+// provided key material. The security of the resulting key depends on the
+// quality of the key material.
+func newPrivateKey(keyMaterial [32]byte) PrivateKey {
+	res := PrivateKey{}
+	res.secretKey = *blst.KeyGen(keyMaterial[:])
+	return res
+}
+
+// PublicKey returns the public key corresponding to the private key.
+func (k PrivateKey) PublicKey() PublicKey {
+	res := PublicKey{}
+	res.publicKey = *res.publicKey.From(&k.secretKey)
+	return res
+}
+
+// Sign signs the provided message using the private key and returns the
+// resulting signature.
+func (k PrivateKey) Sign(message []byte) Signature {
+	buffer := [96]byte{}
+	res := Signature{}
+	res.sign.Sign(&k.secretKey, message, buffer[:])
+	return res
+}
+
+// GetProofOfPossession returns a proof of possession for the private key. The
+// proof of possession can be used to prove that the signer knew the private key
+// corresponding to the public key at some point in time.
+func (k PrivateKey) GetProofOfPossession() Signature {
+	msg := k.PublicKey().Serialize()
+	return k.Sign(msg[:])
+}
+
+// Serialize exports the private key into a 32-byte array. This format can be
+// used to serialize the key to disk or to transmit it over the network.
+func (k PrivateKey) Serialize() [32]byte {
+	res := [32]byte{}
+	copy(res[:], k.secretKey.Serialize())
+	return res
+}
+
+// DeserializePrivateKey deserializes a private key from the provided serialized
+// representation.If the provided serialized representation is invalid, an error
+// is returned.
+func DeserializePrivateKey(serialized [32]byte) (PrivateKey, error) {
+	res := PrivateKey{}
+	if key := res.secretKey.Deserialize(serialized[:]); key == nil {
+		return PrivateKey{}, fmt.Errorf("failed to deserialize private key")
+	}
+	return res, nil
+}
+
+// String returns the private key as a hexadecimal string prefixed with "0x".
+func (k PrivateKey) String() string {
+	return fmt.Sprintf("0x%x", k.Serialize())
+}
+
+// --- Public Keys ------------------------------------------------------------
+
+// Validate returns true if the public key is valid, false otherwise. A public
+// key is considered valid if it is on the BLS12-381 curve. Invalid public keys
+// must not be used in cryptographic operations.
+func (k PublicKey) Validate() bool {
+	return k.publicKey.KeyValidate()
+}
+
+// CheckProofOfPossession returns true if the provided signature is a valid proof
+// of possession for the public key, false otherwise. A valid proof of possession
+// guarantees that the signer knew at some point in time the private key
+// corresponding to the public key.
+func (k PublicKey) CheckProofOfPossession(signature Signature) bool {
+	msg := k.Serialize()
+	return signature.Verify(k, msg[:])
+}
+
+// AggregatePublicKeys aggregates the provided keys into a single key. The
+// provided keys must be valid.
+func AggregatePublicKeys(keys ...PublicKey) PublicKey {
+	agg := blst.P1Aggregate{}
+	for _, key := range keys {
+		agg.Add(&key.publicKey, false)
+	}
+	return PublicKey{publicKey: *agg.ToAffine()}
+}
+
+// DeserializePublicKey deserializes a public key from the provided serialized
+// representation. If the provided serialized representation is invalid, an
+// error is returned.
+func DeserializePublicKey(serialized [48]byte) (PublicKey, error) {
+	res := PublicKey{}
+	if key := res.publicKey.Uncompress(serialized[:]); key == nil {
+		return PublicKey{}, fmt.Errorf("failed to deserialize public key")
+	}
+	return res, nil
+}
+
+// Serialize exports the public key into a 48-byte array. This format can be
+// used to serialize the key to disk or to transmit it over the network.
+func (k PublicKey) Serialize() [48]byte {
+	res := [48]byte{}
+	copy(res[:], k.publicKey.Compress())
+	return res
+}
+
+// String returns the public key as a hexadecimal string prefixed with "0x".
+func (k PublicKey) String() string {
+	return fmt.Sprintf("0x%x", k.Serialize())
+}
+
+// --- Signatures -------------------------------------------------------------
+
+// Validate returns true if the signature is valid, false otherwise. A signature
+// is considered valid if it is on the BLS12-381 curve. Invalid signatures must
+// not be used in cryptographic operations.
+func (s Signature) Validate() bool {
+	return s.sign.SigValidate(true)
+}
+
+// Verify returns true if the signature is valid for the provided message and
+// public key, false otherwise. A signature is considered valid if it was
+// produced by the corresponding private key and the message has not been
+// tampered with.
+func (s Signature) Verify(publicKey PublicKey, message []byte) bool {
+	buffer := [96]byte{}
+	return s.sign.Verify(true, &publicKey.publicKey, true, message, buffer[:])
+}
+
+// VerifyAll returns true if the signature is the aggregation of all signature
+// produced by the owners of the all the given public keys for the given
+// message, false otherwise. Using this function is more efficient than
+// aggregating the public keys first and then verifying the signature against
+// the aggregated public key.
+func (s Signature) VerifyAll(publicKeys []PublicKey, message []byte) bool {
+	buffer := [96]byte{}
+	keys := make([]*blst.P1Affine, len(publicKeys))
+	msgs := make([][]byte, len(publicKeys))
+	for i, key := range publicKeys {
+		keys[i] = &key.publicKey
+		msgs[i] = message
+	}
+	return s.sign.AggregateVerify(false, keys, false, msgs, buffer[:])
+}
+
+// AggregateSignatures aggregates the provided signatures into a single
+// signature. The provided signatures must be valid.
+func AggregateSignatures(signatures ...Signature) Signature {
+	agg := blst.P2Aggregate{}
+	for _, sigs := range signatures {
+		agg.Add(&sigs.sign, false)
+	}
+	return Signature{sign: *agg.ToAffine()}
+}
+
+// DeserializeSignature deserializes a signature from the provided serialized
+// representation. If the provided serialized representation is invalid, an
+// error is returned.
+func DeserializeSignature(serialized [96]byte) (Signature, error) {
+	res := Signature{}
+	if key := res.sign.Uncompress(serialized[:]); key == nil {
+		return Signature{}, fmt.Errorf("failed to deserialize signature")
+	}
+	return res, nil
+}
+
+// Serialize exports the signature into a 96-byte array. This format can be used
+// to serialize the signature to disk or to transmit it over the network.
+func (k Signature) Serialize() [96]byte {
+	res := [96]byte{}
+	copy(res[:], k.sign.Compress())
+	return res
+}
+
+// String returns the signature as a hexadecimal string prefixed with "0x".
+func (k Signature) String() string {
+	return fmt.Sprintf("0x%x", k.Serialize())
+}

--- a/scc/bls/bls.go
+++ b/scc/bls/bls.go
@@ -149,7 +149,8 @@ func (k PublicKey) CheckProofOfPossession(signature Signature) bool {
 }
 
 // AggregatePublicKeys aggregates the provided keys into a single key. The
-// provided keys must be valid.
+// provided keys must be valid. Caller must ensure that the provided keys are
+// valid, otherwise the resulting key may be invalid.
 func AggregatePublicKeys(keys ...PublicKey) PublicKey {
 	agg := blst.P1Aggregate{}
 	for _, key := range keys {

--- a/scc/bls/bls.go
+++ b/scc/bls/bls.go
@@ -93,9 +93,8 @@ func (k PrivateKey) PublicKey() PublicKey {
 // Sign signs the provided message using the private key and returns the
 // resulting signature.
 func (k PrivateKey) Sign(message []byte) Signature {
-	buffer := [96]byte{}
 	res := Signature{}
-	res.sign.Sign(&k.secretKey, message, buffer[:])
+	res.sign.Sign(&k.secretKey, message, nil)
 	return res
 }
 
@@ -197,8 +196,7 @@ func (s Signature) Validate() bool {
 // produced by the corresponding private key and the message has not been
 // tampered with.
 func (s Signature) Verify(publicKey PublicKey, message []byte) bool {
-	buffer := [96]byte{}
-	return s.sign.Verify(true, &publicKey.publicKey, true, message, buffer[:])
+	return s.sign.Verify(true, &publicKey.publicKey, true, message, nil)
 }
 
 // VerifyAll returns true if the signature is the aggregation of all signature
@@ -207,14 +205,13 @@ func (s Signature) Verify(publicKey PublicKey, message []byte) bool {
 // aggregating the public keys first and then verifying the signature against
 // the aggregated public key.
 func (s Signature) VerifyAll(publicKeys []PublicKey, message []byte) bool {
-	buffer := [96]byte{}
 	keys := make([]*blst.P1Affine, len(publicKeys))
 	msgs := make([][]byte, len(publicKeys))
 	for i, key := range publicKeys {
 		keys[i] = &key.publicKey
 		msgs[i] = message
 	}
-	return s.sign.AggregateVerify(false, keys, false, msgs, buffer[:])
+	return s.sign.AggregateVerify(false, keys, false, msgs, nil)
 }
 
 // AggregateSignatures aggregates the provided signatures into a single

--- a/scc/bls/bls.go
+++ b/scc/bls/bls.go
@@ -109,9 +109,7 @@ func (k PrivateKey) GetProofOfPossession() Signature {
 // Serialize exports the private key into a 32-byte array. This format can be
 // used to serialize the key to disk or to transmit it over the network.
 func (k PrivateKey) Serialize() [32]byte {
-	res := [32]byte{}
-	copy(res[:], k.secretKey.Serialize())
-	return res
+	return [32]byte(k.secretKey.Serialize())
 }
 
 // DeserializePrivateKey deserializes a private key from the provided serialized
@@ -173,9 +171,7 @@ func DeserializePublicKey(serialized [48]byte) (PublicKey, error) {
 // Serialize exports the public key into a 48-byte array. This format can be
 // used to serialize the key to disk or to transmit it over the network.
 func (k PublicKey) Serialize() [48]byte {
-	res := [48]byte{}
-	copy(res[:], k.publicKey.Compress())
-	return res
+	return [48]byte(k.publicKey.Compress())
 }
 
 // String returns the public key as a hexadecimal string prefixed with "0x".
@@ -239,9 +235,7 @@ func DeserializeSignature(serialized [96]byte) (Signature, error) {
 // Serialize exports the signature into a 96-byte array. This format can be used
 // to serialize the signature to disk or to transmit it over the network.
 func (k Signature) Serialize() [96]byte {
-	res := [96]byte{}
-	copy(res[:], k.sign.Compress())
-	return res
+	return [96]byte(k.sign.Compress())
 }
 
 // String returns the signature as a hexadecimal string prefixed with "0x".

--- a/scc/bls/bls_test.go
+++ b/scc/bls/bls_test.go
@@ -1,0 +1,420 @@
+package bls
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- Private Keys -----------------------------------------------------------
+
+func TestPrivateKey_KeyGenerationProducesDifferentKeys(t *testing.T) {
+	seen := map[PrivateKey]struct{}{}
+	for range 10 {
+		key := NewPrivateKey()
+		if _, ok := seen[key]; ok {
+			t.Fatalf("duplicate key generated")
+		}
+		seen[key] = struct{}{}
+	}
+}
+
+func TestPrivateKey_TestKeyGenerationIsDeterministic(t *testing.T) {
+	require := require.New(t)
+	for i := range byte(10) {
+		key1 := NewPrivateKeyForTests(i)
+		key2 := NewPrivateKeyForTests(i)
+		require.Equal(key1, key2)
+	}
+}
+
+func TestPrivateKey_CanBeAssignedAndReAssigned(t *testing.T) {
+	require := require.New(t)
+	key1 := NewPrivateKey()
+	key2 := NewPrivateKey()
+
+	key3 := key1
+	require.Equal(key1, key3)
+	require.NotEqual(key2, key3)
+
+	key3 = key2
+	require.NotEqual(key1, key3)
+	require.Equal(key2, key3)
+}
+
+func TestPrivateKey_CanBeSerializedAndDeserialized(t *testing.T) {
+	require := require.New(t)
+	key1 := NewPrivateKey()
+	serialized := key1.Serialize()
+	key2, err := DeserializePrivateKey(serialized)
+	require.NoError(err)
+	require.Equal(key1, key2)
+}
+
+func TestPrivateKey_DeserializationDetectsInvalidEncoding(t *testing.T) {
+	serialized := [32]byte{} // <- invalid encoding
+	_, err := DeserializePrivateKey(serialized)
+	require.Error(t, err)
+}
+
+func TestPrivateKey_String_IsHexEncoded(t *testing.T) {
+	regexp := regexp.MustCompile(`^0x[0-9a-f]{64}$`)
+	key := NewPrivateKey()
+	require.Regexp(t, regexp, key.String())
+}
+
+// --- Public Keys ------------------------------------------------------------
+
+func TestPublicKey_DefaultIsInvalid(t *testing.T) {
+	require.False(t, PublicKey{}.Validate())
+}
+
+func TestPublicKey_GeneratedKeysAreValid(t *testing.T) {
+	require := require.New(t)
+	for range 10 {
+		require.True(NewPrivateKey().PublicKey().Validate())
+	}
+}
+
+func TestPublicKey_CheckProofOfPossession_CanValidateValidProof(t *testing.T) {
+	require := require.New(t)
+	private := NewPrivateKey()
+	proof := private.GetProofOfPossession()
+	public := private.PublicKey()
+	require.True(public.CheckProofOfPossession(proof))
+}
+
+func TestPublicKey_CheckProofOfPossession_DetectsInvalidProof(t *testing.T) {
+	require := require.New(t)
+	private := NewPrivateKey()
+	public := private.PublicKey()
+
+	test := map[string]Signature{
+		"invalid proof": Signature{},
+		"wrong key":     NewPrivateKey().GetProofOfPossession(),
+		"wrong message": private.Sign([]byte("wrong message")),
+	}
+
+	for name, proof := range test {
+		t.Run(name, func(t *testing.T) {
+			require.False(public.CheckProofOfPossession(proof))
+		})
+	}
+}
+
+func TestPublicKey_Aggregation_EmptyAggregationIsInvalid(t *testing.T) {
+	require.False(t, AggregatePublicKeys().Validate())
+}
+
+func TestPublicKey_Aggregation_IsAssociative(t *testing.T) {
+	key1 := NewPrivateKey().PublicKey()
+	key2 := NewPrivateKey().PublicKey()
+	key3 := NewPrivateKey().PublicKey()
+
+	require.Equal(
+		t,
+		AggregatePublicKeys(AggregatePublicKeys(key1, key2), key3),
+		AggregatePublicKeys(key1, AggregatePublicKeys(key2, key3)),
+	)
+}
+
+func TestPublicKey_Aggregation_IsCommutative(t *testing.T) {
+	key1 := NewPrivateKey().PublicKey()
+	key2 := NewPrivateKey().PublicKey()
+	key3 := NewPrivateKey().PublicKey()
+
+	ref := AggregatePublicKeys(key1, key2, key3)
+	require.Equal(t, ref, AggregatePublicKeys(key1, key2, key3))
+	require.Equal(t, ref, AggregatePublicKeys(key1, key3, key2))
+	require.Equal(t, ref, AggregatePublicKeys(key2, key1, key3))
+	require.Equal(t, ref, AggregatePublicKeys(key2, key3, key1))
+	require.Equal(t, ref, AggregatePublicKeys(key3, key1, key2))
+	require.Equal(t, ref, AggregatePublicKeys(key3, key2, key1))
+}
+
+func TestPublicKey_Aggregation_IsNotIdempotent(t *testing.T) {
+	key1 := NewPrivateKey().PublicKey()
+
+	require.Equal(t, key1, AggregatePublicKeys(key1))
+	require.NotEqual(t, key1, AggregatePublicKeys(key1, key1))
+	require.NotEqual(t, key1, AggregatePublicKeys(key1, key1, key1))
+}
+
+func TestPublicKey_CanBeSerializedAndDeserialized(t *testing.T) {
+	require := require.New(t)
+	key1 := PublicKey{}
+	serialized := key1.Serialize()
+	key2, err := DeserializePublicKey(serialized)
+	require.NoError(err)
+	require.Equal(key1, key2)
+}
+
+func TestPublicKey_DeserializationDetectsInvalidEncoding(t *testing.T) {
+	serialized := [48]byte{} // <- invalid encoding
+	_, err := DeserializePublicKey(serialized)
+	require.Error(t, err)
+}
+
+func TestPublicKey_String_IsHexEncoded(t *testing.T) {
+	regexp := regexp.MustCompile(`^0x[0-9a-f]{96}$`)
+	key := NewPrivateKey().PublicKey()
+	require.Regexp(t, regexp, key.String())
+}
+
+// --- Signatures -------------------------------------------------------------
+
+func TestSignature_DefaultIsInvalid(t *testing.T) {
+	require.False(t, Signature{}.Validate())
+}
+
+func TestSignature_GeneratedSignaturesAreValid(t *testing.T) {
+	require := require.New(t)
+	for i := range byte(10) {
+		key := NewPrivateKey()
+		require.True(key.Sign([]byte{i}).Validate())
+	}
+}
+
+func TestSignature_Verify_AcceptsValidSignatures(t *testing.T) {
+	require := require.New(t)
+	private := NewPrivateKey()
+	public := private.PublicKey()
+	message := []byte("Hello, world!")
+	signature := private.Sign(message)
+	require.True(signature.Verify(public, message))
+}
+
+func TestSignature_Verify_DetectsInvalidSignatures(t *testing.T) {
+	require := require.New(t)
+	private := NewPrivateKey()
+	public := private.PublicKey()
+	message := []byte("Hello, world!")
+	signature := private.Sign(message)
+
+	test := map[string]struct {
+		message []byte
+		public  PublicKey
+	}{
+		"wrong message": {[]byte("wrong message"), public},
+		"wrong key":     {message, NewPrivateKey().PublicKey()},
+		"invalid key":   {message, PublicKey{}},
+	}
+
+	for name, data := range test {
+		t.Run(name, func(t *testing.T) {
+			require.False(signature.Verify(data.public, data.message))
+		})
+	}
+}
+
+func TestSignature_Aggregation_EmptyAggregationIsInvalid(t *testing.T) {
+	require.False(t, AggregateSignatures().Validate())
+}
+
+func TestSignature_Aggregation_IsAssociative(t *testing.T) {
+	msg := []byte("msg")
+	sig1 := NewPrivateKey().Sign(msg)
+	sig2 := NewPrivateKey().Sign(msg)
+	sig3 := NewPrivateKey().Sign(msg)
+
+	require.Equal(
+		t,
+		AggregateSignatures(AggregateSignatures(sig1, sig2), sig3),
+		AggregateSignatures(sig1, AggregateSignatures(sig2, sig3)),
+	)
+}
+
+func TestSignature_Aggregation_IsCommutative(t *testing.T) {
+	msg := []byte("msg")
+	sig1 := NewPrivateKey().Sign(msg)
+	sig2 := NewPrivateKey().Sign(msg)
+	sig3 := NewPrivateKey().Sign(msg)
+
+	ref := AggregateSignatures(sig1, sig2, sig3)
+	require.Equal(t, ref, AggregateSignatures(sig1, sig2, sig3))
+	require.Equal(t, ref, AggregateSignatures(sig1, sig3, sig2))
+	require.Equal(t, ref, AggregateSignatures(sig2, sig1, sig3))
+	require.Equal(t, ref, AggregateSignatures(sig2, sig3, sig1))
+	require.Equal(t, ref, AggregateSignatures(sig3, sig1, sig2))
+	require.Equal(t, ref, AggregateSignatures(sig3, sig2, sig1))
+}
+
+func TestSignature_Aggregation_IsNotIdempotent(t *testing.T) {
+	msg := []byte("msg")
+	sig := NewPrivateKey().Sign(msg)
+
+	require.Equal(t, sig, AggregateSignatures(sig))
+	require.NotEqual(t, sig, AggregateSignatures(sig, sig))
+	require.NotEqual(t, sig, AggregateSignatures(sig, sig, sig))
+}
+
+func TestSignature_CanBeSerializedAndDeserialized(t *testing.T) {
+	require := require.New(t)
+	signature1 := Signature{}
+	serialized := signature1.Serialize()
+	signature2, err := DeserializeSignature(serialized)
+	require.NoError(err)
+	require.Equal(signature1, signature2)
+}
+
+func TestSignature_DeserializationDetectsInvalidEncoding(t *testing.T) {
+	serialized := [96]byte{} // <- invalid encoding
+	_, err := DeserializeSignature(serialized)
+	require.Error(t, err)
+}
+
+func TestSignature_String_IsHexEncoded(t *testing.T) {
+	regexp := regexp.MustCompile(`^0x[0-9a-f]{192}$`)
+	require.Regexp(t, regexp, Signature{}.String())
+}
+
+// --- Signature Protocol -----------------------------------------------------
+
+func TestBsl_CanSignAndVerifySignature(t *testing.T) {
+	private := NewPrivateKey()
+	public := private.PublicKey()
+
+	message := "Hello, world!"
+	signature := private.Sign([]byte(message))
+
+	if !signature.Verify(public, []byte(message)) {
+		t.Fatalf("failed to verify signature")
+	}
+}
+
+func TestBsl_DeserializedKeysAndSignaturesCanBeVerified(t *testing.T) {
+	private := NewPrivateKey()
+	public := private.PublicKey()
+
+	message := "Hello, world!"
+	signature := private.Sign([]byte(message))
+
+	recoveredKey, err := DeserializePublicKey(public.Serialize())
+	require.NoError(t, err)
+	recoveredSignature, err := DeserializeSignature(signature.Serialize())
+	require.NoError(t, err)
+
+	if !recoveredSignature.Verify(recoveredKey, []byte(message)) {
+		t.Fatalf("failed to verify signature")
+	}
+}
+
+func TestBsl_AggregatedSignaturesCanBeVerified(t *testing.T) {
+	private1 := NewPrivateKey()
+	private2 := NewPrivateKey()
+	public1 := private1.PublicKey()
+	public2 := private2.PublicKey()
+
+	message := []byte("Hello, world!")
+	signature1 := private1.Sign(message)
+	signature2 := private2.Sign(message)
+
+	aggSignature := AggregateSignatures(signature1, signature2)
+	aggPublic := AggregatePublicKeys(public1, public2)
+
+	if !aggSignature.Verify(aggPublic, message) {
+		t.Fatalf("failed to verify aggregated signature")
+	}
+}
+
+func TestBsl_AggregatedSignaturesCanBeVerifiedAgainstPublicKeys(t *testing.T) {
+	private1 := NewPrivateKey()
+	private2 := NewPrivateKey()
+	public1 := private1.PublicKey()
+	public2 := private2.PublicKey()
+
+	message := []byte("Hello, world!")
+	signature1 := private1.Sign(message)
+	signature2 := private2.Sign(message)
+
+	aggSignature := AggregateSignatures(signature1, signature2)
+
+	if !aggSignature.VerifyAll([]PublicKey{public1, public2}, message) {
+		t.Fatalf("failed to verify aggregated signature")
+	}
+}
+
+// TODO: test known signatures
+
+// --- Benchmarks -------------------------------------------------------------
+
+func BenchmarkKey_Generation(b *testing.B) {
+	for range b.N {
+		NewPrivateKey()
+	}
+}
+
+func BenchmarkSignature_Signing(b *testing.B) {
+	message := [32]byte{}
+	private := NewPrivateKey()
+	b.ResetTimer()
+	for range b.N {
+		private.Sign(message[:])
+	}
+}
+
+func BenchmarkSignature_Verification(b *testing.B) {
+	message := [32]byte{}
+	private := NewPrivateKey()
+	signature := private.Sign(message[:])
+	public := private.PublicKey()
+	b.ResetTimer()
+	for range b.N {
+		if !signature.Verify(public, message[:]) {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkSignature_VerificationAggregatedWithKeyAggregation(b *testing.B) {
+	message := []byte("hello")
+	private1 := NewPrivateKey()
+	private2 := NewPrivateKey()
+
+	signature := AggregateSignatures(
+		private1.Sign(message),
+		private2.Sign(message),
+	)
+
+	public1 := private1.PublicKey()
+	public2 := private2.PublicKey()
+
+	b.ResetTimer()
+	for range b.N {
+		public := AggregatePublicKeys(public1, public2)
+		if !signature.Verify(public, message[:]) {
+			b.Fail()
+		}
+	}
+}
+func BenchmarkSignature_VerificationAggregatedWithoutKeyAggregation(b *testing.B) {
+	message := []byte("hello")
+	private1 := NewPrivateKey()
+	private2 := NewPrivateKey()
+
+	signature := AggregateSignatures(
+		private1.Sign(message),
+		private2.Sign(message),
+	)
+
+	public1 := private1.PublicKey()
+	public2 := private2.PublicKey()
+
+	b.ResetTimer()
+	for range b.N {
+		if !signature.VerifyAll([]PublicKey{public1, public2}, message[:]) {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkSignature_Aggregation(b *testing.B) {
+	message := [32]byte{}
+	private := NewPrivateKey()
+	signature := private.Sign(message[:])
+	b.ResetTimer()
+	for range b.N {
+		AggregateSignatures(signature, signature)
+	}
+}


### PR DESCRIPTION
This PR introduces a utility API for handling create and verify BLS signatures. The main involved components are:
- *PrivateKey*s and a secure key generation mechanism
- *PublicKey*s, which can be derived from private keys
- *Signatue*s, linking a document to a private key
- tools to aggregate public keys and signatures and to verify aggregated keys efficiently

Build on this, tools for the following tasks are provided:
- the serialization and deserialization of keys and signatures
- the validation of public keys and signatures
- the creation and verification of proof-of-possession signatures

Follow-up tasks for upcoming PRs:
- integrate test verifying the signature scheme against known key/msg/signature pairs

The BLST library is also used by the go-ethereum project (see [here](https://github.com/ethereum/go-ethereum/blob/ef00a6e9a2bcb7b5737808d7e56a5c196009f918/go.mod#L62)). Thus, this PR is not introducing any new dependencies.
