### PR TITLE
Introduce integration test net options to configure feature set enabled during testing. 

### DIFF
--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -29,7 +29,7 @@ func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 		validatorsNum,
 		futils.ToFtm(1000000000),
 		futils.ToFtm(5000000),
-		opera.SonicFeatures.ToUpgrades(),
+		opera.SonicFeatures,
 	)
 	defer func() {
 		if err := genesisStore.Close(); err != nil {

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/genesis"
 	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	"github.com/0xsoniclabs/sonic/opera"
 	futils "github.com/0xsoniclabs/sonic/utils"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/docker/docker/pkg/reexec"
@@ -28,6 +29,7 @@ func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 		validatorsNum,
 		futils.ToFtm(1000000000),
 		futils.ToFtm(5000000),
+		opera.SonicFeatures.ToUpgrades(),
 	)
 	defer func() {
 		if err := genesisStore.Close(); err != nil {

--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -13,6 +13,7 @@ import (
 
 	sonictool "github.com/0xsoniclabs/sonic/cmd/sonictool/app"
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/genesis"
+	"github.com/0xsoniclabs/sonic/opera"
 	ogenesis "github.com/0xsoniclabs/sonic/opera/genesis"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
 	"github.com/0xsoniclabs/sonic/tests"
@@ -162,7 +163,13 @@ func TestSonicTool_genesis_ExecutesWithoutErrors(t *testing.T) {
 }
 
 func TestSonicTool_heal_ExecutesWithoutErrors(t *testing.T) {
-	net := tests.StartIntegrationTestNet(t, "--statedb.checkpointinterval", "1")
+	net := tests.StartIntegrationTestNet(
+		t,
+		tests.IntegrationTestNetOptions{
+			FeatureSet:           opera.SonicFeatures,
+			ClientExtraArguments: []string{"--statedb.checkpointinterval", "1"},
+		},
+	)
 	generateNBlocks(t, net, 3)
 	net.Stop()
 

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/genesis"
 	"github.com/0xsoniclabs/sonic/config/flags"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
 	futils "github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/caution"
@@ -30,6 +31,11 @@ var (
 	ExperimentalFlag = cli.BoolFlag{
 		Name:  "experimental",
 		Usage: "Allow experimental features",
+	}
+	FakeUpgrades = cli.StringFlag{
+		Name:  "upgrades",
+		Usage: "Feature set enabled in the fake network, sonic|allegro.",
+		Value: "sonic",
 	}
 )
 
@@ -142,10 +148,22 @@ func fakeGenesisImport(ctx *cli.Context) (err error) {
 		return err
 	}
 
+	var featureSet opera.FeatureSet
+	upgradesString := ctx.String(FakeUpgrades.Name)
+	switch upgradesString {
+	case "sonic":
+		featureSet = opera.SonicFeatures
+	case "allegro":
+		featureSet = opera.AllegroFeatures
+	default:
+		return fmt.Errorf("invalid profile %v - must be 'sonic' or 'allegro'", upgradesString)
+	}
+
 	genesisStore := makefakegenesis.FakeGenesisStore(
 		idx.Validator(validatorsNumber),
-		futils.ToFtm(1000000000),
-		futils.ToFtm(5000000),
+		futils.ToFtm(1_000_000_000),
+		futils.ToFtm(5_000_000),
+		featureSet.ToUpgrades(),
 	)
 	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")
 	return genesis.ImportGenesisStore(genesis.ImportParams{

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -163,7 +163,7 @@ func fakeGenesisImport(ctx *cli.Context) (err error) {
 		idx.Validator(validatorsNumber),
 		futils.ToFtm(1_000_000_000),
 		futils.ToFtm(5_000_000),
-		featureSet.ToUpgrades(),
+		featureSet,
 	)
 	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")
 	return genesis.ImportGenesisStore(genesis.ImportParams{

--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -63,12 +63,14 @@ Initialize the database using data from the experimental genesis file.
 					Action:    fakeGenesisImport,
 					Flags: []cli.Flag{
 						ModeFlag,
+						FakeUpgrades,
 					},
 					Description: `
-    sonictool --datadir=<datadir> genesis fake <N> [--mode=validator]
+    sonictool --datadir=<datadir> genesis fake <N> [--mode=validator] [--upgrades=upgrades]
 
 Requires the number of validators in the fake network as the first argument.
 Initialize the database for a testing fakenet.
+--upgrades can be used to define the network features, default is sonic hardfork feature set.
 `,
 				},
 				{

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -138,7 +138,7 @@ func (m testConfirmedEventsModule) Start(bs iblockproc.BlockState, es iblockproc
 }
 
 func newTestEnv(firstEpoch idx.Epoch, validatorsNum idx.Validator, tb testing.TB) *testEnv {
-	rules := opera.FakeNetRules()
+	rules := opera.FakeNetRules(opera.SonicFeatures.ToUpgrades())
 	rules.Epochs.MaxEpochDuration = inter.Timestamp(maxEpochDuration)
 	rules.Blocks.MaxEmptyBlockSkipPeriod = 0
 	rules.Emitter.Interval = 0

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -138,7 +138,7 @@ func (m testConfirmedEventsModule) Start(bs iblockproc.BlockState, es iblockproc
 }
 
 func newTestEnv(firstEpoch idx.Epoch, validatorsNum idx.Validator, tb testing.TB) *testEnv {
-	rules := opera.FakeNetRules(opera.SonicFeatures.ToUpgrades())
+	rules := opera.FakeNetRules(opera.SonicFeatures)
 	rules.Epochs.MaxEpochDuration = inter.Timestamp(maxEpochDuration)
 	rules.Blocks.MaxEmptyBlockSkipPeriod = 0
 	rules.Emitter.Interval = 0

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -65,7 +65,7 @@ func TestEmitter(t *testing.T) {
 
 	t.Run("init", func(t *testing.T) {
 		external.EXPECT().GetRules().
-			Return(opera.FakeNetRules()).
+			Return(opera.FakeNetRules(opera.SonicFeatures.ToUpgrades())).
 			AnyTimes()
 
 		external.EXPECT().GetEpochValidators().

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -65,7 +65,7 @@ func TestEmitter(t *testing.T) {
 
 	t.Run("init", func(t *testing.T) {
 		external.EXPECT().GetRules().
-			Return(opera.FakeNetRules(opera.SonicFeatures.ToUpgrades())).
+			Return(opera.FakeNetRules(opera.SonicFeatures)).
 			AnyTimes()
 
 		external.EXPECT().GetEpochValidators().

--- a/gossip/gasprice/gasprice_test.go
+++ b/gossip/gasprice/gasprice_test.go
@@ -65,8 +65,8 @@ func (t TestBackend) MinGasTip() *big.Int {
 func TestOracle_constructiveGasPrice(t *testing.T) {
 	backend := &TestBackend{
 		totalGasPowerLeft: 0,
-		rules:             opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
-		pendingRules:      opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
+		rules:             opera.FakeNetRules(opera.SonicFeatures),
+		pendingRules:      opera.FakeNetRules(opera.SonicFeatures),
 	}
 
 	gpo := NewOracle(Config{}, backend)
@@ -106,8 +106,8 @@ func TestOracle_constructiveGasPrice(t *testing.T) {
 func TestOracle_reactiveGasPrice(t *testing.T) {
 	backend := &TestBackend{
 		totalGasPowerLeft: 0,
-		rules:             opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
-		pendingRules:      opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
+		rules:             opera.FakeNetRules(opera.SonicFeatures),
+		pendingRules:      opera.FakeNetRules(opera.SonicFeatures),
 	}
 
 	gpo := NewOracle(Config{}, backend)

--- a/gossip/gasprice/gasprice_test.go
+++ b/gossip/gasprice/gasprice_test.go
@@ -65,8 +65,8 @@ func (t TestBackend) MinGasTip() *big.Int {
 func TestOracle_constructiveGasPrice(t *testing.T) {
 	backend := &TestBackend{
 		totalGasPowerLeft: 0,
-		rules:             opera.FakeNetRules(),
-		pendingRules:      opera.FakeNetRules(),
+		rules:             opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
+		pendingRules:      opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
 	}
 
 	gpo := NewOracle(Config{}, backend)
@@ -106,8 +106,8 @@ func TestOracle_constructiveGasPrice(t *testing.T) {
 func TestOracle_reactiveGasPrice(t *testing.T) {
 	backend := &TestBackend{
 		totalGasPowerLeft: 0,
-		rules:             opera.FakeNetRules(),
-		pendingRules:      opera.FakeNetRules(),
+		rules:             opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
+		pendingRules:      opera.FakeNetRules(opera.SonicFeatures.ToUpgrades()),
 	}
 
 	gpo := NewOracle(Config{}, backend)

--- a/integration/makefakegenesis/genesis.go
+++ b/integration/makefakegenesis/genesis.go
@@ -45,8 +45,8 @@ func FakeKey(n idx.ValidatorID) *ecdsa.PrivateKey {
 	return evmcore.FakeKey(uint32(n))
 }
 
-func FakeGenesisStore(num idx.Validator, balance, stake *big.Int, upgrades opera.Upgrades) *genesisstore.Store {
-	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules(upgrades))
+func FakeGenesisStore(num idx.Validator, balance, stake *big.Int, features opera.FeatureSet) *genesisstore.Store {
+	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules(features))
 }
 
 func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *big.Int, rules opera.Rules) *genesisstore.Store {

--- a/integration/makefakegenesis/genesis.go
+++ b/integration/makefakegenesis/genesis.go
@@ -45,8 +45,8 @@ func FakeKey(n idx.ValidatorID) *ecdsa.PrivateKey {
 	return evmcore.FakeKey(uint32(n))
 }
 
-func FakeGenesisStore(num idx.Validator, balance, stake *big.Int) *genesisstore.Store {
-	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules())
+func FakeGenesisStore(num idx.Validator, balance, stake *big.Int, upgrades opera.Upgrades) *genesisstore.Store {
+	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules(upgrades))
 }
 
 func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *big.Int, rules opera.Rules) *genesisstore.Store {

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -56,7 +56,7 @@ func LoadGenesisJson(filename string) (*GenesisJson, error) {
 		return nil, fmt.Errorf("failed to read genesis json file; %v", err)
 	}
 	var decoded GenesisJson
-	upgrades := opera.SonicFeatures.ToUpgrades()
+	upgrades := opera.SonicFeatures
 	decoded.Rules = opera.FakeNetRules(upgrades) // use fakenet rules as defaults
 	err = json.Unmarshal(data, &decoded)
 	if err != nil {

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -56,7 +56,8 @@ func LoadGenesisJson(filename string) (*GenesisJson, error) {
 		return nil, fmt.Errorf("failed to read genesis json file; %v", err)
 	}
 	var decoded GenesisJson
-	decoded.Rules = opera.FakeNetRules() // use fakenet rules as defaults
+	upgrades := opera.SonicFeatures.ToUpgrades()
+	decoded.Rules = opera.FakeNetRules(upgrades) // use fakenet rules as defaults
 	err = json.Unmarshal(data, &decoded)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal genesis json file; %v", err)

--- a/opera/feature_set.go
+++ b/opera/feature_set.go
@@ -1,7 +1,5 @@
 package opera
 
-import "fmt"
-
 // FeatureSet is an enumeration of different releases, each one enabling a
 // different set of features. These are an abstraction that allows to reason
 // about the different releases instead of isolated upgrades.
@@ -14,29 +12,20 @@ const (
 	AllegroFeatures                   // < enables the allegro release features
 )
 
-func (fs FeatureSet) ToUpgrades() (Upgrades, error) {
-	var res Upgrades
-	switch fs {
-	case SonicFeatures:
-		res = Upgrades{
-			Berlin:  true,
-			London:  true,
-			Llr:     false,
-			Sonic:   true,
-			Allegro: false,
-		}
-	case AllegroFeatures:
-		res = Upgrades{
-			Berlin:  true,
-			London:  true,
-			Llr:     false,
-			Sonic:   true,
-			Allegro: true,
-		}
-	default:
-		return res, fmt.Errorf("unknown feature set: %v", fs)
+// ToUpgrades returns the Upgrades that are enabled by the feature set.
+// If called from an unknown feature set, it will return the pre-sonic
+// upgrades.
+func (fs FeatureSet) ToUpgrades() Upgrades {
+	sonic := fs == SonicFeatures
+	allegro := fs == AllegroFeatures
+	res := Upgrades{
+		Berlin:  true,
+		London:  true,
+		Llr:     false,
+		Sonic:   sonic || allegro,
+		Allegro: allegro,
 	}
-	return res, nil
+	return res
 }
 
 func (fs FeatureSet) String() string {

--- a/opera/feature_set_test.go
+++ b/opera/feature_set_test.go
@@ -47,14 +47,22 @@ func TestFeatureSet_CanBeConvertedToUpgrades(t *testing.T) {
 
 	for featureSet, test := range tests {
 		t.Run(featureSet.String(), func(t *testing.T) {
-			got, err := featureSet.ToUpgrades()
-			require.NoError(t, err)
+			got := featureSet.ToUpgrades()
 			require.Equal(t, test.expectedUpgrades, got)
 		})
 	}
 }
 
-func TestFeatureSet_ToUpgradeMayFail(t *testing.T) {
-	_, err := FeatureSet(math.MaxInt).ToUpgrades()
-	require.Error(t, err)
+func TestFeatureSet_ToUpgradesReturnsDefaultIfUnknown(t *testing.T) {
+	fs := FeatureSet(math.MaxInt)
+	expected := Upgrades{
+		Berlin:  true,
+		London:  true,
+		Llr:     false,
+		Sonic:   false,
+		Allegro: false,
+	}
+
+	got := fs.ToUpgrades()
+	require.Equal(t, expected, got)
 }

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -314,7 +314,7 @@ func MainNetRules() Rules {
 	}
 }
 
-func FakeNetRules(upgrades Upgrades) Rules {
+func FakeNetRules(features FeatureSet) Rules {
 	return Rules{
 		Name:      "fake",
 		NetworkID: FakeNetworkID,
@@ -326,7 +326,7 @@ func FakeNetRules(upgrades Upgrades) Rules {
 			MaxBlockGas:             defaultMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(3 * time.Second),
 		},
-		Upgrades: upgrades,
+		Upgrades: features.ToUpgrades(),
 	}
 }
 

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -314,7 +314,7 @@ func MainNetRules() Rules {
 	}
 }
 
-func FakeNetRules() Rules {
+func FakeNetRules(upgrades Upgrades) Rules {
 	return Rules{
 		Name:      "fake",
 		NetworkID: FakeNetworkID,
@@ -326,13 +326,7 @@ func FakeNetRules() Rules {
 			MaxBlockGas:             defaultMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(3 * time.Second),
 		},
-		Upgrades: Upgrades{
-			Berlin:  true,
-			London:  true,
-			Llr:     false,
-			Sonic:   true,
-			Allegro: true,
-		},
+		Upgrades: upgrades,
 	}
 }
 

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -70,6 +70,15 @@ type IntegrationTestNetSession interface {
 	GetClient() (*ethclient.Client, error)
 }
 
+// IntegrationTestNetOptions are configuration options for the integration test network.
+type IntegrationTestNetOptions struct {
+	// FeatureSet specifies the feature set to be used for the integration test network.
+	// The default value is SonicFeatures.
+	FeatureSet opera.FeatureSet
+	// ClientExtraArguments specifies additional arguments to be passed to the client.
+	ClientExtraArguments []string
+}
+
 // IntegrationTestNet is a in-process test network for integration tests. When
 // started, it runs a full Sonic node maintaining a chain within the process
 // containing this object. The network can be used to run transactions on and
@@ -108,9 +117,9 @@ type IntegrationTestNet struct {
 // a network genesis block. To retrieve the directory path, use the GetDirectory.
 func StartIntegrationTestNet(
 	t *testing.T,
-	extraClientArguments ...string,
+	options ...IntegrationTestNetOptions,
 ) *IntegrationTestNet {
-	return StartIntegrationTestNetWithJsonGenesis(t, extraClientArguments...)
+	return StartIntegrationTestNetWithJsonGenesis(t, options...)
 }
 
 // StartIntegrationTestNetWithFakeGenesis starts a single-node test network for
@@ -119,10 +128,22 @@ func StartIntegrationTestNet(
 // and integration testing in Norma.
 func StartIntegrationTestNetWithFakeGenesis(
 	t *testing.T,
-	extraArguments ...string,
+	options ...IntegrationTestNetOptions,
 ) *IntegrationTestNet {
 	t.Helper()
-	net, err := startIntegrationTestNet(t, t.TempDir(), []string{"genesis", "fake", "1"}, extraArguments)
+
+	if len(options) > 1 {
+		t.Fatalf("expected at most one option, got %d", len(options))
+		return nil
+	}
+	effectiveOptions := sanitizeOptions(options...)
+
+	net, err := startIntegrationTestNet(
+		t,
+		t.TempDir(),
+		[]string{"genesis", "fake", "1", "--upgrades", effectiveOptions.FeatureSet.String()},
+		effectiveOptions.ClientExtraArguments,
+	)
 	if err != nil {
 		t.Fatal("failed to start integration test network: ", err)
 	}
@@ -135,9 +156,15 @@ func StartIntegrationTestNetWithFakeGenesis(
 // Sonic mainnet and the testnet.
 func StartIntegrationTestNetWithJsonGenesis(
 	t *testing.T,
-	extraArguments ...string,
+	options ...IntegrationTestNetOptions,
 ) *IntegrationTestNet {
 	t.Helper()
+	if len(options) > 1 {
+		t.Fatalf("expected at most one option, got %d", len(options))
+		return nil
+	}
+	effectiveOptions := sanitizeOptions(options...)
+	upgrades := effectiveOptions.FeatureSet.ToUpgrades()
 	jsonGenesis := makefakegenesis.GenesisJson{
 		Rules:         opera.FakeNetRules(upgrades),
 		BlockZeroTime: time.Now(),
@@ -237,9 +264,12 @@ func StartIntegrationTestNetWithJsonGenesis(
 	if err != nil {
 		t.Fatal("failed to write genesis json file: ", err)
 	}
-	net, err := startIntegrationTestNet(t, directory,
+
+	net, err := startIntegrationTestNet(
+		t,
+		directory,
 		[]string{"genesis", "json", "--experimental", jsonFile},
-		extraArguments,
+		effectiveOptions.ClientExtraArguments,
 	)
 	if err != nil {
 		t.Fatal("failed to start integration test network: ", err)
@@ -254,7 +284,7 @@ func startIntegrationTestNet(
 	extraClientArguments []string,
 ) (*IntegrationTestNet, error) {
 	// start the fakenet sonic node
-	result := &IntegrationTestNet{
+	net := &IntegrationTestNet{
 		directory:            directory,
 		extraClientArguments: extraClientArguments,
 		Session: Session{
@@ -263,11 +293,10 @@ func startIntegrationTestNet(
 	}
 
 	// initialize the data directory for the single node on the test network
-	// equivalent to running `sonictool --datadir <dataDir> genesis fake 1`
 	originalArgs := os.Args
 	os.Args = append([]string{
 		"sonictool",
-		"--datadir", result.stateDir(),
+		"--datadir", net.stateDir(),
 		"--statedb.livecache", "1",
 		"--statedb.archivecache", "1",
 		"--statedb.cache", "1024",
@@ -278,13 +307,10 @@ func startIntegrationTestNet(
 	}
 	os.Args = originalArgs
 
-	if err := result.start(); err != nil {
+	if err := net.start(); err != nil {
 		return nil, fmt.Errorf("failed to start the test network: %w", err)
 	}
-	t.Cleanup(func() {
-		result.Stop()
-	})
-	return result, nil
+	return net, nil
 }
 
 func (n *IntegrationTestNet) stateDir() string {
@@ -734,4 +760,14 @@ func (s *Session) GetSessionSponsor() *Account {
 // The resulting client must be closed after use.
 func (s *Session) GetClient() (*ethclient.Client, error) {
 	return ethclient.Dial(fmt.Sprintf("http://localhost:%d", s.httpPort))
+}
+
+// sanitizeOptions ensures that the options are valid and sets the default values.
+func sanitizeOptions(options ...IntegrationTestNetOptions) IntegrationTestNetOptions {
+	if len(options) == 0 {
+		return IntegrationTestNetOptions{
+			FeatureSet: opera.SonicFeatures,
+		}
+	}
+	return options[0]
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -139,7 +139,7 @@ func StartIntegrationTestNetWithJsonGenesis(
 ) *IntegrationTestNet {
 	t.Helper()
 	jsonGenesis := makefakegenesis.GenesisJson{
-		Rules:         opera.FakeNetRules(),
+		Rules:         opera.FakeNetRules(upgrades),
 		BlockZeroTime: time.Now(),
 	}
 

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -310,6 +310,7 @@ func startIntegrationTestNet(
 	if err := net.start(); err != nil {
 		return nil, fmt.Errorf("failed to start the test network: %w", err)
 	}
+	t.Cleanup(net.Stop)
 	return net, nil
 }
 

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/batch"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/0xsoniclabs/sonic/tests/contracts/privilege_deescalation"
@@ -34,7 +35,9 @@ import (
 // and do not implement ERC-20 as described in the EIP use case examples.
 func TestSetCodeTransaction(t *testing.T) {
 
-	net := StartIntegrationTestNet(t)
+	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
+		FeatureSet: opera.AllegroFeatures,
+	})
 
 	t.Run("Operation", func(t *testing.T) {
 		t.Parallel()

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -20,7 +20,6 @@ func TestTransactionOrder(t *testing.T) {
 		numTxs      = numAccounts * numPerAcc
 	)
 	net := StartIntegrationTestNet(t)
-	defer net.Stop()
 
 	contract, _, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(t, err)

--- a/tests/transaction_store_test.go
+++ b/tests/transaction_store_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
@@ -19,7 +20,10 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 	// was executed and check if the transaction is present in the block and the
 	// values match, by comparing the hashes.
 
-	net := StartIntegrationTestNet(t)
+	net := StartIntegrationTestNet(t,
+		IntegrationTestNetOptions{
+			FeatureSet: opera.AllegroFeatures,
+		})
 
 	client, err := net.GetClient()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR introduces the following changes:
- An argument to the fake net rules generation 
- A command line in the sonictool genesis fake command to specify the features profile.
- An "options" argument in the integration test net, which is optional and defaults to the previous status quo.


