### PR TITLE
Change Integration test net constructors to improve test cleanup lifetimes. 

### DIFF
--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -27,12 +27,11 @@ import (
 
 func TestSonicTool_check_ExecutesWithoutErrors(t *testing.T) {
 
-	net, err := tests.StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
+	net := tests.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
-	_, err = executeSonicTool(t,
+	_, err := executeSonicTool(t,
 		"--datadir", net.GetDirectory()+"/state",
 		"check", "live")
 	require.NoError(t, err)
@@ -45,12 +44,11 @@ func TestSonicTool_check_ExecutesWithoutErrors(t *testing.T) {
 
 func TestSonicTool_compact_ExecutesWithoutErrors(t *testing.T) {
 
-	net, err := tests.StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
+	net := tests.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
-	_, err = executeSonicTool(t,
+	_, err := executeSonicTool(t,
 		"--datadir", net.GetDirectory()+"/state",
 		"compact")
 	require.NoError(t, err)
@@ -121,21 +119,17 @@ func TestSonicTool_account_ExecutesWithoutErrors(t *testing.T) {
 }
 
 func TestSonicTool_genesis_ExecutesWithoutErrors(t *testing.T) {
-	tmp := t.TempDir()
-	dataDirA := fmt.Sprintf("%s/A", tmp)
-	dataDirB := fmt.Sprintf("%s/B", tmp)
 
 	// Create a history by running some transactions
-	net, err := tests.StartIntegrationTestNet(dataDirA)
-	require.NoError(t, err)
+	net := tests.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
 	passwordFileName := fmt.Sprintf("%s/password_file", t.TempDir())
 	require.NoError(t, generatePasswordFile(passwordFileName, "this is the passphrase"))
 
-	exportFile := fmt.Sprintf("%s/genesis", tmp)
-	_, err = executeSonicTool(t,
+	exportFile := fmt.Sprintf("%s/genesis", t.TempDir())
+	_, err := executeSonicTool(t,
 		"--datadir", net.GetDirectory()+"/state",
 		"genesis", "export", exportFile)
 	require.NoError(t, err)
@@ -159,7 +153,7 @@ func TestSonicTool_genesis_ExecutesWithoutErrors(t *testing.T) {
 	promptMock.EXPECT().PromptInput("Signature (hex): ").Return(hexutil.Encode(signature), nil)
 
 	_, err = executeSonicTool(t,
-		"--datadir", fmt.Sprintf("%s/state", dataDirB),
+		"--datadir", fmt.Sprintf("%s/state", t.TempDir()),
 		"genesis", "sign", exportFile)
 	// Note, this how far we can get without the actual key
 	require.ErrorContains(t, err, "genesis signature does not match any trusted signer")
@@ -167,25 +161,22 @@ func TestSonicTool_genesis_ExecutesWithoutErrors(t *testing.T) {
 }
 
 func TestSonicTool_heal_ExecutesWithoutErrors(t *testing.T) {
-	net, err := tests.StartIntegrationTestNet(t.TempDir(),
-		"--statedb.checkpointinterval", "1")
-	require.NoError(t, err)
+	net := tests.StartIntegrationTestNet(t, "--statedb.checkpointinterval", "1")
 	generateNBlocks(t, net, 3)
 	net.Stop()
 
-	_, err = executeSonicTool(t, "--datadir", net.GetDirectory()+"/state", "heal")
+	_, err := executeSonicTool(t, "--datadir", net.GetDirectory()+"/state", "heal")
 	require.NoError(t, err)
 }
 
 func TestSonicTool_config_ExecutesWithoutErrors(t *testing.T) {
 
-	net, err := tests.StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
+	net := tests.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
 	configFileName := t.TempDir() + "config.toml"
-	_, err = executeSonicTool(t,
+	_, err := executeSonicTool(t,
 		"--datadir", net.GetDirectory()+"/state",
 		"dumpconfig", configFileName)
 	require.NoError(t, err)
@@ -212,14 +203,13 @@ func TestSonicTool_config_ExecutesWithoutErrors(t *testing.T) {
 }
 
 func TestSonicTool_events_ExecutesWithoutErrors(t *testing.T) {
-	net, err := tests.StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
+	net := tests.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
 	eventsExportFile := t.TempDir() + "/events.json"
 
-	_, err = executeSonicTool(t,
+	_, err := executeSonicTool(t,
 		"--datadir", net.GetDirectory()+"/state",
 		"events", "export", eventsExportFile)
 	require.NoError(t, err)

--- a/tests/address_access_test.go
+++ b/tests/address_access_test.go
@@ -13,11 +13,7 @@ import (
 func TestAddressAccess(t *testing.T) {
 	someAccountAddress := common.Address{1}
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	contract, receipt, err := DeployContract(net, accessCost.DeployAccessCost)
 	checkTxExecution(t, receipt, err)

--- a/tests/basefee_test.go
+++ b/tests/basefee_test.go
@@ -9,11 +9,7 @@ import (
 )
 
 func TestBaseFee_CanReadBaseFeeFromHeadAndBlockAndHistory(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the base fee contract.
 	contract, _, err := DeployContract(net, basefee.DeployBasefee)

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -199,8 +199,7 @@ type testContext struct {
 }
 
 func MakeTestContext(t *testing.T) *testContext {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
+	net := StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)

--- a/tests/blobbasefee_test.go
+++ b/tests/blobbasefee_test.go
@@ -18,9 +18,7 @@ import (
 
 func TestBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T) {
 	require := require.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err, "Failed to start the fake network: ", err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the blob base fee contract.
 	contract, _, err := DeployContract(net, blobbasefee.DeployBlobbasefee)
@@ -74,9 +72,7 @@ func getBlobBaseFeeFrom(header *types.Header) uint64 {
 
 func TestBlobBaseFee_CanReadBlobGasUsed(t *testing.T) {
 	require := require.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err, "Failed to start the fake network: ", err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	require.NoError(err, "failed to get client; ", err)

--- a/tests/block_hash_test.go
+++ b/tests/block_hash_test.go
@@ -14,11 +14,7 @@ import (
 
 func TestBlockHash_CorrectBlockHashesAreAccessibleInContracts(t *testing.T) {
 	require := req.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the block hash observer contract.
 	_, receipt, err := DeployContract(net, block_hash.DeployBlockHash)

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -34,18 +34,12 @@ import (
 )
 
 func TestBlockHeader_FakeGenesis_SatisfiesInvariants(t *testing.T) {
-	require := require.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 	testBlockHeadersOnNetwork(t, net)
 }
 
 func TestBlockHeader_JsonGenesis_SatisfiesInvariants(t *testing.T) {
-	require := require.New(t)
-	net, err := StartIntegrationTestNetFromJsonGenesis(t.TempDir())
-	require.NoError(err)
-	defer net.Stop()
+	net := StartIntegrationTestNetFromJsonGenesis(t)
 	testBlockHeadersOnNetwork(t, net)
 }
 

--- a/tests/block_override_test.go
+++ b/tests/block_override_test.go
@@ -20,11 +20,7 @@ const (
 
 func TestBlockOverride(t *testing.T) {
 	require := req.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the block override observer contract.
 	_, receipt, err := DeployContract(net, block_override.DeployBlockOverride)

--- a/tests/counter_test.go
+++ b/tests/counter_test.go
@@ -10,11 +10,7 @@ import (
 )
 
 func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the counter contract.
 	contract, _, err := DeployContract(net, counter.DeployCounter)
@@ -41,11 +37,7 @@ func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
 }
 
 func TestCounter_CanReadHistoricCounterValues(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the counter contract.
 	contract, receipt, err := DeployContract(net, counter.DeployCounter)

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -93,9 +93,7 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 }
 
 func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *ethclient.Client) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
-	t.Cleanup(func() { net.Stop() })
+	net := StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)

--- a/tests/genesis_import_test.go
+++ b/tests/genesis_import_test.go
@@ -12,9 +12,7 @@ func TestGenesis_NetworkCanCreateNewBlocksAfterExportImport(t *testing.T) {
 	const numBlocks = 3
 	require := require.New(t)
 
-	tempDir := t.TempDir()
-	net, err := StartIntegrationTestNet(tempDir)
-	require.NoError(err)
+	net := StartIntegrationTestNet(t)
 
 	// Produce a few blocks on the network.
 	for range numBlocks {

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -1,19 +1,18 @@
 package tests
 
 import (
+	"testing"
+
 	"github.com/0xsoniclabs/sonic/ethapi"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestGetAccount(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err, "failed to start the fake network")
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the transient storage contract
 	_, deployReceipt, err := DeployContract(net, counter.DeployCounter)

--- a/tests/initcoder_test.go
+++ b/tests/initcoder_test.go
@@ -20,9 +20,7 @@ const sufficientGas = uint64(100_000)
 func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	requireBase := require.New(t)
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	requireBase.NoError(err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	contract, receipt, err := DeployContract(net, contractcreator.DeployContractcreator)
 	requireBase.NoError(err)

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 func TestIntegrationTestNet_CanStartRestartAndStopIntegrationTestNet(t *testing.T) {
-	dataDir := t.TempDir()
-	net, err := StartIntegrationTestNet(dataDir)
-	if err != nil {
-		t.Fatalf("Failed to start the test network: %v", err)
-	}
+	net := StartIntegrationTestNet(t)
 	if err := net.Restart(); err != nil {
 		t.Fatalf("Failed to restart the test network: %v", err)
 	}
@@ -23,23 +19,14 @@ func TestIntegrationTestNet_CanStartRestartAndStopIntegrationTestNet(t *testing.
 }
 
 func TestIntegrationTestNet_CanStartMultipleConsecutiveInstances(t *testing.T) {
-	for i := 0; i < 2; i++ {
-		dataDir := t.TempDir()
-		net, err := StartIntegrationTestNet(dataDir)
-		if err != nil {
-			t.Fatalf("Failed to start the fake network: %v", err)
-		}
+	for range 2 {
+		net := StartIntegrationTestNet(t)
 		net.Stop()
 	}
 }
 
 func TestIntegrationTestNet_CanFetchInformationFromTheNetwork(t *testing.T) {
-	dataDir := t.TempDir()
-	net, err := StartIntegrationTestNet(dataDir)
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	if err != nil {
@@ -58,12 +45,7 @@ func TestIntegrationTestNet_CanFetchInformationFromTheNetwork(t *testing.T) {
 }
 
 func TestIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T) {
-	dataDir := t.TempDir()
-	net, err := StartIntegrationTestNet(dataDir)
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	if err != nil {
@@ -100,12 +82,7 @@ func TestIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T) {
 }
 
 func TestIntegrationTestNet_CanDeployContracts(t *testing.T) {
-	dataDir := t.TempDir()
-	net, err := StartIntegrationTestNet(dataDir)
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	_, receipt, err := DeployContract(net, counter.DeployCounter)
 	if err != nil {
@@ -117,12 +94,7 @@ func TestIntegrationTestNet_CanDeployContracts(t *testing.T) {
 }
 
 func TestIntegrationTestNet_CanInteractWithContract(t *testing.T) {
-	dataDir := t.TempDir()
-	net, err := StartIntegrationTestNet(dataDir)
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	contract, _, err := DeployContract(net, counter.DeployCounter)
 	if err != nil {

--- a/tests/invalid_start_test.go
+++ b/tests/invalid_start_test.go
@@ -15,9 +15,7 @@ func TestInvalidStart_IdentifiesInvalidStartContract(t *testing.T) {
 	invalidCode := []byte{0x60, 0xef, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
 	validCode := []byte{0x60, 0xfe, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	r.NoError(err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the invalid start contract.
 	contract, _, err := DeployContract(net, invalidstart.DeployInvalidstart)

--- a/tests/log_subscription_test.go
+++ b/tests/log_subscription_test.go
@@ -14,9 +14,7 @@ import (
 func TestLogSubscription_CanGetCallBacksForLogEvents(t *testing.T) {
 	const NumEvents = 3
 	require := require.New(t)
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err, "Failed to start the fake network: ", err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	contract, _, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(err)

--- a/tests/node_restart_test.go
+++ b/tests/node_restart_test.go
@@ -15,9 +15,7 @@ func TestNodeRestart_CanRestartAndRestoreItsState(t *testing.T) {
 	const numRestarts = 2
 	require := require.New(t)
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// All transaction hashes indexed by their blocks.
 	receipts := map[int]types.Receipts{}

--- a/tests/prevrandao_test.go
+++ b/tests/prevrandao_test.go
@@ -2,18 +2,16 @@ package tests
 
 import (
 	"context"
-	"github.com/0xsoniclabs/sonic/tests/contracts/prevrandao"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"math/big"
 	"testing"
+
+	"github.com/0xsoniclabs/sonic/tests/contracts/prevrandao"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
 func TestPrevRandao(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
+
 	// Deploy the contract.
 	contract, _, err := DeployContract(net, prevrandao.DeployPrevrandao)
 	if err != nil {

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -16,9 +16,7 @@ func TestRejectedTx(t *testing.T) {
 	require := require.New(t)
 
 	// start network
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// create a client
 	client, err := net.GetClient()

--- a/tests/selfdestruct_test.go
+++ b/tests/selfdestruct_test.go
@@ -15,11 +15,8 @@ import (
 )
 
 func TestSelfDestruct(t *testing.T) {
-	require := require.New(t)
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err, "failed to start test network")
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	t.Run("constructor", func(t *testing.T) {
 		testSelfDestruct_Constructor(t, net)

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -33,11 +33,7 @@ import (
 // and do not implement ERC-20 as described in the EIP use case examples.
 func TestSetCodeTransaction(t *testing.T) {
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	t.Run("Operation", func(t *testing.T) {
 		// operation tests check basic operation of the SetCode transaction

--- a/tests/storage_override_test.go
+++ b/tests/storage_override_test.go
@@ -1,20 +1,20 @@
 package tests
 
 import (
-	"github.com/0xsoniclabs/sonic/tests/contracts/storage"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"strings"
 	"testing"
+
+	"github.com/0xsoniclabs/sonic/tests/contracts/storage"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err, "Failed to start the fake network: %v", err)
+	net := StartIntegrationTestNet(t)
 
 	defer net.Stop()
 
@@ -90,9 +90,7 @@ func TestSetStorage_Contract_Not_On_Blockchain_Executed_With_Extra_Storage(t *te
 	require := require.New(t)
 
 	// start network
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// create a client
 	client, err := net.GetClient()

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -17,9 +17,7 @@ const enoughGasPrice = 150_000_000_000
 
 func TestTransactionGasPrice(t *testing.T) {
 
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -20,8 +20,7 @@ func TestTransactionOrder(t *testing.T) {
 		numBlocks   = uint64(3)
 		numTxs      = numAccounts * numPerAcc
 	)
-	net, err := StartIntegrationTestNet(t.TempDir())
-	require.NoError(t, err)
+	net := StartIntegrationTestNet(t)
 	defer net.Stop()
 
 	contract, _, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)

--- a/tests/transientstorage_test.go
+++ b/tests/transientstorage_test.go
@@ -9,11 +9,7 @@ import (
 )
 
 func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
-	net, err := StartIntegrationTestNet(t.TempDir())
-	if err != nil {
-		t.Fatalf("Failed to start the fake network: %v", err)
-	}
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// Deploy the transient storage contract
 	contract, _, err := DeployContract(net, transientstorage.DeployTransientstorage)

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -16,9 +16,7 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	requireBase := require.New(t)
 
 	// start network.
-	net, err := StartIntegrationTestNet(t.TempDir())
-	requireBase.NoErrorf(err, "Failed to start the fake network: ", err)
-	defer net.Stop()
+	net := StartIntegrationTestNet(t)
 
 	// run endowment to ensure at least one block exists
 	receipt, err := net.EndowAccount(common.Address{42}, 1)


### PR DESCRIPTION
The issue when introducing parallel sub-tests using integration test networks is that cleanup would happen before sub-tests terminate, closing the network and crashing the tests. 
This change manages automatically cleanup registration in the context of t. 

- temp directory for client storage is generated from within the constructor.
- Net is automatically registered for cleanup in the context of t.
- Adding t as argument forces this code to be test only.

