### PR TITLE
Cleanup and documentation of JSON certificates

### DIFF
--- a/ethapi/block_cert_json.go
+++ b/ethapi/block_cert_json.go
@@ -8,16 +8,21 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// blockCertificateJson is a JSON representation of a block certificate
+// as returned by the Sonic API. This type provides a conversion between the
+// internal certificate representation and the JSON representation provided to
+// the API clients. The external API is expected to be stable over time and
+// should only be updated in a backward compatible way.
 type blockCertificateJson struct {
 	ChainId   uint64                    `json:"chainId"`
-	Number    uint64                    `json:"period"`
-	Hash      common.Hash               `json:"height"`
-	StateRoot common.Hash               `json:"hash"`
+	Number    uint64                    `json:"number"`
+	Hash      common.Hash               `json:"hash"`
+	StateRoot common.Hash               `json:"stateRoot"`
 	Signers   cert.BitSet[scc.MemberId] `json:"signers"`
 	Signature bls.Signature             `json:"signature"`
 }
 
-func (b blockCertificateJson) ToBlockCertificate() cert.BlockCertificate {
+func (b blockCertificateJson) toCertificate() cert.BlockCertificate {
 	aggregatedSignature := cert.NewAggregatedSignature[cert.BlockStatement](
 		b.Signers, b.Signature)
 
@@ -32,7 +37,7 @@ func (b blockCertificateJson) ToBlockCertificate() cert.BlockCertificate {
 	return newCert
 }
 
-func blockCertificateToJson(b cert.BlockCertificate) blockCertificateJson {
+func toJsonBlockCertificate(b cert.BlockCertificate) blockCertificateJson {
 	sub := b.Subject()
 	agg := b.Signature()
 	return blockCertificateJson{

--- a/ethapi/block_cert_json_test.go
+++ b/ethapi/block_cert_json_test.go
@@ -28,7 +28,7 @@ func TestBlockCertificateJson_ToBlockCertificate_ConvertsToHealthyCertificate(t 
 		Signature: sig,
 	}
 
-	got := b.ToBlockCertificate()
+	got := b.toCertificate()
 	aggregatedSignature := cert.NewAggregatedSignature[cert.BlockStatement](
 		b.Signers,
 		b.Signature,
@@ -57,7 +57,7 @@ func TestBlockCertificateJson_CanBeJsonEncodedAndDecoded(t *testing.T) {
 	)
 
 	// encode
-	certJson := blockCertificateToJson(c)
+	certJson := toJsonBlockCertificate(c)
 	data, err := json.Marshal(certJson)
 	require.NoError(err)
 
@@ -68,7 +68,7 @@ func TestBlockCertificateJson_CanBeJsonEncodedAndDecoded(t *testing.T) {
 
 	// check
 	require.Equal(certJson, decoded)
-	cert := decoded.ToBlockCertificate()
+	cert := decoded.toCertificate()
 	require.Equal(c, cert)
 }
 
@@ -82,7 +82,7 @@ func TestBlockCertificateToJson(t *testing.T) {
 		cert.NewAggregatedSignature[cert.BlockStatement](bitset, sig),
 	)
 
-	json := blockCertificateToJson(cert)
+	json := toJsonBlockCertificate(cert)
 	require.Equal(uint64(123), json.ChainId)
 	require.Equal(uint64(456), json.Number)
 	require.Equal(common.Hash{0x1}, json.Hash)

--- a/ethapi/committee_cert_json.go
+++ b/ethapi/committee_cert_json.go
@@ -6,6 +6,11 @@ import (
 	"github.com/0xsoniclabs/sonic/scc/cert"
 )
 
+// committeeCertificateJson is a JSON representation of a committee certificate
+// as returned by the Sonic API. This type provides a conversion between the
+// internal certificate representation and the JSON representation provided to
+// the API clients. The external API is expected to be stable over time and
+// should only be updated in a backward compatible way.
 type committeeCertificateJson struct {
 	ChainId   uint64                    `json:"chainId"`
 	Period    uint64                    `json:"period"`
@@ -14,7 +19,7 @@ type committeeCertificateJson struct {
 	Signature bls.Signature             `json:"signature"`
 }
 
-func (c committeeCertificateJson) ToCommitteeCertificate() cert.CommitteeCertificate {
+func (c committeeCertificateJson) toCertificate() cert.CommitteeCertificate {
 	aggregatedSignature := cert.NewAggregatedSignature[cert.CommitteeStatement](c.Signers, c.Signature)
 
 	newCert := cert.NewCertificateWithSignature(
@@ -27,7 +32,7 @@ func (c committeeCertificateJson) ToCommitteeCertificate() cert.CommitteeCertifi
 	return newCert
 }
 
-func committeeCertificateToJson(c cert.CommitteeCertificate) committeeCertificateJson {
+func toJsonCommitteeCertificate(c cert.CommitteeCertificate) committeeCertificateJson {
 	sub := c.Subject()
 	agg := c.Signature()
 	return committeeCertificateJson{

--- a/ethapi/committee_cert_json_test.go
+++ b/ethapi/committee_cert_json_test.go
@@ -24,7 +24,7 @@ func TestCommitteeCertificateJson_ToCommitteeCertificate_ConvertsToHealthyCertif
 		Signature: sig,
 	}
 
-	got := c.ToCommitteeCertificate()
+	got := c.toCertificate()
 	aggregatedSignature := cert.NewAggregatedSignature[cert.CommitteeStatement](
 		c.Signers,
 		c.Signature,
@@ -57,7 +57,7 @@ func TestCommitteeCertificateJson_CanBeJsonEncodedAndDecoded(t *testing.T) {
 	)
 
 	// encode
-	certJson := committeeCertificateToJson(c)
+	certJson := toJsonCommitteeCertificate(c)
 	data, err := json.Marshal(certJson)
 	require.NoError(err)
 
@@ -67,7 +67,7 @@ func TestCommitteeCertificateJson_CanBeJsonEncodedAndDecoded(t *testing.T) {
 	require.NoError(err)
 
 	// check
-	cert := certJson2.ToCommitteeCertificate()
+	cert := certJson2.toCertificate()
 	require.Equal(c, cert)
 }
 
@@ -93,6 +93,6 @@ func TestCommitteeCertificateToJson(t *testing.T) {
 		Signers:   bitSet,
 		Signature: sig,
 	}
-	got := committeeCertificateToJson(c)
+	got := toJsonCommitteeCertificate(c)
 	require.Equal(want, got)
 }


### PR DESCRIPTION
This PR adds some documentation to the JSON encoding types for SCC certificates used for SCC related RPC methods.

The PR also fixes the naming of some fields used in the JSON encoding.