### PR TITLE
Add support for iterating through certificates to DB

### DIFF
--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -1,8 +1,9 @@
-package gossip
+package gossip_test
 
 import (
 	"testing"
 
+	. "github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/stretchr/testify/require"

--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -1,9 +1,8 @@
-package gossip_test
+package gossip
 
 import (
 	"testing"
 
-	. "github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
This PR introduces support for iterating through certificates in their native order to the certification store.