### PR TITLE
Remove implicit validity check in committee factory

### DIFF
--- a/scc/cert/certificate_test.go
+++ b/scc/cert/certificate_test.go
@@ -16,8 +16,8 @@ func TestCertificate_CanBeGraduallyAccumulatedAndVerified(t *testing.T) {
 		keys[i] = bls.NewPrivateKey()
 		members[i] = newMember(keys[i], 1)
 	}
-	committee, err := scc.NewCommittee(members...)
-	requires.NoError(err)
+	committee := scc.NewCommittee(members...)
+	requires.NoError(committee.Validate())
 
 	stmt := testStatement(1)
 
@@ -42,11 +42,11 @@ func TestCertificate_VerifyAuthority_AcceptsDifferentAuthority(t *testing.T) {
 
 	stmt := testStatement(1)
 
-	producer, err := scc.NewCommittee(newMember(key0, 1), newMember(key1, 2))
-	require.NoError(err)
+	producer := scc.NewCommittee(newMember(key0, 1), newMember(key1, 2))
+	require.NoError(producer.Validate())
 
-	authority, err := scc.NewCommittee(newMember(key0, 1))
-	require.NoError(err)
+	authority := scc.NewCommittee(newMember(key0, 1))
+	require.NoError(producer.Validate())
 
 	// Initially the certificate is for nobody valid.
 	cert := NewCertificate(stmt)

--- a/scc/cert/statement_test.go
+++ b/scc/cert/statement_test.go
@@ -77,12 +77,12 @@ func TestCommitteeStatement_GetSignData_HasStatementPrefix(t *testing.T) {
 
 func TestCommitteeStatement_GetSignData_EncodesCommitteeInformation(t *testing.T) {
 	key := bls.NewPrivateKey()
-	committee, err := scc.NewCommittee(scc.Member{
+	committee := scc.NewCommittee(scc.Member{
 		PublicKey:         key.PublicKey(),
 		ProofOfPossession: key.GetProofOfPossession(),
 		VotingPower:       12,
 	})
-	require.NoError(t, err)
+	require.NoError(t, committee.Validate())
 
 	statement := CommitteeStatement{
 		Period:    123,

--- a/scc/committee.go
+++ b/scc/committee.go
@@ -32,20 +32,11 @@ const MaxCommitteeSize = 512
 // ordered list of members.
 type MemberId uint16
 
-// NewCommittee creates a new committee with the provided members. There must be
-// at least one member, all members must be valid, and no duplicates are allowed.
-func NewCommittee(members ...Member) (Committee, error) {
-	res := NewCommitteeForTests(members...)
-	if err := res.Validate(); err != nil {
-		return Committee{}, err
-	}
-	return res, nil
-}
-
-// NewCommitteeForTests creates a new committee with the provided members. This
-// function is intended for testing purposes only and does not validate the
-// committee.
-func NewCommitteeForTests(members ...Member) Committee {
+// NewCommittee creates a new committee with the provided members. The list of
+// members is not implicitly validated, thus it is possible to create invalid
+// committees. To ensure that the committee is well-formed, call the Validate
+// method.
+func NewCommittee(members ...Member) Committee {
 	return Committee{members: slices.Clone(members)}
 }
 

--- a/scc/committee_test.go
+++ b/scc/committee_test.go
@@ -8,18 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommittee_NewCommittee_CanCreateValidCommittee(t *testing.T) {
-	_, err := NewCommittee(
-		newTestMember(1, 10),
-		newTestMember(2, 20),
-		newTestMember(3, 15),
-	)
-	require.NoError(t, err)
-}
-
-func TestCommittee_NewCommittee_DetectsInvalidCommittee(t *testing.T) {
-	_, err := NewCommittee()
-	require.Error(t, err)
+func TestCommittee_NewCommittee_EmptyCommitteeUsesNilMembers(t *testing.T) {
+	committee := NewCommittee()
+	require.Nil(t, committee.members)
 }
 
 func TestCommittee_Members_EnumeratesMembers(t *testing.T) {


### PR DESCRIPTION
This PR removes the implicit validity check of committees in the `NewCommittee` factory function.

This is motivated by multiple arguments:
- the factory can not grantee that all `Committee`s are valid; for instance, default instances are not valid, yet may be created by any external package; thus, any consumer of `Committee`s, for instance signature verification code, is required to explicitly validate committees either way
- the validity check in the constructor led to confusion in reviews by implying that all `Committee`s are always valid; this is not the case, as outlined above; thus, to avoid this issue, the implicit validity check was removed
- code using the `Committee` type may need finer control over the creation and validation of committees; for instance, when loading committees from a trusted source (e.g. your local database) an extra verification of all members and their proof of possession may not be needed; Thus, the only non-default factory for `Committee`s should not have an implicit validity check


This change also makes the `NewCommitteeForTest` function superfluous.