### PR TITLE
Add feature changes and test for EIP-7623

### DIFF
--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -92,4 +92,8 @@ var (
 
 	// ErrEmptyAuthorizations is returned if a SetCode transaction has no authorizations.
 	ErrEmptyAuthorizations = errors.New("empty authorizations")
+
+	// ErrMaxInitCodeSizeExceeded is returned if creation transaction provides the init code bigger
+	// than init code size limit.
+	ErrMaxInitCodeSizeExceeded = errors.New("max initcode size exceeded")
 )

--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -63,6 +63,10 @@ var (
 	// than required to start the invocation.
 	ErrIntrinsicGas = core.ErrIntrinsicGas
 
+	// ErrFloorDataGas is returned if the transaction is specified to use less gas
+	// than required for the data floor cost.
+	ErrFloorDataGas = errors.New("insufficient gas for floor data gas cost")
+
 	// ErrTxTypeNotSupported is returned if a transaction is not supported in the
 	// current network configuration.
 	ErrTxTypeNotSupported = types.ErrTxTypeNotSupported

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -18,6 +18,7 @@ package evmcore
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"math/rand/v2"
@@ -692,6 +693,12 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if uint64(tx.Size()) > txMaxSize {
 		return ErrOversizedData
 	}
+
+	// Check whether the init code size has been exceeded
+	if pool.shanghai && tx.To() == nil && len(tx.Data()) > params.MaxInitCodeSize {
+		return fmt.Errorf("%w: code size %v, limit %v", ErrMaxInitCodeSizeExceeded, len(tx.Data()), params.MaxInitCodeSize)
+	}
+
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur if you create a transaction using the RPC.
 	if tx.Value().Sign() < 0 {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -260,6 +260,7 @@ type TxPool struct {
 	eip2718  bool // Fork indicator whether we are using EIP-2718 type transactions.
 	eip1559  bool // Fork indicator whether we are using EIP-1559 type transactions.
 	eip4844  bool // Fork indicator whether we are using EIP-4844 type transactions.
+	eip7623  bool // Fork indicator whether we are using EIP-7623 floor gas validation.
 	eip7702  bool // Fork indicator whether we are using EIP-7702 type transactions.
 
 	currentState  TxPoolStateDB // Current state in the blockchain head
@@ -757,6 +758,19 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if tx.Gas() < intrGas {
 		return ErrIntrinsicGas
 	}
+
+	// EIP-7623: Floor data gas
+	// see: https://eips.ethereum.org/EIPS/eip-7623
+	if pool.eip7623 {
+		floorDataGas, err := core.FloorDataGas(tx.Data())
+		if err != nil {
+			return err
+		}
+		if tx.Gas() < floorDataGas {
+			return fmt.Errorf("%w: have %d, want %d", ErrFloorDataGas, tx.Gas(), floorDataGas)
+		}
+	}
+
 	return nil
 }
 
@@ -1445,6 +1459,7 @@ func (pool *TxPool) reset(oldHead, newHead *EvmHeader) {
 	pool.eip1559 = pool.chainconfig.IsLondon(next)
 	pool.shanghai = pool.chainconfig.IsShanghai(next, uint64(newHead.Time.Unix()))
 	pool.eip4844 = pool.chainconfig.IsCancun(next, uint64(newHead.Time.Unix()))
+	pool.eip7623 = pool.chainconfig.IsPrague(next, uint64(newHead.Time.Unix()))
 	pool.eip7702 = pool.chainconfig.IsPrague(next, uint64(newHead.Time.Unix()))
 }
 

--- a/tests/gas_cost_test.go
+++ b/tests/gas_cost_test.go
@@ -1,0 +1,423 @@
+package tests
+
+import (
+	"context"
+	"iter"
+	"strings"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type txModification func(tx *types.AccessListTx)
+
+type CostDefinition struct {
+	name         string
+	modification txModification
+	cost         uint64
+
+	variableCost func(tx *types.AccessListTx) uint64
+}
+
+type TestCase struct {
+	names     []string
+	txPayload types.AccessListTx
+}
+
+func (tc *TestCase) String() string {
+	return strings.Join(tc.names, "/")
+}
+
+func TestGasCostTest_Sonic(t *testing.T) {
+
+	net := StartIntegrationTestNet(t,
+		IntegrationTestNetOptions{
+			FeatureSet: opera.SonicFeatures,
+		})
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	t.Cleanup(net.Stop)
+
+	chainId, err := client.ChainID(context.Background())
+	require.NoError(t, err)
+
+	// From https://eips.ethereum.org/EIPS/eip-7623
+	// Gas used before Prague update:
+	// > tx.gasUsed = (
+	// >     21000
+	// >     + STANDARD_TOKEN_COST * tokens_in_calldata
+	// >     + execution_gas_used
+	// >     + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata))
+	// > )
+
+	t.Run("reject transactions with insufficient gas", func(t *testing.T) {
+		t.Parallel()
+		session := net.SpawnSession(t)
+		for test := range makeGasCostTestInputs(t, session) {
+			t.Run(test.String(), func(t *testing.T) {
+				test.txPayload.Gas = test.txPayload.Gas - 1
+
+				tx := signTransaction(t, chainId, &test.txPayload, session.GetSessionSponsor())
+				require.NoError(t, err)
+
+				err := client.SendTransaction(context.Background(), tx)
+				require.Error(t, err)
+				require.Condition(t, func() bool {
+					return strings.Contains(err.Error(), "intrinsic gas too low")
+				}, err.Error())
+			})
+		}
+	})
+
+	t.Run("transactions with exact gas succeed", func(t *testing.T) {
+		t.Parallel()
+		session := net.SpawnSession(t)
+		for test := range makeGasCostTestInputs(t, session) {
+			t.Run(test.String(), func(t *testing.T) {
+				tx := signTransaction(t, chainId, &test.txPayload, session.GetSessionSponsor())
+				require.NoError(t, err)
+
+				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
+				// t.Log("gas:", expectedCost, tx.Gas(), tx.Gas()-expectedCost)
+				require.NoError(t, err)
+				require.Equal(t, expectedCost, tx.Gas())
+
+				receipt, err := session.Run(tx)
+				require.NoError(t, err)
+				assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+				assert.Equal(t, expectedCost, receipt.GasUsed)
+			})
+		}
+	})
+
+	t.Run("Sonic processor charges 10% of unused gas", func(t *testing.T) {
+		t.Parallel()
+		session := net.SpawnSession(t)
+		for test := range makeGasCostTestInputs(t, session) {
+			t.Run(test.String(), func(t *testing.T) {
+
+				// Increase gas by 20% to make sure we have some unused gas
+				test.txPayload.Gas = uint64(float32(test.txPayload.Gas) * 1.2)
+
+				tx := signTransaction(t, chainId, &test.txPayload, session.GetSessionSponsor())
+				require.NoError(t, err)
+
+				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
+				require.NoError(t, err)
+				unused := tx.Gas() - expectedCost
+				expectedCost += unused / 10
+
+				receipt, err := session.Run(tx)
+				require.NoError(t, err)
+				assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+				assert.Equal(t, expectedCost, receipt.GasUsed)
+			})
+		}
+	})
+}
+
+func TestGasCostTest_Allegro(t *testing.T) {
+
+	net := StartIntegrationTestNet(t,
+		IntegrationTestNetOptions{
+			FeatureSet: opera.AllegroFeatures,
+		})
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	t.Cleanup(net.Stop)
+
+	chainId, err := client.ChainID(context.Background())
+	require.NoError(t, err)
+
+	// From https://eips.ethereum.org/EIPS/eip-7623
+	// Gas used after Prague update:
+	// > tx.gasUsed = (
+	// >     21000
+	// >     +
+	// >     max(
+	// >         STANDARD_TOKEN_COST * tokens_in_calldata
+	// >         + execution_gas_used
+	// >         + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata)),
+	// >         TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
+	// >     )
+	// > )
+
+	computeEIP7623GasCost := func(t *testing.T, tx *types.AccessListTx) uint64 {
+		intrinsicGas, err := core.IntrinsicGas(tx.Data, tx.AccessList, nil, tx.To == nil, true, true, true)
+		require.NoError(t, err)
+		require.Equal(t, intrinsicGas, tx.Gas)
+
+		floorDataGas, err := core.FloorDataGas(tx.Data)
+		require.NoError(t, err)
+
+		return max(intrinsicGas, floorDataGas)
+	}
+
+	t.Run("reject transactions with insufficient gas", func(t *testing.T) {
+		t.Parallel()
+		session := net.SpawnSession(t)
+		for test := range makeGasCostTestInputs(t, session) {
+			t.Run(test.String(), func(t *testing.T) {
+
+				test.txPayload.Gas = computeEIP7623GasCost(t, &test.txPayload) - 1
+
+				tx := signTransaction(t, chainId, &test.txPayload, session.GetSessionSponsor())
+				require.NoError(t, err)
+
+				err := client.SendTransaction(context.Background(), tx)
+				require.Error(t, err)
+				require.Condition(t, func() bool {
+					return strings.Contains(err.Error(), "intrinsic gas too low") ||
+						strings.Contains(err.Error(), "insufficient gas for floor data gas cost")
+				}, "unexpected error, got:", err.Error())
+			})
+		}
+	})
+
+	t.Run("transactions with exact gas succeed", func(t *testing.T) {
+		t.Parallel()
+		session := net.SpawnSession(t)
+
+		var corrections int
+		for test := range makeGasCostTestInputs(t, session) {
+			t.Run(test.String(), func(t *testing.T) {
+
+				correctedGasCost := computeEIP7623GasCost(t, &test.txPayload)
+				if correctedGasCost != test.txPayload.Gas {
+					corrections++
+				}
+				test.txPayload.Gas = correctedGasCost
+
+				tx := signTransaction(t, chainId, &test.txPayload, session.GetSessionSponsor())
+				require.NoError(t, err)
+
+				receipt, err := session.Run(tx)
+				require.NoError(t, err)
+				assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+				assert.Equal(t, correctedGasCost, receipt.GasUsed)
+			})
+		}
+		// If the test case generation is modified, please change the expected number of corrections
+		// It is important for this test that this value is never 0
+		require.Equal(t, 16, corrections, "expected 16 floor data gas corrections in the generated inputs, got %d", corrections)
+	})
+
+	t.Run("Sonic processor charges 10% of unused gas", func(t *testing.T) {
+		t.Parallel()
+		session := net.SpawnSession(t)
+
+		var floorGreaterThan20Percent int
+		var expectedSmallerThanFloor int
+		for test := range makeGasCostTestInputs(t, session) {
+			t.Run(test.String(), func(t *testing.T) {
+
+				floorDataGas, err := core.FloorDataGas(test.txPayload.Data)
+				require.NoError(t, err)
+
+				// Increase gas by 20% to make sure we have some unused gas
+				incremented := uint64(float32(test.txPayload.Gas) * 1.2)
+				// If increased gas is still less than floor data gas, increase it until it is
+				// more than necessary
+				if floorDataGas > incremented {
+					incremented = uint64(float32(floorDataGas) * 1.2)
+					floorGreaterThan20Percent++
+				}
+
+				test.txPayload.Gas = incremented
+
+				tx := signTransaction(t, chainId, &test.txPayload, session.GetSessionSponsor())
+				require.NoError(t, err)
+
+				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
+				require.NoError(t, err)
+				unused := tx.Gas() - expectedCost
+				expectedCost += unused / 10
+
+				if floorDataGas > expectedCost {
+					expectedCost = floorDataGas
+					expectedSmallerThanFloor++
+				}
+
+				receipt, err := session.Run(tx)
+				require.NoError(t, err)
+				assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+				assert.Equal(t, expectedCost, receipt.GasUsed)
+			})
+		}
+
+		// If the test case generation is modified, please change the expected number of out of bound cases
+		// It is important for this test that these values are never 0
+		require.Equal(t, 12, floorGreaterThan20Percent, "expected 12 cases where floor data gas is greater than 20% of the gas, got %d", floorGreaterThan20Percent)
+		require.Equal(t, 12, expectedSmallerThanFloor, "expected 12 cases where the expected cost is smaller than the floor data gas, got %d", expectedSmallerThanFloor)
+	})
+}
+
+func makeGasCostTestInputs(
+	t *testing.T,
+	session IntegrationTestNetSession,
+) iter.Seq[TestCase] {
+	t.Helper()
+
+	client, err := session.GetClient()
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	gasPrice, err := client.SuggestGasPrice(context.Background())
+	require.NoError(t, err)
+
+	existingAccountAddress := session.GetSessionSponsor().Address()
+	nonExistingAccountAddress := NewAccount().Address()
+
+	return generateTestDataBasedOnModificationCombinations(
+		func() TestCase {
+			t.Helper()
+
+			nonce, err := client.NonceAt(context.Background(), session.GetSessionSponsor().Address(), nil)
+			require.NoError(t, err)
+
+			tc := TestCase{
+				txPayload: types.AccessListTx{
+					Nonce:    nonce,
+					GasPrice: gasPrice,
+					Gas:      21000,
+				}}
+
+			return tc
+		},
+		[][]CostDefinition{
+
+			// Call data domain
+			// STANDARD_TOKEN_COST * tokens_in_calldata
+			// STANDARD_TOKEN_COST = 4
+			// tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4
+			{
+				{
+					name:         "no calldata",
+					modification: withCallData(0, 0),
+					cost:         0,
+				},
+				{
+					name:         "ones calldata",
+					modification: withCallData(10, 1),
+					cost:         (9*4 + 1) * 4,
+				},
+				{
+					name:         "mix calldata",
+					modification: withCallData(10, 5),
+					cost:         (5*4 + 5) * 4,
+				},
+				{
+					name:         "max code size calldata",
+					modification: withCallData(params.MaxCodeSize, 500),
+					cost:         (((params.MaxCodeSize - 500) * 4) + 500) * 4,
+				},
+			},
+			// To domain
+			// isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata))
+			// INITCODE_WORD_COST = 2
+			{
+				{
+					name:         "existing account",
+					modification: withTo(&existingAccountAddress),
+				},
+				{
+					name:         "non existing account",
+					modification: withTo(&nonExistingAccountAddress),
+				},
+				{
+					name:         "contract creation",
+					modification: withTo(nil),
+					cost:         32000,
+					variableCost: func(tx *types.AccessListTx) uint64 {
+						lenWords := (uint64(len(tx.Data)) + 31) / 32
+						return lenWords * params.InitCodeWordGas
+					},
+				},
+			},
+			// Access list domain
+			// Represents the execution_gas_used part of the gas calculation,
+			// this allows to exercise the formula without having to execute real
+			// contracts.
+			{
+				{
+					name:         "no access list",
+					modification: withAccessList(0, 0),
+					cost:         0,
+				},
+				{
+					name:         "access list one account",
+					modification: withAccessList(1, 0),
+					cost:         2400,
+				},
+				{
+					name:         "access list one account one key",
+					modification: withAccessList(1, 1),
+					cost:         2400 + 1900,
+				},
+				{
+					name:         "heavy access list",
+					modification: withAccessList(8, 4),
+					cost:         8*2400 + 8*4*1900,
+				},
+			},
+		},
+		func(tc TestCase, pieces []CostDefinition) TestCase {
+			for _, piece := range pieces {
+				if piece.modification != nil {
+					piece.modification(&tc.txPayload)
+				}
+				tc.txPayload.Gas += piece.cost
+				if piece.variableCost != nil {
+					tc.txPayload.Gas += piece.variableCost(&tc.txPayload)
+				}
+				tc.names = append(tc.names, piece.name)
+			}
+			return tc
+		},
+	)
+
+}
+
+func withCallData(size, zeroes int) txModification {
+	return func(tx *types.AccessListTx) {
+		if zeroes > size {
+			panic("zeroes cannot be greater than size")
+		}
+
+		if size != 0 && zeroes == 0 {
+			panic("please use at least one zero to start calldata, otherwise create contract code does not start with STOP")
+		}
+
+		tx.Data = make([]byte, size)
+		for i := zeroes; i < size; i++ {
+			tx.Data[i] = 1
+		}
+	}
+}
+
+func withTo(addr *common.Address) txModification {
+	return func(tx *types.AccessListTx) {
+		tx.To = addr
+	}
+}
+
+func withAccessList(accounts, storageKeysPerAccount int) txModification {
+	return func(tx *types.AccessListTx) {
+		tx.AccessList = make([]types.AccessTuple, accounts)
+		for i := 0; i < accounts; i++ {
+			tx.AccessList[i].Address = NewAccount().Address()
+			tx.AccessList[i].StorageKeys = make([]common.Hash, storageKeysPerAccount)
+			for j := 0; j < storageKeysPerAccount; j++ {
+				tx.AccessList[i].StorageKeys[j] = common.Hash{0x42}
+			}
+		}
+	}
+}

--- a/tests/gas_cost_test.go
+++ b/tests/gas_cost_test.go
@@ -43,7 +43,7 @@ func TestGasCostTest_Sonic(t *testing.T) {
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
-	t.Cleanup(net.Stop)
+	defer client.Close()
 
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err)
@@ -85,7 +85,6 @@ func TestGasCostTest_Sonic(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
-				// t.Log("gas:", expectedCost, tx.Gas(), tx.Gas()-expectedCost)
 				require.NoError(t, err)
 				require.Equal(t, expectedCost, tx.Gas())
 
@@ -132,7 +131,7 @@ func TestGasCostTest_Allegro(t *testing.T) {
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
-	t.Cleanup(net.Stop)
+	defer client.Close()
 
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err)
@@ -268,7 +267,7 @@ func makeGasCostTestInputs(
 
 	client, err := session.GetClient()
 	require.NoError(t, err)
-	t.Cleanup(client.Close)
+	defer client.Close()
 
 	gasPrice, err := client.SuggestGasPrice(context.Background())
 	require.NoError(t, err)

--- a/tests/initcoder_test.go
+++ b/tests/initcoder_test.go
@@ -15,7 +15,7 @@ import (
 const MAX_CODE_SIZE uint64 = 24576
 const MAX_INIT_CODE_SIZE uint64 = 2 * MAX_CODE_SIZE
 
-const sufficientGas = uint64(100_000)
+const sufficientGas = uint64(150_000)
 
 func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	requireBase := require.New(t)
@@ -131,7 +131,7 @@ func testForTransaction(t *testing.T, net *IntegrationTestNet) {
 		_, err := runTransactionWithCodeSizeAndGas(t, net, MAX_INIT_CODE_SIZE+1, sufficientGas)
 		require.ErrorContains(
 			err,
-			"intrinsic gas too low",
+			"max initcode size exceeded",
 			"unexpectedly succeeded to create contract with init code larger than MAX_INITCODE_SIZE",
 		)
 	})


### PR DESCRIPTION
This PR introduces calldata cost changes https://eips.ethereum.org/EIPS/eip-7623.

The transaction pool validation is extended to reject transactions not having enough Gas according to new formulas.
The test is introduced to check calldata costs, and its interaction with the sonic 10% cost of the unused gas rule.

Additionally, Init code size limit check has been added to the transaction pool validation to reject transactions which would otherwise be accepted to be ignored in the processor. 