### PR TITLE
Add support for running multiple nodes in integration tests

### DIFF
--- a/cmd/sonicd/app/app.go
+++ b/cmd/sonicd/app/app.go
@@ -11,22 +11,46 @@ func Run() error {
 	return RunWithArgs(os.Args, nil)
 }
 
+// AppControl is a struct of channels facilitating the interaction of a test
+// harness with a sonicd application instance.
+type AppControl struct {
+	// Upon a successful start of the sonicd node, the node ID is sent to this
+	// channel. The channel is closed when the process stops.
+	NodeIdAnnouncement chan<- string
+	// Upon a successful start of the sonicd node, the HTTP port used by the HTTP
+	// server is sent to this channel. The channel is closed when the process
+	HttpPortAnnouncement chan<- string
+	// The process is stopped by sending a message through this channel, or by
+	// closing it.
+	Shutdown <-chan struct{}
+}
+
 // RunWithArgs starts sonicd with the given command line arguments.
-// An optional httpPortAnnouncement channel can be provided to announce the HTTP port
-// used by the HTTP server of the started sonicd node. The channel is closed when the
-// when the process stops.
+// An optional httpPortAnnouncement channel can be provided to announce the HTTP
+// port used by the HTTP server of the started sonicd node. The channel is
+// closed when the process stops.
+// Another optional stop channel can be provided. By sending a message through
+// this channel, or closing it, the shutdown of the process is triggered.
 func RunWithArgs(
 	args []string,
-	httpPortAnnouncement chan<- string,
+	control *AppControl,
 ) error {
 	app := initApp()
 	initAppHelp()
 
-	// If present, inject the http port announcement channel into the action.
-	if httpPortAnnouncement != nil {
-		defer close(httpPortAnnouncement)
+	// If present, take ownership and inject the control struct into the action.
+	if control != nil {
+		if control.NodeIdAnnouncement != nil {
+			defer close(control.NodeIdAnnouncement)
+		}
+		if control.HttpPortAnnouncement != nil {
+			defer close(control.HttpPortAnnouncement)
+		}
 		app.Action = func(ctx *cli.Context) error {
-			return lachesisMainInternal(ctx, httpPortAnnouncement)
+			return lachesisMainInternal(
+				ctx,
+				control,
+			)
 		}
 	}
 

--- a/cmd/sonicd/app/usage.go
+++ b/cmd/sonicd/app/usage.go
@@ -19,9 +19,11 @@
 package app
 
 import (
-	"github.com/0xsoniclabs/sonic/cmd/sonicd/cmdhelper"
 	"io"
 	"sort"
+	"sync"
+
+	"github.com/0xsoniclabs/sonic/cmd/sonicd/cmdhelper"
 
 	cli "gopkg.in/urfave/cli.v1"
 
@@ -83,7 +85,10 @@ func calcAppHelpFlagGroups() []cmdhelper.FlagGroup {
 	}
 }
 
-func initAppHelp() {
+// initAppHelp is a thread-safe run-once function initializing the app help template.
+var initAppHelp = sync.OnceFunc(initAppHelpInternal)
+
+func initAppHelpInternal() {
 	// Override the default app help template
 	cli.AppHelpTemplate = cmdhelper.AppHelpTemplate
 

--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -10,6 +10,10 @@ import (
 )
 
 func Run() error {
+	return RunWithArgs(os.Args)
+}
+
+func RunWithArgs(args []string) error {
 	app := cli.NewApp()
 	app.Name = "sonictool"
 	app.Usage = "the Sonic management tool"
@@ -401,5 +405,5 @@ Converts an account private key to a validator private key and saves in the vali
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
 
-	return app.Run(os.Args)
+	return app.Run(args)
 }


### PR DESCRIPTION
Adds support for running more than one node in Sonic's integration tests. This is required for integration tests targeting P2P layer features depending on the interactions of multiple nodes. In particular, upcoming tests for the certification chain are of this type.

To facilitate the clean operation of multiple nodes, the previous process-signaling based mechanism for triggering the shutdown of a node was replaced by an explicit control channel into the `sonicd` process. This allows to signal the request to shut down to individual nodes. Also, all usage of `os.Args` is eliminated. These changes eliminate further obstacles for running integration tests in parallel.