### PR TITLE
Add Light Client State

### DIFF
--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -62,8 +62,12 @@ func (s *State) Sync(p provider.Provider) (idx.Block, error) {
 	headCert := blockCerts[0]
 	headPeriod := scc.GetPeriod(headCert.Subject().Number)
 
-	if headCert.Subject().Number <= s.headNumber {
-		return 0, fmt.Errorf("invalid block number: %d, expected > %d",
+	// if the latest block is not newer than the current head, return the current head
+	if headCert.Subject().Number == s.headNumber {
+		return s.headNumber, nil
+	}
+	if headCert.Subject().Number < s.headNumber {
+		return 0, fmt.Errorf("provider returned old block head %d, expected > %d",
 			headCert.Subject().Number, s.headNumber)
 	}
 

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -52,7 +52,7 @@ func (s *State) Sync(p provider.Provider) (idx.Block, error) {
 	// Get the latest block number from the provider.
 	blockCerts, err := p.GetBlockCertificates(provider.LatestBlock, uint64(1))
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to get block certificates: %w", err)
 	}
 	if len(blockCerts) == 0 {
 		return 0, fmt.Errorf("provider returned zero block certificates")
@@ -70,12 +70,12 @@ func (s *State) Sync(p provider.Provider) (idx.Block, error) {
 	// sync from current period to latest.
 	// this process will update the committee and period of the state.
 	if err := s.syncToPeriod(p, headPeriod); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to sync to period %d: %w", headPeriod, err)
 	}
 
 	// verify latest block certificate with latest committee
 	if err := headCert.Verify(s.committee); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to verify block certificate: %w", err)
 	}
 
 	// update the state with the latest block

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -75,7 +75,9 @@ func (s *State) Sync(p provider.Provider) (idx.Block, error) {
 
 	// verify latest block certificate with latest committee
 	if err := headCert.Verify(s.committee); err != nil {
-		return 0, fmt.Errorf("failed to verify block certificate: %w", err)
+		return 0,
+			fmt.Errorf("failed to authenticate block certificate for block %d: %w",
+				headCert.Subject().Number, err)
 	}
 
 	// update the state with the latest block

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -1,0 +1,134 @@
+package lc_state
+
+import (
+	"fmt"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/0xsoniclabs/sonic/scc/light_client/provider"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// State holds the current state of the light client.
+type State struct {
+	committee  scc.Committee
+	period     scc.Period
+	headNumber idx.Block
+	headHash   common.Hash
+}
+
+// NewState creates a new State with the given committee.
+func NewState(committee scc.Committee) *State {
+	return &State{
+		committee: committee,
+	}
+}
+
+// Head returns the block number of the latest known block.
+func (s *State) Head() idx.Block {
+	return s.headNumber
+}
+
+// Sync updates the light client state using certificates from the provider.
+// This serves as the primary method for synchronizing the light client state
+// with the network.
+// If successful, the most recent block number is returned.
+// If an error occurs, the returned block number is 0 with the corresponding error.
+func (s *State) Sync(p provider.Provider) (idx.Block, error) {
+	if p == nil {
+		return 0, fmt.Errorf("cannot update with nil provider")
+	}
+
+	// Get the latest block number from the provider.
+	blockCerts, err := p.GetBlockCertificates(provider.LatestBlock, uint64(1))
+	if err != nil {
+		return 0, err
+	}
+	if len(blockCerts) == 0 {
+		return 0, fmt.Errorf("provider returned zero block certificates")
+	}
+
+	// get period for the latest block
+	headCert := blockCerts[0]
+	headPeriod := scc.GetPeriod(headCert.Subject().Number)
+
+	if headCert.Subject().Number <= s.headNumber {
+		return 0, fmt.Errorf("invalid block number: %d, expected > %d",
+			headCert.Subject().Number, s.headNumber)
+	}
+
+	// sync from current period to latest.
+	// this process will update the committee and period of the state.
+	if err := s.syncToPeriod(p, headPeriod); err != nil {
+		return 0, err
+	}
+
+	// verify latest block certificate with latest committee
+	if err := headCert.Verify(s.committee); err != nil {
+		return 0, err
+	}
+
+	// update the state with the latest block
+	s.headNumber = headCert.Subject().Number
+	s.headHash = headCert.Subject().Hash
+
+	// return the latest block number
+	return s.headNumber, nil
+}
+
+// syncToPeriod is a helper function to updates the light client state
+// to the given period using the given provider
+func (s *State) syncToPeriod(p provider.Provider, target scc.Period) error {
+	if s.period == target {
+		return nil
+	}
+	if s.period > target {
+		return fmt.Errorf("cannot sync to a previous period. current: %d, target: %d",
+			s.period, target)
+	}
+
+	// get all the committee certificates from the current period to the target.
+	committeeCerts, err := p.GetCommitteeCertificates(s.period+1, uint64(target-s.period))
+	if err != nil {
+		return err
+	}
+
+	for _, c := range committeeCerts {
+		// update the state with the committee certificate
+		if err = s.updateCommittee(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// updateCommittee is a helper function to update the light client state
+// to the next period with the given certificate.
+func (s *State) updateCommittee(c cert.CommitteeCertificate) error {
+	// verify the period
+	target := s.period + 1
+	if c.Subject().Period != target {
+		return fmt.Errorf("unexpected committee certificate period: %d. expected: %d",
+			c.Subject().Period, target)
+	}
+
+	// verify the committee certificate
+	if err := c.Subject().Committee.Validate(); err != nil {
+		return fmt.Errorf("invalid committee for period %d failed, %w",
+			target, err)
+	}
+
+	// verify the committee certificate with the current committee
+	if err := c.Verify(s.committee); err != nil {
+		return fmt.Errorf("committee certificate verification for period %d failed, %w",
+			target, err)
+	}
+
+	// update the state with the committee certificate
+	s.committee = c.Subject().Committee
+	s.period = target
+
+	return nil
+}

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -16,6 +16,7 @@ type State struct {
 	period     scc.Period
 	headNumber idx.Block
 	headHash   common.Hash
+	headRoot   common.Hash
 }
 
 // NewState creates a new State with the given committee.
@@ -28,6 +29,11 @@ func NewState(committee scc.Committee) *State {
 // Head returns the block number of the latest known block.
 func (s *State) Head() idx.Block {
 	return s.headNumber
+}
+
+// StateRoot returns the state root of the latest known block.
+func (s *State) StateRoot() common.Hash {
+	return s.headRoot
 }
 
 // Sync updates the light client state using certificates from the provider.
@@ -72,6 +78,7 @@ func (s *State) Sync(p provider.Provider) (idx.Block, error) {
 	// update the state with the latest block
 	s.headNumber = headCert.Subject().Number
 	s.headHash = headCert.Subject().Hash
+	s.headRoot = headCert.Subject().StateRoot
 
 	// return the latest block number
 	return s.headNumber, nil

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -3,10 +3,10 @@ package lc_state
 import (
 	"fmt"
 
+	"github.com/0xsoniclabs/consensus/inter/idx"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/0xsoniclabs/sonic/scc/light_client/provider"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 )
 

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -17,9 +17,12 @@ type State struct {
 	headNumber idx.Block
 	headHash   common.Hash
 	headRoot   common.Hash
+	hasSynced  bool
 }
 
 // NewState creates a new State with the given committee.
+// The given committee must be a valid committee and it is expected to be the
+// committee for the genesis period.
 func NewState(committee scc.Committee) *State {
 	return &State{
 		committee: committee,
@@ -27,13 +30,13 @@ func NewState(committee scc.Committee) *State {
 }
 
 // Head returns the block number of the latest known block.
-func (s *State) Head() idx.Block {
-	return s.headNumber
+func (s *State) Head() (idx.Block, bool) {
+	return s.headNumber, s.hasSynced
 }
 
 // StateRoot returns the state root of the latest known block.
-func (s *State) StateRoot() common.Hash {
-	return s.headRoot
+func (s *State) StateRoot() (common.Hash, bool) {
+	return s.headRoot, s.hasSynced
 }
 
 // Sync updates the light client state using certificates from the provider.
@@ -79,6 +82,7 @@ func (s *State) Sync(p provider.Provider) (idx.Block, error) {
 	s.headNumber = headCert.Subject().Number
 	s.headHash = headCert.Subject().Hash
 	s.headRoot = headCert.Subject().StateRoot
+	s.hasSynced = true
 
 	// return the latest block number
 	return s.headNumber, nil

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -30,11 +30,13 @@ func NewState(committee scc.Committee) *State {
 }
 
 // Head returns the block number of the latest known block.
+// The second value is true only if the state has been successfully synced.
 func (s *State) Head() (idx.Block, bool) {
 	return s.headNumber, s.hasSynced
 }
 
 // StateRoot returns the state root of the latest known block.
+// The second value is true only if the state has been successfully synced.
 func (s *State) StateRoot() (common.Hash, bool) {
 	return s.headRoot, s.hasSynced
 }

--- a/scc/light_client/light_client_state/light_client_state.go
+++ b/scc/light_client/light_client_state/light_client_state.go
@@ -29,14 +29,14 @@ func NewState(committee scc.Committee) *State {
 	}
 }
 
-// Head returns the block number of the latest known block.
-// The second value is true only if the state has been successfully synced.
+// Head returns the block number of the latest known block and a bool which
+// is only true if the state has already been successfully synced.
 func (s *State) Head() (idx.Block, bool) {
 	return s.headNumber, s.hasSynced
 }
 
-// StateRoot returns the state root of the latest known block.
-// The second value is true only if the state has been successfully synced.
+// StateRoot returns the state root of the latest known block and a bool which
+// is only true if the state has already been successfully synced.
 func (s *State) StateRoot() (common.Hash, bool) {
 	return s.headRoot, s.hasSynced
 }

--- a/scc/light_client/light_client_state/light_client_state_sync_test.go
+++ b/scc/light_client/light_client_state/light_client_state_sync_test.go
@@ -5,11 +5,11 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/0xsoniclabs/consensus/inter/idx"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/bls"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/0xsoniclabs/sonic/scc/light_client/provider"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"

--- a/scc/light_client/light_client_state/light_client_state_sync_test.go
+++ b/scc/light_client/light_client_state/light_client_state_sync_test.go
@@ -1,0 +1,195 @@
+package lc_state
+
+import (
+	"crypto/sha256"
+	"slices"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/bls"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/0xsoniclabs/sonic/scc/light_client/provider"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLightClientState_CanSyncWithProvider(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+
+	// generate history of blocks and committees certificates
+	blockHeight := scc.BLOCKS_PER_PERIOD * 50 / 3
+	firstCommittee, provider, err := generateCertificatesAndProvider(
+		ctrl, idx.Block(blockHeight))
+	require.NoError(err)
+
+	// create a new state with the first committee
+	state := NewState(firstCommittee)
+	headNumber, err := state.Sync(provider)
+	require.NoError(err)
+	require.Equal(idx.Block(blockHeight), headNumber)
+}
+
+// /////////////////////////
+// Helper functions
+// /////////////////////////
+
+// generateCertificatesAndProvider generates a committee and a provider for testing.
+// The amount of committee certificates is generated based on the given
+// block height.
+// The provider is a mock provider that returns the generated committee and
+// blocks certificates.
+func generateCertificatesAndProvider(
+	ctrl *gomock.Controller,
+	blockHeight idx.Block,
+) (scc.Committee, provider.Provider, error) {
+
+	// generate first committee with committees and blocks certificates
+	firstCommittee, blocks, committees, err := generateHistory(blockHeight)
+	if err != nil {
+		return scc.Committee{}, nil, err
+	}
+
+	// prepare mock provider
+	prov := prepareProvider(ctrl, blockHeight, blocks, committees)
+
+	return firstCommittee, prov, nil
+}
+
+// generateHistory generates a history of blocks and committees certificates.
+// Certificates are signed by 3 committee members and the committee rotates
+// every period.
+func generateHistory(blockHeight idx.Block) (
+	genesis scc.Committee,
+	blocks []cert.BlockCertificate,
+	committees []cert.CommitteeCertificate,
+	err error,
+) {
+
+	keys := []bls.PrivateKey{
+		bls.NewPrivateKey(),
+		bls.NewPrivateKey(),
+		bls.NewPrivateKey(),
+	}
+
+	genesis = scc.NewCommittee(
+		makeMember(keys[0]),
+		makeMember(keys[1]),
+		makeMember(keys[2]))
+
+	// generate first block and committee certificates.
+	blocks = append(blocks, cert.NewCertificate(cert.BlockStatement{}))
+	committees = append(committees, cert.NewCertificate(cert.CommitteeStatement{
+		Committee: genesis,
+	}))
+
+	// generate certificates up to blockHeight.
+	committee := genesis
+	head := idx.Block(0)
+	headHash := common.Hash{}
+	for i := head; i < blockHeight; i++ {
+
+		// Compute next block.
+		head += 1
+		// the next line is a dummy hash, only for testing purposes.
+		headHash = common.Hash(sha256.Sum256(headHash[:]))
+
+		// Add period boundaries, update the committee.
+		if scc.IsFirstBlockOfPeriod(head) {
+			committee := scc.NewCommittee(rotate(committee.Members())...)
+
+			certificate := cert.NewCertificate(
+				cert.NewCommitteeStatement(
+					1234,
+					scc.GetPeriod(head),
+					committee))
+
+			for i, key := range keys {
+				err := certificate.Add(
+					scc.MemberId(i),
+					cert.Sign(certificate.Subject(), key))
+				if err != nil {
+					return scc.Committee{}, nil, nil, err
+				}
+			}
+			committees = append(committees, certificate)
+			keys = rotate(keys)
+		}
+
+		// Sign the new block using the current committee.
+		block := cert.NewCertificate(
+			cert.NewBlockStatement(
+				1234,
+				head,
+				headHash,
+				headHash,
+			))
+
+		for i, key := range keys {
+			err := block.Add(scc.MemberId(i), cert.Sign(block.Subject(), key))
+			if err != nil {
+				return scc.Committee{}, nil, nil, err
+			}
+		}
+		blocks = append(blocks, block)
+
+	}
+
+	return genesis, blocks, committees, nil
+}
+
+// prepareProvider prepares a mock provider that returns the given blocks and
+// committees certificates.
+// if the block number is LatestBlock, it returns the latest block.
+func prepareProvider(
+	ctrl *gomock.Controller,
+	blockHeight idx.Block,
+	blocks []cert.BlockCertificate,
+	committees []cert.CommitteeCertificate,
+) provider.Provider {
+
+	prov := provider.NewMockProvider(ctrl)
+	prov.
+		EXPECT().
+		GetBlockCertificates(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(number idx.Block, max uint64) ([]cert.BlockCertificate, error) {
+			if number == provider.LatestBlock {
+				return blocks[len(blocks)-1:], nil
+			}
+			start := uint64(number)
+			end := start + max
+			end = min(end, uint64(len(committees)))
+			start = min(start, end)
+			return blocks[start:end], nil
+		}).
+		AnyTimes()
+
+	prov.EXPECT().
+		GetCommitteeCertificates(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(from scc.Period, max uint64) ([]cert.CommitteeCertificate, error) {
+			start := uint64(from)
+			end := start + max
+			end = min(end, uint64(len(committees)))
+			start = min(start, end)
+			return committees[start:end], nil
+		}).
+		AnyTimes()
+
+	return prov
+}
+
+func makeMember(key bls.PrivateKey) scc.Member {
+	return scc.Member{
+		PublicKey:         key.PublicKey(),
+		ProofOfPossession: key.GetProofOfPossession(),
+		VotingPower:       1,
+	}
+}
+
+func rotate[T any](list []T) []T {
+	res := slices.Clone(list)
+	res = append(res[1:], res[0])
+	return res
+}

--- a/scc/light_client/light_client_state/light_client_state_test.go
+++ b/scc/light_client/light_client_state/light_client_state_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/0xsoniclabs/consensus/inter/idx"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/bls"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/0xsoniclabs/sonic/scc/light_client/provider"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"

--- a/scc/light_client/light_client_state/light_client_state_test.go
+++ b/scc/light_client/light_client_state/light_client_state_test.go
@@ -1,0 +1,296 @@
+package lc_state
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/bls"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/0xsoniclabs/sonic/scc/light_client/provider"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLightClientState_PropagatesErrorsFrom(t *testing.T) {
+	require := require.New(t)
+
+	tests := map[string]func(prov *provider.MockProvider){
+		"GettingFirstBlockCertificate": func(prov *provider.MockProvider) {
+			prov.EXPECT().
+				GetBlockCertificates(provider.LatestBlock, uint64(1)).
+				Return(nil, fmt.Errorf("failed to get block certificates"))
+		},
+		"GettingCommitteeCertificates": func(prov *provider.MockProvider) {
+			expectBlockForPeriod(prov, 1)
+			prov.EXPECT().
+				GetCommitteeCertificates(scc.Period(1), uint64(1)).
+				Return(nil, fmt.Errorf("failed to get committee certificates"))
+		},
+	}
+
+	for name, expectedCalls := range tests {
+		t.Run(name, func(t *testing.T) {
+			prov := provider.NewMockProvider(gomock.NewController(t))
+			state := NewState(scc.Committee{})
+			expectedCalls(prov)
+			_, err := state.Sync(prov)
+			require.ErrorContains(err, "failed to get")
+		})
+	}
+}
+
+func TestLightClientState_Sync_ChangesNothingWhen_LatestBlockIsEmpty(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	prov.EXPECT().
+		GetBlockCertificates(provider.LatestBlock, uint64(1)).
+		Return([]cert.BlockCertificate{}, nil)
+
+	state := NewState(scc.Committee{})
+	_, err := state.Sync(prov)
+	require.ErrorContains(err, "zero block certificates")
+	want := State{}
+	compareStates(t, &want, state)
+}
+
+func TestLightClientState_Sync_UpdatesOnlyHeadWhen_SyncToCurrentPeriod(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	// setup state with non empty committee
+	key := bls.NewPrivateKey()
+	member := makeMember(key)
+	state := NewState(scc.NewCommittee(member))
+	state.period = 1
+
+	// setup block for period 1.
+	blockNumber := idx.Block(scc.BLOCKS_PER_PERIOD*1 + 1)
+	blockCert := cert.NewCertificate(
+		cert.NewBlockStatement(0, blockNumber, common.Hash{0x1}, common.Hash{}))
+
+	// sigh the block certificate with the committee member
+	err := blockCert.Add(scc.MemberId(0), cert.Sign(blockCert.Subject(), key))
+	require.NoError(err)
+
+	prov.EXPECT().
+		GetBlockCertificates(provider.LatestBlock, uint64(1)).
+		Return([]cert.BlockCertificate{blockCert}, nil)
+
+	_, err = state.Sync(prov)
+	require.NoError(err)
+	want := State{
+		period:     scc.Period(1),
+		committee:  scc.NewCommittee(member),
+		headNumber: blockCert.Subject().Number,
+		headHash:   common.Hash{0x1},
+	}
+	compareStates(t, &want, state)
+}
+
+func TestLightClientState_Sync_CanNotSyncToPastPeriod(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	// setup block for period 1.
+	expectBlockForPeriod(prov, 1)
+
+	// setup synced to period 2
+	state := State{period: 2}
+	_, err := state.Sync(prov)
+	require.ErrorContains(err, "cannot sync to a previous period")
+}
+
+func TestLightClientState_Sync_ReportsFailedVerificationOfLatestBlock(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	// setup state with non empty committee
+	key := bls.NewPrivateKey()
+	member := makeMember(key)
+	state := NewState(scc.NewCommittee(member))
+	state.period = 1
+
+	// setup unsigned block for period 1.
+	expectBlockForPeriod(prov, 1)
+
+	_, err := state.Sync(prov)
+	require.ErrorContains(err, "insufficient voting power")
+}
+
+func TestLightClientState_Sync_FailsWithNilProvider(t *testing.T) {
+	require := require.New(t)
+	state := NewState(scc.Committee{})
+	_, err := state.Sync(nil)
+	require.ErrorContains(err, "cannot update with nil provider")
+}
+
+func TestLightClientState_Sync_FailsWhenHeadProvidedIsSmallerThanCurrent(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	expectBlockForPeriod(prov, 0)
+
+	state := NewState(scc.NewCommittee())
+	lastBlockOfPeriod := idx.Block(3)
+	state.headNumber = lastBlockOfPeriod
+
+	_, err := state.Sync(prov)
+	require.ErrorContains(err, "invalid block number")
+	want := State{
+		headNumber: lastBlockOfPeriod,
+	}
+	compareStates(t, &want, state)
+}
+
+func TestLightClientState_Sync_FailsWithUnorderedCommitteeCertificates(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	// setup block.
+	expectBlockForPeriod(prov, 2)
+
+	// setup committee certificates for period 2.
+	committeeCert2 := cert.NewCertificate(cert.CommitteeStatement{
+		Period: 2,
+	})
+
+	// return list of certificates missing certificate for period 1
+	prov.EXPECT().
+		GetCommitteeCertificates(scc.Period(1), uint64(2)).
+		Return([]cert.CommitteeCertificate{committeeCert2}, nil)
+
+	state := NewState(scc.Committee{})
+	_, err := state.Sync(prov)
+	require.ErrorContains(err, "unexpected committee certificate period")
+}
+
+func TestLightClientState_Sync_FailsWithInvalidCommitteeCertificate(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	// setup block
+	expectBlockForPeriod(prov, 1)
+
+	// setup committee certificates for period 1.
+	committeeCert1 := cert.NewCertificate(cert.CommitteeStatement{
+		Period: 1,
+	})
+
+	// return certificate without a valid committee
+	prov.EXPECT().
+		GetCommitteeCertificates(scc.Period(1), uint64(1)).
+		Return([]cert.CommitteeCertificate{committeeCert1}, nil)
+
+	state := NewState(scc.Committee{})
+	_, err := state.Sync(prov)
+	require.ErrorContains(err, "invalid committee")
+}
+
+func TestLightClientState_Sync_ReportsCurrentCommitteeFailsToVerifyNextCommittee(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	// setup block for period 1.
+	expectBlockForPeriod(prov, 1)
+
+	// setup committee certificate for period 1.
+	key := bls.NewPrivateKey()
+	member := makeMember(key)
+	committeeCert1 := cert.NewCertificate(cert.CommitteeStatement{
+		Period:    1,
+		Committee: scc.NewCommittee(member),
+	})
+
+	// return certificate for period 1 that has not been sign
+	prov.EXPECT().
+		GetCommitteeCertificates(scc.Period(1), uint64(1)).
+		Return([]cert.CommitteeCertificate{committeeCert1}, nil)
+
+	state := NewState(scc.NewCommittee(member))
+	_, err := state.Sync(prov)
+	require.ErrorContains(err, "committee certificate verification")
+}
+
+func TestLightClientState_Sync_UpdatesState(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := provider.NewMockProvider(ctrl)
+
+	// setup block for period 1.
+	blockNumber := idx.Block(scc.BLOCKS_PER_PERIOD*1 + 1)
+	blockCert := cert.NewCertificate(
+		cert.NewBlockStatement(0, blockNumber, common.Hash{0x1}, common.Hash{0x2}))
+
+	// setup committee certificate for period 1.
+	key := bls.NewPrivateKey()
+	member := makeMember(key)
+	committeeCert1 := cert.NewCertificate(cert.CommitteeStatement{
+		Period:    1,
+		Committee: scc.NewCommittee(member),
+	})
+
+	// member signs the certificates
+	err := committeeCert1.Add(scc.MemberId(0), cert.Sign(committeeCert1.Subject(), key))
+	require.NoError(err)
+	err = blockCert.Add(scc.MemberId(0), cert.Sign(blockCert.Subject(), key))
+	require.NoError(err)
+
+	// provider calls
+	prov.EXPECT().
+		GetBlockCertificates(provider.LatestBlock, uint64(1)).
+		Return([]cert.BlockCertificate{blockCert}, nil)
+	prov.EXPECT().
+		GetCommitteeCertificates(scc.Period(1), uint64(1)).
+		Return([]cert.CommitteeCertificate{committeeCert1}, nil)
+
+	// sync
+	state := NewState(scc.NewCommittee(member))
+	_, err = state.Sync(prov)
+	require.NoError(err)
+
+	want := State{
+		period:     scc.Period(1),
+		committee:  scc.NewCommittee(member),
+		headNumber: blockNumber,
+		headHash:   common.Hash{0x1},
+	}
+	compareStates(t, &want, state)
+
+}
+
+// /////////////////////////
+// Helper functions
+// /////////////////////////
+
+func compareStates(t *testing.T, expected, actual *State) {
+	require := require.New(t)
+	require.Equal(expected.Head(), actual.Head())
+	require.Equal(expected.period, actual.period)
+	require.Equal(expected.headHash, actual.headHash)
+	require.True(reflect.DeepEqual(expected.committee, actual.committee))
+}
+
+func expectBlockForPeriod(prov *provider.MockProvider, period scc.Period) cert.BlockCertificate {
+	blockNumber := idx.Block(scc.BLOCKS_PER_PERIOD*period + 1)
+	blockCert := cert.NewCertificate(
+		cert.NewBlockStatement(0, blockNumber, common.Hash{}, common.Hash{}))
+
+	prov.EXPECT().
+		GetBlockCertificates(provider.LatestBlock, uint64(1)).
+		Return([]cert.BlockCertificate{blockCert}, nil)
+
+	return blockCert
+}

--- a/scc/light_client/light_client_state/light_client_state_test.go
+++ b/scc/light_client/light_client_state/light_client_state_test.go
@@ -43,7 +43,17 @@ func TestLightClientState_PropagatesErrorsFrom(t *testing.T) {
 	}
 }
 
-func TestLightClientState_Sync_ChangesNothingWhen_LatestBlockIsEmpty(t *testing.T) {
+func TestLightClientState_Head_StateRoot_ReturnsFalseForUnsyncedState(t *testing.T) {
+	require := require.New(t)
+	state := NewState(scc.Committee{})
+	head, synced := state.Head()
+	require.False(synced)
+	require.Zero(head)
+	root, synced := state.StateRoot()
+	require.False(synced)
+	require.Zero(root)
+}
+
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	prov := provider.NewMockProvider(ctrl)
@@ -91,6 +101,7 @@ func TestLightClientState_Sync_UpdatesOnlyHeadWhen_SyncToCurrentPeriod(t *testin
 		headNumber: blockCert.Subject().Number,
 		headHash:   common.Hash{0x1},
 		headRoot:   common.Hash{0x2},
+		hasSynced:  true,
 	}
 	compareStates(t, &want, state)
 }
@@ -268,6 +279,7 @@ func TestLightClientState_Sync_UpdatesState(t *testing.T) {
 		headNumber: blockNumber,
 		headHash:   common.Hash{0x1},
 		headRoot:   common.Hash{0x2},
+		hasSynced:  true,
 	}
 	compareStates(t, &want, state)
 

--- a/scc/light_client/light_client_state/light_client_state_test.go
+++ b/scc/light_client/light_client_state/light_client_state_test.go
@@ -73,7 +73,7 @@ func TestLightClientState_Sync_UpdatesOnlyHeadWhen_SyncToCurrentPeriod(t *testin
 	// setup block for period 1.
 	blockNumber := idx.Block(scc.BLOCKS_PER_PERIOD*1 + 1)
 	blockCert := cert.NewCertificate(
-		cert.NewBlockStatement(0, blockNumber, common.Hash{0x1}, common.Hash{}))
+		cert.NewBlockStatement(0, blockNumber, common.Hash{0x1}, common.Hash{0x2}))
 
 	// sigh the block certificate with the committee member
 	err := blockCert.Add(scc.MemberId(0), cert.Sign(blockCert.Subject(), key))
@@ -90,6 +90,7 @@ func TestLightClientState_Sync_UpdatesOnlyHeadWhen_SyncToCurrentPeriod(t *testin
 		committee:  scc.NewCommittee(member),
 		headNumber: blockCert.Subject().Number,
 		headHash:   common.Hash{0x1},
+		headRoot:   common.Hash{0x2},
 	}
 	compareStates(t, &want, state)
 }
@@ -266,6 +267,7 @@ func TestLightClientState_Sync_UpdatesState(t *testing.T) {
 		committee:  scc.NewCommittee(member),
 		headNumber: blockNumber,
 		headHash:   common.Hash{0x1},
+		headRoot:   common.Hash{0x2},
 	}
 	compareStates(t, &want, state)
 
@@ -280,6 +282,7 @@ func compareStates(t *testing.T, expected, actual *State) {
 	require.Equal(expected.Head(), actual.Head())
 	require.Equal(expected.period, actual.period)
 	require.Equal(expected.headHash, actual.headHash)
+	require.Equal(expected.StateRoot(), actual.StateRoot())
 	require.True(reflect.DeepEqual(expected.committee, actual.committee))
 }
 

--- a/scc/light_client/light_client_state/light_client_state_test.go
+++ b/scc/light_client/light_client_state/light_client_state_test.go
@@ -135,7 +135,7 @@ func TestLightClientState_Sync_ReportsFailedVerificationOfLatestBlock(t *testing
 	expectQueryForBlockOfPeriod(prov, 1)
 
 	_, err := state.Sync(prov)
-	require.ErrorContains(err, "failed to sync to period 1")
+	require.ErrorContains(err, "failed to authenticate block certificate")
 }
 
 func TestLightClientState_Sync_FailsWithNilProvider(t *testing.T) {

--- a/scc/light_client/light_client_state/light_client_state_test.go
+++ b/scc/light_client/light_client_state/light_client_state_test.go
@@ -153,13 +153,13 @@ func TestLightClientState_Sync_IgnoresSameBlockOrPeriod(t *testing.T) {
 	expectQueryForBlockOfPeriod(prov, 0)
 
 	state := NewState(scc.NewCommittee())
-	lastBlockOfPeriod := idx.Block(1)
-	state.headNumber = lastBlockOfPeriod
+	lastBlockSyncedTo := idx.Block(1)
+	state.headNumber = lastBlockSyncedTo
 
 	_, err := state.Sync(prov)
 	require.NoError(err)
 	want := State{
-		headNumber: lastBlockOfPeriod,
+		headNumber: lastBlockSyncedTo,
 	}
 	require.Equal(&want, state)
 }
@@ -172,13 +172,13 @@ func TestLightClientState_Sync_FailsWithOlderHead(t *testing.T) {
 	expectQueryForBlockOfPeriod(prov, 0)
 
 	state := NewState(scc.NewCommittee())
-	lastBlockOfPeriod := idx.Block(3)
-	state.headNumber = lastBlockOfPeriod
+	lastBlockSyncedTo := idx.Block(3)
+	state.headNumber = lastBlockSyncedTo
 
 	_, err := state.Sync(prov)
 	require.ErrorContains(err, "provider returned old block head")
 	want := State{
-		headNumber: lastBlockOfPeriod,
+		headNumber: lastBlockSyncedTo,
 	}
 	require.Equal(&want, state)
 }


### PR DESCRIPTION
This PR depends on #91 

This PR adds the Light Client State (`LCS`). This represents the current state of the Light Client (`LC`), that is, up to which period and committee is the `LC` synced to. 
Two tests files are added:
- One aiming for unit testing, checking errors are properly propagated, etc.
- Another that generates a history of block certificates with the corresponding committee certificates (rotating between 3 different members), and then attempts to sync from a genesis committee to the period of the latest block reported by the `Provider`. 