### PR TITLE
Refactor logs initialization.

### DIFF
--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/0xsoniclabs/sonic/config/flags"
+	"github.com/0xsoniclabs/sonic/debug"
 	"github.com/0xsoniclabs/sonic/version"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -25,6 +26,8 @@ func RunWithArgs(args []string) error {
 		flags.ArchiveCacheFlag,
 		flags.StateDbCacheCapacityFlag,
 	}
+	app.Flags = append(app.Flags, debug.Flags...)
+
 	app.Commands = []cli.Command{
 		{
 			Name:  "genesis",
@@ -403,6 +406,11 @@ Converts an account private key to a validator private key and saves in the vali
 			},
 		},
 	}
+
+	app.Before = func(ctx *cli.Context) error {
+		return debug.Setup(ctx)
+	}
+
 	sort.Sort(cli.CommandsByName(app.Commands))
 
 	return app.Run(args)

--- a/debug/flags.go
+++ b/debug/flags.go
@@ -37,9 +37,10 @@ import (
 
 var (
 	verbosityFlag = cli.IntFlag{
-		Name:  "verbosity",
-		Usage: "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
-		Value: 3,
+		Name:   "verbosity",
+		Usage:  "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
+		Value:  3,
+		EnvVar: "SONIC_VERBOSITY",
 	}
 	vmoduleFlag = cli.StringFlag{
 		Name:  "vmodule",

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -211,12 +211,18 @@ func startIntegrationTestNet(
 	}
 	net.Session.net = net
 
+	if verbosityVariable := os.Getenv("SONIC_VERBOSITY"); verbosityVariable == "" {
+		if err := os.Setenv("SONIC_VERBOSITY", "0"); err != nil {
+			t.Fatal("failed to set verbosity: ", err)
+		}
+	}
+
 	// start the integration test nodes
 	for i := range net.nodes {
 		net.nodes[i].directory = filepath.Join(directory, fmt.Sprintf("node%d", i))
 
 		// initialize the data directory for the single node on the test network
-		// equivalent to running `sonictool --datadir <dataDir> genesis fake 1`
+		// using the configuration arguments provided by the caller
 		args := append([]string{
 			"sonictool",
 			"--datadir", net.nodes[i].getStateDir(),


### PR DESCRIPTION
This PR introduces some changes in the logging initialization of the Sonic project.
- Introduces logging arguments into the sonictool. Log format, log level, per module verbosity, etc.
- Introduces an environment variable `SONIC_VERBOSITY` to tune log verbosity of sonictool, sonicd, and integration tests without recompiling.  
- Defaults to silent logs when running integration tests.

Example of use: 
`SONIC_VERBOSITY=3 go test -timeout 10m -run ^TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart$ github.com/0xsoniclabs/sonic/tests -v -count 1
`

This PR has been written with the "single point of responsibility" principle in mind, therefore the feature has been implemented in the command line arguments instead of duplicating the feature in the integration test tooling. 
For this reason, the complete debug namespace is utilized in sonictool as well, instead of cherry-picking the log level flag.


