### PR TITLE
Introduce support for storing SCC certificates in the DB

### DIFF
--- a/gossip/store.go
+++ b/gossip/store.go
@@ -40,6 +40,10 @@ type Store struct {
 		Genesis                kvdb.Store `table:"g"`
 		UpgradeHeights         kvdb.Store `table:"U"`
 
+		// Sonic Certification Chain tables
+		CommitteeCertificates kvdb.Store `table:"C"`
+		BlockCertificates     kvdb.Store `table:"c"`
+
 		// P2P-only
 		HighestLamport kvdb.Store `table:"l"`
 

--- a/gossip/store_certificates.go
+++ b/gossip/store_certificates.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
@@ -36,6 +37,9 @@ func (s *Store) GetCommitteeCertificate(period scc.Period) (CommitteeCertificate
 	if err != nil {
 		return res, err
 	}
+	if data == nil {
+		return res, fmt.Errorf("no certificate found for period %d", period)
+	}
 	return res, res.Deserialize(data)
 }
 
@@ -58,6 +62,9 @@ func (s *Store) GetBlockCertificate(block idx.Block) (BlockCertificate, error) {
 	data, err := table.Get(getBlockCertificateKey(block))
 	if err != nil {
 		return res, err
+	}
+	if data == nil {
+		return res, fmt.Errorf("no certificate found for block %d", block)
 	}
 	return res, res.Deserialize(data)
 }

--- a/gossip/store_certificates.go
+++ b/gossip/store_certificates.go
@@ -1,0 +1,77 @@
+package gossip
+
+import (
+	"encoding/binary"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+)
+
+// CommitteeCertificate is a certificate for a committee. This is an alias
+// for cert.Certificate[cert.CommitteeStatement] to improve readability.
+type CommitteeCertificate = cert.Certificate[cert.CommitteeStatement]
+
+// CommitteeCertificate is a certificate for a block. This is an alias
+// for cert.Certificate[cert.BlockStatement] to improve readability.
+type BlockCertificate = cert.Certificate[cert.BlockStatement]
+
+// UpdateCommitteeCertificate adds or updates the certificate in the store.
+// If a certificate for the same period is already present, it is overwritten.
+func (s *Store) UpdateCommitteeCertificate(certificate CommitteeCertificate) error {
+	data, err := certificate.Serialize()
+	if err != nil {
+		return err
+	}
+	key := getCommitteeCertificateKey(certificate.Subject().Period)
+	return s.table.CommitteeCertificates.Put(key, data)
+}
+
+// GetCommitteeCertificate retrieves the certificate for the given period.
+// If no certificate is found, an error is returned.
+func (s *Store) GetCommitteeCertificate(period scc.Period) (CommitteeCertificate, error) {
+	var res CommitteeCertificate
+	table := s.table.CommitteeCertificates
+	data, err := table.Get(getCommitteeCertificateKey(period))
+	if err != nil {
+		return res, err
+	}
+	return res, res.Deserialize(data)
+}
+
+// UpdateBlockCertificate adds or updates the certificate in the store.
+// If a certificate for the same block is already present, it is overwritten.
+func (s *Store) UpdateBlockCertificate(certificate BlockCertificate) error {
+	data, err := certificate.Serialize()
+	if err != nil {
+		return err
+	}
+	key := getBlockCertificateKey(certificate.Subject().Number)
+	return s.table.BlockCertificates.Put(key, data)
+}
+
+// GetBlockCertificate retrieves the certificate for the given block.
+// If no certificate is found, an error is returned.
+func (s *Store) GetBlockCertificate(block idx.Block) (BlockCertificate, error) {
+	var res BlockCertificate
+	table := s.table.BlockCertificates
+	data, err := table.Get(getBlockCertificateKey(block))
+	if err != nil {
+		return res, err
+	}
+	return res, res.Deserialize(data)
+}
+
+// getCommitteeCertificateKey returns the key used to store committee
+// certificates in the key/value store.
+func getCommitteeCertificateKey(period scc.Period) []byte {
+	// big endian to sort entries in DB by period
+	return binary.BigEndian.AppendUint64(nil, uint64(period))
+}
+
+// getBlockCertificateKey returns the key used to store block certificates
+// in the key/value store.
+func getBlockCertificateKey(number idx.Block) []byte {
+	// big endian to sort entries in DB by block
+	return binary.BigEndian.AppendUint64(nil, uint64(number))
+}

--- a/gossip/store_certificates.go
+++ b/gossip/store_certificates.go
@@ -7,6 +7,7 @@ import (
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
 )
 
 // CommitteeCertificate is a certificate for a committee. This is an alias
@@ -20,53 +21,39 @@ type BlockCertificate = cert.Certificate[cert.BlockStatement]
 // UpdateCommitteeCertificate adds or updates the certificate in the store.
 // If a certificate for the same period is already present, it is overwritten.
 func (s *Store) UpdateCommitteeCertificate(certificate CommitteeCertificate) error {
-	data, err := certificate.Serialize()
-	if err != nil {
-		return err
-	}
-	key := getCommitteeCertificateKey(certificate.Subject().Period)
-	return s.table.CommitteeCertificates.Put(key, data)
+	return updateCertificate(
+		getCommitteeCertificateKey(certificate.Subject().Period),
+		s.table.CommitteeCertificates,
+		certificate,
+	)
 }
 
 // GetCommitteeCertificate retrieves the certificate for the given period.
 // If no certificate is found, an error is returned.
 func (s *Store) GetCommitteeCertificate(period scc.Period) (CommitteeCertificate, error) {
-	var res CommitteeCertificate
-	table := s.table.CommitteeCertificates
-	data, err := table.Get(getCommitteeCertificateKey(period))
-	if err != nil {
-		return res, err
-	}
-	if data == nil {
-		return res, fmt.Errorf("no certificate found for period %d", period)
-	}
-	return res, res.Deserialize(data)
+	return getCertificate[cert.CommitteeStatement](
+		getCommitteeCertificateKey(period),
+		s.table.CommitteeCertificates,
+	)
 }
 
 // UpdateBlockCertificate adds or updates the certificate in the store.
 // If a certificate for the same block is already present, it is overwritten.
 func (s *Store) UpdateBlockCertificate(certificate BlockCertificate) error {
-	data, err := certificate.Serialize()
-	if err != nil {
-		return err
-	}
-	key := getBlockCertificateKey(certificate.Subject().Number)
-	return s.table.BlockCertificates.Put(key, data)
+	return updateCertificate(
+		getBlockCertificateKey(certificate.Subject().Number),
+		s.table.BlockCertificates,
+		certificate,
+	)
 }
 
 // GetBlockCertificate retrieves the certificate for the given block.
 // If no certificate is found, an error is returned.
 func (s *Store) GetBlockCertificate(block idx.Block) (BlockCertificate, error) {
-	var res BlockCertificate
-	table := s.table.BlockCertificates
-	data, err := table.Get(getBlockCertificateKey(block))
-	if err != nil {
-		return res, err
-	}
-	if data == nil {
-		return res, fmt.Errorf("no certificate found for block %d", block)
-	}
-	return res, res.Deserialize(data)
+	return getCertificate[cert.BlockStatement](
+		getBlockCertificateKey(block),
+		s.table.BlockCertificates,
+	)
 }
 
 // getCommitteeCertificateKey returns the key used to store committee
@@ -81,4 +68,35 @@ func getCommitteeCertificateKey(period scc.Period) []byte {
 func getBlockCertificateKey(number idx.Block) []byte {
 	// big endian to sort entries in DB by block
 	return binary.BigEndian.AppendUint64(nil, uint64(number))
+}
+
+// updateCertificate stores the certificate in the key/value store.
+// If a certificate for the same key is already present, it is overwritten.
+func updateCertificate[S cert.Statement](
+	key []byte,
+	table kvdb.Store,
+	certificate cert.Certificate[S],
+) error {
+	data, err := certificate.Serialize()
+	if err != nil {
+		return err
+	}
+	return table.Put(key, data)
+}
+
+// getCertificate retrieves the certificate from the key/value store.
+// If no certificate is found, an error is returned.
+func getCertificate[S cert.Statement](
+	key []byte,
+	table kvdb.Store,
+) (cert.Certificate[S], error) {
+	var res cert.Certificate[S]
+	data, err := table.Get(key)
+	if err != nil {
+		return res, err
+	}
+	if data == nil {
+		return res, fmt.Errorf("no such certificate")
+	}
+	return res, res.Deserialize(data)
 }

--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -1,0 +1,155 @@
+package gossip
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_GetCommitteeCertificate_FailsIfNotPresent(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+	_, err = store.GetCommitteeCertificate(1)
+	require.Error(err)
+}
+
+func TestStore_GetCommitteeCertificate_RetrievesPresentEntries(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	original := cert.NewCertificate(cert.CommitteeStatement{
+		Period: 1,
+	})
+
+	require.NoError(store.UpdateCommitteeCertificate(original))
+
+	restored, err := store.GetCommitteeCertificate(1)
+	require.NoError(err)
+	require.Equal(original, restored)
+}
+
+func TestStore_GetCommitteeCertificate_DistinguishesBetweenPeriods(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	original1 := cert.NewCertificate(cert.CommitteeStatement{
+		Period:    1,
+		Committee: scc.NewCommittee(),
+	})
+
+	original2 := cert.NewCertificate(cert.CommitteeStatement{
+		Period:    2,
+		Committee: scc.NewCommittee(scc.Member{}),
+	})
+
+	require.NoError(store.UpdateCommitteeCertificate(original1))
+	require.NoError(store.UpdateCommitteeCertificate(original2))
+
+	restored1, err := store.GetCommitteeCertificate(1)
+	require.NoError(err)
+	require.Equal(original1, restored1)
+
+	restored2, err := store.GetCommitteeCertificate(2)
+	require.NoError(err)
+	require.Equal(original2, restored2)
+}
+
+func TestStore_UpdateCommitteeCertificate_CanOverrideExisting(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	original1 := cert.NewCertificate(cert.CommitteeStatement{
+		Period:    1,
+		Committee: scc.NewCommittee(scc.Member{}),
+	})
+	require.NoError(store.UpdateCommitteeCertificate(original1))
+
+	original2 := cert.NewCertificate(cert.CommitteeStatement{
+		Period:    1,
+		Committee: scc.NewCommittee(scc.Member{}, scc.Member{}),
+	})
+	require.NoError(store.UpdateCommitteeCertificate(original2))
+
+	restored, err := store.GetCommitteeCertificate(1)
+	require.NoError(err)
+	require.Equal(original2, restored)
+}
+
+func TestStore_GetBlockCertificate_FailsIfNotPresent(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+	_, err = store.GetBlockCertificate(1)
+	require.Error(err)
+}
+
+func TestStore_GetBlockCertificate_RetrievesPresentEntries(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	original := cert.NewCertificate(cert.BlockStatement{
+		Number: 1,
+	})
+
+	require.NoError(store.UpdateBlockCertificate(original))
+
+	restored, err := store.GetBlockCertificate(1)
+	require.NoError(err)
+	require.Equal(original, restored)
+}
+
+func TestStore_GetBlockCertificate_DistinguishesBetweenPeriods(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	original1 := cert.NewCertificate(cert.BlockStatement{
+		Number: 1,
+		Hash:   [32]byte{1, 2, 3},
+	})
+
+	original2 := cert.NewCertificate(cert.BlockStatement{
+		Number: 2,
+		Hash:   [32]byte{4, 5, 6},
+	})
+
+	require.NoError(store.UpdateBlockCertificate(original1))
+	require.NoError(store.UpdateBlockCertificate(original2))
+
+	restored1, err := store.GetBlockCertificate(1)
+	require.NoError(err)
+	require.Equal(original1, restored1)
+
+	restored2, err := store.GetBlockCertificate(2)
+	require.NoError(err)
+	require.Equal(original2, restored2)
+}
+
+func TestStore_UpdateBlockCertificate_CanOverrideExisting(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	original1 := cert.NewCertificate(cert.BlockStatement{
+		Number: 1,
+		Hash:   [32]byte{1, 2, 3},
+	})
+	require.NoError(store.UpdateBlockCertificate(original1))
+
+	original2 := cert.NewCertificate(cert.BlockStatement{
+		Number: 1,
+		Hash:   [32]byte{4, 5, 6},
+	})
+	require.NoError(store.UpdateBlockCertificate(original2))
+
+	restored, err := store.GetBlockCertificate(1)
+	require.NoError(err)
+	require.Equal(original2, restored)
+}

--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -47,6 +47,7 @@ func TestStore_GetCommitteeCertificate_DistinguishesBetweenPeriods(t *testing.T)
 		Period:    2,
 		Committee: scc.NewCommittee(scc.Member{}),
 	})
+	require.NotEqual(original1, original2)
 
 	require.NoError(store.UpdateCommitteeCertificate(original1))
 	require.NoError(store.UpdateCommitteeCertificate(original2))
@@ -75,6 +76,7 @@ func TestStore_UpdateCommitteeCertificate_CanOverrideExisting(t *testing.T) {
 		Period:    1,
 		Committee: scc.NewCommittee(scc.Member{}, scc.Member{}),
 	})
+	require.NotEqual(original1, original2)
 	require.NoError(store.UpdateCommitteeCertificate(original2))
 
 	restored, err := store.GetCommitteeCertificate(1)
@@ -120,6 +122,7 @@ func TestStore_GetBlockCertificate_DistinguishesBetweenPeriods(t *testing.T) {
 		Number: 2,
 		Hash:   [32]byte{4, 5, 6},
 	})
+	require.NotEqual(original1, original2)
 
 	require.NoError(store.UpdateBlockCertificate(original1))
 	require.NoError(store.UpdateBlockCertificate(original2))
@@ -148,6 +151,7 @@ func TestStore_UpdateBlockCertificate_CanOverrideExisting(t *testing.T) {
 		Number: 1,
 		Hash:   [32]byte{4, 5, 6},
 	})
+	require.NotEqual(original1, original2)
 	require.NoError(store.UpdateBlockCertificate(original2))
 
 	restored, err := store.GetBlockCertificate(1)

--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -14,7 +14,7 @@ func TestStore_GetCommitteeCertificate_FailsIfNotPresent(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(err)
 	_, err = store.GetCommitteeCertificate(1)
-	require.ErrorContains(err, "no certificate found for period 1")
+	require.ErrorContains(err, "no such certificate")
 }
 
 func TestStore_GetCommitteeCertificate_RetrievesPresentEntries(t *testing.T) {
@@ -89,7 +89,7 @@ func TestStore_GetBlockCertificate_FailsIfNotPresent(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(err)
 	_, err = store.GetBlockCertificate(1)
-	require.ErrorContains(err, "no certificate found for block 1")
+	require.ErrorContains(err, "no such certificate")
 }
 
 func TestStore_GetBlockCertificate_RetrievesPresentEntries(t *testing.T) {

--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -1,9 +1,8 @@
-package gossip_test
+package gossip
 
 import (
 	"testing"
 
-	. "github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/stretchr/testify/require"

--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -1,8 +1,9 @@
-package gossip
+package gossip_test
 
 import (
 	"testing"
 
+	. "github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ func TestStore_GetCommitteeCertificate_FailsIfNotPresent(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(err)
 	_, err = store.GetCommitteeCertificate(1)
-	require.Error(err)
+	require.ErrorContains(err, "no certificate found for period 1")
 }
 
 func TestStore_GetCommitteeCertificate_RetrievesPresentEntries(t *testing.T) {
@@ -86,7 +87,7 @@ func TestStore_GetBlockCertificate_FailsIfNotPresent(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(err)
 	_, err = store.GetBlockCertificate(1)
-	require.Error(err)
+	require.ErrorContains(err, "no certificate found for block 1")
 }
 
 func TestStore_GetBlockCertificate_RetrievesPresentEntries(t *testing.T) {


### PR DESCRIPTION
This PR introduces functionality to store and retrieve certificates in the client's central key/value store.