### PR TITLE
Add serialization support to generic certificate type

### DIFF
--- a/scc/cert/certificate.go
+++ b/scc/cert/certificate.go
@@ -20,6 +20,11 @@ func NewCertificate[S Statement](subject S) Certificate[S] {
 	return Certificate[S]{subject: subject}
 }
 
+// Subject returns the statement that is certified by this certificate.
+func (c *Certificate[S]) Subject() S {
+	return c.subject
+}
+
 // Add adds a signature to the certificate for the given signer ID. The ID is
 // used to identify signers in a certificate creation committee.
 func (c *Certificate[S]) Add(id scc.MemberId, signature Signature[S]) error {

--- a/scc/cert/certificate_test.go
+++ b/scc/cert/certificate_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCertificate_NewCertificate_ContainsStatement(t *testing.T) {
+	require := require.New(t)
+	stmt := testStatement(1)
+	cert := NewCertificate(stmt)
+	require.Equal(stmt, cert.Subject())
+}
+
 func TestCertificate_CanBeGraduallyAccumulatedAndVerified(t *testing.T) {
 	requires := require.New(t)
 	keys := make([]bls.PrivateKey, 6)


### PR DESCRIPTION
While working on the DB integration it was realized that handling specialized certification types is causing too much complexity for serializing and deserializing certificates.

Thus, the former type definitions
```
type CommitteeCertificate Certificate[CommitteeStatement]
type BlockCertificate Certificate[BlockStatement]
```
got removed and the serialization and deserialization support was added to the generic `Certificate[S]` type.

Furthermore, a public accessor for the certificate's subject was added to allow external code to obtain statement data.