### PR TITLE
kmeeth/vecfc-reorg

### DIFF
--- a/ethapi/mock_backend.go
+++ b/ethapi/mock_backend.go
@@ -15,6 +15,8 @@ import (
 	reflect "reflect"
 	time "time"
 
+	hash "github.com/0xsoniclabs/consensus/hash"
+	idx "github.com/0xsoniclabs/consensus/inter/idx"
 	evmcore "github.com/0xsoniclabs/sonic/evmcore"
 	inter "github.com/0xsoniclabs/sonic/inter"
 	iblockproc "github.com/0xsoniclabs/sonic/inter/iblockproc"

--- a/ethapi/mock_backend.go
+++ b/ethapi/mock_backend.go
@@ -19,8 +19,6 @@ import (
 	inter "github.com/0xsoniclabs/sonic/inter"
 	iblockproc "github.com/0xsoniclabs/sonic/inter/iblockproc"
 	state "github.com/0xsoniclabs/sonic/inter/state"
-	hash "github.com/0xsoniclabs/consensus/hash"
-	idx "github.com/0xsoniclabs/consensus/inter/idx"
 	accounts "github.com/ethereum/go-ethereum/accounts"
 	common "github.com/ethereum/go-ethereum/common"
 	core "github.com/ethereum/go-ethereum/core"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff
-	github.com/0xsoniclabs/consensus v0.0.0-20250225125107-df2b1fd116dd
+	github.com/0xsoniclabs/consensus v0.0.0-20250305150018-46890c1558a3
 	github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc
 	github.com/cespare/cp v1.1.1
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -132,5 +132,3 @@ require (
 replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210201043429-a8e90a2a4f88
-
-replace github.com/0xsoniclabs/consensus v0.0.0-20250225125107-df2b1fd116dd => ../sonic-consensus

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff
 	github.com/0xsoniclabs/consensus v0.0.0-20250225125107-df2b1fd116dd
-	github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc
+    github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc
 	github.com/cespare/cp v1.1.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff
 	github.com/0xsoniclabs/consensus v0.0.0-20250225125107-df2b1fd116dd
-    github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc
+	github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc
 	github.com/cespare/cp v1.1.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0
@@ -132,3 +132,5 @@ require (
 replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809
 
 replace github.com/dvyukov/go-fuzz => github.com/guzenok/go-fuzz v0.0.0-20210201043429-a8e90a2a4f88
+
+replace github.com/0xsoniclabs/consensus v0.0.0-20250225125107-df2b1fd116dd => ../sonic-consensus

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff h1:ItY2JgmM0lH/kLHRGOHh7sEAB6w/lT5qv/xkkS5zO6o=
 github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff/go.mod h1:/u6oDZBv6eyPs9K7Ug5D4aL9l1Q7N43BnWEUPsvKmYw=
+github.com/0xsoniclabs/consensus v0.0.0-20250305150018-46890c1558a3 h1:8RMTZUUdJZuaiJR7W/sQL/esqyiQDjPXxB9XZeUj3DM=
+github.com/0xsoniclabs/consensus v0.0.0-20250305150018-46890c1558a3/go.mod h1:iqY4OlMSIpNvXZ0e7FiPsMJFcjPfem2VYmsYyluLr14=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809 h1:MtKV0hC7b58vimXYzmNRBNZJw1ovewt5GbanzPgl68k=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809/go.mod h1:9SAhGia6ukqZnvwJ3npNEmQDFjusZ/vXgbU1Z7J1vhw=
 github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc h1:3JvCgp/G+0VQCz74vXKjH475/JvCM7r1Kny0wzUN7TI=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff h1:ItY2JgmM0lH/kLHRGOHh7sEAB6w/lT5qv/xkkS5zO6o=
 github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff/go.mod h1:/u6oDZBv6eyPs9K7Ug5D4aL9l1Q7N43BnWEUPsvKmYw=
-github.com/0xsoniclabs/consensus v0.0.0-20250225125107-df2b1fd116dd h1:HNtFVzo6K5+zkNGRV6fDIN/P6Iiur2PFCfyltF6nOdw=
-github.com/0xsoniclabs/consensus v0.0.0-20250225125107-df2b1fd116dd/go.mod h1:iqY4OlMSIpNvXZ0e7FiPsMJFcjPfem2VYmsYyluLr14=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809 h1:MtKV0hC7b58vimXYzmNRBNZJw1ovewt5GbanzPgl68k=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809/go.mod h1:9SAhGia6ukqZnvwJ3npNEmQDFjusZ/vXgbU1Z7J1vhw=
 github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc h1:3JvCgp/G+0VQCz74vXKjH475/JvCM7r1Kny0wzUN7TI=

--- a/gossip/emitter/mock/world.go
+++ b/gossip/emitter/mock/world.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	inter "github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/inter/state"
 	validatorpk "github.com/0xsoniclabs/sonic/inter/validatorpk"
 	opera "github.com/0xsoniclabs/sonic/opera"
 	vecmt "github.com/0xsoniclabs/sonic/vecmt"
@@ -18,7 +19,6 @@ import (
 	common "github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
 	gomock "github.com/golang/mock/gomock"
-	"github.com/0xsoniclabs/sonic/inter/state"
 )
 
 // MockExternal is a mock of External interface.

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -14,9 +14,12 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
+	"github.com/0xsoniclabs/consensus/gossip/dagprocessor"
+	"github.com/0xsoniclabs/consensus/gossip/itemsfetcher"
 	"github.com/0xsoniclabs/consensus/hash"
 	"github.com/0xsoniclabs/consensus/inter/dag"
 	"github.com/0xsoniclabs/consensus/inter/idx"
+	"github.com/0xsoniclabs/consensus/utils/datasemaphore"
 	"github.com/0xsoniclabs/sonic/eventcheck"
 	"github.com/0xsoniclabs/sonic/eventcheck/epochcheck"
 	"github.com/0xsoniclabs/sonic/eventcheck/heavycheck"

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -14,12 +14,9 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
-	"github.com/0xsoniclabs/consensus/gossip/dagprocessor"
-	"github.com/0xsoniclabs/consensus/gossip/itemsfetcher"
 	"github.com/0xsoniclabs/consensus/hash"
 	"github.com/0xsoniclabs/consensus/inter/dag"
 	"github.com/0xsoniclabs/consensus/inter/idx"
-	"github.com/0xsoniclabs/consensus/utils/datasemaphore"
 	"github.com/0xsoniclabs/sonic/eventcheck"
 	"github.com/0xsoniclabs/sonic/eventcheck/epochcheck"
 	"github.com/0xsoniclabs/sonic/eventcheck/heavycheck"

--- a/opera/genesis/types.go
+++ b/opera/genesis/types.go
@@ -1,9 +1,8 @@
 package genesis
 
 import (
-	"io"
-
 	"github.com/0xsoniclabs/consensus/hash"
+	"io"
 
 	"github.com/0xsoniclabs/sonic/inter/ibr"
 	"github.com/0xsoniclabs/sonic/inter/ier"

--- a/topicsdb/dummy.go
+++ b/topicsdb/dummy.go
@@ -2,7 +2,6 @@ package topicsdb
 
 import (
 	"context"
-
 	"github.com/0xsoniclabs/consensus/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/utils/adapters/vecmt2dagidx/vecmt2lachesis.go
+++ b/utils/adapters/vecmt2dagidx/vecmt2lachesis.go
@@ -5,7 +5,7 @@ import (
 	"github.com/0xsoniclabs/consensus/abft/dagidx"
 	"github.com/0xsoniclabs/consensus/hash"
 	"github.com/0xsoniclabs/consensus/inter/idx"
-	"github.com/0xsoniclabs/consensus/vecfc"
+	"github.com/0xsoniclabs/consensus/vecengine"
 
 	"github.com/0xsoniclabs/sonic/vecmt"
 )
@@ -21,7 +21,7 @@ type AdapterSeq struct {
 }
 
 type BranchSeq struct {
-	vecfc.BranchSeq
+	vecengine.BranchSeq
 }
 
 // Seq is a maximum observed e.Seq in the branch

--- a/utils/dbutil/dbcounter/dbcounter.go
+++ b/utils/dbutil/dbcounter/dbcounter.go
@@ -2,9 +2,8 @@ package dbcounter
 
 import (
 	"fmt"
-	"sync/atomic"
-
 	"github.com/0xsoniclabs/sonic/utils/dbutil"
+	"sync/atomic"
 
 	"github.com/0xsoniclabs/consensus/kvdb"
 	"github.com/ethereum/go-ethereum/log"

--- a/vecmt/median_time.go
+++ b/vecmt/median_time.go
@@ -21,11 +21,10 @@ type medianTimeIndex struct {
 func (vi *Index) MedianTime(id hash.Event, defaultTime inter.Timestamp) inter.Timestamp {
 	vi.Engine.InitBranchesInfo()
 	// Get event by hash
-	_before := vi.Engine.GetMergedHighestBefore(id)
-	if _before == nil {
+	before := vi.GetMergedHighestBefore(id)
+	if before == nil {
 		vi.crit(fmt.Errorf("event=%s not found", id.String()))
 	}
-	before := _before.(*HighestBefore)
 
 	honestTotalWeight := pos.Weight(0) // isn't equal to validators.TotalWeight(), because doesn't count cheaters
 	highests := make([]medianTimeIndex, 0, len(vi.validatorIdxs))

--- a/vecmt/median_time_test.go
+++ b/vecmt/median_time_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/inter/idx"
-	"github.com/0xsoniclabs/consensus/vecfc"
+	"github.com/0xsoniclabs/consensus/vecengine"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/0xsoniclabs/consensus/hash"
@@ -30,19 +30,19 @@ func TestMedianTimeOnIndex(t *testing.T) {
 		// validator indexes are sorted by weight amount
 		before := NewHighestBefore(idx.Validator(validators.Len()))
 
-		before.VSeq.Set(0, vecfc.BranchSeq{Seq: 0})
+		before.VSeq.Set(0, vecengine.BranchSeq{Seq: 0})
 		before.VTime.Set(0, 100)
 
-		before.VSeq.Set(1, vecfc.BranchSeq{Seq: 0})
+		before.VSeq.Set(1, vecengine.BranchSeq{Seq: 0})
 		before.VTime.Set(1, 100)
 
-		before.VSeq.Set(2, vecfc.BranchSeq{Seq: 1})
+		before.VSeq.Set(2, vecengine.BranchSeq{Seq: 1})
 		before.VTime.Set(2, 10)
 
-		before.VSeq.Set(3, vecfc.BranchSeq{Seq: 1})
+		before.VSeq.Set(3, vecengine.BranchSeq{Seq: 1})
 		before.VTime.Set(3, 10)
 
-		before.VSeq.Set(4, vecfc.BranchSeq{Seq: 1})
+		before.VSeq.Set(4, vecengine.BranchSeq{Seq: 1})
 		before.VTime.Set(4, 10)
 
 		vi.SetHighestBefore(e, before)
@@ -60,13 +60,13 @@ func TestMedianTimeOnIndex(t *testing.T) {
 		before.SetForkDetected(1)
 		before.VTime.Set(1, 100)
 
-		before.VSeq.Set(2, vecfc.BranchSeq{Seq: 1})
+		before.VSeq.Set(2, vecengine.BranchSeq{Seq: 1})
 		before.VTime.Set(2, 10)
 
-		before.VSeq.Set(3, vecfc.BranchSeq{Seq: 1})
+		before.VSeq.Set(3, vecengine.BranchSeq{Seq: 1})
 		before.VTime.Set(3, 10)
 
-		before.VSeq.Set(4, vecfc.BranchSeq{Seq: 1})
+		before.VSeq.Set(4, vecengine.BranchSeq{Seq: 1})
 		before.VTime.Set(4, 10)
 
 		vi.SetHighestBefore(e, before)
@@ -78,19 +78,19 @@ func TestMedianTimeOnIndex(t *testing.T) {
 		// validator indexes are sorted by weight amount
 		before := NewHighestBefore(idx.Validator(validators.Len()))
 
-		before.VSeq.Set(0, vecfc.BranchSeq{Seq: 1})
+		before.VSeq.Set(0, vecengine.BranchSeq{Seq: 1})
 		before.VTime.Set(0, 11)
 
-		before.VSeq.Set(1, vecfc.BranchSeq{Seq: 2})
+		before.VSeq.Set(1, vecengine.BranchSeq{Seq: 2})
 		before.VTime.Set(1, 12)
 
-		before.VSeq.Set(2, vecfc.BranchSeq{Seq: 2})
+		before.VSeq.Set(2, vecengine.BranchSeq{Seq: 2})
 		before.VTime.Set(2, 13)
 
-		before.VSeq.Set(3, vecfc.BranchSeq{Seq: 3})
+		before.VSeq.Set(3, vecengine.BranchSeq{Seq: 3})
 		before.VTime.Set(3, 14)
 
-		before.VSeq.Set(4, vecfc.BranchSeq{Seq: 4})
+		before.VSeq.Set(4, vecengine.BranchSeq{Seq: 4})
 		before.VTime.Set(4, 15)
 
 		vi.SetHighestBefore(e, before)

--- a/vecmt/no_cheaters.go
+++ b/vecmt/no_cheaters.go
@@ -19,7 +19,7 @@ func (vi *Index) NoCheaters(selfParent *hash.Event, options hash.Events) hash.Ev
 	}
 
 	// no need to merge, because every branch is marked by IsForkDetected if fork is observed
-	highest := vi.Base.GetHighestBefore(*selfParent)
+	highest := vi.Engine.GetHighestBefore(*selfParent)
 	filtered := make(hash.Events, 0, len(options))
 	for _, id := range options {
 		e := vi.getEvent(id)

--- a/vecmt/store_vectors.go
+++ b/vecmt/store_vectors.go
@@ -39,7 +39,7 @@ func (vi *Index) GetHighestBeforeTime(id hash.Event) *HighestBeforeTime {
 // GetHighestBefore reads the vector from DB
 func (vi *Index) GetHighestBefore(id hash.Event) *HighestBefore {
 	return &HighestBefore{
-		VSeq:  vi.Base.GetHighestBefore(id),
+		VSeq:  vi.Engine.GetHighestBefore(id),
 		VTime: vi.GetHighestBeforeTime(id),
 	}
 }
@@ -53,6 +53,6 @@ func (vi *Index) SetHighestBeforeTime(id hash.Event, vec *HighestBeforeTime) {
 
 // SetHighestBefore stores the vectors into DB
 func (vi *Index) SetHighestBefore(id hash.Event, vec *HighestBefore) {
-	vi.Base.SetHighestBefore(id, vec.VSeq)
+	vi.Engine.SetHighestBefore(id, vec.VSeq)
 	vi.SetHighestBeforeTime(id, vec.VTime)
 }

--- a/vecmt/vector.go
+++ b/vecmt/vector.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 
 	"github.com/0xsoniclabs/consensus/inter/idx"
-	"github.com/0xsoniclabs/consensus/vecfc"
+	"github.com/0xsoniclabs/consensus/vecengine"
 
 	"github.com/0xsoniclabs/sonic/inter"
 )
@@ -18,7 +18,7 @@ type (
 	HighestBeforeTime []byte
 
 	HighestBefore struct {
-		VSeq  *vecfc.HighestBeforeSeq
+		VSeq  *vecengine.HighestBeforeSeq
 		VTime *HighestBeforeTime
 	}
 )
@@ -26,7 +26,7 @@ type (
 // NewHighestBefore creates new HighestBefore vector.
 func NewHighestBefore(size idx.Validator) *HighestBefore {
 	return &HighestBefore{
-		VSeq:  vecfc.NewHighestBeforeSeq(size),
+		VSeq:  vecengine.NewHighestBeforeSeq(size),
 		VTime: NewHighestBeforeTime(size),
 	}
 }

--- a/vecmt/vector_ops.go
+++ b/vecmt/vector_ops.go
@@ -4,7 +4,6 @@ import (
 	"github.com/0xsoniclabs/consensus/inter/dag"
 	"github.com/0xsoniclabs/consensus/inter/idx"
 	"github.com/0xsoniclabs/consensus/vecengine"
-	"github.com/0xsoniclabs/consensus/vecfc"
 
 	"github.com/0xsoniclabs/sonic/inter"
 )
@@ -74,7 +73,7 @@ func (hb *HighestBefore) CollectFrom(_other vecengine.HighestBeforeI, num idx.Va
 func (hb *HighestBefore) GatherFrom(to idx.Validator, _other vecengine.HighestBeforeI, from []idx.Validator) {
 	other := _other.(*HighestBefore)
 	// read all branches to find highest event
-	highestBranchSeq := vecfc.BranchSeq{}
+	highestBranchSeq := vecengine.BranchSeq{}
 	highestBranchTime := inter.Timestamp(0)
 	for _, branchID := range from {
 		vseq := other.VSeq.Get(branchID)


### PR DESCRIPTION
Changes made to the client so that the
changes from PR #41 in Consensus can be leveraged.
vecmt.Index now contains a vecengine.Engine, to account for the fact that vecfc no longer exists.
Refer to #41 in Consensus it to for further details.
