### PR TITLE
Add hex slice serialization

### DIFF
--- a/scc/cert/bitset.go
+++ b/scc/cert/bitset.go
@@ -62,3 +62,30 @@ func (b BitSet[T]) String() string {
 type unsigned interface {
 	~uint8 | ~uint16 | ~uint32 | ~uint64
 }
+
+func (b *BitSet[T]) Serialize() []byte {
+	result := []byte{}
+	for _, entry := range b.Entries() {
+		result = append(result, byte(entry))
+	}
+	return result
+}
+
+func (b *BitSet[T]) Deserialize(data []byte) {
+	for _, entry := range data {
+		b.Add(T(entry))
+	}
+}
+
+func (b *BitSet[T]) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"0x%x\"", b.Serialize())), nil
+}
+
+func (b *BitSet[T]) UnmarshalJSON(data []byte) error {
+	var mask []byte
+	if _, err := fmt.Sscanf(string(data), "\"0x%x\"", &mask); err != nil {
+		return err
+	}
+	b.Deserialize(mask)
+	return nil
+}

--- a/scc/cert/bitset.go
+++ b/scc/cert/bitset.go
@@ -3,6 +3,8 @@ package cert
 import (
 	"fmt"
 	"strings"
+
+	"github.com/0xsoniclabs/sonic/scc/cert/serialization"
 )
 
 // BitSet is a variable-size bit-mask based unsigned integer set representation.
@@ -82,10 +84,12 @@ func (b *BitSet[T]) MarshalJSON() ([]byte, error) {
 }
 
 func (b *BitSet[T]) UnmarshalJSON(data []byte) error {
-	var mask []byte
-	if _, err := fmt.Sscanf(string(data), "\"0x%x\"", &mask); err != nil {
+	hexBytes := serialization.HexBytes{}
+	err := hexBytes.UnmarshalJSON(data)
+	if err != nil {
 		return err
 	}
-	b.Deserialize(mask)
+
+	b.Deserialize(hexBytes)
 	return nil
 }

--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -69,3 +69,53 @@ func TestBitSet_String_PrintsListOfEntries(t *testing.T) {
 	b.Add(123)
 	require.Equal(t, "{1, 12, 123}", b.String())
 }
+
+func TestBitSet_Serialize(t *testing.T) {
+	require := require.New(t)
+
+	var b BitSet[uint8]
+	require.Equal([]byte{}, b.Serialize())
+	b.Add(1)
+	require.Equal([]byte{0x01}, b.Serialize())
+	b.Add(12)
+	require.Equal([]byte{0x01, 0xc}, b.Serialize())
+	b.Add(123)
+	require.Equal([]byte{0x01, 0xc, 0x7b}, b.Serialize())
+}
+
+func TestBitSet_Deserialize(t *testing.T) {
+	require := require.New(t)
+
+	var b BitSet[uint8]
+	b.Deserialize([]byte{0x01, 0xc, 0x7b})
+	require.Equal([]uint8{1, 12, 123}, b.Entries())
+}
+
+func TestBitSet_MarshalJSON(t *testing.T) {
+	require := require.New(t)
+
+	var b BitSet[uint8]
+	b.Add(1)
+	b.Add(12)
+	b.Add(123)
+	data, err := b.MarshalJSON()
+	require.NoError(err)
+	require.Equal(`"0x010c7b"`, string(data))
+}
+
+func TestBitSet_UnmarshalJSON(t *testing.T) {
+	require := require.New(t)
+
+	var b BitSet[uint8]
+	err := b.UnmarshalJSON([]byte(`"0x010c7b"`))
+	require.NoError(err)
+	require.Equal([]uint8{1, 12, 123}, b.Entries())
+}
+
+func TestBitSet_InvalidUnmarshalJSON(t *testing.T) {
+	require := require.New(t)
+
+	var b BitSet[uint8]
+	err := b.UnmarshalJSON([]byte(`"010c7"`))
+	require.Error(err)
+}

--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -116,6 +116,6 @@ func TestBitSet_InvalidUnmarshalJSON(t *testing.T) {
 	require := require.New(t)
 
 	var b BitSet[uint8]
-	err := b.UnmarshalJSON([]byte(`"010c7"`))
+	err := b.UnmarshalJSON([]byte(`"g"`))
 	require.Error(err)
 }

--- a/scc/cert/serialization/types.go
+++ b/scc/cert/serialization/types.go
@@ -19,6 +19,9 @@ func (h *HexBytes) UnmarshalJSON(data []byte) error {
 		*h = nil
 		return nil
 	}
+	if !strings.HasPrefix(s, "0x") {
+		return fmt.Errorf("invalid hex string %s", s)
+	}
 	s = strings.TrimPrefix(s, "0x")
 	if len(s)%2 == 1 {
 		s = "0" + s
@@ -31,11 +34,22 @@ func (h *HexBytes) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func UnmarshallFixLenghtHexBytes(data []byte, length int) (HexBytes, error) {
+	var h HexBytes
+	err := h.UnmarshalJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(h) != length {
+		return nil, fmt.Errorf("invalid length %d, expected %d", len(h), length)
+	}
+	return h, nil
+}
+
 type PublicKey [48]byte
 
 func (p *PublicKey) UnmarshalJSON(data []byte) error {
-	hexBytes := HexBytes{}
-	err := hexBytes.UnmarshalJSON(data)
+	hexBytes, err := UnmarshallFixLenghtHexBytes(data, 48)
 	if err != nil {
 		return err
 	}
@@ -50,8 +64,7 @@ func (p PublicKey) String() string {
 type Signature [96]byte
 
 func (s *Signature) UnmarshalJSON(data []byte) error {
-	hexBytes := HexBytes{}
-	err := hexBytes.UnmarshalJSON(data)
+	hexBytes, err := UnmarshallFixLenghtHexBytes(data, 96)
 	if err != nil {
 		return err
 	}

--- a/scc/cert/serialization/types.go
+++ b/scc/cert/serialization/types.go
@@ -1,0 +1,64 @@
+package serialization
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type HexBytes []byte
+
+func (h *HexBytes) UnmarshalJSON(data []byte) error {
+	var s string
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+	if s == "null" {
+		*h = nil
+		return nil
+	}
+	s = strings.TrimPrefix(s, "0x")
+	if len(s)%2 == 1 {
+		s = "0" + s
+	}
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	*h = raw
+	return nil
+}
+
+type PublicKey [48]byte
+
+func (p *PublicKey) UnmarshalJSON(data []byte) error {
+	hexBytes := HexBytes{}
+	err := hexBytes.UnmarshalJSON(data)
+	if err != nil {
+		return err
+	}
+	*p = PublicKey(hexBytes)
+	return nil
+}
+
+func (p PublicKey) String() string {
+	return fmt.Sprintf("0x%x", []byte(p[:]))
+}
+
+type Signature [96]byte
+
+func (s *Signature) UnmarshalJSON(data []byte) error {
+	hexBytes := HexBytes{}
+	err := hexBytes.UnmarshalJSON(data)
+	if err != nil {
+		return err
+	}
+	*s = Signature(hexBytes)
+	return nil
+}
+
+func (h Signature) String() string {
+	return fmt.Sprintf("0x%x", []byte(h[:]))
+}

--- a/scc/cert/serialization/types_test.go
+++ b/scc/cert/serialization/types_test.go
@@ -6,17 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHexBytes_UnmarshalJSON(t *testing.T) {
+func TestHexBytes_UnmarshalJSON_ValidHexString(t *testing.T) {
 	var h HexBytes
-
 	data := []byte(`"0x012abc"`)
 	err := h.UnmarshalJSON(data)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 }
 
-func TestHexBytes_InvalidUnmarshallJSON(t *testing.T) {
+func TestHexBytes_UnmarshallJSON_Invalid(t *testing.T) {
 	var h HexBytes
 	data := []byte(`"0xg"`)
 	err := h.UnmarshalJSON(data)
@@ -27,12 +24,30 @@ func TestHexBytes_InvalidUnmarshallJSON(t *testing.T) {
 
 }
 
-func TestPublicKey_UnmarshalJSON(t *testing.T) {
+func TestPublicKey_UnmarshalJSON_ShortHexString(t *testing.T) {
 	var p PublicKey
-
-	data := []byte(`"0xdeadbeef"`)
+	data := []byte(`"0x1234567"`)
 	err := p.UnmarshalJSON(data)
-	if err != nil {
-		panic(err)
-	}
+	require.Error(t, err)
+}
+
+func TestPublicKey_UnmarshalJSON_ValidHexString(t *testing.T) {
+	var p PublicKey
+	data := []byte(`"0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"`)
+	err := p.UnmarshalJSON(data)
+	require.NoError(t, err)
+}
+
+func TestSignature_UnmarshallJSON_ShortHexString(t *testing.T) {
+	var s Signature
+	data := []byte(`"0x1234567"`)
+	require.Error(t, s.UnmarshalJSON(data))
+	data = []byte(`"0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"`)
+	require.Error(t, s.UnmarshalJSON(data))
+}
+
+func TestSignature_UnmarshallJSON_ValidHexString(t *testing.T) {
+	var s Signature
+	data := []byte(`"0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"`)
+	require.NoError(t, s.UnmarshalJSON(data))
 }

--- a/scc/cert/serialization/types_test.go
+++ b/scc/cert/serialization/types_test.go
@@ -1,0 +1,38 @@
+package serialization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHexBytes_UnmarshalJSON(t *testing.T) {
+	var h HexBytes
+
+	data := []byte(`"0x012abc"`)
+	err := h.UnmarshalJSON(data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestHexBytes_InvalidUnmarshallJSON(t *testing.T) {
+	var h HexBytes
+	data := []byte(`"0xg"`)
+	err := h.UnmarshalJSON(data)
+	require.Error(t, err)
+	data = []byte(`"01"`)
+	err = h.UnmarshalJSON(data)
+	require.Error(t, err)
+
+}
+
+func TestPublicKey_UnmarshalJSON(t *testing.T) {
+	var p PublicKey
+
+	data := []byte(`"0xdeadbeef"`)
+	err := p.UnmarshalJSON(data)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/scc/committee.go
+++ b/scc/committee.go
@@ -40,6 +40,13 @@ func NewCommittee(members ...Member) Committee {
 	return Committee{members: slices.Clone(members)}
 }
 
+// NewCommitteeForTests creates a new committee with the provided members. This
+// function is intended for testing purposes only and does not validate the
+// committee.
+func NewCommitteeForTests(members ...Member) Committee {
+	return Committee{members: slices.Clone(members)}
+}
+
 // Members returns a copy of the members in the committee.
 func (c Committee) Members() []Member {
 	return slices.Clone(c.members)

--- a/scc/committee.go
+++ b/scc/committee.go
@@ -40,13 +40,6 @@ func NewCommittee(members ...Member) Committee {
 	return Committee{members: slices.Clone(members)}
 }
 
-// NewCommitteeForTests creates a new committee with the provided members. This
-// function is intended for testing purposes only and does not validate the
-// committee.
-func NewCommitteeForTests(members ...Member) Committee {
-	return Committee{members: slices.Clone(members)}
-}
-
 // Members returns a copy of the members in the committee.
 func (c Committee) Members() []Member {
 	return slices.Clone(c.members)


### PR DESCRIPTION
This PR adds a hex string to byte slice general type with its Unmarshalling methog, a couple of byte array instances that use it.
This new type should facilitate the conversion to/from JSON for bls keys and signatures, but that work is left for future PRs.

The bitset is also extended to be de/serialized as well as un/marshall using the introduced `serialization.Hexbyte`. 