### PR TITLE
Create canonical certificate alias definitions

### DIFF
--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -14,6 +14,7 @@ import (
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore/fileshash"
 	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/0xsoniclabs/sonic/utils/devnullfile"
 	"github.com/0xsoniclabs/sonic/utils/objstream"
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
@@ -175,7 +176,7 @@ func exportCommitteeCertificates(ctx context.Context, gdb *gossip.Store, writer 
 	log.Info("Exporting committee certificates", "to", toPeriod)
 
 	count := 0
-	out := objstream.NewWriter[gossip.CommitteeCertificate](writer)
+	out := objstream.NewWriter[cert.CommitteeCertificate](writer)
 	for entry := range gdb.EnumerateCommitteeCertificates(0) {
 		count++
 		cert, err := entry.Unwrap()
@@ -204,7 +205,7 @@ func exportBlockCertificates(ctx context.Context, gdb *gossip.Store, writer *uni
 	log.Info("Exporting block certificates", "to", to)
 
 	count := 0
-	out := objstream.NewWriter[gossip.BlockCertificate](writer)
+	out := objstream.NewWriter[cert.BlockCertificate](writer)
 	for entry := range gdb.EnumerateBlockCertificates(0) {
 		count++
 		cert, err := entry.Unwrap()

--- a/gossip/store_certificates.go
+++ b/gossip/store_certificates.go
@@ -13,17 +13,9 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// CommitteeCertificate is a certificate for a committee. This is an alias
-// for cert.Certificate[cert.CommitteeStatement] to improve readability.
-type CommitteeCertificate = cert.Certificate[cert.CommitteeStatement]
-
-// CommitteeCertificate is a certificate for a block. This is an alias
-// for cert.Certificate[cert.BlockStatement] to improve readability.
-type BlockCertificate = cert.Certificate[cert.BlockStatement]
-
 // UpdateCommitteeCertificate adds or updates the certificate in the store.
 // If a certificate for the same period is already present, it is overwritten.
-func (s *Store) UpdateCommitteeCertificate(certificate CommitteeCertificate) error {
+func (s *Store) UpdateCommitteeCertificate(certificate cert.CommitteeCertificate) error {
 	return updateCertificate(
 		getCommitteeCertificateKey(certificate.Subject().Period),
 		s.table.CommitteeCertificates,
@@ -33,7 +25,7 @@ func (s *Store) UpdateCommitteeCertificate(certificate CommitteeCertificate) err
 
 // GetCommitteeCertificate retrieves the certificate for the given period.
 // If no certificate is found, an error is returned.
-func (s *Store) GetCommitteeCertificate(period scc.Period) (CommitteeCertificate, error) {
+func (s *Store) GetCommitteeCertificate(period scc.Period) (cert.CommitteeCertificate, error) {
 	return getCertificate[cert.CommitteeStatement](
 		getCommitteeCertificateKey(period),
 		s.table.CommitteeCertificates,
@@ -44,7 +36,7 @@ func (s *Store) GetCommitteeCertificate(period scc.Period) (CommitteeCertificate
 // starting from the given period. The certificates are yielded in ascending
 // order of period. If an error occurs during iteration, it is yielded as the
 // last result.
-func (s *Store) EnumerateCommitteeCertificates(first scc.Period) iter.Seq[result.T[CommitteeCertificate]] {
+func (s *Store) EnumerateCommitteeCertificates(first scc.Period) iter.Seq[result.T[cert.CommitteeCertificate]] {
 	return enumerateCertificates[cert.CommitteeStatement](
 		getCommitteeCertificateKey(first),
 		s.table.CommitteeCertificates,
@@ -54,7 +46,7 @@ func (s *Store) EnumerateCommitteeCertificates(first scc.Period) iter.Seq[result
 
 // UpdateBlockCertificate adds or updates the certificate in the store.
 // If a certificate for the same block is already present, it is overwritten.
-func (s *Store) UpdateBlockCertificate(certificate BlockCertificate) error {
+func (s *Store) UpdateBlockCertificate(certificate cert.BlockCertificate) error {
 	return updateCertificate(
 		getBlockCertificateKey(certificate.Subject().Number),
 		s.table.BlockCertificates,
@@ -64,7 +56,7 @@ func (s *Store) UpdateBlockCertificate(certificate BlockCertificate) error {
 
 // GetBlockCertificate retrieves the certificate for the given block.
 // If no certificate is found, an error is returned.
-func (s *Store) GetBlockCertificate(block idx.Block) (BlockCertificate, error) {
+func (s *Store) GetBlockCertificate(block idx.Block) (cert.BlockCertificate, error) {
 	return getCertificate[cert.BlockStatement](
 		getBlockCertificateKey(block),
 		s.table.BlockCertificates,
@@ -75,7 +67,7 @@ func (s *Store) GetBlockCertificate(block idx.Block) (BlockCertificate, error) {
 // the given block number. The certificates are yielded in ascending order of
 // block number. If an error occurs during iteration, it is yielded as the
 // last result.
-func (s *Store) EnumerateBlockCertificates(first idx.Block) iter.Seq[result.T[BlockCertificate]] {
+func (s *Store) EnumerateBlockCertificates(first idx.Block) iter.Seq[result.T[cert.BlockCertificate]] {
 	return enumerateCertificates[cert.BlockStatement](
 		getBlockCertificateKey(first),
 		s.table.BlockCertificates,

--- a/gossip/store_certificates_test.go
+++ b/gossip/store_certificates_test.go
@@ -71,7 +71,7 @@ func TestStore_EnumerateCommitteeCertificates_ReturnsAllCertificates(t *testing.
 	require.NoError(err)
 
 	var members []scc.Member
-	var originals []CommitteeCertificate
+	var originals []cert.CommitteeCertificate
 	for period := range scc.Period(N) {
 		cur := cert.NewCertificate(cert.CommitteeStatement{
 			Period:    period,
@@ -88,7 +88,7 @@ func TestStore_EnumerateCommitteeCertificates_ReturnsAllCertificates(t *testing.
 		if last > N {
 			last = N
 		}
-		restored := []CommitteeCertificate{}
+		restored := []cert.CommitteeCertificate{}
 		for c := range store.EnumerateCommitteeCertificates(first) {
 			cur, err := c.Unwrap()
 			require.NoError(err)
@@ -182,7 +182,7 @@ func TestStore_EnumerateBlockCertificates_ReturnsAllCertificates(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
-	var originals []BlockCertificate
+	var originals []cert.BlockCertificate
 	for number := range idx.Block(N) {
 		cur := cert.NewCertificate(cert.BlockStatement{
 			Number: number,
@@ -198,7 +198,7 @@ func TestStore_EnumerateBlockCertificates_ReturnsAllCertificates(t *testing.T) {
 		if last > N {
 			last = N
 		}
-		restored := []BlockCertificate{}
+		restored := []cert.BlockCertificate{}
 		for c := range store.EnumerateBlockCertificates(first) {
 			cur, err := c.Unwrap()
 			require.NoError(err)

--- a/scc/cert/types.go
+++ b/scc/cert/types.go
@@ -1,0 +1,9 @@
+package cert
+
+// CommitteeCertificate is a certificate for a committee. This is an alias
+// for cert.Certificate[cert.CommitteeStatement] to improve readability.
+type CommitteeCertificate = Certificate[CommitteeStatement]
+
+// CommitteeCertificate is a certificate for a block. This is an alias
+// for cert.Certificate[cert.BlockStatement] to improve readability.
+type BlockCertificate = Certificate[BlockStatement]

--- a/scc/node/store.go
+++ b/scc/node/store.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 )
 
@@ -13,17 +14,17 @@ import (
 type Store interface {
 	// GetCommitteeCertificate retrieves the certificate for the given period.
 	// If no certificate is found, an error is returned.
-	GetCommitteeCertificate(scc.Period) (CommitteeCertificate, error)
+	GetCommitteeCertificate(scc.Period) (cert.CommitteeCertificate, error)
 
 	// GetBlockCertificate retrieves the certificate for the given block.
 	// If no certificate is found, an error is returned.
-	GetBlockCertificate(idx.Block) (BlockCertificate, error)
+	GetBlockCertificate(idx.Block) (cert.BlockCertificate, error)
 
 	// UpdateCommitteeCertificate adds or updates the certificate in the store.
 	// If a certificate for the same period is already present, it is overwritten.
-	UpdateCommitteeCertificate(CommitteeCertificate) error
+	UpdateCommitteeCertificate(cert.CommitteeCertificate) error
 
 	// UpdateBlockCertificate adds or updates the certificate in the store.
 	// If a certificate for the same block is already present, it is overwritten.
-	UpdateBlockCertificate(BlockCertificate) error
+	UpdateBlockCertificate(cert.BlockCertificate) error
 }

--- a/scc/node/store_mock.go
+++ b/scc/node/store_mock.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	scc "github.com/0xsoniclabs/sonic/scc"
+	cert "github.com/0xsoniclabs/sonic/scc/cert"
 	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -41,10 +42,10 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // GetBlockCertificate mocks base method.
-func (m *MockStore) GetBlockCertificate(arg0 idx.Block) (BlockCertificate, error) {
+func (m *MockStore) GetBlockCertificate(arg0 idx.Block) (cert.BlockCertificate, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockCertificate", arg0)
-	ret0, _ := ret[0].(BlockCertificate)
+	ret0, _ := ret[0].(cert.BlockCertificate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -56,10 +57,10 @@ func (mr *MockStoreMockRecorder) GetBlockCertificate(arg0 any) *gomock.Call {
 }
 
 // GetCommitteeCertificate mocks base method.
-func (m *MockStore) GetCommitteeCertificate(arg0 scc.Period) (CommitteeCertificate, error) {
+func (m *MockStore) GetCommitteeCertificate(arg0 scc.Period) (cert.CommitteeCertificate, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCommitteeCertificate", arg0)
-	ret0, _ := ret[0].(CommitteeCertificate)
+	ret0, _ := ret[0].(cert.CommitteeCertificate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -71,7 +72,7 @@ func (mr *MockStoreMockRecorder) GetCommitteeCertificate(arg0 any) *gomock.Call 
 }
 
 // UpdateBlockCertificate mocks base method.
-func (m *MockStore) UpdateBlockCertificate(arg0 BlockCertificate) error {
+func (m *MockStore) UpdateBlockCertificate(arg0 cert.BlockCertificate) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBlockCertificate", arg0)
 	ret0, _ := ret[0].(error)
@@ -85,7 +86,7 @@ func (mr *MockStoreMockRecorder) UpdateBlockCertificate(arg0 any) *gomock.Call {
 }
 
 // UpdateCommitteeCertificate mocks base method.
-func (m *MockStore) UpdateCommitteeCertificate(arg0 CommitteeCertificate) error {
+func (m *MockStore) UpdateCommitteeCertificate(arg0 cert.CommitteeCertificate) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCommitteeCertificate", arg0)
 	ret0, _ := ret[0].(error)

--- a/scc/node/types.go
+++ b/scc/node/types.go
@@ -1,6 +1,0 @@
-package node
-
-import "github.com/0xsoniclabs/sonic/scc/cert"
-
-type CommitteeCertificate = cert.Certificate[cert.CommitteeStatement]
-type BlockCertificate = cert.Certificate[cert.BlockStatement]


### PR DESCRIPTION
This PR introduces canonical definitions of the `CommitteCertificate` and `BlockCertificate` aliases in the `cert` package and replaces the former duplicated definitions in the `gossip` and `node` packages.