### PR TITLE
Add json encode/decode methods to `scc.Committee`

### DIFF
--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -140,6 +140,12 @@ func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
 	if json.GenesisCommittee == nil {
 		return nil, fmt.Errorf("genesis committee must be set")
 	}
+	if len(json.GenesisCommittee.Members()) == 0 {
+		return nil, fmt.Errorf("genesis committee must have at least one member")
+	}
+	if err := json.GenesisCommittee.Validate(); err != nil {
+		return nil, fmt.Errorf("genesis committee is invalid")
+	}
 	builder.SetGenesisCommitteeCertificate(cert.NewCertificate(
 		cert.NewCommitteeStatement(
 			json.Rules.NetworkID,

--- a/scc/committee.go
+++ b/scc/committee.go
@@ -1,6 +1,7 @@
 package scc
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -182,4 +183,21 @@ func DeserializeCommittee(data []byte) (Committee, error) {
 	}
 
 	return Committee{members}, nil
+}
+
+// MarshalJSON implements the json.Marshaler interface. The committee is
+// serialized into a JSON array of members.
+func (c Committee) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.members)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface. The committee is
+// deserialized from a JSON array of members.
+func (c *Committee) UnmarshalJSON(data []byte) error {
+	var members []Member
+	if err := json.Unmarshal(data, &members); err != nil {
+		return err
+	}
+	*c = NewCommittee(members...)
+	return nil
 }

--- a/scc/committee_test.go
+++ b/scc/committee_test.go
@@ -1,6 +1,7 @@
 package scc
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -217,4 +218,23 @@ func newTestMember(i byte, power uint64) Member {
 		ProofOfPossession: key.GetProofOfPossession(),
 		VotingPower:       power,
 	}
+}
+
+func TestCommittee_CanEncodeDecodeJson(t *testing.T) {
+	members := []Member{
+		newTestMember(1, 10),
+		newTestMember(2, 20),
+		newTestMember(3, 15),
+	}
+	committee := Committee{members: members}
+
+	data, err := json.Marshal(committee)
+	require.NoError(t, err)
+	require.NotEqual(t, "{}", string(data))
+
+	var committee2 Committee
+	err = json.Unmarshal(data, &committee2)
+	require.NoError(t, err)
+
+	require.Equal(t, committee, committee2)
 }


### PR DESCRIPTION
The `GenesisJson` type stores the genesis committee as a `*scc.Committee`, which contains a private field. As a result, when encoding with `json.Marshal`, reflection couldn't access the committee members, causing them to be lost when exporting the genesis to a JSON file.

This PR introduces two key changes to address this issue:
- Adds two extra validation checks when decoding a JSON genesis: ensuring that the genesis committee has members and that they form a valid committee.
- Implements `MarshalJSON` and `UnmarshalJSON` methods for `scc.Committee` to properly handle JSON serialization.