### PR TITLE
Update ChainConfig to enable Prague fork

### DIFF
--- a/opera/rules.go
+++ b/opera/rules.go
@@ -327,10 +327,11 @@ func FakeNetRules() Rules {
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(3 * time.Second),
 		},
 		Upgrades: Upgrades{
-			Berlin: true,
-			London: true,
-			Llr:    false,
-			Sonic:  true,
+			Berlin:  true,
+			London:  true,
+			Llr:     false,
+			Sonic:   true,
+			Allegro: true,
 		},
 	}
 }

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -281,10 +281,19 @@ func (r Rules) EvmChainConfig(hh []UpgradeHeight) *ethparams.ChainConfig {
 			cfg.ShanghaiTime = timestamp
 			cfg.CancunTime = timestamp
 		}
+
+		if cfg.PragueTime == nil && h.Upgrades.Allegro {
+			cfg.PragueTime = timestamp
+		}
+
 		if !h.Upgrades.Sonic {
 			// disabling upgrade breaks the history replay - should be never used
 			cfg.ShanghaiTime = nil
 			cfg.CancunTime = nil
+		}
+
+		if !h.Upgrades.Allegro {
+			cfg.PragueTime = nil
 		}
 	}
 	return &cfg


### PR DESCRIPTION
This Pr adds the forktime for Prague to the chain config if the allegro update is enabled. 
Additionally, set fakenet to use the allegro update, used in integration tests and other testing. 

Required by https://github.com/0xsoniclabs/sonic-admin/issues/28