### PR TITLE
use json null instead of "null" in certificate encoding

### DIFF
--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -100,7 +100,7 @@ func TestBitSet_InvalidUnmarshalJSON(t *testing.T) {
 	require.Error(err)
 }
 
-func TestBitSet_EmptySet_CanBeMarshalledAndUnmarshalled(t *testing.T) {
+func TestBitSet_EmptySet_CanBeMarshalledAndUnmarshaled(t *testing.T) {
 	require := require.New(t)
 
 	var b BitSet[uint8]

--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -100,7 +100,7 @@ func TestBitSet_InvalidUnmarshalJSON(t *testing.T) {
 	require.Error(err)
 }
 
-func TestBitSet_EmptySet_CanBeMarshalledAndUnmarshaled(t *testing.T) {
+func TestBitSet_EmptySet_CanBeMarshaledAndUnmarshaled(t *testing.T) {
 	require := require.New(t)
 
 	var b BitSet[uint8]

--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -78,7 +78,7 @@ func TestBitSet_MarshalJSON(t *testing.T) {
 	b.Add(1)
 	b.Add(12)
 	b.Add(123)
-	data, err := b.MarshalJSON()
+	data, err := json.Marshal(b)
 	require.NoError(err)
 	require.Equal(`"0x02100000000000000000000000000008"`, string(data))
 }
@@ -87,7 +87,7 @@ func TestBitSet_UnmarshalJSON(t *testing.T) {
 	require := require.New(t)
 
 	var b BitSet[uint8]
-	err := b.UnmarshalJSON([]byte(`"0x02100000000000000000000000000008"`))
+	err := json.Unmarshal([]byte(`"0x02100000000000000000000000000008"`), &b)
 	require.NoError(err)
 	require.Equal([]uint8{1, 12, 123}, b.Entries())
 }
@@ -96,7 +96,7 @@ func TestBitSet_InvalidUnmarshalJSON(t *testing.T) {
 	require := require.New(t)
 
 	var b BitSet[uint8]
-	err := b.UnmarshalJSON([]byte(`"g"`))
+	err := json.Unmarshal([]byte(`"g"`), &b)
 	require.Error(err)
 }
 

--- a/utils/jsonhex/types.go
+++ b/utils/jsonhex/types.go
@@ -49,9 +49,6 @@ func (h Bytes) String() string {
 	if h == nil {
 		return `null`
 	}
-	if len(h) == 0 {
-		return `"0x"`
-	}
 	return fmt.Sprintf(`"0x%x"`, []byte(h))
 }
 

--- a/utils/jsonhex/types.go
+++ b/utils/jsonhex/types.go
@@ -27,6 +27,10 @@ func (h *Bytes) UnmarshalJSON(data []byte) error {
 		*h = nil
 		return nil
 	}
+	if s == `""` {
+		h = &Bytes{}
+		return nil
+	}
 	if !strings.HasPrefix(s, "0x") {
 		return fmt.Errorf("invalid hex string %s", s)
 	}
@@ -46,6 +50,9 @@ func (h *Bytes) UnmarshalJSON(data []byte) error {
 func (h Bytes) String() string {
 	if h == nil {
 		return `null`
+	}
+	if len(h) == 0 {
+		return `""`
 	}
 	return fmt.Sprintf(`"0x%x"`, []byte(h))
 }

--- a/utils/jsonhex/types.go
+++ b/utils/jsonhex/types.go
@@ -18,15 +18,17 @@ func (h Bytes) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON parses a JSON hex string into a Bytes.
 // The input string must have a "0x" prefix or be "null".
 func (h *Bytes) UnmarshalJSON(data []byte) error {
-	var s string
-	err := json.Unmarshal(data, &s)
+	var rawData json.RawMessage
+	err := json.Unmarshal(data, &rawData)
+	s := string(rawData)
 	if err != nil {
 		return err
 	}
-	if s == `` {
+	if s == `null` {
 		*h = nil
 		return nil
 	}
+	s = strings.Trim(s, `\"`)
 	if !strings.HasPrefix(s, "0x") {
 		return fmt.Errorf("invalid hex string %s", s)
 	}

--- a/utils/jsonhex/types.go
+++ b/utils/jsonhex/types.go
@@ -23,12 +23,8 @@ func (h *Bytes) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	if s == "null" {
+	if s == `` {
 		*h = nil
-		return nil
-	}
-	if s == `""` {
-		h = &Bytes{}
 		return nil
 	}
 	if !strings.HasPrefix(s, "0x") {
@@ -52,7 +48,7 @@ func (h Bytes) String() string {
 		return `null`
 	}
 	if len(h) == 0 {
-		return `""`
+		return `"0x"`
 	}
 	return fmt.Sprintf(`"0x%x"`, []byte(h))
 }

--- a/utils/jsonhex/types.go
+++ b/utils/jsonhex/types.go
@@ -45,7 +45,7 @@ func (h *Bytes) UnmarshalJSON(data []byte) error {
 // String returns the hex string representation of Bytes.
 func (h Bytes) String() string {
 	if h == nil {
-		return `"null"`
+		return `null`
 	}
 	return fmt.Sprintf(`"0x%x"`, []byte(h))
 }

--- a/utils/jsonhex/types_test.go
+++ b/utils/jsonhex/types_test.go
@@ -36,21 +36,21 @@ func TestBytes_JsonEncoding_MapsToProperEncodingAndCanBeDecoded(t *testing.T) {
 func TestBytes_UnmarshalJSON_ValidHexString_DoesNotProduceError(t *testing.T) {
 	var h Bytes
 	data := []byte(`"0x012abc"`)
-	require.NoError(t, h.UnmarshalJSON(data))
+	require.NoError(t, json.Unmarshal(data, &h))
 	data = []byte(`null`)
-	require.NoError(t, h.UnmarshalJSON(data))
+	require.NoError(t, json.Unmarshal(data, &h))
 	data = []byte(`"0x12abc"`)
-	require.NoError(t, h.UnmarshalJSON(data))
+	require.NoError(t, json.Unmarshal(data, &h))
 	require.Equal(t, Bytes([]byte{0x1, 0x2a, 0xbc}), h)
 }
 
 func TestBytes_UnmarshalJSON_InvalidHexString_ProducesError(t *testing.T) {
 	var h Bytes
 	data := []byte(`"0xg"`)
-	err := h.UnmarshalJSON(data)
+	err := json.Unmarshal(data, &h)
 	require.Error(t, err)
 	data = []byte(`"01"`)
-	err = h.UnmarshalJSON(data)
+	err = json.Unmarshal(data, &h)
 	require.Error(t, err)
 }
 
@@ -60,7 +60,7 @@ func TestBytes_String_IsCorrectlyProduced(t *testing.T) {
 	h = nil
 	require.Equal(t, `null`, h.String())
 	h = []byte{}
-	require.Equal(t, `""`, h.String())
+	require.Equal(t, `"0x"`, h.String())
 }
 
 func TestBytes_CanBeJSONEncodedAndDecoded(t *testing.T) {
@@ -75,7 +75,7 @@ func TestBytes_CanBeJSONEncodedAndDecoded(t *testing.T) {
 
 func TestBytes48_MarshalJSON_StringIsCorrectlyProduced(t *testing.T) {
 	p := Bytes48([48]byte{0x01})
-	data, err := p.MarshalJSON()
+	data, err := json.Marshal(p)
 	require.NoError(t, err)
 	expected := `"0x010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"`
 	require.Equal(t, []byte(expected), data)
@@ -83,7 +83,7 @@ func TestBytes48_MarshalJSON_StringIsCorrectlyProduced(t *testing.T) {
 
 func TestBytes48_MarshalJSON_ZeroValue(t *testing.T) {
 	var p Bytes48
-	data, err := p.MarshalJSON()
+	data, err := json.Marshal(p)
 	require.NoError(t, err)
 	require.Equal(t, []byte(`"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"`), data)
 }
@@ -91,14 +91,14 @@ func TestBytes48_MarshalJSON_ZeroValue(t *testing.T) {
 func TestBytes48_UnmarshalJSON_TooShortHexStringIsRejected(t *testing.T) {
 	var p Bytes48
 	data := []byte(`"0x1234567"`)
-	err := p.UnmarshalJSON(data)
+	err := json.Unmarshal(data, &p)
 	require.Error(t, err)
 }
 
 func TestBytes48_UnmarshalJSON_ValidHexString(t *testing.T) {
 	var p Bytes48
 	data := []byte(`"0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"`)
-	err := p.UnmarshalJSON(data)
+	err := json.Unmarshal(data, &p)
 	require.NoError(t, err)
 	want := Bytes48{0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}
 	require.Equal(t, want, p)
@@ -122,7 +122,7 @@ func TestBytes48_CanBeJsonEncodedAndDecoded(t *testing.T) {
 
 func TestBytes96_MarshalJSON(t *testing.T) {
 	s := Bytes96([96]byte{0x01})
-	data, err := s.MarshalJSON()
+	data, err := json.Marshal(s)
 	require.NoError(t, err)
 	expected := []byte(`"0x010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"`)
 	require.Equal(t, len(expected), len(data))
@@ -132,15 +132,15 @@ func TestBytes96_MarshalJSON(t *testing.T) {
 func TestBytes96_UnmarshalJSON_ShortHexString(t *testing.T) {
 	var s Bytes96
 	data := []byte(`0x1234567`)
-	require.Error(t, s.UnmarshalJSON(data))
+	require.Error(t, json.Unmarshal(data, &s))
 	data = []byte(`0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef`)
-	require.Error(t, s.UnmarshalJSON(data))
+	require.Error(t, json.Unmarshal(data, &s))
 }
 
 func TestBytes96_UnmarshalJSON_ValidHexString(t *testing.T) {
 	var s Bytes96
 	data := []byte(`"0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"`)
-	require.NoError(t, s.UnmarshalJSON(data))
+	require.NoError(t, json.Unmarshal(data, &s))
 	want := Bytes96{0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x1, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}
 	require.Equal(t, want, s)
 }

--- a/utils/jsonhex/types_test.go
+++ b/utils/jsonhex/types_test.go
@@ -45,13 +45,16 @@ func TestBytes_UnmarshalJSON_ValidHexString_DoesNotProduceError(t *testing.T) {
 }
 
 func TestBytes_UnmarshalJSON_InvalidHexString_ProducesError(t *testing.T) {
-	var h Bytes
-	data := []byte(`"0xg"`)
-	err := json.Unmarshal(data, &h)
-	require.Error(t, err)
-	data = []byte(`"01"`)
-	err = json.Unmarshal(data, &h)
-	require.Error(t, err)
+	tests := []string{
+		`"0xg"`,
+		`"01"`,
+		`""`,
+	}
+	for _, data := range tests {
+		var h Bytes
+		err := json.Unmarshal([]byte(data), &h)
+		require.Error(t, err)
+	}
 }
 
 func TestBytes_String_IsCorrectlyProduced(t *testing.T) {

--- a/utils/jsonhex/types_test.go
+++ b/utils/jsonhex/types_test.go
@@ -12,7 +12,7 @@ func TestBytes_JsonEncoding_MapsToProperEncodingAndCanBeDecoded(t *testing.T) {
 		bytes Bytes
 		json  string
 	}{
-		{nil, `"null"`},
+		{nil, `null`},
 		{[]byte{}, `"0x"`},
 		{[]byte{0x1a}, `"0x1a"`},
 		{[]byte{0x01, 0x2a, 0xbc}, `"0x012abc"`},
@@ -37,7 +37,7 @@ func TestBytes_UnmarshalJSON_ValidHexString_DoesNotProduceError(t *testing.T) {
 	var h Bytes
 	data := []byte(`"0x012abc"`)
 	require.NoError(t, h.UnmarshalJSON(data))
-	data = []byte(`"null"`)
+	data = []byte(`null`)
 	require.NoError(t, h.UnmarshalJSON(data))
 	data = []byte(`"0x12abc"`)
 	require.NoError(t, h.UnmarshalJSON(data))
@@ -58,7 +58,7 @@ func TestBytes_String_IsCorrectlyProduced(t *testing.T) {
 	h := Bytes([]byte{0x01, 0x2a, 0xbc})
 	require.Equal(t, `"0x012abc"`, h.String())
 	h = nil
-	require.Equal(t, `"null"`, h.String())
+	require.Equal(t, `null`, h.String())
 }
 
 func TestBytes_CanBeJSONEncodedAndDecoded(t *testing.T) {

--- a/utils/jsonhex/types_test.go
+++ b/utils/jsonhex/types_test.go
@@ -59,6 +59,8 @@ func TestBytes_String_IsCorrectlyProduced(t *testing.T) {
 	require.Equal(t, `"0x012abc"`, h.String())
 	h = nil
 	require.Equal(t, `null`, h.String())
+	h = []byte{}
+	require.Equal(t, `""`, h.String())
 }
 
 func TestBytes_CanBeJSONEncodedAndDecoded(t *testing.T) {


### PR DESCRIPTION
This PR changes jsonhex.Byte encoding so that `nil` byte slices are encoded as the JSON null value instead of the string "null". 