### PR TITLE
Update intrinsic gas computation and checks

### DIFF
--- a/eventcheck/basiccheck/basic_check.go
+++ b/eventcheck/basiccheck/basic_check.go
@@ -49,6 +49,9 @@ func validateTx(tx *types.Transaction) error {
 
 		// is eip-3860 (limit and meter init-code )
 		// Disable to get the lower intrinsic gas cost of both options
+		// FIXME: from allegro on, this flag should be enabled.
+		// It should have been enabled since shanghai, but it was not and changing
+		// it now would be a hard fork.
 		false,
 	)
 	if err != nil {

--- a/eventcheck/basiccheck/basic_check.go
+++ b/eventcheck/basiccheck/basic_check.go
@@ -41,7 +41,16 @@ func validateTx(tx *types.Transaction) error {
 		return ErrNegativeValue
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
-	intrGas, err := evmcore.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil)
+	intrGas, err := evmcore.IntrinsicGas(
+		tx.Data(),
+		tx.AccessList(),
+		tx.SetCodeAuthorizations(),
+		tx.To() == nil, // is contract creation
+
+		// is eip-3860 (limit and meter init-code )
+		// Disable to get the lower intrinsic gas cost of both options
+		false,
+	)
 	if err != nil {
 		return err
 	}

--- a/evmcore/state_transition.go
+++ b/evmcore/state_transition.go
@@ -1,62 +1,75 @@
-// Copyright 2015 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
 package evmcore
 
 import (
+	"bytes"
 	"math"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool) (uint64, error) {
+// IntrinsicGas computes the minimum amount of gas required to process a transaction
+// before executing any smart contract logic.
+// This cost ensures th data transmission and transaction validation, are covered.
+//
+// This implementation is based in:
+// go-ethereum@v0.0.0-20241022121122-7063a6b506bd/core/state_transition.go
+//
+// The minimum revision considered is Istanbul, any previous revision cost differences are ignored.
+func IntrinsicGas(
+	data []byte,
+	accessList types.AccessList,
+	authList []types.SetCodeAuthorization,
+	isContractCreation bool,
+	isEIP3860 bool,
+) (uint64, error) {
 	// Set the starting gas for the raw transaction
-	var gas uint64
+	gas := params.TxGas
 	if isContractCreation {
 		gas = params.TxGasContractCreation
-	} else {
-		gas = params.TxGas
 	}
+	dataLen := uint64(len(data))
 	// Bump the required gas by the amount of transactional data
-	if len(data) > 0 {
+	if dataLen > 0 {
 		// Zero and non-zero bytes are priced differently
-		var nz uint64
-		for _, byt := range data {
-			if byt != 0 {
-				nz++
-			}
-		}
-		// Make sure we don't exceed uint64 for all data combinations
-		if (math.MaxUint64-gas)/params.TxDataNonZeroGasEIP2028 < nz {
-			return 0, vm.ErrOutOfGas
-		}
-		gas += nz * params.TxDataNonZeroGasEIP2028
+		z := uint64(bytes.Count(data, []byte{0}))
+		nz := dataLen - z
 
-		z := uint64(len(data)) - nz
+		// Make sure we don't exceed uint64 for all data combinations
+		nonZeroGas := params.TxDataNonZeroGasEIP2028
+		if (math.MaxUint64-gas)/nonZeroGas < nz {
+			return 0, ErrGasUintOverflow
+		}
+		gas += nz * nonZeroGas
+
 		if (math.MaxUint64-gas)/params.TxDataZeroGas < z {
 			return 0, ErrGasUintOverflow
 		}
 		gas += z * params.TxDataZeroGas
+
+		if isContractCreation && isEIP3860 {
+			lenWords := toWordSize(dataLen)
+			if (math.MaxUint64-gas)/params.InitCodeWordGas < lenWords {
+				return 0, ErrGasUintOverflow
+			}
+			gas += lenWords * params.InitCodeWordGas
+		}
 	}
 	if accessList != nil {
 		gas += uint64(len(accessList)) * params.TxAccessListAddressGas
 		gas += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
 	}
+	if authList != nil {
+		gas += uint64(len(authList)) * params.CallNewAccountGas
+	}
 	return gas, nil
+}
+
+// toWordSize returns the ceiled word size required for init code payment calculation.
+func toWordSize(size uint64) uint64 {
+	if size > math.MaxUint64-31 {
+		return math.MaxUint64/32 + 1
+	}
+
+	return (size + 31) / 32
 }

--- a/evmcore/state_transition.go
+++ b/evmcore/state_transition.go
@@ -10,7 +10,7 @@ import (
 
 // IntrinsicGas computes the minimum amount of gas required to process a transaction
 // before executing any smart contract logic.
-// This cost ensures th data transmission and transaction validation, are covered.
+// This cost ensures that data transmission and transaction validation, are covered.
 //
 // This implementation is based in:
 // go-ethereum@v0.0.0-20241022121122-7063a6b506bd/core/state_transition.go

--- a/evmcore/state_transition_test.go
+++ b/evmcore/state_transition_test.go
@@ -1,0 +1,77 @@
+package evmcore
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntrinsicGas_IsCompatibleWithGethImplementation(t *testing.T) {
+
+	// The intention of this test is to detect deviations between the geth
+	// implementation of intrinsic gas calculation and the sonic implementation.
+	//
+	// This test alerts us if the intrinsic gas calculation is changed.
+
+	tests := []testData{}
+	for _, dataSize := range []int{
+		0, 1, 16, 1024, 2048, 4096, 8192, 16384,
+	} {
+		for _, zeroesRatio := range []int{1, 2, 4} {
+			for _, accessList := range []types.AccessList{
+				nil,
+				{},
+				{
+					{Address: common.Address{}, StorageKeys: []common.Hash{}},
+				},
+				{
+					{Address: common.Address{0x42}, StorageKeys: []common.Hash{{1}}},
+					{Address: common.Address{0x42}, StorageKeys: []common.Hash{{1}}},
+				},
+			} {
+
+				for _, isEIP3860 := range []bool{true, false} {
+					for _, contractCreation := range []bool{true, false} {
+						tests = append(tests, testData{
+							data:               makeData(dataSize, dataSize/zeroesRatio),
+							accessList:         accessList,
+							isContractCreation: contractCreation,
+							isEIP3860:          isEIP3860,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	for _, test := range tests {
+
+		sonicValue, sonicError := IntrinsicGas(test.data, test.accessList, nil, test.isContractCreation, test.isEIP3860)
+		gethValue, gethError := core.IntrinsicGas(test.data, test.accessList, nil, test.isContractCreation, true, true, test.isEIP3860)
+
+		require.Equal(t, sonicError, gethError, "both implementation shall return the same error with the same input")
+		if sonicError != nil {
+			require.Equal(t, sonicValue, gethValue, "both implementation shall return the same value with the same input")
+		}
+	}
+}
+
+type testData struct {
+	data               []byte
+	accessList         types.AccessList
+	isContractCreation bool
+	isEIP3860          bool
+}
+
+// makeData creates a byte slice of the given size with the given number of zeroes at the end.
+// This is relevant for the intrinsic gas calculation, as zero bytes are priced differently.
+func makeData(size, zeroesCount int) []byte {
+	zeroes := bytes.Repeat([]byte{0}, zeroesCount)
+	nonZeroes := bytes.Repeat([]byte{1}, size)
+	copy(nonZeroes, zeroes)
+	return nonZeroes
+}

--- a/evmcore/state_transition_test.go
+++ b/evmcore/state_transition_test.go
@@ -2,76 +2,148 @@ package evmcore
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntrinsicGas_IsCompatibleWithGethImplementation(t *testing.T) {
+var (
+	accessListInputs = []types.AccessList{
+		nil,
+		{},
+		{
+			{Address: common.Address{}, StorageKeys: nil},
+		},
+		{
+			{Address: common.Address{}, StorageKeys: []common.Hash{}},
+		},
+		{
+			{Address: common.Address{0x42}, StorageKeys: []common.Hash{{1}}},
+			{Address: common.Address{0x42}, StorageKeys: []common.Hash{{1}, {2}}},
+		},
+	}
 
-	// The intention of this test is to detect deviations between the geth
-	// implementation of intrinsic gas calculation and the sonic implementation.
-	//
-	// This test alerts us if the intrinsic gas calculation is changed.
+	authorizationListInputs = [][]types.SetCodeAuthorization{
+		nil,
+		{},
+		{{Address: common.Address{0x42}}},
+		{{Address: common.Address{0x42}}, {Address: common.Address{0x43}}},
+	}
+)
 
-	tests := []testData{}
-	for _, dataSize := range []int{
+// This test is a fuzz test for the intrinsic gas calculation.
+// It tests the sonic implementation against the geth implementation for a variety of inputs.
+// This test alerts us if the intrinsic gas calculation is changed.
+// It additionally checks the legacy intrinsic gas calculation for compatibility with the
+// changes introduced by the Prague update.
+func FuzzTestIntrinsicGas(f *testing.F) {
+
+	for _, dataSize := range []uint{
 		0, 1, 16, 1024, 2048, 4096, 8192, 16384,
 	} {
-		for _, zeroesRatio := range []int{1, 2, 4} {
-			for _, accessList := range []types.AccessList{
-				nil,
-				{},
-				{
-					{Address: common.Address{}, StorageKeys: []common.Hash{}},
-				},
-				{
-					{Address: common.Address{0x42}, StorageKeys: []common.Hash{{1}}},
-					{Address: common.Address{0x42}, StorageKeys: []common.Hash{{1}}},
-				},
-			} {
-
-				for _, isEIP3860 := range []bool{true, false} {
-					for _, contractCreation := range []bool{true, false} {
-						tests = append(tests, testData{
-							data:               makeData(dataSize, dataSize/zeroesRatio),
-							accessList:         accessList,
-							isContractCreation: contractCreation,
-							isEIP3860:          isEIP3860,
-						})
+		for _, zeroesRatio := range []uint{1, 2, 4} {
+			for accessListIndex := range len(accessListInputs) {
+				for authorizationListIndex := range len(authorizationListInputs) {
+					for _, isEIP3860 := range []bool{true, false} {
+						for _, contractCreation := range []bool{true, false} {
+							f.Add(dataSize, zeroesRatio, accessListIndex, authorizationListIndex, isEIP3860, contractCreation)
+						}
 					}
 				}
 			}
 		}
 	}
 
-	for _, test := range tests {
+	// for _, test := range tests {
+	f.Fuzz(func(t *testing.T, dataSize, zeroesRation uint, accessListIndex, authorizationListIndex int, isEIP3860, isContractCreation bool) {
+		if zeroesRation == 0 {
+			t.Skip()
+		}
+		data := makeData(dataSize, dataSize/zeroesRation)
 
-		sonicValue, sonicError := IntrinsicGas(test.data, test.accessList, nil, test.isContractCreation, test.isEIP3860)
-		gethValue, gethError := core.IntrinsicGas(test.data, test.accessList, nil, test.isContractCreation, true, true, test.isEIP3860)
+		if accessListIndex < 0 || accessListIndex >= len(accessListInputs) {
+			t.Skip()
+		}
+		accessList := accessListInputs[accessListIndex]
+
+		if authorizationListIndex < 0 || authorizationListIndex >= len(authorizationListInputs) {
+			t.Skip()
+		}
+		authList := authorizationListInputs[authorizationListIndex]
+
+		sonicValue, sonicError := IntrinsicGas(data, accessList, authList, isContractCreation, isEIP3860)
+		gethValue, gethError := core.IntrinsicGas(data, accessList, authList, isContractCreation, true, true, isEIP3860)
 
 		require.Equal(t, sonicError, gethError, "both implementation shall return the same error with the same input")
 		if sonicError != nil {
 			require.Equal(t, sonicValue, gethValue, "both implementation shall return the same value with the same input")
 		}
-	}
-}
 
-type testData struct {
-	data               []byte
-	accessList         types.AccessList
-	isContractCreation bool
-	isEIP3860          bool
+		if isEIP3860 || len(authList) > 0 {
+			// we only test legacy compatibility when EIP-3860 is disabled and no authorization list is provided
+			// we do not skip, as the test is still valid
+			return
+		}
+
+		legacyValue, legacyError := LegacyIntrinsicGas(data, accessList, isContractCreation)
+		require.Equal(t, legacyError, gethError, "both implementation shall return the same error with the same input")
+		if legacyError != nil {
+			require.Equal(t, legacyValue, gethValue, "both implementation shall return the same value with the same input")
+		}
+	})
 }
 
 // makeData creates a byte slice of the given size with the given number of zeroes at the end.
 // This is relevant for the intrinsic gas calculation, as zero bytes are priced differently.
-func makeData(size, zeroesCount int) []byte {
-	zeroes := bytes.Repeat([]byte{0}, zeroesCount)
-	nonZeroes := bytes.Repeat([]byte{1}, size)
+func makeData(size, zeroesCount uint) []byte {
+	zeroes := bytes.Repeat([]byte{0}, int(zeroesCount))
+	nonZeroes := bytes.Repeat([]byte{1}, int(size))
 	copy(nonZeroes, zeroes)
 	return nonZeroes
+}
+
+// LegacyIntrinsicGas is the Intrinsic gas computation used by the sonic before the Prague update.
+// The behavior of the new implementation, without the EIP-3860 flag, and empty authorization list
+// must remain the same as the legacy implementation.
+// DO NOT MODIFY THIS FUNCTION.
+func LegacyIntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool) (uint64, error) {
+	// Set the starting gas for the raw transaction
+	var gas uint64
+	if isContractCreation {
+		gas = params.TxGasContractCreation
+	} else {
+		gas = params.TxGas
+	}
+	// Bump the required gas by the amount of transactional data
+	if len(data) > 0 {
+		// Zero and non-zero bytes are priced differently
+		var nz uint64
+		for _, byt := range data {
+			if byt != 0 {
+				nz++
+			}
+		}
+		// Make sure we don't exceed uint64 for all data combinations
+		if (math.MaxUint64-gas)/params.TxDataNonZeroGasEIP2028 < nz {
+			return 0, vm.ErrOutOfGas
+		}
+		gas += nz * params.TxDataNonZeroGasEIP2028
+
+		z := uint64(len(data)) - nz
+		if (math.MaxUint64-gas)/params.TxDataZeroGas < z {
+			return 0, ErrGasUintOverflow
+		}
+		gas += z * params.TxDataZeroGas
+	}
+	if accessList != nil {
+		gas += uint64(len(accessList)) * params.TxAccessListAddressGas
+		gas += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
+	}
+	return gas, nil
 }


### PR DESCRIPTION
This PR updates the intrinsic gas computation to cover the range of changes that affect sonic. 
- Any cost computation related to versions older than Istanbul is removed. 
- Added check eip-3860 (limit and meter init-code), introduced in Shanghai
- Added support for EIP-7702 transactions

Event check is updated to utilize the new version in a conservative manner, for correctness, but it should be upgraded to do a correct validation according to the current block height revision for robustness reasons. 
