### PR TITLE
feat: datasemaphore tests

### DIFF
--- a/utils/datasemaphore/datasemaphore.go
+++ b/utils/datasemaphore/datasemaphore.go
@@ -7,14 +7,21 @@ import (
 	"github.com/0xsoniclabs/consensus/inter/dag"
 )
 
+// DataSemaphore implements a resource control mechanism for limiting concurrent processing
+// of DAG elements based on two resource dimensions: number of events and total size.
+// It allows callers to acquire resources up to configured limits and blocks if limits would be exceeded.
 type DataSemaphore struct {
-	processing    dag.Metric
-	maxProcessing dag.Metric
-
-	mu   sync.Mutex
-	cond *sync.Cond
-
-	warning func(received dag.Metric, processing dag.Metric, releasing dag.Metric)
+	// github.com/0xsoniclabs/consensus/inter/dag
+	//
+	// type Metric struct {
+	//     Num  idx.Event // Event is a uint64
+	//     Size uint64
+	// }
+	processing    dag.Metric                                                             // Tracks currently used resources (event count and size)
+	maxProcessing dag.Metric                                                             // Maximum allowed resources to be used concurrently
+	mu            sync.Mutex                                                             // Mutex for thread-safe access to semaphore state
+	cond          *sync.Cond                                                             // Condition variable for signaling when resources become available
+	warning       func(received dag.Metric, processing dag.Metric, releasing dag.Metric) // Callback for resource accounting anomalies
 }
 
 func New(maxProcessing dag.Metric, warning func(received dag.Metric, processing dag.Metric, releasing dag.Metric)) *DataSemaphore {
@@ -26,64 +33,116 @@ func New(maxProcessing dag.Metric, warning func(received dag.Metric, processing 
 	return s
 }
 
+// Acquire attempts to acquire resources specified by weight, blocking until resources
+// are available or timeout occurs.
+// weight: resources to acquire (event count and size)
+// timeout: maximum time to wait for resources to become available
+// Returns true if resources were successfully acquired, false otherwise
 func (s *DataSemaphore) Acquire(weight dag.Metric, timeout time.Duration) bool {
+	// Calculate deadline for timeout
 	deadline := time.Now().Add(timeout)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for !s.tryAcquire(weight) {
-		if weight.Size > s.maxProcessing.Size || weight.Num > s.maxProcessing.Num || time.Now().After(deadline) {
+
+	for {
+		s.mu.Lock()
+		// Check if we've exceeded the deadline
+		if time.Now().After(deadline) {
+			s.mu.Unlock()
 			return false
 		}
+
+		// Try to acquire resources, blocking and waiting if not immediately available
+		if s.tryAcquire(weight) {
+			s.mu.Unlock()
+			return true
+		}
+
+		// Set up a timer to wake goroutines up when the deadline is reached
+		timer := time.AfterFunc(time.Until(deadline), func() {
+			s.cond.Broadcast() // Wake up anyone waiting
+		})
+
+		// Wait for a signal that resources have been released or timeout
 		s.cond.Wait()
+
+		// Stop the timer if it hasn't fired yet
+		timer.Stop()
+
+		s.mu.Unlock()
 	}
-	return true
 }
 
+// TryAcquire attempts to acquire resources without blocking.
+// weight: resources to acquire (event count and size)
+// Returns true if resources were acquired, false if not enough resources were available
 func (s *DataSemaphore) TryAcquire(weight dag.Metric) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.tryAcquire(weight)
 }
 
+// Must be called with mutex already locked.
 func (s *DataSemaphore) tryAcquire(metric dag.Metric) bool {
-	tmp := s.processing
+	tmp := s.processing // Create temporary copy to check if acquisition is possible
 	tmp.Num += metric.Num
 	tmp.Size += metric.Size
+
+	// Check if acquisition would exceed either resource limit
 	if tmp.Num > s.maxProcessing.Num || tmp.Size > s.maxProcessing.Size {
 		return false
 	}
+
+	// If we reach here, acquisition is possible - update the processing state
 	s.processing = tmp
 	return true
 }
 
+// Release returns previously acquired resources to the semaphore.
+// If more resources are released than were acquired, triggers the warning callback
+// and resets the semaphore state to prevent further anomalies
 func (s *DataSemaphore) Release(weight dag.Metric) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Check for resource accounting anomaly (releasing more than what's being processed)
 	if s.processing.Num < weight.Num || s.processing.Size < weight.Size {
 		if s.warning != nil {
+			// Call warning callback with the anomalous state
 			s.warning(s.processing, s.processing, weight)
 		}
+		// Reset processing to prevent further issues
 		s.processing = dag.Metric{}
 	} else {
+		// Normal case - subtract the released resources
 		s.processing.Num -= weight.Num
 		s.processing.Size -= weight.Size
 	}
+
+	// Notify all waiting goroutines that resources have been released
 	s.cond.Broadcast()
 }
 
+// Terminate stops the semaphore by setting max capacity to zero.
+// This effectively prevents any new acquisitions and wakes up all
+// waiting goroutines so they can detect termination
 func (s *DataSemaphore) Terminate() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Set max processing to zero to prevent new acquisitions
 	s.maxProcessing = dag.Metric{}
+
+	// Wake up all waiting goroutines so they can detect termination
 	s.cond.Broadcast()
 }
 
+// Processing returns the current resource usage
 func (s *DataSemaphore) Processing() dag.Metric {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.processing
 }
 
+// Available returns the currently available resource capacity.
 func (s *DataSemaphore) Available() dag.Metric {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/utils/datasemaphore/datasemaphore_test.go
+++ b/utils/datasemaphore/datasemaphore_test.go
@@ -1,0 +1,334 @@
+package datasemaphore
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/consensus/inter/dag"
+)
+
+func TestNew(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	warningFunc := func(received, processing, releasing dag.Metric) {}
+
+	semaphore := New(maxProcessing, warningFunc)
+
+	if semaphore == nil {
+		t.Fatal("New should return a non-nil DataSemaphore")
+	}
+
+	if semaphore.maxProcessing != maxProcessing {
+		t.Errorf("Expected maxProcessing to be %v, got %v", maxProcessing, semaphore.maxProcessing)
+	}
+
+	if semaphore.cond == nil {
+		t.Error("Condition variable should be initialized")
+	}
+}
+
+func TestTryAcquire(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	// Test successful acquisition
+	weight := dag.Metric{Num: 5, Size: 500}
+	if !semaphore.TryAcquire(weight) {
+		t.Errorf("Expected to acquire semaphore with weight %v", weight)
+	}
+
+	processing := semaphore.Processing()
+	if processing.Num != 5 || processing.Size != 500 {
+		t.Errorf("Expected processing to be {Num=5,Size=500}, got %v", processing)
+	}
+
+	// Test successful second acquisition
+	weight2 := dag.Metric{Num: 3, Size: 300}
+	if !semaphore.TryAcquire(weight2) {
+		t.Errorf("Expected to acquire semaphore with weight %v", weight2)
+	}
+
+	processing = semaphore.Processing()
+	if processing.Num != 8 || processing.Size != 800 {
+		t.Errorf("Expected processing to be {Num=8,Size=800}, got %v", processing)
+	}
+
+	// Test failed acquisition due to exceeding Num
+	weightExceedNum := dag.Metric{Num: 3, Size: 100}
+	if semaphore.TryAcquire(weightExceedNum) {
+		t.Errorf("Expected acquisition to fail with weight %v", weightExceedNum)
+	}
+
+	// Test failed acquisition due to exceeding Size
+	weightExceedSize := dag.Metric{Num: 1, Size: 201}
+	if semaphore.TryAcquire(weightExceedSize) {
+		t.Errorf("Expected acquisition to fail with weight %v", weightExceedSize)
+	}
+}
+
+func TestAcquire(t *testing.T) {
+	// Test 1: Immediate acquisition (no waiting)
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	weight := dag.Metric{Num: 5, Size: 500}
+	if !semaphore.Acquire(weight, 100*time.Millisecond) {
+		t.Errorf("Expected immediate acquisition to succeed")
+	}
+
+	// Test 2: Acquisition that should fail due to timeout
+	weightExceed := dag.Metric{Num: 6, Size: 600}
+	if semaphore.Acquire(weightExceed, 10*time.Millisecond) {
+		t.Errorf("Expected acquisition to fail due to timeout")
+	}
+
+	// Test 3: Immediate failure due to weight > maxProcessing
+	weightTooLarge := dag.Metric{Num: 11, Size: 500}
+	if semaphore.Acquire(weightTooLarge, 10*time.Millisecond) {
+		t.Errorf("Expected immediate failure for weight > maxProcessing")
+	}
+
+	// Test 4: Immediate failure due to weight.Size > maxProcessing.Size
+	weightTooLargeSize := dag.Metric{Num: 5, Size: 1001}
+	if semaphore.Acquire(weightTooLargeSize, 10*time.Millisecond) {
+		t.Errorf("Expected immediate failure for weight.Size > maxProcessing.Size")
+	}
+}
+
+// Acquire with a separate goroutine for release
+func TestAcquireWithRelease(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	// First, acquire all resources
+	semaphore.TryAcquire(maxProcessing)
+	// Set up a channel to signal completion
+	done := make(chan bool, 1)
+
+	// Start a goroutine that will release resources after a short delay
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		semaphore.Release(maxProcessing) // Release all resources
+		done <- true
+	}()
+
+	smallWeight := dag.Metric{Num: 1, Size: 100}
+	result := semaphore.Acquire(smallWeight, 200*time.Millisecond)
+
+	// Wait for the release goroutine to complete
+	select {
+	case <-done:
+		// Release (should have) completed
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("Release goroutine did not complete")
+	}
+
+	if !result {
+		t.Error("Expected acquisition to succeed after resources were released")
+	}
+}
+
+func TestRelease(t *testing.T) {
+	var warningCalled bool
+	warningFunc := func(received, processing, releasing dag.Metric) {
+		warningCalled = true
+	}
+
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, warningFunc)
+	weight := dag.Metric{Num: 5, Size: 500}
+	semaphore.TryAcquire(weight)
+
+	// Test normal release
+	semaphore.Release(weight)
+	processing := semaphore.Processing()
+	if processing.Num != 0 || processing.Size != 0 {
+		t.Errorf("Expected processing to be {Num=0,Size=0}, got %v", processing)
+	}
+
+	// Test over-release (should trigger warning)
+	semaphore.TryAcquire(weight)
+	overWeight := dag.Metric{Num: 6, Size: 500}
+	semaphore.Release(overWeight)
+
+	if !warningCalled {
+		t.Error("Warning function should have been called for over-release")
+	}
+
+	processing = semaphore.Processing()
+	if processing.Num != 0 || processing.Size != 0 {
+		t.Errorf("Processing should be reset to zero after over-release, got %v", processing)
+	}
+
+	// Test warning is nil
+	semaphore = New(maxProcessing, nil)
+	semaphore.TryAcquire(weight)
+	// This should NOT panic even though warning is nil
+	semaphore.Release(overWeight)
+}
+
+func TestTerminate(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	semaphore.Terminate()
+
+	weight := dag.Metric{Num: 1, Size: 1}
+	if semaphore.TryAcquire(weight) {
+		t.Error("Acquisition should fail after termination")
+	}
+}
+
+func TestTerminateWithWaiting(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	semaphore.TryAcquire(dag.Metric{Num: 8, Size: 800})
+
+	// Set up a channel to signal completion
+	done := make(chan bool, 1)
+
+	// Start a goroutine that will try to acquire more resources than available
+	go func() {
+		defer func() {
+			done <- true
+		}()
+
+		// This should block until terminated
+		largeWeight := dag.Metric{Num: 5, Size: 500}
+		result := semaphore.Acquire(largeWeight, 500*time.Millisecond)
+		if result {
+			t.Error("Expected acquisition to fail after terminate")
+		}
+	}()
+
+	// Give goroutine time to start waiting
+	time.Sleep(50 * time.Millisecond)
+
+	// Now terminate the semaphore
+	semaphore.Terminate()
+
+	// Wait for the acquisition goroutine to complete
+	select {
+	case <-done:
+		// Test passed - goroutine completed
+	case <-time.After(600 * time.Millisecond):
+		t.Fatal("Acquire did not complete after Terminate was called")
+	}
+}
+
+func TestAvailable(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	// Test initial available resources
+	available := semaphore.Available()
+	if available.Num != 10 || available.Size != 1000 {
+		t.Errorf("Expected initial available to be {Num=10,Size=1000}, got %v", available)
+	}
+
+	// Test available after acquisition
+	weight := dag.Metric{Num: 4, Size: 400}
+	semaphore.TryAcquire(weight)
+
+	available = semaphore.Available()
+	if available.Num != 6 || available.Size != 600 {
+		t.Errorf("Expected available after acquisition to be {Num=6,Size=600}, got %v", available)
+	}
+}
+
+func TestConcurrentAcquireRelease(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	const numGoroutines = 5
+	const iterations = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+
+			for j := 0; j < iterations; j++ {
+				weight := dag.Metric{Num: 1, Size: 100}
+				if semaphore.TryAcquire(weight) {
+					// Brief work simulation
+					time.Sleep(1 * time.Millisecond)
+					semaphore.Release(weight)
+				} else {
+					// Brief pause before retry
+					time.Sleep(1 * time.Millisecond)
+				}
+			}
+		}(i)
+	}
+
+	// Use a timeout to prevent test hanging
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Test completed normally
+	case <-time.After(2 * time.Second):
+		t.Fatal("Test timed out")
+	}
+
+	processing := semaphore.Processing()
+	if processing.Num != 0 || processing.Size != 0 {
+		t.Errorf("Expected processing to be {Num=0,Size=0} after all releases, got %v", processing)
+	}
+}
+
+func TestAcquireWithWaiting(t *testing.T) {
+	maxProcessing := dag.Metric{Num: 10, Size: 1000}
+	semaphore := New(maxProcessing, nil)
+
+	// Acquire most resources
+	semaphore.TryAcquire(dag.Metric{Num: 8, Size: 800})
+	// Set up a channel to signal completion
+	done := make(chan bool, 1)
+	acquireSucceeded := false
+
+	go func() {
+		// This should initially block, then succeed
+		weight := dag.Metric{Num: 3, Size: 300}
+		acquireSucceeded = semaphore.Acquire(weight, 500*time.Millisecond)
+		if acquireSucceeded {
+			semaphore.Release(weight)
+		}
+		done <- true
+	}()
+
+	// Give goroutine time to start waiting
+	time.Sleep(50 * time.Millisecond)
+
+	// Release resources to allow waiting goroutine to proceed
+	semaphore.Release(dag.Metric{Num: 2, Size: 200})
+
+	// Wait for goroutine completion with timeout
+	select {
+	case <-done:
+		// Test completed normally
+	case <-time.After(600 * time.Millisecond):
+		t.Fatal("Test timed out waiting for acquisition to complete")
+	}
+
+	if !acquireSucceeded {
+		t.Error("Expected acquisition to succeed after resources were released")
+	}
+
+	// Release remaining resources
+	semaphore.Release(dag.Metric{Num: 6, Size: 600})
+
+	// Check final state
+	processing := semaphore.Processing()
+	if processing.Num != 0 || processing.Size != 0 {
+		t.Errorf("Expected processing to be {Num=0,Size=0} after all releases, got %v", processing)
+	}
+}


### PR DESCRIPTION
This PR adds tests to the `datasemaphore` utils package and adds comments explaining how `datasemaphore` works in detail - as it is a bit complicated.

The `Acquire` function has been rewritten because the previous implementation made it possible for `Acquire` to hang because the `sync.Cond` condition variable associated with the semaphore would never have `Broadcast()` called - while `Broadcast()` would potentially be triggered through the `Release` function called on the same semaphore instance - this is not guaranteed. A timer with a broadcast has now been added to the `Acquire` function and is called after the timeout to acquire the resources has elapsed to wake up **_all_** goroutines that may be waiting for a signal to retry - _including the same process that started the acquisition attempt_ so that `Acquire` does not hang.

Verification:

![image](https://github.com/user-attachments/assets/07a125b0-aa3f-44c4-9d3c-41f6b4a198fe)