### PR TITLE
Use members instead of committee for genesis json

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -259,7 +259,7 @@ func StartIntegrationTestNetWithJsonGenesis(
 	if err := committee.Validate(); err != nil {
 		t.Fatal("failed to validate the committee:", err)
 	}
-	jsonGenesis.GenesisCommittee = &committee
+	jsonGenesis.GenesisCommittee = committee.Members()
 
 	encoded, err := json.MarshalIndent(jsonGenesis, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Since the `GenesisJson` type used a `*scc.Committee` to store the genesis committee, `json.marshall` could not access the committee members, because this a private field, and so when exporting the genesis into a json file,  the committee was lost.

This PR adds 2 main changes, to fix this:
- First, two extra checks when decoding a json genesis, that the genesis committee has members, and these constitute a valid committee.
- Second, changes the `GenesisJson` member from `*scc.Committee` to `[]scc.Member`