### PR TITLE
add json encoding to public key and signature

### DIFF
--- a/scc/bls/bls.go
+++ b/scc/bls/bls.go
@@ -34,6 +34,7 @@ import (
 	"crypto/rand"
 	"fmt"
 
+	"github.com/0xsoniclabs/sonic/utils/jsonhex"
 	blst "github.com/supranational/blst/bindings/go"
 )
 
@@ -179,6 +180,24 @@ func (k PublicKey) String() string {
 	return fmt.Sprintf("0x%x", k.Serialize())
 }
 
+func (k PublicKey) MarshalJSON() ([]byte, error) {
+	json := jsonhex.Bytes48(k.Serialize())
+	return json.MarshalJSON()
+}
+
+func (k *PublicKey) UnmarshalJSON(data []byte) error {
+	var json jsonhex.Bytes48
+	if err := json.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	key, err := DeserializePublicKey([48]byte(json))
+	if err != nil {
+		return err
+	}
+	*k = key
+	return nil
+}
+
 // --- Signatures -------------------------------------------------------------
 
 // Validate returns true if the signature is valid, false otherwise. A signature
@@ -241,4 +260,22 @@ func (k Signature) Serialize() [96]byte {
 // String returns the signature as a hexadecimal string prefixed with "0x".
 func (k Signature) String() string {
 	return fmt.Sprintf("0x%x", k.Serialize())
+}
+
+func (k Signature) MarshalJSON() ([]byte, error) {
+	json := jsonhex.Bytes96(k.Serialize())
+	return json.MarshalJSON()
+}
+
+func (k *Signature) UnmarshalJSON(data []byte) error {
+	var json jsonhex.Bytes96
+	if err := json.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	sig, err := DeserializeSignature([96]byte(json))
+	if err != nil {
+		return err
+	}
+	*k = sig
+	return nil
 }

--- a/scc/bls/bls_test.go
+++ b/scc/bls/bls_test.go
@@ -1,6 +1,7 @@
 package bls
 
 import (
+	"encoding/json"
 	"regexp"
 	"testing"
 
@@ -162,16 +163,35 @@ func TestPublicKey_String_IsHexEncoded(t *testing.T) {
 	require.Regexp(t, regexp, key.String())
 }
 
+func TestPublicKey_JsonEncodingUsesHexFormat(t *testing.T) {
+	regexp := regexp.MustCompile(`^"0x[0-9a-f]{96}"$`)
+	key := NewPrivateKey().PublicKey()
+	data, err := json.Marshal(key)
+	require.NoError(t, err)
+	require.Regexp(t, regexp, string(data))
+}
+
 func TestPublicKey_CanBeMarshalAndUnmarshal(t *testing.T) {
 	require := require.New(t)
 	key := PublicKey{}
-	data, err := key.MarshalJSON()
+	data, err := json.Marshal(key)
 	require.NoError(err)
 
 	var key2 PublicKey
-	err = key2.UnmarshalJSON(data)
+	err = json.Unmarshal(data, &key2)
 	require.NoError(err)
 	require.Equal(key, key2)
+}
+
+func TestPublicKey_UnmarshalFailsForInvalidData(t *testing.T) {
+	data := []byte(`"0xg"`)
+	var key PublicKey
+	err := json.Unmarshal(data, &key)
+	require.Error(t, err)
+	invalid := [96]byte{}
+	data = []byte(invalid[:])
+	err = json.Unmarshal(data, &key)
+	require.Error(t, err)
 }
 
 // --- Signatures -------------------------------------------------------------
@@ -281,16 +301,35 @@ func TestSignature_String_IsHexEncoded(t *testing.T) {
 	require.Regexp(t, regexp, Signature{}.String())
 }
 
+func TestSignature_JsonEncodingUsesHexFormat(t *testing.T) {
+	regexp := regexp.MustCompile(`^"0x[0-9a-f]{192}"$`)
+	signature := NewPrivateKey().Sign([]byte("Hello, world!"))
+	data, err := json.Marshal(signature)
+	require.NoError(t, err)
+	require.Regexp(t, regexp, string(data))
+}
+
 func TestSignature_CanBeMarshalAndUnmarshal(t *testing.T) {
 	require := require.New(t)
 	signature := Signature{}
-	data, err := signature.MarshalJSON()
+	data, err := json.Marshal(signature)
 	require.NoError(err)
 
 	var signature2 Signature
-	err = signature2.UnmarshalJSON(data)
+	err = json.Unmarshal(data, &signature2)
 	require.NoError(err)
 	require.Equal(signature, signature2)
+}
+
+func TestSignature_UnmarshalFailsForInvalidData(t *testing.T) {
+	data := []byte(`"0xg"`)
+	var signature Signature
+	err := json.Unmarshal(data, &signature)
+	require.Error(t, err)
+	invalid := [192]byte{}
+	data = []byte(invalid[:])
+	err = json.Unmarshal(data, &signature)
+	require.Error(t, err)
 }
 
 // --- Signature Protocol -----------------------------------------------------

--- a/scc/bls/bls_test.go
+++ b/scc/bls/bls_test.go
@@ -162,6 +162,18 @@ func TestPublicKey_String_IsHexEncoded(t *testing.T) {
 	require.Regexp(t, regexp, key.String())
 }
 
+func TestPublicKey_CanBeMarshalAndUnmarshal(t *testing.T) {
+	require := require.New(t)
+	key := PublicKey{}
+	data, err := key.MarshalJSON()
+	require.NoError(err)
+
+	var key2 PublicKey
+	err = key2.UnmarshalJSON(data)
+	require.NoError(err)
+	require.Equal(key, key2)
+}
+
 // --- Signatures -------------------------------------------------------------
 
 func TestSignature_DefaultIsInvalid(t *testing.T) {
@@ -267,6 +279,18 @@ func TestSignature_DeserializationDetectsInvalidEncoding(t *testing.T) {
 func TestSignature_String_IsHexEncoded(t *testing.T) {
 	regexp := regexp.MustCompile(`^0x[0-9a-f]{192}$`)
 	require.Regexp(t, regexp, Signature{}.String())
+}
+
+func TestSignature_CanBeMarshalAndUnmarshal(t *testing.T) {
+	require := require.New(t)
+	signature := Signature{}
+	data, err := signature.MarshalJSON()
+	require.NoError(err)
+
+	var signature2 Signature
+	err = signature2.UnmarshalJSON(data)
+	require.NoError(err)
+	require.Equal(signature, signature2)
 }
 
 // --- Signature Protocol -----------------------------------------------------

--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -79,7 +79,7 @@ func TestBitSet_MarshalJSON(t *testing.T) {
 	b.Add(123)
 	data, err := b.MarshalJSON()
 	require.NoError(err)
-	require.Equal(`0x02100000000000000000000000000008`, string(data))
+	require.Equal(`"0x02100000000000000000000000000008"`, string(data))
 }
 
 func TestBitSet_UnmarshalJSON(t *testing.T) {

--- a/utils/jsonhex/types.go
+++ b/utils/jsonhex/types.go
@@ -45,9 +45,9 @@ func (h *Bytes) UnmarshalJSON(data []byte) error {
 // String returns the hex string representation of Bytes.
 func (h Bytes) String() string {
 	if h == nil {
-		return "null"
+		return `"null"`
 	}
-	return fmt.Sprintf("0x%x", []byte(h))
+	return fmt.Sprintf(`"0x%x"`, []byte(h))
 }
 
 // UnmarshalFixLengthBytes decodes a JSON hex string into a fixed-length Bytes slice.
@@ -68,8 +68,8 @@ func UnmarshalFixLengthBytes(data []byte, length int) (Bytes, error) {
 type Bytes48 [48]byte
 
 // MarshalJSON converts the Bytes48 into a JSON-compatible hex string.
-func (h *Bytes48) MarshalJSON() ([]byte, error) {
-	return Bytes((*h)[:]).MarshalJSON()
+func (h Bytes48) MarshalJSON() ([]byte, error) {
+	return Bytes(h[:]).MarshalJSON()
 }
 
 // UnmarshalJSON parses a JSON hex string into a Bytes48.
@@ -91,8 +91,8 @@ func (h Bytes48) String() string {
 type Bytes96 [96]byte
 
 // MarshalJSON converts the Bytes96 into a JSON-compatible hex string.
-func (h *Bytes96) MarshalJSON() ([]byte, error) {
-	return Bytes((*h)[:]).MarshalJSON()
+func (h Bytes96) MarshalJSON() ([]byte, error) {
+	return Bytes(h[:]).MarshalJSON()
 }
 
 // UnmarshalJSON parses a JSON hex string into a Bytes96.

--- a/utils/jsonhex/types_test.go
+++ b/utils/jsonhex/types_test.go
@@ -1,6 +1,7 @@
 package jsonhex
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,15 +11,15 @@ func TestBytes_MarshalJSON_HandlesAllCases(t *testing.T) {
 	h := Bytes([]byte{0x01, 0x2a, 0xbc})
 	data, err := h.MarshalJSON()
 	require.NoError(t, err)
-	require.Equal(t, []byte(`0x012abc`), data)
+	require.Equal(t, []byte(`"0x012abc"`), data)
 	h = nil
 	data, err = h.MarshalJSON()
 	require.NoError(t, err)
-	require.Equal(t, []byte("null"), data)
+	require.Equal(t, []byte(`"null"`), data)
 	h = Bytes([]byte{0x1, 0x2a, 0xbc})
 	data, err = h.MarshalJSON()
 	require.NoError(t, err)
-	require.Equal(t, []byte(`0x012abc`), data)
+	require.Equal(t, []byte(`"0x012abc"`), data)
 }
 
 func TestBytes_UnmarshalJSON_ValidHexString_DoesNotProduceError(t *testing.T) {
@@ -44,16 +45,26 @@ func TestBytes_UnmarshalJSON_InvalidHexString_ProducesError(t *testing.T) {
 
 func TestBytes_String_IsCorrectlyProduced(t *testing.T) {
 	h := Bytes([]byte{0x01, 0x2a, 0xbc})
-	require.Equal(t, "0x012abc", h.String())
+	require.Equal(t, `"0x012abc"`, h.String())
 	h = nil
-	require.Equal(t, "null", h.String())
+	require.Equal(t, `"null"`, h.String())
+}
+
+func TestBytes_CanBeJSONEncodedAndDecoded(t *testing.T) {
+	h := Bytes([]byte{0x01, 0x2a, 0xbc})
+	data, err := json.Marshal(h)
+	require.NoError(t, err)
+	var h2 Bytes
+	err = json.Unmarshal(data, &h2)
+	require.NoError(t, err)
+	require.Equal(t, h, h2)
 }
 
 func TestBytes48_MarshalJSON_StringIsCorrectlyProduced(t *testing.T) {
 	p := Bytes48([48]byte{0x01})
 	data, err := p.MarshalJSON()
 	require.NoError(t, err)
-	expected := `0x010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`
+	expected := `"0x010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"`
 	require.Equal(t, []byte(expected), data)
 }
 
@@ -61,7 +72,7 @@ func TestBytes48_MarshalJSON_ZeroValue(t *testing.T) {
 	var p Bytes48
 	data, err := p.MarshalJSON()
 	require.NoError(t, err)
-	require.Equal(t, []byte("0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"), data)
+	require.Equal(t, []byte(`"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"`), data)
 }
 
 func TestBytes48_UnmarshalJSON_TooShortHexStringIsRejected(t *testing.T) {
@@ -81,16 +92,26 @@ func TestBytes48_UnmarshalJSON_ValidHexString(t *testing.T) {
 }
 
 func TestBytes48_String(t *testing.T) {
-	byteString := "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
+	byteString := `"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"`
 	p := Bytes48([]byte{47: 0x01})
 	require.Equal(t, byteString, p.String())
+}
+
+func TestBytes48_CanBeJsonEncodedAndDecoded(t *testing.T) {
+	p := Bytes48([]byte{47: 0x01})
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+	var p2 Bytes48
+	err = json.Unmarshal(data, &p2)
+	require.NoError(t, err)
+	require.Equal(t, p, p2)
 }
 
 func TestBytes96_MarshalJSON(t *testing.T) {
 	s := Bytes96([96]byte{0x01})
 	data, err := s.MarshalJSON()
 	require.NoError(t, err)
-	expected := []byte(`0x010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`)
+	expected := []byte(`"0x010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"`)
 	require.Equal(t, len(expected), len(data))
 	require.Equal(t, []byte(expected), data)
 }
@@ -112,7 +133,17 @@ func TestBytes96_UnmarshalJSON_ValidHexString(t *testing.T) {
 }
 
 func TestBytes96_UnmarshalJSON_String(t *testing.T) {
-	byteString := "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
+	byteString := `"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"`
 	S := Bytes96([]byte{95: 0x01})
 	require.Equal(t, byteString, S.String())
+}
+
+func TestBytes96_CanBeJsonEncodedAndDecoded(t *testing.T) {
+	s := Bytes96([]byte{95: 0x01})
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
+	var s2 Bytes96
+	err = json.Unmarshal(data, &s2)
+	require.NoError(t, err)
+	require.Equal(t, s, s2)
 }


### PR DESCRIPTION
This PR:

- Fixes a formatting issue in jsonhex formatting issue.
- Adds a test in jsonhex that uses `json.Marshall` and `json.Unmarshall` to ensure this issues are caught.
- Adds json encoding functions for `bls.PublicKey` and `bls.Signature`.