### PR TITLE
Reduce block time in integration tests

### DIFF
--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -122,7 +122,7 @@ func TestSonicTool_account_ExecutesWithoutErrors(t *testing.T) {
 func TestSonicTool_genesis_ExecutesWithoutErrors(t *testing.T) {
 
 	// Create a history by running some transactions
-	net := tests.StartIntegrationTestNet(t)
+	net := tests.StartIntegrationTestNetWithFakeGenesis(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -70,9 +70,6 @@ func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
 	}
 
 	builder := makegenesis.NewGenesisBuilder()
-
-	fmt.Printf("Building genesis file - rules: %+v\n", json.Rules)
-
 	for _, acc := range json.Accounts {
 		if acc.Balance != nil {
 			builder.AddBalance(acc.Address, acc.Balance)

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -34,12 +34,12 @@ import (
 )
 
 func TestBlockHeader_FakeGenesis_SatisfiesInvariants(t *testing.T) {
-	net := StartIntegrationTestNet(t)
+	net := StartIntegrationTestNetWithFakeGenesis(t)
 	testBlockHeadersOnNetwork(t, net)
 }
 
 func TestBlockHeader_JsonGenesis_SatisfiesInvariants(t *testing.T) {
-	net := StartIntegrationTestNetFromJsonGenesis(t)
+	net := StartIntegrationTestNetWithJsonGenesis(t)
 	testBlockHeadersOnNetwork(t, net)
 }
 


### PR DESCRIPTION
This PR switches the genesis default for integration tests from a `fakenet` genesis to a test-package specific JSON genesis.

The `fakenet` genesis is a general feature facilitating the low-effort setup of a test net of multiple nodes for evaluation purposes. It is, for instance, used by Norma for setting up and running scenarios. Due to its scope, it is set up with a default event-emitter delay of 600ms, causing a block time of ~1 second.

For testing the JSON genesis feature, which is used for starting long-running networks like the Sonic main-net or public test nets, the integration test infrastructure also supports a mode to start a network using JSON file based genesis. This, so far, was only used for very few tests.

With this PR, the JSON genesis mode is made the default, and the emitter time for all tests is configured to be a single millisecond. As a result, blocks are produced much faster in tests, reducing the test time.

For instance, the time for the `TestTransactionOrder` test is reduced from 31 to 13 seconds on my development machine.