### PR TITLE
Improve error reporting in DB content iteration

### DIFF
--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -90,7 +90,9 @@ func TestStore_EnumerateCommitteeCertificates_ReturnsAllCertificates(t *testing.
 		}
 		restored := []CommitteeCertificate{}
 		for c := range store.EnumerateCommitteeCertificates(first) {
-			restored = append(restored, c)
+			cur, err := c.Unwrap()
+			require.NoError(err)
+			restored = append(restored, cur)
 			if len(restored) == 2 {
 				break
 			}
@@ -198,7 +200,9 @@ func TestStore_EnumerateBlockCertificates_ReturnsAllCertificates(t *testing.T) {
 		}
 		restored := []BlockCertificate{}
 		for c := range store.EnumerateBlockCertificates(first) {
-			restored = append(restored, c)
+			cur, err := c.Unwrap()
+			require.NoError(err)
+			restored = append(restored, cur)
 			if len(restored) == 2 {
 				break
 			}

--- a/utils/result/result.go
+++ b/utils/result/result.go
@@ -13,8 +13,8 @@ func New[V any](value V) T[V] {
 }
 
 // Error creates a new result with an error. This is the type of result that is
-// returned when the operation is unsuccessful. Note, passing nil will as a
-// an error will result in a non-error result containing the zero value.
+// returned when the operation is unsuccessful. Note, passing nil as an error
+// will result in a non-error result containing the zero value.
 func Error[V any](err error) T[V] {
 	return T[V]{err: err}
 }

--- a/utils/result/result.go
+++ b/utils/result/result.go
@@ -1,0 +1,32 @@
+package result
+
+// T is a result of an operation that can return a value or an error.
+type T[V any] struct {
+	value V
+	err   error
+}
+
+// New creates a new result with a value. This is the type of result that is
+// returned when the operation is successful.
+func New[V any](value V) T[V] {
+	return T[V]{value: value}
+}
+
+// Error creates a new result with an error. This is the type of result that is
+// returned when the operation is unsuccessful. Note, passing nil will as a
+// an error will result in a non-error result containing the zero value.
+func Error[V any](err error) T[V] {
+	return T[V]{err: err}
+}
+
+// Unwrap returns the value and error of the result. If the operation was a
+// success, the error will be nil. If the operation was a failure, the value
+// will be the zero value of the type and the error will describe the failure.
+func (r T[V]) Unwrap() (V, error) {
+	return r.value, r.err
+}
+
+// IsError returns true if the result is an error.
+func (r T[V]) IsError() bool {
+	return r.err != nil
+}

--- a/utils/result/result_test.go
+++ b/utils/result/result_test.go
@@ -1,0 +1,28 @@
+package result
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResult_New_ProducesASuccessfulResult(t *testing.T) {
+	res := New[int](42)
+	require.False(t, res.IsError())
+	v, err := res.Unwrap()
+	require.Equal(t, 42, v)
+	require.Nil(t, err)
+}
+
+func TestResult_Error_ProducesAFailedResult(t *testing.T) {
+	require.True(t, Error[int](fmt.Errorf("fail")).IsError())
+}
+
+func TestResult_Error_NilResultsInZeroValue(t *testing.T) {
+	res := Error[int](nil)
+	require.False(t, res.IsError())
+	v, err := res.Unwrap()
+	require.Zero(t, v)
+	require.Nil(t, err)
+}


### PR DESCRIPTION
This PR improves the certification enumeration feature of the gossip store by adding support for reporting errors during the enumeration process.

To do so, this PR introduces an new, generic "Result" utility, inspired by similar features found in other languages.