### PR TITLE
Fix tag pattern recognition in release actions

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-    - 'v+([0-9]).+([0-9]).+([0-9])' # example: v2.0.12 (rc intentionally excluded)
+      - "v[0-9]+.[0-9]+.[0-9]+" # example: v2.0.12 (rc intentionally excluded)
 
 jobs:
   release:
@@ -15,7 +15,7 @@ jobs:
       - name: Golang dependency
         uses: actions/setup-go@v3
         with:
-          go-version: '1.23'
+          go-version: "1.23"
 
       - name: Build
         run: make


### PR DESCRIPTION
tag v2.0.3 was not recognized by the release action. This PR intend to fix the expected tag pattern such that v2.0.3 is accepted but v2.0.3-rc* is not. 