### PR TITLE
Add Member and Committee definitions

### DIFF
--- a/scc/committee.go
+++ b/scc/committee.go
@@ -16,7 +16,7 @@ import (
 // Among those statements is the confirmation of the succeeding period's
 // committee.
 //
-// Committees are composed of a ordered list of Members, each weighted with a
+// Committees are composed of an ordered list of Members, each weighted with a
 // non-zero voting power. Members are identified by their public keys, for which
 // they are required to provide a proof of possession.
 type Committee struct {

--- a/scc/committee.go
+++ b/scc/committee.go
@@ -1,0 +1,172 @@
+package scc
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/0xsoniclabs/sonic/scc/bls"
+)
+
+// Committee is a group of Members that can sign statements to produce
+// certificates.
+//
+// On the Sonic Certification Chain (SCC), time is divided into periods. For
+// each period, a committee is authorized to sign the statement for that period.
+// Among those statements is the confirmation of the succeeding period's
+// committee.
+//
+// Committees are composed of a ordered list of Members, each weighted with a
+// non-zero voting power. Members are identified by their public keys, for which
+// they are required to provide a proof of possession.
+type Committee struct {
+	members []Member
+}
+
+// MaxCommitteeSize is the maximum number of members that can be in a committee.
+// The number needs to be limited to prevent Committee certificates from becoming
+// too large.
+const MaxCommitteeSize = 512
+
+// MemberId is used to identify a member in a committee by its position in the
+// ordered list of members.
+type MemberId uint16
+
+// NewCommittee creates a new committee with the provided members. There must be
+// at least one member, all members must be valid, and no duplicates are allowed.
+func NewCommittee(members ...Member) (Committee, error) {
+	res := Committee{members: slices.Clone(members)}
+	if err := res.Validate(); err != nil {
+		return Committee{}, err
+	}
+	return res, nil
+}
+
+// Members returns a copy of the members in the committee.
+func (c Committee) Members() []Member {
+	return slices.Clone(c.members)
+}
+
+// GetMember returns the member with the given id. If the id is out of bounds,
+// the second return value is false.
+func (c Committee) GetMember(id MemberId) (Member, bool) {
+	if int(id) >= len(c.members) {
+		return Member{}, false
+	}
+	return c.members[id], true
+}
+
+// GetMemberId returns the id of the member with the given public key. If the
+// public key is not found, the second return value is false.
+func (c Committee) GetMemberId(publicKey bls.PublicKey) (MemberId, bool) {
+	for id, m := range c.members {
+		if m.PublicKey == publicKey {
+			return MemberId(id), true
+		}
+	}
+	return 0, false
+}
+
+// Validate checks that the committee is well-formed. For a committee to be well
+// formed, the following properties need to be satisfied:
+// - The committee must have at least one member.
+// - The committee size must not exceed the maximum committee size.
+// - All members must be valid.
+// - No two members can have the same public key.
+// - The sum of the voting power must not exceed 2^64 - 1.
+// If any of these properties are violated, an error is returned.
+func (c Committee) Validate() error {
+	if len(c.members) == 0 {
+		return fmt.Errorf("committee must have at least one member")
+	}
+
+	if len(c.members) > MaxCommitteeSize {
+		return fmt.Errorf("committee size exceeds the maximum of %d", MaxCommitteeSize)
+	}
+
+	for _, m := range c.members {
+		if err := m.Validate(); err != nil {
+			return fmt.Errorf("invalid member %v, %w", m, err)
+		}
+	}
+
+	for i, a := range c.members {
+		for j, b := range c.members {
+			if i != j && a.PublicKey == b.PublicKey {
+				return fmt.Errorf("duplicate members at indexes %d and %d", i, j)
+			}
+		}
+	}
+
+	sum := uint64(0)
+	for _, m := range c.members {
+		next := sum + m.VotingPower
+		if next < sum {
+			return fmt.Errorf("voting power overflow")
+		}
+		sum = next
+	}
+
+	return nil
+}
+
+// String produces a human-readable summary of the Committee information mainly
+// for debugging purposes. The output is not sufficient to reconstruct the
+// committee.
+func (c Committee) String() string {
+	result := strings.Builder{}
+	result.WriteString("Committee{")
+	for i, m := range c.Members() {
+		key := m.PublicKey.Serialize()
+		result.WriteString(
+			fmt.Sprintf(
+				"%d: 0x%x..%x -> %d, ",
+				i, key[:2], key[len(key)-2:],
+				m.VotingPower,
+			),
+		)
+	}
+	result.WriteString(fmt.Sprintf("Valid: %t}", c.Validate() == nil))
+	return result.String()
+}
+
+// Serialize serializes the committee into a byte slice. The serialization format
+// is a concatenation of the serialized members. Note that also invalid committees
+// can be serialized.
+func (c Committee) Serialize() []byte {
+	if len(c.members) == 0 {
+		return nil
+	}
+	res := make([]byte, 0, len(c.members)*len(EncodedMember{}))
+	for _, m := range c.Members() {
+		cur := m.Serialize()
+		res = append(res, cur[:]...)
+	}
+	return res
+}
+
+// DeserializeCommittee deserializes a committee from a byte slice. An error is
+// returned if the provided data does not contain a valid encoding of a
+// committee. Note, this function does not validate members nor the committee.
+// Thus, it is possible to deserialize invalid committees.
+func DeserializeCommittee(data []byte) (Committee, error) {
+	if len(data) == 0 {
+		return Committee{}, nil
+	}
+	if len(data)%len(EncodedMember{}) != 0 {
+		return Committee{}, fmt.Errorf("invalid committee data length")
+	}
+
+	members := make([]Member, 0, len(data)/len(EncodedMember{}))
+	for len(data) > 0 {
+		var m Member
+		m, err := DeserializeMember(*(*EncodedMember)(data))
+		if err != nil {
+			return Committee{}, fmt.Errorf("invalid member, %w", err)
+		}
+		members = append(members, m)
+		data = data[len(EncodedMember{}):]
+	}
+
+	return Committee{members}, nil
+}

--- a/scc/committee_test.go
+++ b/scc/committee_test.go
@@ -1,0 +1,206 @@
+package scc
+
+import (
+	"math"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/scc/bls"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommittee_NewCommittee_CanCreateValidCommittee(t *testing.T) {
+	_, err := NewCommittee(
+		newTestMember(1, 10),
+		newTestMember(2, 20),
+		newTestMember(3, 15),
+	)
+	require.NoError(t, err)
+}
+
+func TestCommittee_NewCommittee_DetectsInvalidCommittee(t *testing.T) {
+	_, err := NewCommittee()
+	require.Error(t, err)
+}
+
+func TestCommittee_Members_EnumeratesMembers(t *testing.T) {
+	tests := [][]Member{
+		{},
+		{newTestMember(1, 10)},
+		{newTestMember(1, 10), newTestMember(2, 20)},
+	}
+
+	for _, members := range tests {
+		committee := Committee{members: members}
+		require.Equal(t, members, committee.Members())
+	}
+}
+
+func TestCommittee_GetMember_ReturnsCorrectMember(t *testing.T) {
+	members := []Member{
+		newTestMember(1, 10),
+		newTestMember(2, 20),
+		newTestMember(3, 15),
+	}
+	committee := Committee{members: members}
+
+	for i, m := range members {
+		got, found := committee.GetMember(MemberId(i))
+		require.True(t, found)
+		require.Equal(t, m, got)
+	}
+}
+
+func TestCommittee_GetMember_ReturnsNotFoundIfOutOfBounds(t *testing.T) {
+	committee := Committee{members: []Member{newTestMember(1, 10)}}
+	_, found := committee.GetMember(1)
+	require.False(t, found)
+	_, found = committee.GetMember(2)
+	require.False(t, found)
+}
+
+func TestCommittee_GetMemberId_ReturnsCorrectId(t *testing.T) {
+	members := []Member{
+		newTestMember(1, 10),
+		newTestMember(2, 20),
+		newTestMember(3, 15),
+	}
+	committee := Committee{members: members}
+
+	for i, m := range members {
+		id, found := committee.GetMemberId(m.PublicKey)
+		require.True(t, found)
+		require.Equal(t, MemberId(i), id)
+	}
+}
+
+func TestCommittee_GetMemberId_ReturnsNotFoundIfNotPresent(t *testing.T) {
+	committee := Committee{members: []Member{newTestMember(1, 10)}}
+	_, found := committee.GetMemberId(bls.NewPrivateKeyForTests(2).PublicKey())
+	require.False(t, found)
+}
+
+func TestCommittee_Validate_AcceptsMaximumVotingPower(t *testing.T) {
+	members := []Member{
+		newTestMember(1, math.MaxUint64),
+	}
+	committee := Committee{members: members}
+	require.NoError(t, committee.Validate())
+}
+
+func TestCommittee_Validate_DetectsInvalidCommittee(t *testing.T) {
+	tests := map[string]struct {
+		members []Member
+		err     string
+	}{
+		"empty": {
+			members: nil,
+			err:     "at least one member",
+		},
+		"too many members": {
+			members: make([]Member, MaxCommitteeSize+1),
+			err:     "committee size exceeds the maximum",
+		},
+		"invalid member": {
+			members: []Member{
+				newTestMember(1, 10),
+				{},
+				newTestMember(3, 15),
+			},
+			err: "invalid member",
+		},
+		"duplicate members": {
+			members: []Member{
+				newTestMember(1, 10),
+				newTestMember(2, 20),
+				newTestMember(1, 15),
+			},
+			err: "duplicate members",
+		},
+		"voting power overflow": {
+			members: []Member{
+				newTestMember(1, 10),
+				newTestMember(2, 20),
+				newTestMember(3, math.MaxUint64-10),
+			},
+			err: "voting power overflow",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := Committee{members: test.members}.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.err)
+		})
+	}
+}
+
+func TestCommittee_String_ReturnsHumanReadableSummary(t *testing.T) {
+	members := []Member{
+		newTestMember(1, 10),
+		newTestMember(2, 20),
+		newTestMember(3, 15),
+	}
+	committee := Committee{members: members}
+
+	print := committee.String()
+	require.Contains(t, print, "0: 0x84fe..1f52 -> 10")
+	require.Contains(t, print, "1: 0x8b85..e766 -> 20")
+	require.Contains(t, print, "2: 0xb526..7132 -> 15")
+	require.Contains(t, print, "Valid: true")
+}
+
+func TestCommittee_Serialize_DeserializeRoundTrip(t *testing.T) {
+	members := []Member{
+		newTestMember(1, 10),
+		newTestMember(2, 20),
+		newTestMember(3, 15),
+	}
+	committee := Committee{members: members}
+
+	data := committee.Serialize()
+	got, err := DeserializeCommittee(data)
+	require.NoError(t, err)
+	require.Equal(t, committee, got)
+}
+
+func TestCommittee_Serialize_EmptyCommitteeCanBeSerializedAndDeserialized(t *testing.T) {
+	committee := Committee{}
+	data := committee.Serialize()
+	got, err := DeserializeCommittee(data)
+	require.NoError(t, err)
+	require.Equal(t, committee, got)
+}
+
+func TestCommittee_Deserialize_HandlesInvalidInput(t *testing.T) {
+	tests := map[string]struct {
+		data []byte
+		err  string
+	}{
+		"invalid data length": {
+			data: make([]byte, 1),
+			err:  "invalid committee data length",
+		},
+		"invalid member": {
+			data: make([]byte, len(EncodedMember{})),
+			err:  "invalid member",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := DeserializeCommittee(test.data)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.err)
+		})
+	}
+}
+
+func newTestMember(i byte, power uint64) Member {
+	key := bls.NewPrivateKeyForTests(i)
+	return Member{
+		PublicKey:         key.PublicKey(),
+		ProofOfPossession: key.GetProofOfPossession(),
+		VotingPower:       power,
+	}
+}

--- a/scc/member.go
+++ b/scc/member.go
@@ -1,0 +1,74 @@
+package scc
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/0xsoniclabs/sonic/scc/bls"
+)
+
+// Member is a member of a committee. Members are identified by their public key.
+// To defend against rogue key attacks, members must provide a proof of possession
+// for their public key. The voting power of a member determines their relative
+// influence in committees.
+type Member struct {
+	PublicKey         bls.PublicKey
+	ProofOfPossession bls.Signature
+	VotingPower       uint64
+}
+
+func (m Member) Validate() error {
+	if !m.PublicKey.Validate() {
+		return fmt.Errorf("invalid public key")
+	}
+	if !m.PublicKey.CheckProofOfPossession(m.ProofOfPossession) {
+		return fmt.Errorf("invalid proof of possession")
+	}
+	if m.VotingPower == 0 {
+		return fmt.Errorf("invalid zero voting power")
+	}
+	return nil
+}
+
+// String produces a human-readable summary of the member information mainly for
+// debugging purposes. The output is not sufficient to reconstruct the member.
+func (m Member) String() string {
+	key := m.PublicKey.Serialize()
+	return fmt.Sprintf(
+		"Member{PublicKey: 0x%x..%x, Valid: %t, VotingPower: %d}",
+		key[:2],
+		key[len(key)-2:],
+		m.Validate() == nil,
+		m.VotingPower,
+	)
+}
+
+// EncodedMember is a fixed-length byte array that represents a serialized member.
+type EncodedMember [48 + 96 + 8]byte
+
+// Serialize serializes the member into a fixed-length byte array.
+func (m Member) Serialize() EncodedMember {
+	res := EncodedMember{}
+	*(*[48]byte)(res[0:]) = m.PublicKey.Serialize()
+	*(*[96]byte)(res[48:]) = m.ProofOfPossession.Serialize()
+	binary.BigEndian.PutUint64(res[48+96:], m.VotingPower)
+	return res
+}
+
+// DeserializeMember deserializes a member from a fixed-length byte array. An
+// error is returned if the provided data does not contain a valid encoding of
+// a public key or proof of possession.
+func DeserializeMember(data EncodedMember) (Member, error) {
+	var m Member
+	var err error
+	m.PublicKey, err = bls.DeserializePublicKey(*(*[48]byte)(data[0:]))
+	if err != nil {
+		return m, fmt.Errorf("invalid public key, %w", err)
+	}
+	m.ProofOfPossession, err = bls.DeserializeSignature(*(*[96]byte)(data[48:]))
+	if err != nil {
+		return m, fmt.Errorf("invalid proof of possession, %w", err)
+	}
+	m.VotingPower = binary.BigEndian.Uint64(data[48+96:])
+	return m, nil
+}

--- a/scc/member_test.go
+++ b/scc/member_test.go
@@ -1,0 +1,121 @@
+package scc
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/scc/bls"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMember_Default_IsInvalid(t *testing.T) {
+	require.Error(t, Member{}.Validate())
+}
+
+func TestMember_String_CanProduceHumanReadableSummary(t *testing.T) {
+	require := require.New(t)
+	member := Member{}
+	print := member.String()
+
+	require.Contains(print, "PublicKey: 0xc000..0000")
+	require.Contains(print, "Valid: false")
+	require.Contains(print, "VotingPower: 0")
+
+	key := bls.NewPrivateKeyForTests()
+	member = Member{
+		PublicKey:         key.PublicKey(),
+		ProofOfPossession: key.GetProofOfPossession(),
+		VotingPower:       12,
+	}
+	print = member.String()
+	require.Contains(print, "PublicKey: 0xa695..8759")
+	require.Contains(print, "Valid: true")
+	require.Contains(print, "VotingPower: 12")
+}
+
+func TestMember_Validate_AcceptsValidMembers(t *testing.T) {
+	key := bls.NewPrivateKey()
+	pub := key.PublicKey()
+	proof := key.GetProofOfPossession()
+
+	tests := map[string]Member{
+		"regular": {
+			PublicKey:         pub,
+			ProofOfPossession: proof,
+			VotingPower:       12,
+		},
+		"huge voting power": {
+			PublicKey:         pub,
+			ProofOfPossession: proof,
+			VotingPower:       math.MaxUint64,
+		},
+	}
+
+	for name, m := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := m.Validate(); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMember_Validate_DetectsInvalidMembers(t *testing.T) {
+	key := bls.NewPrivateKey()
+	pub := key.PublicKey()
+	proof := key.GetProofOfPossession()
+
+	tests := map[string]Member{
+		"invalid public key": {
+			PublicKey:         bls.PublicKey{},
+			ProofOfPossession: proof,
+			VotingPower:       12,
+		},
+		"invalid proof of possession": {
+			PublicKey:         pub,
+			ProofOfPossession: bls.Signature{},
+			VotingPower:       12,
+		},
+		"zero voting power": {
+			PublicKey:         pub,
+			ProofOfPossession: proof,
+			VotingPower:       0,
+		},
+	}
+
+	for name, m := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := m.Validate()
+			if err == nil || !strings.Contains(err.Error(), name) {
+				t.Errorf("expected error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestMember_Serialization_CanEncodeAndDecodeMember(t *testing.T) {
+	key := bls.NewPrivateKey()
+	original := Member{
+		PublicKey:         key.PublicKey(),
+		ProofOfPossession: key.GetProofOfPossession(),
+		VotingPower:       12,
+	}
+	recovered, err := DeserializeMember(original.Serialize())
+	require.NoError(t, err)
+	require.Equal(t, original, recovered)
+}
+
+func TestMember_Deserialize_DetectsEncodingErrors(t *testing.T) {
+	encoded := [152]byte{}
+	_, err := DeserializeMember(encoded)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid public key")
+
+	key := bls.NewPrivateKey()
+	*(*[48]byte)(encoded[:]) = key.PublicKey().Serialize()
+
+	_, err = DeserializeMember(encoded)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid proof of possession")
+}


### PR DESCRIPTION
This PR introduces data definitions for a Committee authorized to sign certificates.

A committee is composed of a group of members following these rules:
 - there must be at least one member
 - the public keys of all members must be unique
 - all members must provide a proof-of-possession for their public keys
 - all members must have a non-zero voting power
 - the sum of the voting power must not exceed 2^64-1 (maximum of uint64)

In addition to the type definitions, debug printing and serialization support is added.