### PR TITLE
Improve JSON genesis file infrastructure

### DIFF
--- a/integration/makefakegenesis/json_test.go
+++ b/integration/makefakegenesis/json_test.go
@@ -1,0 +1,21 @@
+package makefakegenesis
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonGenesis_CanApplyGeneratedFakeJsonGensis(t *testing.T) {
+	genesis := GenerateFakeJsonGenesis(1, opera.SonicFeatures)
+	_, err := ApplyGenesisJson(genesis)
+	require.NoError(t, err)
+}
+
+func TestJsonGenesis_AcceptsGenesisWithoutCommittee(t *testing.T) {
+	genesis := GenerateFakeJsonGenesis(1, opera.SonicFeatures)
+	genesis.GenesisCommittee = nil
+	_, err := ApplyGenesisJson(genesis)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR applies a number of improvements and fixes to the JSON genesis file handling:
- the functionality of producing a JSON genesis file following fake-net rules is moved from the integration `tests` package to the `makefakegenesis` package to be co-located with other fake-genesis related code
- the fake-genesis JSON file generation process was updated to produce a customize-able number of validators, allowing voting power to be distributed among multiple nodes in an integration test environment
- the provisioning of a genesis committee for the SCC is made optional to re-establish backward compatibility with the Sonic main-net JSON genesis file