### PR TITLE
Introduce integration test network sessions to parallelize integration test subtests.

### DIFF
--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"regexp"
 	"strings"
@@ -350,7 +351,7 @@ func createAccount(t *testing.T, net *tests.IntegrationTestNet) {
 	_, err := rand.Read(addr[:])
 	require.NoError(t, err)
 
-	receipt, err := net.EndowAccount(common.Address{42}, 100)
+	receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(100))
 	require.NoError(t, err)
 	require.Equal(
 		t,

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -106,7 +106,7 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 	chainId, err := ctxt.client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.validator.Address(), nil)
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	var sidecar *types.BlobTxSidecar
@@ -150,7 +150,7 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 		Sidecar:    sidecar,               // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.validator.PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetAccount().PrivateKey)
 }
 
 func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*types.Transaction, error) {
@@ -159,7 +159,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 	chainId, err := ctxt.client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.validator.Address(), nil)
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	// Create and return transaction with the blob data and cryptographic proofs
@@ -176,7 +176,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 		Sidecar:    nil,                   // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.validator.PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetAccount().PrivateKey)
 }
 
 func checkBlocksSanity(t *testing.T, client *ethclient.Client) {

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -106,7 +106,7 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 	chainId, err := ctxt.client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetAccount().Address(), nil)
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	var sidecar *types.BlobTxSidecar
@@ -150,7 +150,7 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 		Sidecar:    sidecar,               // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetAccount().PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetSessionSponsor().PrivateKey)
 }
 
 func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*types.Transaction, error) {
@@ -159,7 +159,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 	chainId, err := ctxt.client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetAccount().Address(), nil)
+	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	// Create and return transaction with the blob data and cryptographic proofs
@@ -176,7 +176,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 		Sidecar:    nil,                   // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetAccount().PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetSessionSponsor().PrivateKey)
 }
 
 func checkBlocksSanity(t *testing.T, client *ethclient.Client) {

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -55,11 +55,11 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.GetAccount().Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	factory := &txFactory{
-		senderKey: net.GetAccount().PrivateKey,
+		senderKey: net.GetSessionSponsor().PrivateKey,
 		chainId:   chainId,
 	}
 

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -55,11 +55,11 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.validator.Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	factory := &txFactory{
-		senderKey: net.validator.PrivateKey,
+		senderKey: net.GetAccount().PrivateKey,
 		chainId:   chainId,
 	}
 

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -25,7 +25,7 @@ func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 		require.NoError(err)
 
 		// new block
-		receipt, err := net.EndowAccount(common.Address{42}, 100)
+		receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(100))
 		require.NoError(err)
 
 		lastBlock, err := client.BlockByNumber(ctxt, receipt.BlockNumber)

--- a/tests/genesis_import_test.go
+++ b/tests/genesis_import_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -16,7 +17,7 @@ func TestGenesis_NetworkCanCreateNewBlocksAfterExportImport(t *testing.T) {
 
 	// Produce a few blocks on the network.
 	for range numBlocks {
-		_, err := net.EndowAccount(common.Address{42}, 100)
+		_, err := net.EndowAccount(common.Address{42}, big.NewInt(100))
 		require.NoError(err, "failed to endow account")
 	}
 
@@ -51,7 +52,7 @@ func TestGenesis_NetworkCanCreateNewBlocksAfterExportImport(t *testing.T) {
 
 	// Produce a few blocks on the network
 	for range numBlocks {
-		_, err := net.EndowAccount(common.Address{42}, 100)
+		_, err := net.EndowAccount(common.Address{42}, big.NewInt(100))
 		require.NoError(err, "failed to endow account")
 	}
 

--- a/tests/initcoder_test.go
+++ b/tests/initcoder_test.go
@@ -164,7 +164,7 @@ func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, cod
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.GetAccount().Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	price, err := client.SuggestGasPrice(context.Background())
@@ -178,7 +178,7 @@ func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, cod
 		To:       nil,
 		Nonce:    nonce,
 		Data:     make([]byte, codeSize),
-	}), types.NewLondonSigner(chainId), net.GetAccount().PrivateKey)
+	}), types.NewLondonSigner(chainId), net.GetSessionSponsor().PrivateKey)
 	require.NoError(err, "failed to sign transaction:")
 	return net.Run(transaction)
 }

--- a/tests/initcoder_test.go
+++ b/tests/initcoder_test.go
@@ -164,7 +164,7 @@ func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, cod
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.validator.Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetAccount().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	price, err := client.SuggestGasPrice(context.Background())
@@ -178,7 +178,7 @@ func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, cod
 		To:       nil,
 		Nonce:    nonce,
 		Data:     make([]byte, codeSize),
-	}), types.NewLondonSigner(chainId), net.validator.PrivateKey)
+	}), types.NewLondonSigner(chainId), net.GetAccount().PrivateKey)
 	require.NoError(err, "failed to sign transaction:")
 	return net.Run(transaction)
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -32,8 +34,40 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	geth_crypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
+
+// IntegrationTestNetSession a collection of methods to run tests against the
+// integration test network.
+// It provides the methods to launch transactions and queries against the network.
+// Additionally, it provides the methods to endow accounts with funds.
+type IntegrationTestNetSession interface {
+
+	// EndowAccount sends a requested amount of tokens to the given account. This is
+	// mainly intended to provide funds to accounts for testing purposes.
+	EndowAccount(address common.Address, value *big.Int) (*types.Receipt, error)
+
+	// Run sends the given transaction to the network and waits for it to be processed.
+	// The resulting receipt is returned.
+	Run(tx *types.Transaction) (*types.Receipt, error)
+	// GetReceipt waits for the receipt of the given transaction hash to be available.
+	GetReceipt(txHash common.Hash) (*types.Receipt, error)
+
+	// GetTransactOptions provides transaction options to be used to send a transaction
+	// from the given account.
+	GetTransactOptions(account *Account) (*bind.TransactOpts, error)
+	// Apply sends a transaction to the network using the session account.
+	// and waits for the transaction to be processed. The resulting receipt is returned.
+	Apply(issue func(*bind.TransactOpts) (*types.Transaction, error)) (*types.Receipt, error)
+
+	// GetAccount returns the default account of the session. This account is used
+	// to sign transactions and pay for gas when using the apply method.
+	GetAccount() *Account
+	// GetClient provides raw access to a fresh connection to the network.
+	// The resulting client must be closed after use.
+	GetClient() (*ethclient.Client, error)
+}
 
 // IntegrationTestNet is a in-process test network for integration tests. When
 // started, it runs a full Sonic node maintaining a chain within the process
@@ -58,9 +92,10 @@ import (
 type IntegrationTestNet struct {
 	directory            string
 	done                 <-chan struct{}
-	validator            Account
-	httpPort             int
 	extraClientArguments []string
+
+	sessionsMutex sync.Mutex
+	Session
 }
 
 // StartIntegrationTestNet starts a single-node test network for integration tests.
@@ -204,8 +239,10 @@ func startIntegrationTestNet(directory string, sonicToolArguments []string, extr
 	// start the fakenet sonic node
 	result := &IntegrationTestNet{
 		directory:            directory,
-		validator:            Account{evmcore.FakeKey(1)},
 		extraClientArguments: extraClientArguments,
+		Session: Session{
+			account: Account{evmcore.FakeKey(1)},
+		},
 	}
 
 	// initialize the data directory for the single node on the test network
@@ -364,154 +401,6 @@ func (n *IntegrationTestNet) Restart() error {
 	return n.start()
 }
 
-// EndowAccount sends a requested amount of tokens to the given account. This is
-// mainly intended to provide funds to accounts for testing purposes.
-func (n *IntegrationTestNet) EndowAccount(
-	address common.Address,
-	value *big.Int,
-) (*types.Receipt, error) {
-	client, err := n.GetClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to the network: %w", err)
-	}
-	defer client.Close()
-
-	chainId, err := client.ChainID(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain ID: %w", err)
-	}
-
-	// The requested funds are moved from the validator account to the target account.
-	nonce, err := client.NonceAt(context.Background(), n.validator.Address(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get nonce: %w", err)
-	}
-
-	price, err := client.SuggestGasPrice(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get gas price: %w", err)
-	}
-
-	transaction, err := types.SignTx(types.NewTx(&types.AccessListTx{
-		ChainID:  chainId,
-		Gas:      21000,
-		GasPrice: price,
-		To:       &address,
-		Value:    value,
-		Nonce:    nonce,
-	}), types.NewLondonSigner(chainId), n.validator.PrivateKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to sign transaction: %w", err)
-	}
-	return n.Run(transaction)
-}
-
-// Run sends the given transaction to the network and waits for it to be processed.
-// The resulting receipt is returned. This function times out after 10 seconds.
-func (n *IntegrationTestNet) Run(tx *types.Transaction) (*types.Receipt, error) {
-	client, err := n.GetClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
-	}
-	defer client.Close()
-	err = client.SendTransaction(context.Background(), tx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send transaction: %w", err)
-	}
-	return n.GetReceipt(tx.Hash())
-}
-
-// GetReceipt waits for the receipt of the given transaction hash to be available.
-// The function times out after 10 seconds.
-func (n *IntegrationTestNet) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
-	client, err := n.GetClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
-	}
-	defer client.Close()
-
-	// Wait for the response with some exponential backoff.
-	const maxDelay = 100 * time.Millisecond
-	now := time.Now()
-	delay := time.Millisecond
-	for time.Since(now) < 100*time.Second {
-		receipt, err := client.TransactionReceipt(context.Background(), txHash)
-		if errors.Is(err, ethereum.NotFound) {
-			time.Sleep(delay)
-			delay = 2 * delay
-			if delay > maxDelay {
-				delay = maxDelay
-			}
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
-		}
-		return receipt, nil
-	}
-	return nil, fmt.Errorf("failed to get transaction receipt: timeout")
-}
-
-// Apply sends a transaction to the network using the network's validator account
-// and waits for the transaction to be processed. The resulting receipt is returned.
-func (n *IntegrationTestNet) Apply(
-	issue func(*bind.TransactOpts) (*types.Transaction, error),
-) (*types.Receipt, error) {
-	txOpts, err := n.GetTransactOptions(&n.validator)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get transaction options: %w", err)
-	}
-	transaction, err := issue(txOpts)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create transaction: %w", err)
-	}
-	return n.GetReceipt(transaction.Hash())
-}
-
-// GetTransactOptions provides transaction options to be used to send a transaction
-// with the given account. The options include the chain ID, a suggested gas price,
-// the next free nonce of the given account, and a hard-coded gas limit of 1e6.
-// The main purpose of this function is to provide a convenient way to collect all
-// the necessary information required to create a transaction in one place.
-func (n *IntegrationTestNet) GetTransactOptions(account *Account) (*bind.TransactOpts, error) {
-	client, err := n.GetClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
-	}
-	defer client.Close()
-
-	ctxt := context.Background()
-	chainId, err := client.ChainID(ctxt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain ID: %w", err)
-	}
-
-	gasPrice, err := client.SuggestGasPrice(ctxt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get gas price suggestion: %w", err)
-	}
-
-	nonce, err := client.NonceAt(ctxt, account.Address(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get nonce: %w", err)
-	}
-
-	txOpts, err := bind.NewKeyedTransactorWithChainID(account.PrivateKey, chainId)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create transaction options: %w", err)
-	}
-	txOpts.GasPrice = new(big.Int).Mul(gasPrice, big.NewInt(2))
-	txOpts.Nonce = big.NewInt(int64(nonce))
-	txOpts.GasLimit = 1e6
-	return txOpts, nil
-}
-
-// GetClient provides raw access to a fresh connection to the network.
-// The resulting client must be closed after use.
-func (n *IntegrationTestNet) GetClient() (*ethclient.Client, error) {
-	return ethclient.Dial(fmt.Sprintf("http://localhost:%d", n.httpPort))
-}
-
 // GetWebSocketClient provides raw access to a fresh connection to the network
 // using the WebSocket protocol. The resulting client must be closed after use.
 func (n *IntegrationTestNet) GetWebSocketClient() (*ethclient.Client, error) {
@@ -595,17 +484,58 @@ func (n *IntegrationTestNet) GetHeaders() ([]*types.Header, error) {
 	return headers, nil
 }
 
+// SpawnSession(t) creates a new test session on the network.
+// The session is backed by an account which will be used to sign and pay for
+// transactions. By using this function, multiple test sessions can be run in
+// parallel on the same network, without conflicting nonce issues, since the
+// accounts are isolated.
+//
+// A typical use case would look as follows:
+//
+//	net, err := StartIntegrationTestNet(t.TempDir())
+//	if err != nil {
+//	    ...
+//	}
+//	t.Cleanup(func(){net.Stop()})
+//	t.Run("test_case",, func(t *testing.T) {
+//			t.Parallel()
+//			session := net.SpawnSession(t)
+//	        < use session instead of net of the rest of the test >
+//	})
+func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSession {
+	t.Helper()
+	n.sessionsMutex.Lock()
+	defer n.sessionsMutex.Unlock()
+
+	key, _ := geth_crypto.GenerateKey()
+	nextSessionAccount := Account{
+		PrivateKey: key,
+	}
+	receipt, err := n.EndowAccount(nextSessionAccount.Address(), new(big.Int).SetUint64(math.MaxUint64))
+	if err != nil {
+		t.Fatalf("Failed to endow account: %v", err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		t.Fatalf("Failed to endow account: %v", receipt.Status)
+	}
+
+	return &Session{
+		account:  nextSessionAccount,
+		httpPort: n.httpPort,
+	}
+}
+
 // DeployContract is a utility function handling the deployment of a contract on the network.
 // The contract is deployed with by the network's validator account. The function returns the
 // deployed contract instance and the transaction receipt.
-func DeployContract[T any](n *IntegrationTestNet, deploy contractDeployer[T]) (*T, *types.Receipt, error) {
+func DeployContract[T any](n IntegrationTestNetSession, deploy contractDeployer[T]) (*T, *types.Receipt, error) {
 	client, err := n.GetClient()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
 	}
 	defer client.Close()
 
-	transactOptions, err := n.GetTransactOptions(&n.validator)
+	transactOptions, err := n.GetTransactOptions(n.GetAccount())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get transaction options: %w", err)
 	}
@@ -624,3 +554,164 @@ func DeployContract[T any](n *IntegrationTestNet, deploy contractDeployer[T]) (*
 
 // contractDeployer is the type of the deployment functions generated by abigen.
 type contractDeployer[T any] func(*bind.TransactOpts, bind.ContractBackend) (common.Address, *types.Transaction, *T, error)
+
+// Session is a test session on the network. It is backed by an account which
+// will be used to sign and pay for transactions.
+// Its purpose is to isolate transaction issuing accounts, so that multiple test
+// sessions can be run in parallel on the same network without conflicting nonce issues.
+type Session struct {
+	account  Account
+	httpPort int
+}
+
+// EndowAccount sends a requested amount of tokens to the given account. This is
+// mainly intended to provide funds to accounts for testing purposes.
+func (s *Session) EndowAccount(
+	address common.Address,
+	value *big.Int,
+) (*types.Receipt, error) {
+	client, err := s.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to the network: %w", err)
+	}
+	defer client.Close()
+
+	chainId, err := client.ChainID(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain ID: %w", err)
+	}
+
+	// The requested funds are moved from the validator account to the target account.
+	nonce, err := client.NonceAt(context.Background(), s.account.Address(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce: %w", err)
+	}
+
+	price, err := client.SuggestGasPrice(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gas price: %w", err)
+	}
+
+	transaction, err := types.SignTx(types.NewTx(&types.AccessListTx{
+		ChainID:  chainId,
+		Gas:      21000,
+		GasPrice: price,
+		To:       &address,
+		Value:    value,
+		Nonce:    nonce,
+	}), types.NewLondonSigner(chainId), s.account.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign transaction: %w", err)
+	}
+	return s.Run(transaction)
+}
+
+// Run sends the given transaction to the network and waits for it to be processed.
+// The resulting receipt is returned. This function times out after 10 seconds.
+func (s *Session) Run(tx *types.Transaction) (*types.Receipt, error) {
+	client, err := s.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
+	}
+	defer client.Close()
+	err = client.SendTransaction(context.Background(), tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send transaction: %w", err)
+	}
+	return s.GetReceipt(tx.Hash())
+}
+
+// GetReceipt waits for the receipt of the given transaction hash to be available.
+// The function times out after 10 seconds.
+func (s *Session) GetReceipt(txHash common.Hash) (*types.Receipt, error) {
+	client, err := s.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
+	}
+	defer client.Close()
+
+	// Wait for the response with some exponential backoff.
+	const maxDelay = 100 * time.Millisecond
+	now := time.Now()
+	delay := time.Millisecond
+	for time.Since(now) < 100*time.Second {
+		receipt, err := client.TransactionReceipt(context.Background(), txHash)
+		if errors.Is(err, ethereum.NotFound) {
+			time.Sleep(delay)
+			delay = 2 * delay
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to get transaction receipt: %w", err)
+		}
+		return receipt, nil
+	}
+	return nil, fmt.Errorf("failed to get transaction receipt: timeout")
+}
+
+// Apply sends a transaction to the network using the session account
+// and waits for the transaction to be processed. The resulting receipt is returned.
+func (s *Session) Apply(
+	issue func(*bind.TransactOpts) (*types.Transaction, error),
+) (*types.Receipt, error) {
+	txOpts, err := s.GetTransactOptions(&s.account)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transaction options: %w", err)
+	}
+	transaction, err := issue(txOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transaction: %w", err)
+	}
+	return s.GetReceipt(transaction.Hash())
+}
+
+// GetTransactOptions provides transaction options to be used to send a transaction
+// with the given account. The options include the chain ID, a suggested gas price,
+// the next free nonce of the given account, and a hard-coded gas limit of 1e6.
+// The main purpose of this function is to provide a convenient way to collect all
+// the necessary information required to create a transaction in one place.
+func (s *Session) GetTransactOptions(account *Account) (*bind.TransactOpts, error) {
+	client, err := s.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
+	}
+	defer client.Close()
+
+	ctxt := context.Background()
+	chainId, err := client.ChainID(ctxt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain ID: %w", err)
+	}
+
+	gasPrice, err := client.SuggestGasPrice(ctxt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gas price suggestion: %w", err)
+	}
+
+	nonce, err := client.NonceAt(ctxt, account.Address(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get nonce: %w", err)
+	}
+
+	txOpts, err := bind.NewKeyedTransactorWithChainID(account.PrivateKey, chainId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transaction options: %w", err)
+	}
+	txOpts.GasPrice = new(big.Int).Mul(gasPrice, big.NewInt(2))
+	txOpts.Nonce = big.NewInt(int64(nonce))
+	txOpts.GasLimit = 1e6
+	return txOpts, nil
+}
+
+func (s *Session) GetAccount() *Account {
+	return &s.account
+}
+
+// GetClient provides raw access to a fresh connection to the network.
+// The resulting client must be closed after use.
+func (s *Session) GetClient() (*ethclient.Client, error) {
+	return ethclient.Dial(fmt.Sprintf("http://localhost:%d", s.httpPort))
+}

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -368,7 +368,7 @@ func (n *IntegrationTestNet) Restart() error {
 // mainly intended to provide funds to accounts for testing purposes.
 func (n *IntegrationTestNet) EndowAccount(
 	address common.Address,
-	value int64,
+	value *big.Int,
 ) (*types.Receipt, error) {
 	client, err := n.GetClient()
 	if err != nil {
@@ -397,7 +397,7 @@ func (n *IntegrationTestNet) EndowAccount(
 		Gas:      21000,
 		GasPrice: price,
 		To:       &address,
-		Value:    big.NewInt(value),
+		Value:    value,
 		Nonce:    nonce,
 	}), types.NewLondonSigner(chainId), n.validator.PrivateKey)
 	if err != nil {

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -61,9 +61,9 @@ type IntegrationTestNetSession interface {
 	// and waits for the transaction to be processed. The resulting receipt is returned.
 	Apply(issue func(*bind.TransactOpts) (*types.Transaction, error)) (*types.Receipt, error)
 
-	// GetAccount returns the default account of the session. This account is used
-	// to sign transactions and pay for gas when using the apply method.
-	GetAccount() *Account
+	// GetSessionSponsor returns the default account of the session. This account is used
+	// to sign transactions and pay for gas when using the Apply and EndowAccount methods.
+	GetSessionSponsor() *Account
 	// GetClient provides raw access to a fresh connection to the network.
 	// The resulting client must be closed after use.
 	GetClient() (*ethclient.Client, error)
@@ -535,7 +535,7 @@ func DeployContract[T any](n IntegrationTestNetSession, deploy contractDeployer[
 	}
 	defer client.Close()
 
-	transactOptions, err := n.GetTransactOptions(n.GetAccount())
+	transactOptions, err := n.GetTransactOptions(n.GetSessionSponsor())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get transaction options: %w", err)
 	}
@@ -706,7 +706,7 @@ func (s *Session) GetTransactOptions(account *Account) (*bind.TransactOpts, erro
 	return txOpts, nil
 }
 
-func (s *Session) GetAccount() *Account {
+func (s *Session) GetSessionSponsor() *Account {
 	return &s.account
 }
 

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -61,7 +61,7 @@ func TestIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		increment := int64(1000)
 
-		receipt, err := net.EndowAccount(address, increment)
+		receipt, err := net.EndowAccount(address, big.NewInt(increment))
 		if err != nil {
 			t.Fatalf("Failed to endow account 1: %v", err)
 		}

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -112,11 +112,7 @@ func TestIntegrationTestNet_CanInteractWithContract(t *testing.T) {
 }
 
 func TestIntegrationTestNet_CanSpawnParallelSessions(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	t.Cleanup(func() { net.Stop() })
+	net := StartIntegrationTestNet(t)
 
 	for i := range 15 {
 		t.Run(fmt.Sprint("SpawnSession", i), func(t *testing.T) {

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -107,5 +108,23 @@ func TestIntegrationTestNet_CanInteractWithContract(t *testing.T) {
 	}
 	if receipt.Status != types.ReceiptStatusSuccessful {
 		t.Errorf("Contract deployment failed: %v", receipt)
+	}
+}
+
+func TestIntegrationTestNet_CanSpawnParallelSessions(t *testing.T) {
+	net, err := StartIntegrationTestNet(t.TempDir())
+	if err != nil {
+		t.Fatalf("Failed to start the fake network: %v", err)
+	}
+	t.Cleanup(func() { net.Stop() })
+
+	for i := range 15 {
+		t.Run(fmt.Sprint("SpawnSession", i), func(t *testing.T) {
+			t.Parallel()
+			session := net.SpawnSession(t)
+
+			receipt, err := session.EndowAccount(common.Address{0x42}, big.NewInt(1000))
+			checkTxExecution(t, receipt, err)
+		})
 	}
 }

--- a/tests/invalid_start_test.go
+++ b/tests/invalid_start_test.go
@@ -69,7 +69,7 @@ func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net
 	chainId, err := client.ChainID(context.Background())
 	r.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.GetAccount().Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetSessionSponsor().Address(), nil)
 	r.NoError(err, "failed to get nonce:")
 
 	price, err := client.SuggestGasPrice(context.Background())
@@ -83,7 +83,7 @@ func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net
 		To:       nil,
 		Nonce:    nonce,
 		Data:     code,
-	}), types.NewLondonSigner(chainId), net.GetAccount().PrivateKey)
+	}), types.NewLondonSigner(chainId), net.GetSessionSponsor().PrivateKey)
 	r.NoError(err, "failed to sign transaction:")
 
 	return transaction, nil

--- a/tests/invalid_start_test.go
+++ b/tests/invalid_start_test.go
@@ -69,7 +69,7 @@ func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net
 	chainId, err := client.ChainID(context.Background())
 	r.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.validator.Address(), nil)
+	nonce, err := client.NonceAt(context.Background(), net.GetAccount().Address(), nil)
 	r.NoError(err, "failed to get nonce:")
 
 	price, err := client.SuggestGasPrice(context.Background())
@@ -83,7 +83,7 @@ func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net
 		To:       nil,
 		Nonce:    nonce,
 		Data:     code,
-	}), types.NewLondonSigner(chainId), net.validator.PrivateKey)
+	}), types.NewLondonSigner(chainId), net.GetAccount().PrivateKey)
 	r.NoError(err, "failed to sign transaction:")
 
 	return transaction, nil

--- a/tests/node_restart_test.go
+++ b/tests/node_restart_test.go
@@ -23,7 +23,7 @@ func TestNodeRestart_CanRestartAndRestoreItsState(t *testing.T) {
 	// Run through multiple restarts.
 	for i := 0; i < numRestarts; i++ {
 		for range numBlocks {
-			receipt, err := net.EndowAccount(common.Address{42}, 100)
+			receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(100))
 			if err != nil {
 				t.Fatalf("failed to endow account; %v", err)
 			}

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -87,7 +87,7 @@ func testRejectedTx(t *testing.T, net *IntegrationTestNet, account common.Addres
 	require.Equal(tx.Cost().Uint64(), estimatedCost, "transaction estimation is not equal to test estimation")
 
 	// provide just enough balance to NOT cover the cost
-	_, err := net.EndowAccount(account, int64(estimatedCost-1))
+	_, err := net.EndowAccount(account, new(big.Int).SetUint64(estimatedCost-1))
 	require.NoError(err, "failed to endow account")
 
 	// run transaction to be rejected
@@ -96,7 +96,7 @@ func testRejectedTx(t *testing.T, net *IntegrationTestNet, account common.Addres
 	require.Nil(receipt)
 
 	// provide enough balance to cover the cost
-	_, err = net.EndowAccount(account, int64(1))
+	_, err = net.EndowAccount(account, big.NewInt(1))
 	require.NoError(err, "failed to endow account")
 
 	// run transaction to be successful

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -36,57 +37,79 @@ func TestSetCodeTransaction(t *testing.T) {
 	net := StartIntegrationTestNet(t)
 
 	t.Run("Operation", func(t *testing.T) {
+		t.Parallel()
 		// operation tests check basic operation of the SetCode transaction
 
 		t.Run("Delegate can be set and unset", func(t *testing.T) {
-			testDelegateCanBeSetAndUnset(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testDelegateCanBeSetAndUnset(t, session)
 		})
 
 		t.Run("Invalid authorizations are ignored", func(t *testing.T) {
+			t.Parallel()
 			testInvalidAuthorizationsAreIgnored(t, net)
 		})
 
 		t.Run("Authorizations are executed in order", func(t *testing.T) {
-			testAuthorizationsAreExecutedInOrder(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testAuthorizationsAreExecutedInOrder(t, session)
 		})
 
 		t.Run("Multiple accounts can submit authorizations", func(t *testing.T) {
-			testMultipleAccountsCanSubmitAuthorizations(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testMultipleAccountsCanSubmitAuthorizations(t, session)
 		})
 
 		t.Run("Authorization succeeds with failing tx", func(t *testing.T) {
-			testAuthorizationSucceedsWithFailingTx(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testAuthorizationSucceedsWithFailingTx(t, session)
 		})
 
 		t.Run("Authorization can be issued from a non existing account", func(t *testing.T) {
-			testAuthorizationFromNonExistingAccount(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testAuthorizationFromNonExistingAccount(t, session)
 		})
 
 		t.Run("Delegations cannot be transitive", func(t *testing.T) {
-			testNoDelegateToDelegated(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testNoDelegateToDelegated(t, session)
 		})
 
 		t.Run("Delegations can trigger chains of calls", func(t *testing.T) {
-			testChainOfCalls(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testChainOfCalls(t, session)
 		})
 
 	})
 
 	t.Run("UseCase", func(t *testing.T) {
+		t.Parallel()
 		// UseCase tests check the use cases described in the EIP-7702 specification
 
 		t.Run("Transaction Sponsoring", func(t *testing.T) {
-			testSponsoring(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testSponsoring(t, session)
 		})
 
 		t.Run("Transaction Batching", func(t *testing.T) {
-			testBatching(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testBatching(t, session)
 		})
 
 		t.Run("Privilege Deescalation", func(t *testing.T) {
-			testPrivilegeDeescalation(t, net)
+			t.Parallel()
+			session := net.SpawnSession(t)
+			testPrivilegeDeescalation(t, session)
 		})
-
 	})
 }
 
@@ -94,7 +117,7 @@ func TestSetCodeTransaction(t *testing.T) {
 // - The sponsor account pays for the gas for the transaction
 // - The sponsored account is the context of the transaction, and its state is modified
 // - The delegate account is the contract that will be executed
-func testSponsoring(t *testing.T, net *IntegrationTestNet) {
+func testSponsoring(t *testing.T, net IntegrationTestNetSession) {
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -153,7 +176,7 @@ func testSponsoring(t *testing.T, net *IntegrationTestNet) {
 // - The sponsor and sponsored accounts are the same, this is a self-sponsored transaction.
 // - The delegate account is the contract that will be executed, which implements the batch of calls
 // - Multiple receiver accounts will receive the funds
-func testBatching(t *testing.T, net *IntegrationTestNet) {
+func testBatching(t *testing.T, net IntegrationTestNetSession) {
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -217,9 +240,9 @@ func testBatching(t *testing.T, net *IntegrationTestNet) {
 
 // testPrivilegeDeescalation executes a transaction where an account allows restricted access
 // to its internal state to a second account.
-func testPrivilegeDeescalation(t *testing.T, net *IntegrationTestNet) {
+func testPrivilegeDeescalation(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -227,23 +250,23 @@ func testPrivilegeDeescalation(t *testing.T, net *IntegrationTestNet) {
 	// - Account A (account) is the context of the transaction, and its state is modified
 	// - Account B (userAccount) pays for the gas for the transaction
 	// - Some part of the contract interface (DoPayment) is executable from account B
-	account := makeAccountWithBalance(t, net, big.NewInt(1e18))     // < will transfer funds
-	userAccount := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < will pay for gas
-	receiver := NewAccount()                                        // < will receive funds
+	account := makeAccountWithBalance(t, session, big.NewInt(1e18))     // < will transfer funds
+	userAccount := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < will pay for gas
+	receiver := NewAccount()                                            // < will receive funds
 
 	// Deploy the a contract to use as delegate
-	contract, receipt, err := DeployContract(net, privilege_deescalation.DeployPrivilegeDeescalation)
+	contract, receipt, err := DeployContract(session, privilege_deescalation.DeployPrivilegeDeescalation)
 	require.NoError(t, err)
 	delegate := receipt.ContractAddress
 
 	// Install delegation in account and allow access by userAccount
-	callData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	callData := getCallData(t, session, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		// The contract will whitelist the userAccount to execute the DoPayment function
 		// within the same transaction that sets the delegation.
 		return contract.AllowPayment(opts, userAccount.Address())
 	})
 	setCodeTx := makeEip7702Transaction(t, client, account, account, delegate, callData)
-	receipt, err = net.Run(setCodeTx)
+	receipt, err = session.Run(setCodeTx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -261,12 +284,12 @@ func testPrivilegeDeescalation(t *testing.T, net *IntegrationTestNet) {
 	require.NoError(t, err)
 
 	// issue a normal transaction from userAccount to transfer funds to receiver
-	txOpts, err := net.GetTransactOptions(userAccount)
+	txOpts, err := session.GetTransactOptions(userAccount)
 	require.NoError(t, err)
 	txOpts.NoSend = true
 	tx, err := delegatedContract.DoPayment(txOpts, receiver.Address(), big.NewInt(1234))
 	require.NoError(t, err)
-	receipt, err = net.Run(tx)
+	receipt, err = session.Run(tx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -280,22 +303,22 @@ func testPrivilegeDeescalation(t *testing.T, net *IntegrationTestNet) {
 	assert.Equal(t, big.NewInt(1234), receivedBalance)
 
 	// issue a transaction from and unauthorized account
-	unauthorizedAccount := makeAccountWithBalance(t, net, big.NewInt(1e18))
-	txOpts, err = net.GetTransactOptions(unauthorizedAccount)
+	unauthorizedAccount := makeAccountWithBalance(t, session, big.NewInt(1e18))
+	txOpts, err = session.GetTransactOptions(unauthorizedAccount)
 	require.NoError(t, err)
 	txOpts.NoSend = true
 	tx, err = delegatedContract.AllowPayment(txOpts, receiver.Address())
 	require.NoError(t, err)
-	receipt, err = net.Run(tx)
+	receipt, err = session.Run(tx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusFailed, receipt.Status, "tx shall be executed and rejected")
 
-	txOpts, err = net.GetTransactOptions(unauthorizedAccount)
+	txOpts, err = session.GetTransactOptions(unauthorizedAccount)
 	require.NoError(t, err)
 	txOpts.NoSend = true
 	tx, err = delegatedContract.DoPayment(txOpts, receiver.Address(), big.NewInt(42))
 	require.NoError(t, err)
-	receipt, err = net.Run(tx)
+	receipt, err = session.Run(tx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusFailed, receipt.Status, "tx shall be executed and rejected")
 }
@@ -303,25 +326,25 @@ func testPrivilegeDeescalation(t *testing.T, net *IntegrationTestNet) {
 // testDelegateCanBeSetAndUnset checks that a delegate can be set and unset
 // The EIP-7702 specification describes the method to restore an EOA code to
 // its original state by setting the delegate to the zero address.
-func testDelegateCanBeSetAndUnset(t *testing.T, net *IntegrationTestNet) {
+func testDelegateCanBeSetAndUnset(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	account := makeAccountWithBalance(t, net, big.NewInt(1e18))
+	account := makeAccountWithBalance(t, session, big.NewInt(1e18))
 
 	// Deploy the a contract to use as delegate
-	counter, receipt, err := DeployContract(net, counter.DeployCounter)
+	counter, receipt, err := DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err)
 	delegateAddress := receipt.ContractAddress
 
 	// set delegation
-	callData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	callData := getCallData(t, session, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return counter.IncrementCounter(opts)
 	})
 	setCodeTx := makeEip7702Transaction(t, client, account, account, delegateAddress, callData)
-	receipt, err = net.Run(setCodeTx)
+	receipt, err = session.Run(setCodeTx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -333,7 +356,7 @@ func testDelegateCanBeSetAndUnset(t *testing.T, net *IntegrationTestNet) {
 
 	// unset by delegating to an empty address
 	unsetCodeTx := makeEip7702Transaction(t, client, account, account, common.Address{}, []byte{})
-	receipt, err = net.Run(unsetCodeTx)
+	receipt, err = session.Run(unsetCodeTx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -468,60 +491,60 @@ func testInvalidAuthorizationsAreIgnored(t *testing.T, net *IntegrationTestNet) 
 		},
 	}
 
-	for name, test := range wrongAuthorizations {
-		t.Run(name, func(t *testing.T) {
-			for name, scenario := range scenarios {
-				t.Run(name, func(t *testing.T) {
+	for caseName, test := range wrongAuthorizations {
+		for scenarioName, scenario := range scenarios {
+			t.Run(fmt.Sprintf("%s/%s", caseName, scenarioName), func(t *testing.T) {
+				t.Parallel()
+				session := net.SpawnSession(t)
 
-					wrongAuthAccount := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < will transfer funds
-					nonce, err := client.NonceAt(context.Background(), wrongAuthAccount.Address(), nil)
-					require.NoError(t, err, "failed to get nonce for account", wrongAuthAccount.Address())
+				wrongAuthAccount := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < will transfer funds
+				nonce, err := client.NonceAt(context.Background(), wrongAuthAccount.Address(), nil)
+				require.NoError(t, err, "failed to get nonce for account", wrongAuthAccount.Address())
 
-					wrongAuthorization, err := test.makeAuthorization(wrongAuthAccount, nonce)
-					require.NoError(t, err, "failed to sign SetCode authorization")
+				wrongAuthorization, err := test.makeAuthorization(wrongAuthAccount, nonce)
+				require.NoError(t, err, "failed to sign SetCode authorization")
 
-					rightAuthAccount := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < will transfer funds
-					authorizations := scenario.makeAuthorizations(t, wrongAuthorization, rightAuthAccount)
+				rightAuthAccount := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < will transfer funds
+				authorizations := scenario.makeAuthorizations(t, wrongAuthorization, rightAuthAccount)
 
-					tx, err := types.SignTx(
-						types.NewTx(&types.SetCodeTx{
-							ChainID:   uint256.MustFromBig(chainId),
-							Nonce:     nonce,
-							To:        wrongAuthAccount.Address(),
-							Gas:       150_000,
-							GasFeeCap: uint256.NewInt(10e10),
-							AuthList:  authorizations,
-						}),
-						types.NewPragueSigner(chainId),
-						wrongAuthAccount.PrivateKey,
-					)
-					require.NoError(t, err, "failed to create transaction")
+				tx, err := types.SignTx(
+					types.NewTx(&types.SetCodeTx{
+						ChainID:   uint256.MustFromBig(chainId),
+						Nonce:     nonce,
+						To:        wrongAuthAccount.Address(),
+						Gas:       150_000,
+						GasFeeCap: uint256.NewInt(10e10),
+						AuthList:  authorizations,
+					}),
+					types.NewPragueSigner(chainId),
+					wrongAuthAccount.PrivateKey,
+				)
+				require.NoError(t, err, "failed to create transaction")
 
-					// execute transaction
-					receipt, err := net.Run(tx)
-					require.NoError(t, err)
-					// because no delegation is set, transaction call to self (no code) will succeed
-					require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+				// execute transaction
+				receipt, err := session.Run(tx)
+				require.NoError(t, err)
+				// because no delegation is set, transaction call to self (no code) will succeed
+				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-					// check delegations
-					scenario.check(t, wrongAuthAccount, rightAuthAccount)
-				})
-			}
-		})
+				// check delegations
+				scenario.check(t, wrongAuthAccount, rightAuthAccount)
+			})
+		}
 	}
 }
 
 // testAuthorizationsAreExecutedInOrder checks that authorizations are executed in order
-func testAuthorizationsAreExecutedInOrder(t *testing.T, net *IntegrationTestNet) {
+func testAuthorizationsAreExecutedInOrder(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err, "failed to get chain ID")
 
-	account := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < will transfer funds
+	account := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < will transfer funds
 
 	nonce, err := client.NonceAt(context.Background(), account.Address(), nil)
 	require.NoError(t, err, "failed to get nonce for account", account.Address())
@@ -559,7 +582,7 @@ func testAuthorizationsAreExecutedInOrder(t *testing.T, net *IntegrationTestNet)
 	require.NoError(t, err, "failed to create transaction")
 
 	// execute transaction
-	receipt, err := net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(t, err)
 	// because no delegation is set, transaction call to self will succeed
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
@@ -573,16 +596,16 @@ func testAuthorizationsAreExecutedInOrder(t *testing.T, net *IntegrationTestNet)
 
 // testMultipleAccountsCanSubmitAuthorizations checks that multiple accounts can submit authorizations
 // and those accounts may be unrelated to the account receiver of the transaction.
-func testMultipleAccountsCanSubmitAuthorizations(t *testing.T, net *IntegrationTestNet) {
+func testMultipleAccountsCanSubmitAuthorizations(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err, "failed to get chain ID")
 
-	account := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < Pays for the transaction
+	account := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < Pays for the transaction
 	nonce, err := client.NonceAt(context.Background(), account.Address(), nil)
 	require.NoError(t, err, "failed to get nonce for account", account.Address())
 
@@ -628,7 +651,7 @@ func testMultipleAccountsCanSubmitAuthorizations(t *testing.T, net *IntegrationT
 	require.NoError(t, err, "failed to create transaction")
 
 	// execute transaction
-	receipt, err := net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(t, err)
 	// transaction call to self will succeed
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
@@ -647,20 +670,20 @@ func testMultipleAccountsCanSubmitAuthorizations(t *testing.T, net *IntegrationT
 
 // testAuthorizationSucceedsWithFailingTx checks that an authorization is executed
 // even if the transaction fails
-func testAuthorizationSucceedsWithFailingTx(t *testing.T, net *IntegrationTestNet) {
+func testAuthorizationSucceedsWithFailingTx(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	account := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < Pays for the transaction
+	account := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < Pays for the transaction
 
-	_, receipt, err := DeployContract(net, counter.DeployCounter)
+	_, receipt, err := DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err)
 	delegateAddress := receipt.ContractAddress
 
 	tx := makeEip7702Transaction(t, client, account, account, delegateAddress, nil)
-	receipt, err = net.Run(tx)
+	receipt, err = session.Run(tx)
 	require.NoError(t, err)
 	// Submitting a call to the counter contract without callData must fail
 	require.Equal(t, types.ReceiptStatusFailed, receipt.Status)
@@ -674,13 +697,13 @@ func testAuthorizationSucceedsWithFailingTx(t *testing.T, net *IntegrationTestNe
 
 // testAuthorizationFromNonExistingAccount checks that an authorization can signed by
 // a non exiting account, creating the account on the fly.
-func testAuthorizationFromNonExistingAccount(t *testing.T, net *IntegrationTestNet) {
+func testAuthorizationFromNonExistingAccount(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	sponsor := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < Pays for the transaction
+	sponsor := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < Pays for the transaction
 
 	// create an account from a key without endowing it
 	key, _ := crypto.GenerateKey()
@@ -689,7 +712,7 @@ func testAuthorizationFromNonExistingAccount(t *testing.T, net *IntegrationTestN
 	}
 
 	tx := makeEip7702Transaction(t, client, sponsor, &nonExistingAccount, common.Address{42}, nil)
-	_, err = net.Run(tx)
+	_, err = session.Run(tx)
 	require.NoError(t, err)
 	// whenever the transaction succeeds, is not relevant for this test
 
@@ -705,21 +728,21 @@ func testAuthorizationFromNonExistingAccount(t *testing.T, net *IntegrationTestN
 // > In case a delegation designator points to another designator, creating a
 // > potential  chain or loop of designators, clients must retrieve only the
 // > first code and then stop following the designator chain.
-func testNoDelegateToDelegated(t *testing.T, net *IntegrationTestNet) {
+func testNoDelegateToDelegated(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err, "failed to get chain ID")
 
-	sponsor := makeAccountWithBalance(t, net, big.NewInt(1e18))
+	sponsor := makeAccountWithBalance(t, session, big.NewInt(1e18))
 	account1 := NewAccount()
 	account2 := NewAccount()
 
 	// deploy the batch counterContract
-	_, deployReceipt, err := DeployContract(net, counter.DeployCounter)
+	_, deployReceipt, err := DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, deployReceipt.Status)
 	counterContractAddress := deployReceipt.ContractAddress
@@ -762,7 +785,7 @@ func testNoDelegateToDelegated(t *testing.T, net *IntegrationTestNet) {
 		sponsor.PrivateKey,
 	)
 	require.NoError(t, err, "failed to sign transaction")
-	receipt, err := net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -771,34 +794,34 @@ func testNoDelegateToDelegated(t *testing.T, net *IntegrationTestNet) {
 	// fails because of ABI issues
 	counterInAccount1, err := counter.NewCounter(account1.Address(), client)
 	require.NoError(t, err)
-	receipt, err = net.Apply(counterInAccount1.IncrementCounter)
+	receipt, err = session.Apply(counterInAccount1.IncrementCounter)
 	require.NoError(t, err)
 	assert.Equal(t, types.ReceiptStatusFailed, receipt.Status)
 
 	// account2 has direct delegation, must succeed
 	counterInAccount2, err := counter.NewCounter(account2.Address(), client)
 	require.NoError(t, err)
-	receipt, err = net.Apply(counterInAccount2.IncrementCounter)
+	receipt, err = session.Apply(counterInAccount2.IncrementCounter)
 	require.NoError(t, err)
 	assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 }
 
 // testChainOfCalls checks that delegations can used over transitive calls between contracts.
-func testChainOfCalls(t *testing.T, net *IntegrationTestNet) {
+func testChainOfCalls(t *testing.T, session IntegrationTestNetSession) {
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err, "failed to get chain ID")
 
-	sponsor := makeAccountWithBalance(t, net, big.NewInt(1e18)) // < Pays for the transaction gas, originates the call-chain
+	sponsor := makeAccountWithBalance(t, session, big.NewInt(1e18)) // < Pays for the transaction gas, originates the call-chain
 	account1 := NewAccount()
 	account2 := NewAccount()
 
 	// deploy the batch contract
-	contract, deployReceipt, err := DeployContract(net, transitive_call.DeployTransitiveCall)
+	contract, deployReceipt, err := DeployContract(session, transitive_call.DeployTransitiveCall)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, deployReceipt.Status)
 	transitiveContractAddress := deployReceipt.ContractAddress
@@ -829,7 +852,7 @@ func testChainOfCalls(t *testing.T, net *IntegrationTestNet) {
 	// calldata is used to fill the arguments passed to the contract call.
 	// id defines a list of addresses to call, one after the other
 	// value from the original transaction is carried with the call
-	callData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	callData := getCallData(t, session, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return contract.TransitiveCall(opts, []common.Address{
 			account1.Address(), // does one call to itself
 			account2.Address(), // calls account2
@@ -854,7 +877,7 @@ func testChainOfCalls(t *testing.T, net *IntegrationTestNet) {
 	)
 	require.NoError(t, err, "failed to sign transaction")
 
-	receipt, err := net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -942,9 +965,9 @@ func makeEip7702Transaction(t *testing.T,
 // getCallData creates a transaction and returns the data field of the transaction.
 // This function can be used to retrieve the ABI encoding of a the call data, and
 // use such encoding to create a SetCode transaction.
-func getCallData(t *testing.T, net *IntegrationTestNet,
+func getCallData(t *testing.T, session IntegrationTestNetSession,
 	transactionConstructor func(*bind.TransactOpts) (*types.Transaction, error)) []byte {
-	txOpts, err := net.GetTransactOptions(&net.validator)
+	txOpts, err := session.GetTransactOptions(session.GetAccount())
 	require.NoError(t, err)
 	txOpts.NoSend = true // <- create the transaction to read callData, but do not send it.
 	tx, err := transactionConstructor(txOpts)

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -967,7 +967,7 @@ func makeEip7702Transaction(t *testing.T,
 // use such encoding to create a SetCode transaction.
 func getCallData(t *testing.T, session IntegrationTestNetSession,
 	transactionConstructor func(*bind.TransactOpts) (*types.Transaction, error)) []byte {
-	txOpts, err := session.GetTransactOptions(session.GetAccount())
+	txOpts, err := session.GetTransactOptions(session.GetSessionSponsor())
 	require.NoError(t, err)
 	txOpts.NoSend = true // <- create the transaction to read callData, but do not send it.
 	tx, err := transactionConstructor(txOpts)

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -263,7 +263,7 @@ func TestTransactionGasPrice(t *testing.T) {
 
 // makeAccountWithBalance creates a new account and endows it with the given balance.
 // Creating the account this way allows to get access to the private key to sign transactions.
-func makeAccountWithBalance(t *testing.T, net *IntegrationTestNet, balance *big.Int) *Account {
+func makeAccountWithBalance(t *testing.T, net IntegrationTestNetSession, balance *big.Int) *Account {
 	t.Helper()
 	account := NewAccount()
 	receipt, err := net.EndowAccount(account.Address(), balance)

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -24,7 +24,7 @@ func TestTransactionGasPrice(t *testing.T) {
 	defer client.Close()
 
 	// use a fresh account to send transactions from
-	account := makeAccountWithBalance(t, net, int64(1e18))
+	account := makeAccountWithBalance(t, net, big.NewInt(1e18))
 
 	t.Run("Legacy transaction, effectivePrice is equal to requested price", func(t *testing.T) {
 
@@ -263,7 +263,7 @@ func TestTransactionGasPrice(t *testing.T) {
 
 // makeAccountWithBalance creates a new account and endows it with the given balance.
 // Creating the account this way allows to get access to the private key to sign transactions.
-func makeAccountWithBalance(t *testing.T, net *IntegrationTestNet, balance int64) *Account {
+func makeAccountWithBalance(t *testing.T, net *IntegrationTestNet, balance *big.Int) *Account {
 	t.Helper()
 	account := NewAccount()
 	receipt, err := net.EndowAccount(account.Address(), balance)

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -140,7 +140,7 @@ func TestTransactionOrder(t *testing.T) {
 
 // makeAccountWithMaxBalance creates a new account and endows it with math.MaxInt64 balance.
 // Creating the account this way allows to get access to the private key to sign transactions.
-func makeAccountWithMaxBalance(t *testing.T, net *IntegrationTestNet) *Account {
+func makeAccountWithMaxBalance(t *testing.T, net IntegrationTestNetSession) *Account {
 	t.Helper()
 	account := NewAccount()
 

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -143,7 +143,14 @@ func TestTransactionOrder(t *testing.T) {
 func makeAccountWithMaxBalance(t *testing.T, net *IntegrationTestNet) *Account {
 	t.Helper()
 	account := NewAccount()
-	receipt, err := net.EndowAccount(account.Address(), math.MaxInt64)
+
+	// endowments are backed up by the test net account, and therefore are
+	// bound by the (very large but not infinite) balance of the test net account.
+	receipt, err := net.EndowAccount(account.Address(),
+		new(big.Int).Mul(
+			big.NewInt(math.MaxInt64),
+			big.NewInt(1e6),
+		))
 	require.NoError(t, err)
 	require.Equal(t,
 		receipt.Status, types.ReceiptStatusSuccessful,

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"math"
 	"math/big"
 	"math/rand/v2"
 	"testing"
@@ -34,7 +33,7 @@ func TestTransactionOrder(t *testing.T) {
 
 	// Only transactions from different accounts can change order.
 	for range numAccounts {
-		accounts = append(accounts, makeAccountWithMaxBalance(t, net))
+		accounts = append(accounts, makeAccountWithBalance(t, net, big.NewInt(1e18)))
 	}
 
 	// Repeat the test for X number of blocks
@@ -136,24 +135,4 @@ func TestTransactionOrder(t *testing.T) {
 		}
 	}
 	require.Equal(t, globalCounter, numTxs*numBlocks)
-}
-
-// makeAccountWithMaxBalance creates a new account and endows it with math.MaxInt64 balance.
-// Creating the account this way allows to get access to the private key to sign transactions.
-func makeAccountWithMaxBalance(t *testing.T, net IntegrationTestNetSession) *Account {
-	t.Helper()
-	account := NewAccount()
-
-	// endowments are backed up by the test net account, and therefore are
-	// bound by the (very large but not infinite) balance of the test net account.
-	receipt, err := net.EndowAccount(account.Address(),
-		new(big.Int).Mul(
-			big.NewInt(math.MaxInt64),
-			big.NewInt(1e6),
-		))
-	require.NoError(t, err)
-	require.Equal(t,
-		receipt.Status, types.ReceiptStatusSuccessful,
-		"endowing account failed")
-	return account
 }

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -19,7 +19,7 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	net := StartIntegrationTestNet(t)
 
 	// run endowment to ensure at least one block exists
-	receipt, err := net.EndowAccount(common.Address{42}, 1)
+	receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(1))
 	requireBase.NoError(err)
 	requireBase.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
 


### PR DESCRIPTION
This PR introduces a proxy account, which can be used to issue transactions in the same manner as the `IntegrationTestNet` object did before. 

Each subtest has a sequence of events, when such events use a disjoint set of accounts from the network, they can be executed concurrently with other workload. This PR introduces a `IntegrationTestNetSession` interface, with the already existing interface to execute transactions and retrieve information from a running network, but who's transactions are backed by a newly created account. 

The existing tests remain compatible, as the `IntegrationTestNet` already implements the interface.

- Set_code_tx_test reduces execution time from 180s to 50s.
- selfdestruct test reduces execution time from 40s to 25s. 

Two challenges arised during this development:
- balance, all transactions are backed by some account. Existing infrastructure uses the validator account, which is provided with a very large balance. The current changes create a new account to pay for transactions with a transfer from that validator account. Unfortunately, uint64 limits are too close to real costs and tests would fail.  This required the migration to big.Int to generate very large accounts to back up sessions. 
- defer conflicts with parallel, as described here: https://brandur.org/fragments/go-prefer-t-cleanup-with-parallel-subtests

**Future work**: I believe that this technique could be scaled to be used by every integration test in their top level, being all of them spawns from a singleton integration test network. Such an implementation would run in parallel with the memory footprint of a single network, tests would behave identically when ran sequentially. But the newly introduced parallelism could lead to clashes of addresses used by tests. 

**Review**: The PR is organized by commits, It may be easier to review the changes when reading one commit at the time.
