### PR TITLE
Implement EIP-7702 support in rpc calls.

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1287,27 +1287,28 @@ func RPCMarshalBlock(block *evmcore.EvmBlock, receipts types.Receipts, inclTx bo
 
 // RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
 type RPCTransaction struct {
-	BlockHash           *common.Hash      `json:"blockHash"`
-	BlockNumber         *hexutil.Big      `json:"blockNumber"`
-	From                common.Address    `json:"from"`
-	Gas                 hexutil.Uint64    `json:"gas"`
-	GasPrice            *hexutil.Big      `json:"gasPrice"`
-	GasFeeCap           *hexutil.Big      `json:"maxFeePerGas,omitempty"`
-	GasTipCap           *hexutil.Big      `json:"maxPriorityFeePerGas,omitempty"`
-	Hash                common.Hash       `json:"hash"`
-	Input               hexutil.Bytes     `json:"input"`
-	Nonce               hexutil.Uint64    `json:"nonce"`
-	To                  *common.Address   `json:"to"`
-	TransactionIndex    *hexutil.Uint64   `json:"transactionIndex"`
-	Value               *hexutil.Big      `json:"value"`
-	Type                hexutil.Uint64    `json:"type"`
-	Accesses            *types.AccessList `json:"accessList,omitempty"`
-	ChainID             *hexutil.Big      `json:"chainId,omitempty"`
-	V                   *hexutil.Big      `json:"v"`
-	R                   *hexutil.Big      `json:"r"`
-	S                   *hexutil.Big      `json:"s"`
-	MaxFeePerBlobGas    *hexutil.Big      `json:"maxFeePerBlobGas"`
-	BlobVersionedHashes []common.Hash     `json:"blobVersionedHashes"`
+	BlockHash           *common.Hash                 `json:"blockHash"`
+	BlockNumber         *hexutil.Big                 `json:"blockNumber"`
+	From                common.Address               `json:"from"`
+	Gas                 hexutil.Uint64               `json:"gas"`
+	GasPrice            *hexutil.Big                 `json:"gasPrice"`
+	GasFeeCap           *hexutil.Big                 `json:"maxFeePerGas,omitempty"`
+	GasTipCap           *hexutil.Big                 `json:"maxPriorityFeePerGas,omitempty"`
+	Hash                common.Hash                  `json:"hash"`
+	Input               hexutil.Bytes                `json:"input"`
+	Nonce               hexutil.Uint64               `json:"nonce"`
+	To                  *common.Address              `json:"to"`
+	TransactionIndex    *hexutil.Uint64              `json:"transactionIndex"`
+	Value               *hexutil.Big                 `json:"value"`
+	Type                hexutil.Uint64               `json:"type"`
+	Accesses            *types.AccessList            `json:"accessList,omitempty"`
+	ChainID             *hexutil.Big                 `json:"chainId,omitempty"`
+	V                   *hexutil.Big                 `json:"v"`
+	R                   *hexutil.Big                 `json:"r"`
+	S                   *hexutil.Big                 `json:"s"`
+	MaxFeePerBlobGas    *hexutil.Big                 `json:"maxFeePerBlobGas"`
+	BlobVersionedHashes []common.Hash                `json:"blobVersionedHashes"`
+	AuthorizationList   []types.SetCodeAuthorization `json:"authorizationList,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -1372,6 +1373,10 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		}
 	}
 
+	copyAuthorizationList := func(tx *types.Transaction, result *RPCTransaction) {
+		result.AuthorizationList = tx.SetCodeAuthorizations()
+	}
+
 	switch tx.Type() {
 	case types.AccessListTxType:
 		copyAccessList(tx, result)
@@ -1384,6 +1389,10 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		copyAccessList(tx, result)
 		copyDynamicPricingFields(tx, result)
 		copyBlobFields(tx, result)
+	case types.SetCodeTxType:
+		copyAccessList(tx, result)
+		copyDynamicPricingFields(tx, result)
+		copyAuthorizationList(tx, result)
 	}
 	return result
 }

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -2,6 +2,8 @@ package ethapi
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	reflect "reflect"
@@ -398,4 +400,236 @@ func setExpectedStateCalls(mockState *state.MockStateDB) {
 	mockState.EXPECT().EndTransaction().AnyTimes()
 	mockState.EXPECT().GetLogs(any, any).AnyTimes()
 	mockState.EXPECT().TxIndex().AnyTimes()
+}
+
+func TestTransactionJSONSerialization(t *testing.T) {
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	authorization := types.SetCodeAuthorization{
+		ChainID: *uint256.NewInt(17),
+		Address: common.Address{42},
+		Nonce:   5,
+		V:       1,
+		R:       *uint256.NewInt(2),
+		S:       *uint256.NewInt(3),
+	}
+
+	tests := map[string]any{
+		"legacy": &types.LegacyTx{
+			Nonce:    0,
+			To:       &common.Address{1},
+			Gas:      1e6,
+			GasPrice: big.NewInt(500e9),
+		},
+		"accessList empty list": &types.AccessListTx{
+			Nonce:    1,
+			To:       &common.Address{1},
+			Gas:      1e6,
+			GasPrice: big.NewInt(500e9),
+		},
+		"accessList": &types.AccessListTx{
+			Nonce:    1,
+			To:       &common.Address{1},
+			Gas:      1e6,
+			GasPrice: big.NewInt(500e9),
+			AccessList: types.AccessList{
+				{Address: common.Address{1}, StorageKeys: []common.Hash{{0x01}}},
+			},
+		},
+		"dynamicFee": &types.DynamicFeeTx{
+			Nonce:     2,
+			To:        &common.Address{1},
+			Gas:       1e6,
+			GasFeeCap: big.NewInt(500e9),
+			GasTipCap: big.NewInt(500e9),
+		},
+		"blob empty list": &types.BlobTx{
+			Nonce:      3,
+			Gas:        1e6,
+			GasFeeCap:  uint256.NewInt(500e9),
+			BlobFeeCap: uint256.NewInt(500e9),
+		},
+		"blob": &types.BlobTx{
+			Nonce:      3,
+			Gas:        1e6,
+			GasFeeCap:  uint256.NewInt(500e9),
+			BlobFeeCap: uint256.NewInt(500e9),
+			BlobHashes: []common.Hash{{0x01}},
+		},
+		"setCode empty list": &types.SetCodeTx{
+			Nonce: 4,
+			To:    common.Address{42},
+			Gas:   1e6,
+		},
+		"setCode": &types.SetCodeTx{
+			Nonce: 4,
+			To:    common.Address{42},
+			Gas:   1e6,
+			AuthList: []types.SetCodeAuthorization{
+				authorization,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			signed := signTransaction(t, big.NewInt(1), test, key)
+
+			blockHash := common.Hash{1, 2, 3, 4}
+			blockNumber := uint64(4321)
+			index := uint64(0)
+			baseFee := big.NewInt(1234)
+
+			rpcTx := newRPCTransaction(signed, blockHash, blockNumber, index, baseFee)
+			require.Equal(t, signed.Hash(), rpcTransactionToTransaction(t, rpcTx).Hash())
+
+			encoded, err := json.Marshal(rpcTx)
+			require.NoError(t, err)
+
+			decoded := new(RPCTransaction)
+			err = json.Unmarshal(encoded, decoded)
+			require.NoError(t, err)
+			require.Equal(t, blockHash, *decoded.BlockHash)
+			require.Equal(t, int64(blockNumber), decoded.BlockNumber.ToInt().Int64())
+			require.Equal(t, index, uint64(*decoded.TransactionIndex))
+			require.Equal(t, signed.Hash(), rpcTransactionToTransaction(t, decoded).Hash())
+		})
+	}
+}
+
+func signTransaction(
+	t *testing.T,
+	chainId *big.Int,
+	payload any,
+	from *ecdsa.PrivateKey,
+) *types.Transaction {
+	t.Helper()
+
+	switch tx := payload.(type) {
+	case *types.LegacyTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewEIP155Signer(chainId),
+			from)
+		require.NoError(t, err)
+		return res
+	case *types.AccessListTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewEIP2930Signer(chainId),
+			from)
+		require.NoError(t, err)
+		return res
+	case *types.DynamicFeeTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewLondonSigner(chainId),
+			from)
+		require.NoError(t, err)
+		return res
+	case *types.BlobTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewCancunSigner(chainId),
+			from)
+		require.NoError(t, err)
+		return res
+	case *types.SetCodeTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewPragueSigner(chainId),
+			from)
+		require.NoError(t, err)
+		return res
+	default:
+		t.Error("unsupported transaction type ", reflect.TypeOf(payload))
+		return nil
+	}
+}
+
+func rpcTransactionToTransaction(t *testing.T, tx *RPCTransaction) *types.Transaction {
+	t.Helper()
+
+	switch tx.Type {
+	case types.LegacyTxType:
+		return types.NewTx(&types.LegacyTx{
+			Nonce:    uint64(tx.Nonce),
+			Gas:      uint64(tx.Gas),
+			GasPrice: tx.GasPrice.ToInt(),
+			To:       tx.To,
+			Value:    tx.Value.ToInt(),
+			Data:     tx.Input,
+			V:        tx.V.ToInt(),
+			R:        tx.R.ToInt(),
+			S:        tx.S.ToInt(),
+		})
+	case types.AccessListTxType:
+		return types.NewTx(&types.AccessListTx{
+			ChainID:    tx.ChainID.ToInt(),
+			Nonce:      uint64(tx.Nonce),
+			Gas:        uint64(tx.Gas),
+			GasPrice:   tx.GasPrice.ToInt(),
+			To:         tx.To,
+			Value:      tx.Value.ToInt(),
+			Data:       tx.Input,
+			AccessList: *tx.Accesses,
+			V:          tx.V.ToInt(),
+			R:          tx.R.ToInt(),
+			S:          tx.S.ToInt(),
+		})
+	case types.DynamicFeeTxType:
+		return types.NewTx(&types.DynamicFeeTx{
+			ChainID:    tx.ChainID.ToInt(),
+			Nonce:      uint64(tx.Nonce),
+			Gas:        uint64(tx.Gas),
+			GasFeeCap:  tx.GasFeeCap.ToInt(),
+			GasTipCap:  tx.GasTipCap.ToInt(),
+			To:         tx.To,
+			Value:      tx.Value.ToInt(),
+			Data:       tx.Input,
+			AccessList: *tx.Accesses,
+			V:          tx.V.ToInt(),
+			R:          tx.R.ToInt(),
+			S:          tx.S.ToInt(),
+		})
+	case types.BlobTxType:
+		return types.NewTx(&types.BlobTx{
+			ChainID:    uint256.MustFromBig(tx.ChainID.ToInt()),
+			Nonce:      uint64(tx.Nonce),
+			Gas:        uint64(tx.Gas),
+			GasFeeCap:  uint256.MustFromBig(tx.GasFeeCap.ToInt()),
+			GasTipCap:  uint256.MustFromBig(tx.GasTipCap.ToInt()),
+			To:         *tx.To,
+			Value:      uint256.MustFromBig(tx.Value.ToInt()),
+			Data:       tx.Input,
+			AccessList: *tx.Accesses,
+			BlobFeeCap: uint256.MustFromBig(tx.MaxFeePerBlobGas.ToInt()),
+			BlobHashes: tx.BlobVersionedHashes,
+			V:          uint256.MustFromBig(tx.V.ToInt()),
+			R:          uint256.MustFromBig(tx.R.ToInt()),
+			S:          uint256.MustFromBig(tx.S.ToInt()),
+		})
+
+	case types.SetCodeTxType:
+		return types.NewTx(&types.SetCodeTx{
+			ChainID:    uint256.MustFromBig(tx.ChainID.ToInt()),
+			Nonce:      uint64(tx.Nonce),
+			Gas:        uint64(tx.Gas),
+			GasFeeCap:  uint256.MustFromBig(tx.GasFeeCap.ToInt()),
+			GasTipCap:  uint256.MustFromBig(tx.GasTipCap.ToInt()),
+			To:         *tx.To,
+			Value:      uint256.MustFromBig(tx.Value.ToInt()),
+			Data:       tx.Input,
+			AccessList: *tx.Accesses,
+			AuthList:   tx.AuthorizationList,
+			V:          uint256.MustFromBig(tx.V.ToInt()),
+			R:          uint256.MustFromBig(tx.R.ToInt()),
+			S:          uint256.MustFromBig(tx.S.ToInt()),
+		})
+	default:
+		t.Error("unsupported transaction type ", tx.Type)
+		return nil
+	}
 }

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -416,7 +416,7 @@ func TestTransactionJSONSerialization(t *testing.T) {
 		S:       *uint256.NewInt(3),
 	}
 
-	tests := map[string]any{
+	tests := map[string]types.TxData{
 		"legacy": &types.LegacyTx{
 			Nonce:    0,
 			To:       &common.Address{1},
@@ -502,51 +502,16 @@ func TestTransactionJSONSerialization(t *testing.T) {
 func signTransaction(
 	t *testing.T,
 	chainId *big.Int,
-	payload any,
-	from *ecdsa.PrivateKey,
+	payload types.TxData,
+	key *ecdsa.PrivateKey,
 ) *types.Transaction {
 	t.Helper()
-
-	switch tx := payload.(type) {
-	case *types.LegacyTx:
-		res, err := types.SignTx(
-			types.NewTx(tx),
-			types.NewEIP155Signer(chainId),
-			from)
-		require.NoError(t, err)
-		return res
-	case *types.AccessListTx:
-		res, err := types.SignTx(
-			types.NewTx(tx),
-			types.NewEIP2930Signer(chainId),
-			from)
-		require.NoError(t, err)
-		return res
-	case *types.DynamicFeeTx:
-		res, err := types.SignTx(
-			types.NewTx(tx),
-			types.NewLondonSigner(chainId),
-			from)
-		require.NoError(t, err)
-		return res
-	case *types.BlobTx:
-		res, err := types.SignTx(
-			types.NewTx(tx),
-			types.NewCancunSigner(chainId),
-			from)
-		require.NoError(t, err)
-		return res
-	case *types.SetCodeTx:
-		res, err := types.SignTx(
-			types.NewTx(tx),
-			types.NewPragueSigner(chainId),
-			from)
-		require.NoError(t, err)
-		return res
-	default:
-		t.Error("unsupported transaction type ", reflect.TypeOf(payload))
-		return nil
-	}
+	res, err := types.SignTx(
+		types.NewTx(payload),
+		types.NewPragueSigner(chainId),
+		key)
+	require.NoError(t, err)
+	return res
 }
 
 func rpcTransactionToTransaction(t *testing.T, tx *RPCTransaction) *types.Transaction {

--- a/tests/gossip_store_test.go
+++ b/tests/gossip_store_test.go
@@ -1,0 +1,183 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGossipStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *testing.T) {
+
+	// This test will execute a series of transactions.
+	// After restarting the network, it will query the block where each transaction
+	// was executed and check if the transaction is present in the block and the
+	// values match, by comparing the hashes.
+
+	net, err := StartIntegrationTestNet(t.TempDir())
+	if err != nil {
+		t.Fatalf("Failed to start the fake network: %v", err)
+	}
+	defer net.Stop()
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+
+	chainId, err := client.ChainID(context.Background())
+	require.NoError(t, err)
+
+	sender := makeAccountWithBalance(t, net, 1e18)
+	senderAddress := sender.Address()
+
+	// launch one transaction from each type
+	txs := make([]*types.Transaction, 0)
+
+	// Type 0: legacy transaction
+	txs = append(txs, signTransaction(t, chainId,
+		&types.LegacyTx{
+			Nonce:    0,
+			To:       &senderAddress,
+			Gas:      1e6,
+			GasPrice: big.NewInt(500e9),
+		},
+		sender))
+
+	// Type 1: AccessList transaction
+	txs = append(txs, signTransaction(t, chainId,
+		&types.AccessListTx{
+			Nonce:    1,
+			To:       &senderAddress,
+			Gas:      1e6,
+			GasPrice: big.NewInt(500e9),
+			AccessList: types.AccessList{
+				{Address: senderAddress, StorageKeys: []common.Hash{{0x01}}},
+			},
+		},
+		sender))
+
+	// Type 2: DynamicFee transaction
+	txs = append(txs, signTransaction(t, chainId,
+		&types.DynamicFeeTx{
+			Nonce:     2,
+			To:        &senderAddress,
+			Gas:       1e6,
+			GasFeeCap: big.NewInt(500e9),
+			GasTipCap: big.NewInt(500e9),
+		},
+		sender))
+
+	// Type 3: Blob transaction
+	txs = append(txs, signTransaction(t, chainId,
+		&types.BlobTx{
+			Nonce:     3,
+			Gas:       1e6,
+			GasFeeCap: uint256.NewInt(500e9),
+			GasTipCap: uint256.NewInt(500e9),
+		},
+		sender))
+
+	// Type 4: SetCode transaction
+	authorization, err := types.SignSetCode(sender.PrivateKey, types.SetCodeAuthorization{
+		ChainID: *uint256.MustFromBig(chainId),
+		Address: common.Address{42},
+		Nonce:   5,
+	})
+	require.NoError(t, err, "failed to sign SetCode authorization")
+	txs = append(txs, signTransaction(t, chainId,
+		&types.SetCodeTx{
+			Nonce:     4,
+			To:        senderAddress,
+			Gas:       1e6,
+			GasFeeCap: uint256.NewInt(500e9),
+			GasTipCap: uint256.NewInt(500e9),
+			AuthList:  []types.SetCodeAuthorization{authorization},
+		},
+		sender))
+
+	for _, tx := range txs {
+		err := client.SendTransaction(context.Background(), tx)
+		require.NoError(t, err)
+	}
+
+	executedIn := make(map[*types.Transaction]*big.Int, len(txs))
+	for i, tx := range txs {
+		receipt, err := net.GetReceipt(tx.Hash())
+		require.NoError(t, err, "failed to get receipt for tx%d", i)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "tx%d failed", i)
+		require.NotNil(t, receipt.BlockNumber)
+		executedIn[tx] = receipt.BlockNumber
+	}
+
+	err = net.Restart()
+	require.NoError(t, err, "failed to restart network; %v", err)
+
+	// query last block, retrieve executed transactions
+	client, err = net.GetClient()
+	require.NoError(t, err)
+
+	for tx, blockNumber := range executedIn {
+		block, err := client.BlockByNumber(context.Background(), blockNumber)
+		require.NoError(t, err, "failed to get block %v", blockNumber)
+
+		require.True(t,
+			slices.ContainsFunc(block.Transactions(), func(received *types.Transaction) bool {
+				return received.Hash() == tx.Hash()
+			}))
+	}
+}
+
+func signTransaction(
+	t *testing.T,
+	chainId *big.Int,
+	payload any,
+	from *Account,
+) *types.Transaction {
+	t.Helper()
+
+	switch tx := payload.(type) {
+	case *types.LegacyTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewEIP155Signer(chainId),
+			from.PrivateKey)
+		require.NoError(t, err)
+		return res
+	case *types.AccessListTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewEIP2930Signer(chainId),
+			from.PrivateKey)
+		require.NoError(t, err)
+		return res
+	case *types.DynamicFeeTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewLondonSigner(chainId),
+			from.PrivateKey)
+		require.NoError(t, err)
+		return res
+	case *types.BlobTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewCancunSigner(chainId),
+			from.PrivateKey)
+		require.NoError(t, err)
+		return res
+	case *types.SetCodeTx:
+		res, err := types.SignTx(
+			types.NewTx(tx),
+			types.NewPragueSigner(chainId),
+			from.PrivateKey)
+		require.NoError(t, err)
+		return res
+	default:
+		t.Error("unsupported transaction type ", reflect.TypeOf(payload))
+		return nil
+	}
+}

--- a/tests/gossip_store_test.go
+++ b/tests/gossip_store_test.go
@@ -19,11 +19,7 @@ func TestGossipStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *testing
 	// was executed and check if the transaction is present in the block and the
 	// values match, by comparing the hashes.
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -32,7 +28,7 @@ func TestGossipStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *testing
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err)
 
-	sender := makeAccountWithBalance(t, net, 1e18)
+	sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
 	senderAddress := sender.Address()
 
 	// launch one transaction from each type

--- a/tests/transaction_store_test.go
+++ b/tests/transaction_store_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGossipStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *testing.T) {
+func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *testing.T) {
 
 	// This test will execute a series of transactions.
 	// After restarting the network, it will query the block where each transaction


### PR DESCRIPTION
This PR extends RPC transaction serialization to enable clients to query the transaction data after the transaction has included in the block. 

The PR introduces the changes in the serialization code, plus a json serialization test in the API code and an integration test for an End-to-end SetCode transactions lifetime in the client test. 