### PR TITLE
Add intergration test for type 4 transaction (set EOA code, eip-7702). 

### DIFF
--- a/tests/contracts/batch/batch.go
+++ b/tests/contracts/batch/batch.go
@@ -1,0 +1,230 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package batch
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BatchCallDelegationCall is an auto generated low-level Go binding around an user-defined struct.
+type BatchCallDelegationCall struct {
+	To    common.Address
+	Value *big.Int
+}
+
+// BatchMetaData contains all meta data concerning the Batch contract.
+var BatchMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"components\":[{\"internalType\":\"addresspayable\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"internalType\":\"structBatchCallDelegation.Call[]\",\"name\":\"calls\",\"type\":\"tuple[]\"}],\"name\":\"execute\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f5ffd5b506104a68061001c5f395ff3fe60806040526004361061001d575f3560e01c806313426fdf14610021575b5f5ffd5b61003b600480360381019061003691906101ae565b61003d565b005b5f5f90505b82829050811015610137575f838383818110610061576100606101f9565b5b905060400201803603810190610077919061038c565b90505f815f015173ffffffffffffffffffffffffffffffffffffffff1682602001516040516100a5906103e4565b5f6040518083038185875af1925050503d805f81146100df576040519150601f19603f3d011682016040523d82523d5f602084013e6100e4565b606091505b5050905080610128576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040161011f90610452565b60405180910390fd5b50508080600101915050610042565b505050565b5f604051905090565b5f5ffd5b5f5ffd5b5f5ffd5b5f5ffd5b5f5ffd5b5f5f83601f84011261016e5761016d61014d565b5b8235905067ffffffffffffffff81111561018b5761018a610151565b5b6020830191508360408202830111156101a7576101a6610155565b5b9250929050565b5f5f602083850312156101c4576101c3610145565b5b5f83013567ffffffffffffffff8111156101e1576101e0610149565b5b6101ed85828601610159565b92509250509250929050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b5f5ffd5b5f601f19601f8301169050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b6102708261022a565b810181811067ffffffffffffffff8211171561028f5761028e61023a565b5b80604052505050565b5f6102a161013c565b90506102ad8282610267565b919050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6102db826102b2565b9050919050565b6102eb816102d1565b81146102f5575f5ffd5b50565b5f81359050610306816102e2565b92915050565b5f819050919050565b61031e8161030c565b8114610328575f5ffd5b50565b5f8135905061033981610315565b92915050565b5f6040828403121561035457610353610226565b5b61035e6040610298565b90505f61036d848285016102f8565b5f8301525060206103808482850161032b565b60208301525092915050565b5f604082840312156103a1576103a0610145565b5b5f6103ae8482850161033f565b91505092915050565b5f81905092915050565b50565b5f6103cf5f836103b7565b91506103da826103c1565b5f82019050919050565b5f6103ee826103c4565b9150819050919050565b5f82825260208201905092915050565b7f63616c6c207265766572746564000000000000000000000000000000000000005f82015250565b5f61043c600d836103f8565b915061044782610408565b602082019050919050565b5f6020820190508181035f83015261046981610430565b905091905056fea264697066735822122027e940d6c5729c95c47d3beddf8305805a065e300adba87b7078b3cbb5e9355564736f6c634300081c0033",
+}
+
+// BatchABI is the input ABI used to generate the binding from.
+// Deprecated: Use BatchMetaData.ABI instead.
+var BatchABI = BatchMetaData.ABI
+
+// BatchBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use BatchMetaData.Bin instead.
+var BatchBin = BatchMetaData.Bin
+
+// DeployBatch deploys a new Ethereum contract, binding an instance of Batch to it.
+func DeployBatch(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Batch, error) {
+	parsed, err := BatchMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(BatchBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Batch{BatchCaller: BatchCaller{contract: contract}, BatchTransactor: BatchTransactor{contract: contract}, BatchFilterer: BatchFilterer{contract: contract}}, nil
+}
+
+// Batch is an auto generated Go binding around an Ethereum contract.
+type Batch struct {
+	BatchCaller     // Read-only binding to the contract
+	BatchTransactor // Write-only binding to the contract
+	BatchFilterer   // Log filterer for contract events
+}
+
+// BatchCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BatchCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BatchTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BatchTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BatchFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BatchFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BatchSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BatchSession struct {
+	Contract     *Batch            // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BatchCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BatchCallerSession struct {
+	Contract *BatchCaller  // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// BatchTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BatchTransactorSession struct {
+	Contract     *BatchTransactor  // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BatchRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BatchRaw struct {
+	Contract *Batch // Generic contract binding to access the raw methods on
+}
+
+// BatchCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BatchCallerRaw struct {
+	Contract *BatchCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BatchTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BatchTransactorRaw struct {
+	Contract *BatchTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBatch creates a new instance of Batch, bound to a specific deployed contract.
+func NewBatch(address common.Address, backend bind.ContractBackend) (*Batch, error) {
+	contract, err := bindBatch(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Batch{BatchCaller: BatchCaller{contract: contract}, BatchTransactor: BatchTransactor{contract: contract}, BatchFilterer: BatchFilterer{contract: contract}}, nil
+}
+
+// NewBatchCaller creates a new read-only instance of Batch, bound to a specific deployed contract.
+func NewBatchCaller(address common.Address, caller bind.ContractCaller) (*BatchCaller, error) {
+	contract, err := bindBatch(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchCaller{contract: contract}, nil
+}
+
+// NewBatchTransactor creates a new write-only instance of Batch, bound to a specific deployed contract.
+func NewBatchTransactor(address common.Address, transactor bind.ContractTransactor) (*BatchTransactor, error) {
+	contract, err := bindBatch(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchTransactor{contract: contract}, nil
+}
+
+// NewBatchFilterer creates a new log filterer instance of Batch, bound to a specific deployed contract.
+func NewBatchFilterer(address common.Address, filterer bind.ContractFilterer) (*BatchFilterer, error) {
+	contract, err := bindBatch(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BatchFilterer{contract: contract}, nil
+}
+
+// bindBatch binds a generic wrapper to an already deployed contract.
+func bindBatch(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BatchMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Batch *BatchRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Batch.Contract.BatchCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Batch *BatchRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Batch.Contract.BatchTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Batch *BatchRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Batch.Contract.BatchTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Batch *BatchCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Batch.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Batch *BatchTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Batch.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Batch *BatchTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Batch.Contract.contract.Transact(opts, method, params...)
+}
+
+// Execute is a paid mutator transaction binding the contract method 0x13426fdf.
+//
+// Solidity: function execute((address,uint256)[] calls) payable returns()
+func (_Batch *BatchTransactor) Execute(opts *bind.TransactOpts, calls []BatchCallDelegationCall) (*types.Transaction, error) {
+	return _Batch.contract.Transact(opts, "execute", calls)
+}
+
+// Execute is a paid mutator transaction binding the contract method 0x13426fdf.
+//
+// Solidity: function execute((address,uint256)[] calls) payable returns()
+func (_Batch *BatchSession) Execute(calls []BatchCallDelegationCall) (*types.Transaction, error) {
+	return _Batch.Contract.Execute(&_Batch.TransactOpts, calls)
+}
+
+// Execute is a paid mutator transaction binding the contract method 0x13426fdf.
+//
+// Solidity: function execute((address,uint256)[] calls) payable returns()
+func (_Batch *BatchTransactorSession) Execute(calls []BatchCallDelegationCall) (*types.Transaction, error) {
+	return _Batch.Contract.Execute(&_Batch.TransactOpts, calls)
+}

--- a/tests/contracts/batch/batch.sol
+++ b/tests/contracts/batch/batch.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// This contract is used to test Batching usage of SetCode transactions,
+// https://eips.ethereum.org/EIPS/eip-7702
+//
+// It is inspired by the example described in https://viem.sh/experimental/eip7702.
+// The code is for testing purposes and lacks of all the protections any production
+// code should have.
+contract BatchCallDelegation {
+    struct Call {
+        address payable to;
+        uint256 value;
+    }
+
+    function execute(Call[] calldata calls) external payable {
+        for (uint256 i = 0; i < calls.length; i++) {
+            Call memory call = calls[i];
+            (bool success, ) = call.to.call{value: call.value}("");
+            require(success, "call reverted");
+        }
+    }
+}

--- a/tests/contracts/batch/gen.go
+++ b/tests/contracts/batch/gen.go
@@ -1,0 +1,4 @@
+package batch
+
+//go:generate solc --bin batch.sol --abi batch.sol -o build --overwrite
+//go:generate abigen --bin=build/BatchCallDelegation.bin --abi=build/BatchCallDelegation.abi --pkg=batch --out=batch.go

--- a/tests/contracts/privilege_deescalation/gen.go
+++ b/tests/contracts/privilege_deescalation/gen.go
@@ -1,0 +1,4 @@
+package privilege_deescalation
+
+//go:generate solc --bin privilege_deescalation.sol --abi privilege_deescalation.sol -o build --overwrite
+//go:generate abigen --bin=build/PrivilegeDeescalation.bin --abi=build/PrivilegeDeescalation.abi --pkg=privilege_deescalation --out=privilege_deescalation.go

--- a/tests/contracts/privilege_deescalation/privilege_deescalation.go
+++ b/tests/contracts/privilege_deescalation/privilege_deescalation.go
@@ -1,0 +1,245 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package privilege_deescalation
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// PrivilegeDeescalationMetaData contains all meta data concerning the PrivilegeDeescalation contract.
+var PrivilegeDeescalationMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"allow_payment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"do_payment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f5ffd5b506105608061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610034575f3560e01c806351d1ddc014610038578063b006fdc014610054575b5f5ffd5b610052600480360381019061004d91906102ec565b610070565b005b61006e6004803603810190610069919061032a565b6101ab565b005b3373ffffffffffffffffffffffffffffffffffffffff165f5f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16146100fe576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016100f5906103d5565b60405180910390fd5b5f8273ffffffffffffffffffffffffffffffffffffffff168260405161012390610420565b5f6040518083038185875af1925050503d805f811461015d576040519150601f19603f3d011682016040523d82523d5f602084013e610162565b606091505b50509050806101a6576040517f08c379a000000000000000000000000000000000000000000000000000000000815260040161019d9061047e565b60405180910390fd5b505050565b3373ffffffffffffffffffffffffffffffffffffffff163073ffffffffffffffffffffffffffffffffffffffff1614610219576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016102109061050c565b60405180910390fd5b805f5f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555050565b5f5ffd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6102888261025f565b9050919050565b6102988161027e565b81146102a2575f5ffd5b50565b5f813590506102b38161028f565b92915050565b5f819050919050565b6102cb816102b9565b81146102d5575f5ffd5b50565b5f813590506102e6816102c2565b92915050565b5f5f604083850312156103025761030161025b565b5b5f61030f858286016102a5565b9250506020610320858286016102d8565b9150509250929050565b5f6020828403121561033f5761033e61025b565b5b5f61034c848285016102a5565b91505092915050565b5f82825260208201905092915050565b7f6f6e6c7920616c6c6f776564206164647265737365732063616e207472616e735f8201527f66657220666f756e647300000000000000000000000000000000000000000000602082015250565b5f6103bf602a83610355565b91506103ca82610365565b604082019050919050565b5f6020820190508181035f8301526103ec816103b3565b9050919050565b5f81905092915050565b50565b5f61040b5f836103f3565b9150610416826103fd565b5f82019050919050565b5f61042a82610400565b9150819050919050565b7f63616c6c207265766572746564000000000000000000000000000000000000005f82015250565b5f610468600d83610355565b915061047382610434565b602082019050919050565b5f6020820190508181035f8301526104958161045c565b9050919050565b7f6f6e6c7920746865206f776e206163636f756e742063616e206368616e6765205f8201527f616363657373206c697374000000000000000000000000000000000000000000602082015250565b5f6104f6602b83610355565b91506105018261049c565b604082019050919050565b5f6020820190508181035f830152610523816104ea565b905091905056fea2646970667358221220e56c2fa80cb67a4bf342b6f0bd0b9c5745467d9b7f9f0b7ae7c3085354134bb264736f6c634300081c0033",
+}
+
+// PrivilegeDeescalationABI is the input ABI used to generate the binding from.
+// Deprecated: Use PrivilegeDeescalationMetaData.ABI instead.
+var PrivilegeDeescalationABI = PrivilegeDeescalationMetaData.ABI
+
+// PrivilegeDeescalationBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use PrivilegeDeescalationMetaData.Bin instead.
+var PrivilegeDeescalationBin = PrivilegeDeescalationMetaData.Bin
+
+// DeployPrivilegeDeescalation deploys a new Ethereum contract, binding an instance of PrivilegeDeescalation to it.
+func DeployPrivilegeDeescalation(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *PrivilegeDeescalation, error) {
+	parsed, err := PrivilegeDeescalationMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(PrivilegeDeescalationBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &PrivilegeDeescalation{PrivilegeDeescalationCaller: PrivilegeDeescalationCaller{contract: contract}, PrivilegeDeescalationTransactor: PrivilegeDeescalationTransactor{contract: contract}, PrivilegeDeescalationFilterer: PrivilegeDeescalationFilterer{contract: contract}}, nil
+}
+
+// PrivilegeDeescalation is an auto generated Go binding around an Ethereum contract.
+type PrivilegeDeescalation struct {
+	PrivilegeDeescalationCaller     // Read-only binding to the contract
+	PrivilegeDeescalationTransactor // Write-only binding to the contract
+	PrivilegeDeescalationFilterer   // Log filterer for contract events
+}
+
+// PrivilegeDeescalationCaller is an auto generated read-only Go binding around an Ethereum contract.
+type PrivilegeDeescalationCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// PrivilegeDeescalationTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type PrivilegeDeescalationTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// PrivilegeDeescalationFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type PrivilegeDeescalationFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// PrivilegeDeescalationSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type PrivilegeDeescalationSession struct {
+	Contract     *PrivilegeDeescalation // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts          // Call options to use throughout this session
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// PrivilegeDeescalationCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type PrivilegeDeescalationCallerSession struct {
+	Contract *PrivilegeDeescalationCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                // Call options to use throughout this session
+}
+
+// PrivilegeDeescalationTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type PrivilegeDeescalationTransactorSession struct {
+	Contract     *PrivilegeDeescalationTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                // Transaction auth options to use throughout this session
+}
+
+// PrivilegeDeescalationRaw is an auto generated low-level Go binding around an Ethereum contract.
+type PrivilegeDeescalationRaw struct {
+	Contract *PrivilegeDeescalation // Generic contract binding to access the raw methods on
+}
+
+// PrivilegeDeescalationCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type PrivilegeDeescalationCallerRaw struct {
+	Contract *PrivilegeDeescalationCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// PrivilegeDeescalationTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type PrivilegeDeescalationTransactorRaw struct {
+	Contract *PrivilegeDeescalationTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewPrivilegeDeescalation creates a new instance of PrivilegeDeescalation, bound to a specific deployed contract.
+func NewPrivilegeDeescalation(address common.Address, backend bind.ContractBackend) (*PrivilegeDeescalation, error) {
+	contract, err := bindPrivilegeDeescalation(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &PrivilegeDeescalation{PrivilegeDeescalationCaller: PrivilegeDeescalationCaller{contract: contract}, PrivilegeDeescalationTransactor: PrivilegeDeescalationTransactor{contract: contract}, PrivilegeDeescalationFilterer: PrivilegeDeescalationFilterer{contract: contract}}, nil
+}
+
+// NewPrivilegeDeescalationCaller creates a new read-only instance of PrivilegeDeescalation, bound to a specific deployed contract.
+func NewPrivilegeDeescalationCaller(address common.Address, caller bind.ContractCaller) (*PrivilegeDeescalationCaller, error) {
+	contract, err := bindPrivilegeDeescalation(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &PrivilegeDeescalationCaller{contract: contract}, nil
+}
+
+// NewPrivilegeDeescalationTransactor creates a new write-only instance of PrivilegeDeescalation, bound to a specific deployed contract.
+func NewPrivilegeDeescalationTransactor(address common.Address, transactor bind.ContractTransactor) (*PrivilegeDeescalationTransactor, error) {
+	contract, err := bindPrivilegeDeescalation(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &PrivilegeDeescalationTransactor{contract: contract}, nil
+}
+
+// NewPrivilegeDeescalationFilterer creates a new log filterer instance of PrivilegeDeescalation, bound to a specific deployed contract.
+func NewPrivilegeDeescalationFilterer(address common.Address, filterer bind.ContractFilterer) (*PrivilegeDeescalationFilterer, error) {
+	contract, err := bindPrivilegeDeescalation(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &PrivilegeDeescalationFilterer{contract: contract}, nil
+}
+
+// bindPrivilegeDeescalation binds a generic wrapper to an already deployed contract.
+func bindPrivilegeDeescalation(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := PrivilegeDeescalationMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_PrivilegeDeescalation *PrivilegeDeescalationRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _PrivilegeDeescalation.Contract.PrivilegeDeescalationCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_PrivilegeDeescalation *PrivilegeDeescalationRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.PrivilegeDeescalationTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_PrivilegeDeescalation *PrivilegeDeescalationRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.PrivilegeDeescalationTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_PrivilegeDeescalation *PrivilegeDeescalationCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _PrivilegeDeescalation.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_PrivilegeDeescalation *PrivilegeDeescalationTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_PrivilegeDeescalation *PrivilegeDeescalationTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.contract.Transact(opts, method, params...)
+}
+
+// AllowPayment is a paid mutator transaction binding the contract method 0xb006fdc0.
+//
+// Solidity: function allow_payment(address account) returns()
+func (_PrivilegeDeescalation *PrivilegeDeescalationTransactor) AllowPayment(opts *bind.TransactOpts, account common.Address) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.contract.Transact(opts, "allow_payment", account)
+}
+
+// AllowPayment is a paid mutator transaction binding the contract method 0xb006fdc0.
+//
+// Solidity: function allow_payment(address account) returns()
+func (_PrivilegeDeescalation *PrivilegeDeescalationSession) AllowPayment(account common.Address) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.AllowPayment(&_PrivilegeDeescalation.TransactOpts, account)
+}
+
+// AllowPayment is a paid mutator transaction binding the contract method 0xb006fdc0.
+//
+// Solidity: function allow_payment(address account) returns()
+func (_PrivilegeDeescalation *PrivilegeDeescalationTransactorSession) AllowPayment(account common.Address) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.AllowPayment(&_PrivilegeDeescalation.TransactOpts, account)
+}
+
+// DoPayment is a paid mutator transaction binding the contract method 0x51d1ddc0.
+//
+// Solidity: function do_payment(address to, uint256 value) returns()
+func (_PrivilegeDeescalation *PrivilegeDeescalationTransactor) DoPayment(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.contract.Transact(opts, "do_payment", to, value)
+}
+
+// DoPayment is a paid mutator transaction binding the contract method 0x51d1ddc0.
+//
+// Solidity: function do_payment(address to, uint256 value) returns()
+func (_PrivilegeDeescalation *PrivilegeDeescalationSession) DoPayment(to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.DoPayment(&_PrivilegeDeescalation.TransactOpts, to, value)
+}
+
+// DoPayment is a paid mutator transaction binding the contract method 0x51d1ddc0.
+//
+// Solidity: function do_payment(address to, uint256 value) returns()
+func (_PrivilegeDeescalation *PrivilegeDeescalationTransactorSession) DoPayment(to common.Address, value *big.Int) (*types.Transaction, error) {
+	return _PrivilegeDeescalation.Contract.DoPayment(&_PrivilegeDeescalation.TransactOpts, to, value)
+}

--- a/tests/contracts/privilege_deescalation/privilege_deescalation.sol
+++ b/tests/contracts/privilege_deescalation/privilege_deescalation.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// This contract is used to test PrivilegeDeescalation usage of SetCode transactions,
+// https://eips.ethereum.org/EIPS/eip-7702
+//
+// The code is for testing purposes and lacks of all the protections any production
+// code should have.
+contract PrivilegeDeescalation {
+    address private authorizedAddress;
+
+    function do_payment(address to, uint256 value) external {
+        require(
+            authorizedAddress == msg.sender,
+            "only allowed addresses can transfer founds"
+        );
+        (bool success, ) = to.call{value: value}("");
+        require(success, "call reverted");
+    }
+
+    function allow_payment(address account) external {
+        require(
+            address(this) == msg.sender,
+            "only the own account can change access list"
+        );
+        authorizedAddress = account;
+    }
+}

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetCodeTransaction(t *testing.T) {
+	net, err := StartIntegrationTestNet(t.TempDir())
+	if err != nil {
+		t.Fatalf("Failed to start the fake network: %v", err)
+	}
+	defer net.Stop()
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// sponsor issues the SetCode transaction and pays for it
+	sponsor := makeAccountWithBalance(t, net, 1e18)
+	// sponsored is used as context for the call, its state will be modified
+	// without paying for the transaction
+	sponsored := makeAccountWithBalance(t, net, 0)
+
+	// Deploy the a contract to use as delegate
+	counter, receipt, err := DeployContract(net, counter.DeployCounter)
+	require.NoError(t, err)
+	delegate := receipt.ContractAddress
+
+	// Extract the call data of a normal call to the delegate contract
+	// to know the ABI encoding of the callData
+	txOpts, err := net.GetTransactOptions(&net.validator)
+	require.NoError(t, err)
+	tx, err := counter.IncrementCounter(txOpts)
+	require.NoError(t, err)
+	callData := tx.Data()
+
+	// Create a setCode transaction calling the incrementCounter function
+	// in the context of the sponsored account.
+	setCodeTx := makeEip7702Transaction(t, client, sponsor, sponsored, delegate, callData)
+	client.Close()
+	receipt, err = net.Run(setCodeTx)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	// read code at sponsored address, must contain the delegate address
+	code, err := client.CodeAt(context.Background(), sponsored.Address(), nil)
+	require.NoError(t, err)
+	expectedCode := append([]byte{0xef, 0x01, 0x00}, delegate[:]...)
+	require.Equal(t, expectedCode, code, "code in account is expected to be delegation designation")
+
+	// read storage at sponsored address (instead of contract address as in a normal tx)
+	// counter must exist and be 1
+	data, err := client.StorageAt(context.Background(), sponsored.Address(), common.Hash{}, nil)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(1), new(big.Int).SetBytes(data), "unexpected storage value")
+}
+
+// makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
+// and gas limit.
+func makeEip7702Transaction(t *testing.T,
+	client *ethclient.Client,
+	sponsor *Account, // signs and pays for the tx
+	sponsored *Account, // the account where the delegator will be written in
+	delegate common.Address, // the address of the delegate contract
+	callData []byte,
+
+) *types.Transaction {
+	t.Helper()
+
+	chainId, err := client.ChainID(context.Background())
+	require.NoError(t, err, "failed to get chain ID")
+
+	sponsoredNonce, err := client.NonceAt(context.Background(), sponsored.Address(), nil)
+	require.NoError(t, err, "failed to get nonce for account", sponsored.Address())
+
+	sponsorNonce, err := client.NonceAt(context.Background(), sponsor.Address(), nil)
+	require.NoError(t, err, "failed to get nonce for account", sponsor.Address())
+
+	authorization, err := types.SignSetCode(sponsored.PrivateKey, types.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainId),
+		Address: delegate,
+		Nonce:   sponsoredNonce,
+	})
+	require.NoError(t, err, "failed to sign SetCode authorization")
+
+	tx := types.NewTx(&types.SetCodeTx{
+		ChainID: uint256.MustFromBig(chainId),
+		Nonce:   sponsorNonce,
+		To:      sponsored.Address(),
+		Gas: 25_000 + // One entry in auth list
+			21_000 + // Base for not creating a contract
+			2400*2 + // Two addresses in access list
+			22_100 + // store cold data
+			5000, // some extra gas gas for other opcodes
+
+		GasFeeCap: uint256.NewInt(10e10),
+		AccessList: types.AccessList{
+			{Address: sponsored.Address()},
+			{Address: delegate},
+		},
+		AuthList: []types.SetCodeAuthorization{
+			authorization,
+		},
+		Data: callData,
+	})
+
+	signer := types.NewPragueSigner(chainId)
+	tx, err = types.SignTx(tx, signer, sponsor.PrivateKey)
+	require.NoError(t, err, "failed to sign transaction")
+	return tx
+}

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -5,20 +5,35 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/tests/contracts/batch"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSetCodeTransaction(t *testing.T) {
+
 	net, err := StartIntegrationTestNet(t.TempDir())
 	if err != nil {
 		t.Fatalf("Failed to start the fake network: %v", err)
 	}
 	defer net.Stop()
+
+	t.Run("Transaction Sponsoring", func(t *testing.T) {
+		testSponsoring(t, net)
+	})
+
+	t.Run("Transaction Batching", func(t *testing.T) {
+		testBatching(t, net)
+	})
+}
+
+func testSponsoring(t *testing.T, net *IntegrationTestNet) {
 	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
@@ -36,11 +51,9 @@ func TestSetCodeTransaction(t *testing.T) {
 
 	// Extract the call data of a normal call to the delegate contract
 	// to know the ABI encoding of the callData
-	txOpts, err := net.GetTransactOptions(&net.validator)
-	require.NoError(t, err)
-	tx, err := counter.IncrementCounter(txOpts)
-	require.NoError(t, err)
-	callData := tx.Data()
+	callData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return counter.IncrementCounter(opts)
+	})
 
 	// Create a setCode transaction calling the incrementCounter function
 	// in the context of the sponsored account.
@@ -50,17 +63,78 @@ func TestSetCodeTransaction(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-	// read code at sponsored address, must contain the delegate address
+	// Read code at sponsored address, must contain the delegate address
 	code, err := client.CodeAt(context.Background(), sponsored.Address(), nil)
 	require.NoError(t, err)
 	expectedCode := append([]byte{0xef, 0x01, 0x00}, delegate[:]...)
 	require.Equal(t, expectedCode, code, "code in account is expected to be delegation designation")
 
-	// read storage at sponsored address (instead of contract address as in a normal tx)
+	// Read storage at sponsored address (instead of contract address as in a normal tx)
 	// counter must exist and be 1
 	data, err := client.StorageAt(context.Background(), sponsored.Address(), common.Hash{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, big.NewInt(1), new(big.Int).SetBytes(data), "unexpected storage value")
+}
+
+func testBatching(t *testing.T, net *IntegrationTestNet) {
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// sender account batches multiple transfers of funds in a single transaction
+	// receivers will receive the funds
+	sender := makeAccountWithBalance(t, net, 1e18)
+	receiver1 := makeAccountWithBalance(t, net, 0)
+	receiver2 := makeAccountWithBalance(t, net, 0)
+
+	batchContract, deployReceipt, err := DeployContract(net, batch.DeployBatch)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, deployReceipt.Status)
+	batchContractAddress := deployReceipt.ContractAddress
+
+	// Extract the call data of a normal call to the delegate contract
+	// to know the ABI encoding of the callData.
+	// This code creates the Batch of calls, which the batch contract will execute
+	callData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return batchContract.Execute(opts, []batch.BatchCallDelegationCall{
+			{
+				To:    receiver1.Address(),
+				Value: big.NewInt(1234),
+			},
+			{
+				To:    receiver2.Address(),
+				Value: big.NewInt(4321),
+			},
+		})
+	})
+
+	// Send a SetCode transaction to the batch contract
+	tx := makeEip7702Transaction(t, client, sender, sender, batchContractAddress, callData)
+	batchReceipt, err := net.Run(tx)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, batchReceipt.Status)
+
+	// Check that the sender has paid for the transaction
+	effectiveCost := new(big.Int)
+	effectiveCost = effectiveCost.Mul(
+		batchReceipt.EffectiveGasPrice,
+		big.NewInt(int64(batchReceipt.GasUsed)))
+	effectiveCost = effectiveCost.Add(effectiveCost, big.NewInt(1234+4321))
+
+	balance, err := client.BalanceAt(context.Background(), sender.Address(), nil)
+	require.NoError(t, err)
+	assert.Equal(t,
+		new(big.Int).Sub(
+			big.NewInt(1e18), effectiveCost), balance)
+
+	// Check that the receivers have received the funds
+	balance1, err := client.BalanceAt(context.Background(), receiver1.Address(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(1234), balance1)
+
+	balance2, err := client.BalanceAt(context.Background(), receiver2.Address(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(4321), balance2)
 }
 
 // makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
@@ -71,7 +145,6 @@ func makeEip7702Transaction(t *testing.T,
 	sponsored *Account, // the account where the delegator will be written in
 	delegate common.Address, // the address of the delegate contract
 	callData []byte,
-
 ) *types.Transaction {
 	t.Helper()
 
@@ -84,28 +157,28 @@ func makeEip7702Transaction(t *testing.T,
 	sponsorNonce, err := client.NonceAt(context.Background(), sponsor.Address(), nil)
 	require.NoError(t, err, "failed to get nonce for account", sponsor.Address())
 
+	// If self sponsored, there are two nonces values to take care of, the transaction
+	// nonce and the authorization nonce. The authorization nonce is checked after
+	// the transaction has incremented nonce. Therefore, the authorization nonce
+	// needs to be 1 higher than the transaction nonce.
+	nonceIncrement := uint64(0)
+	if sponsor == sponsored {
+		nonceIncrement = 1
+	}
+
 	authorization, err := types.SignSetCode(sponsored.PrivateKey, types.SetCodeAuthorization{
 		ChainID: *uint256.MustFromBig(chainId),
 		Address: delegate,
-		Nonce:   sponsoredNonce,
+		Nonce:   sponsoredNonce + nonceIncrement,
 	})
 	require.NoError(t, err, "failed to sign SetCode authorization")
 
 	tx := types.NewTx(&types.SetCodeTx{
-		ChainID: uint256.MustFromBig(chainId),
-		Nonce:   sponsorNonce,
-		To:      sponsored.Address(),
-		Gas: 25_000 + // One entry in auth list
-			21_000 + // Base for not creating a contract
-			2400*2 + // Two addresses in access list
-			22_100 + // store cold data
-			5000, // some extra gas gas for other opcodes
-
+		ChainID:   uint256.MustFromBig(chainId),
+		Nonce:     sponsorNonce,
+		To:        sponsored.Address(),
+		Gas:       150_000,
 		GasFeeCap: uint256.NewInt(10e10),
-		AccessList: types.AccessList{
-			{Address: sponsored.Address()},
-			{Address: delegate},
-		},
 		AuthList: []types.SetCodeAuthorization{
 			authorization,
 		},
@@ -116,4 +189,17 @@ func makeEip7702Transaction(t *testing.T,
 	tx, err = types.SignTx(tx, signer, sponsor.PrivateKey)
 	require.NoError(t, err, "failed to sign transaction")
 	return tx
+}
+
+// getCallData creates a transaction and returns the data field of the transaction.
+// This function can be used to retrieve the ABI encoding of a the call data, and
+// use such encoding to create a SetCode transaction.
+func getCallData(t *testing.T, net *IntegrationTestNet,
+	transactionConstructor func(*bind.TransactOpts) (*types.Transaction, error)) []byte {
+	txOpts, err := net.GetTransactOptions(&net.validator)
+	require.NoError(t, err)
+	txOpts.NoSend = true // <- create the transaction to read callData, but do not send it.
+	tx, err := transactionConstructor(txOpts)
+	require.NoError(t, err)
+	return tx.Data()
 }

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSetCodeTransaction tests the SetCode transaction type use cases
+// described in the EIP-7702 specification: https://eips.ethereum.org/EIPS/eip-7702
+// Notice that the test contracts used in this test model the expected behavior
+// and do not implement ERC-20 as described in the EIP use case examples.
 func TestSetCodeTransaction(t *testing.T) {
 
 	net, err := StartIntegrationTestNet(t.TempDir())
@@ -39,6 +43,12 @@ func TestSetCodeTransaction(t *testing.T) {
 }
 
 func testSponsoring(t *testing.T, net *IntegrationTestNet) {
+
+	// This test executes a transaction in behalf of another account:
+	// - The sponsor account pays for the gas for the transaction
+	// - The sponsored account is the context of the transaction, and its state is modified
+	// - The delegate account is the contract that will be executed
+
 	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
@@ -82,6 +92,12 @@ func testSponsoring(t *testing.T, net *IntegrationTestNet) {
 }
 
 func testBatching(t *testing.T, net *IntegrationTestNet) {
+
+	// This test executes multiple funds transfers within a single transaction:
+	// - The sponsor and sponsored accounts are the same, this is a self-sponsored transaction.
+	// - The delegate account is the contract that will be executed, which implements the batch of calls
+	// - Multiple receiver accounts will receive the funds
+
 	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
@@ -143,15 +159,17 @@ func testBatching(t *testing.T, net *IntegrationTestNet) {
 }
 
 func testPrivilegeDeescalation(t *testing.T, net *IntegrationTestNet) {
+
 	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	// this tests the privilege deescalation pattern
-	// where an account can allow a second account to execute certain operations
-	// on its behalf.
-	// In this test the account will allow a second account to transfer funds to
-	// the receiver account.
+	// This test executes a transaction in behalf of another account, using
+	// the privilege deescalation pattern:
+	// - Account A allows account B to execute certain operations on its behalf
+	// - Account B (userAccount) pays for the gas for the transaction
+	// - Account A (account) is the context of the transaction, and its state is modified
+	// - Some part of the contract interface (DoPayment) is executable from account B
 	account := makeAccountWithBalance(t, net, 1e18)
 	userAccount := makeAccountWithBalance(t, net, 1e18)
 	receiver := makeAccountWithBalance(t, net, 0)

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -44,7 +44,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		var specifiedPrice int64 = enoughGasPrice
 
 		// 2: make & execute transaction
-		tx := makeLegacyTx(t, client, specifiedPrice, account)
+		tx := makeLegacyTx(t, client, specifiedPrice, account, &common.Address{}, nil)
 
 		receipt, err := net.Run(tx)
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		const maxGasPrice int64 = enoughGasPrice
 
 		// 2: make & execute transaction
-		tx := makeEip1559Transaction(t, client, maxGasPrice, 0, account)
+		tx := makeEip1559Transaction(t, client, maxGasPrice, 0, account, &common.Address{}, nil)
 
 		receipt, err := net.Run(tx)
 		require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		const tip = 17
 
 		// 2: make & execute transaction
-		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account)
+		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account, &common.Address{}, nil)
 
 		receipt, err := net.Run(tx)
 		require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		const tip = maxGasPrice // tip cannot be larger than max gas price
 
 		// 2: make & execute transaction
-		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account)
+		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account, &common.Address{}, nil)
 
 		receipt, err := net.Run(tx)
 		require.NoError(t, err)
@@ -297,6 +297,8 @@ func makeLegacyTx(t *testing.T,
 	client *ethclient.Client,
 	gasPrice int64,
 	sender *Account,
+	to *common.Address,
+	data []byte,
 ) *types.Transaction {
 	t.Helper()
 
@@ -305,10 +307,11 @@ func makeLegacyTx(t *testing.T,
 
 	tx := types.NewTx(&types.LegacyTx{
 		Nonce:    nonce,
-		To:       &common.Address{},
+		To:       to,
 		Value:    big.NewInt(1),
 		Gas:      1e6,
 		GasPrice: big.NewInt(gasPrice),
+		Data:     data,
 	})
 
 	chainId, err := client.ChainID(context.Background())
@@ -327,6 +330,8 @@ func makeEip1559Transaction(t *testing.T,
 	maxFeeCap int64,
 	maxGasTip int64,
 	sender *Account,
+	to *common.Address,
+	data []byte,
 ) *types.Transaction {
 	t.Helper()
 
@@ -335,11 +340,12 @@ func makeEip1559Transaction(t *testing.T,
 
 	tx := types.NewTx(&types.DynamicFeeTx{
 		Nonce:     nonce,
-		To:        &common.Address{},
+		To:        to,
 		Value:     big.NewInt(1),
 		Gas:       1e6,
 		GasFeeCap: big.NewInt(maxFeeCap),
 		GasTipCap: big.NewInt(maxGasTip),
+		Data:      data,
 	})
 
 	chainId, err := client.ChainID(context.Background())


### PR DESCRIPTION
This PR depends on #56. Without it, it cannot be executed. 

This PR introduces a unit test for the [EIP-7702 transaction type](https://eips.ethereum.org/EIPS/eip-7702)

The proposed test has the following structure:
```
--- PASS: TestSetCodeTransaction (96.36s)
    --- PASS: TestSetCodeTransaction/Operation (59.43s)
        --- PASS: TestSetCodeTransaction/Operation/Delegate_can_be_set_and_unset (6.74s)
        --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored (32.71s)
            --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_low (10.87s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_low/single_wrong_authorization (3.62s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_low/before_correct_authorization (3.62s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_low/after_correct_authorization (3.62s)
            --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_high (10.97s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_high/single_wrong_authorization (3.62s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_high/before_correct_authorization (3.72s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/authorization_nonce_too_high/after_correct_authorization (3.63s)
            --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/wrong_chain_id (10.87s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/wrong_chain_id/single_wrong_authorization (3.62s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/wrong_chain_id/before_correct_authorization (3.62s)
                --- PASS: TestSetCodeTransaction/Operation/Invalid_authorizations_are_ignored/wrong_chain_id/after_correct_authorization (3.63s)
        --- PASS: TestSetCodeTransaction/Operation/Authorizations_are_executed_in_order (3.63s)
        --- PASS: TestSetCodeTransaction/Operation/Multiple_accounts_can_submit_authorizations (7.26s)
        --- PASS: TestSetCodeTransaction/Operation/Authorization_succeeds_with_failing_tx (5.48s)
        --- PASS: TestSetCodeTransaction/Operation/Authorization_can_be_issued_from_a_non_existing_account (3.62s)
    --- PASS: TestSetCodeTransaction/UseCase (32.64s)
        --- PASS: TestSetCodeTransaction/UseCase/Transaction_Sponsoring (7.25s)
        --- PASS: TestSetCodeTransaction/UseCase/Transaction_Batching (9.02s)
        --- PASS: TestSetCodeTransaction/UseCase/Privilege_Deescalation (16.37s)
PASS

```

- Operation tests check important properties common to the use of the new `SetCodeTx` transaction type.
- Use case tests check examples of the proposed test use cases described in the [eip](https://eips.ethereum.org/EIPS/eip-7702)
   - Batching: where an account can batch several operations together, which would require of a series of transactions before.
   - Sponsoring: where an account can pay for the execution costs of another account's transaction.
   - Privilege deescalation: where an account allows access to internal state in a restricted manner to a second account.
   
Although all the tests have been written in a single file, the review can be done following the commit order, to see the addition of each case independently.
 

this PR releatest to:
- https://github.com/0xsoniclabs/sonic-admin/issues/30
- https://github.com/0xsoniclabs/sonic-admin/issues/28