### PR TITLE
Fix JSON encoding of empty BitSets

### DIFF
--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -1,6 +1,7 @@
 package cert
 
 import (
+	"encoding/json"
 	"math/rand/v2"
 	"testing"
 
@@ -97,4 +98,17 @@ func TestBitSet_InvalidUnmarshalJSON(t *testing.T) {
 	var b BitSet[uint8]
 	err := b.UnmarshalJSON([]byte(`"g"`))
 	require.Error(err)
+}
+
+func TestBitSet_EmptySet_CanBeMarshalledAndUnmarshalled(t *testing.T) {
+	require := require.New(t)
+
+	var b BitSet[uint8]
+	data, err := json.Marshal(b)
+	require.NoError(err)
+
+	var b2 BitSet[uint8]
+	err = json.Unmarshal(data, &b2)
+	require.NoError(err)
+	require.Equal([]uint8{}, b2.Entries())
 }

--- a/utils/jsonhex/types.go
+++ b/utils/jsonhex/types.go
@@ -23,7 +23,7 @@ func (h *Bytes) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	if s == "null" {
+	if s == "null"{
 		*h = nil
 		return nil
 	}
@@ -45,7 +45,7 @@ func (h *Bytes) UnmarshalJSON(data []byte) error {
 // String returns the hex string representation of Bytes.
 func (h Bytes) String() string {
 	if len(h) == 0 {
-		return "null"
+		return `"null"`
 	}
 	return fmt.Sprintf(`"0x%x"`, []byte(h))
 }

--- a/utils/jsonhex/types_test.go
+++ b/utils/jsonhex/types_test.go
@@ -8,22 +8,20 @@ import (
 )
 
 func TestBytes_MarshalJSON_HandlesAllCases(t *testing.T) {
-	h := Bytes([]byte{0x01, 0x2a, 0xbc})
-	data, err := h.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, []byte(`"0x012abc"`), data)
-	h = nil
-	data, err = h.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, []byte("null"), data)
-	h = Bytes([]byte{})
-	data, err = h.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, []byte("null"), data)
-	h = Bytes([]byte{0x1, 0x2a, 0xbc})
-	data, err = h.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, []byte(`"0x012abc"`), data)
+	tests := []struct {
+		input  Bytes
+		output string
+	}{
+		{nil, `"null"`},
+		{[]byte{}, `"null"`},
+		{[]byte{0x01, 0x2a, 0xbc}, `"0x012abc"`},
+	}
+
+	for _, test := range tests {
+		data, err := test.input.MarshalJSON()
+		require.NoError(t, err)
+		require.Equal(t, test.output, string(data))
+	}
 }
 
 func TestBytes_UnmarshalJSON_ValidHexString_DoesNotProduceError(t *testing.T) {
@@ -51,7 +49,7 @@ func TestBytes_String_IsCorrectlyProduced(t *testing.T) {
 	h := Bytes([]byte{0x01, 0x2a, 0xbc})
 	require.Equal(t, `"0x012abc"`, h.String())
 	h = nil
-	require.Equal(t, `null`, h.String())
+	require.Equal(t, `"null"`, h.String())
 }
 
 func TestBytes_CanBeJSONEncodedAndDecoded(t *testing.T) {


### PR DESCRIPTION
This PR fixes the encoding of empty BitSets into JSON by fixing the same issue for the `jsonhex.Bytes` type.