### PR TITLE
feat: migrate wthreshold & add tests

### DIFF
--- a/gossip/emitter/control.go
+++ b/gossip/emitter/control.go
@@ -15,15 +15,15 @@ func scalarUpdMetric(diff idx.Event, weight pos.Weight, totalWeight pos.Weight) 
 	return ancestor.Metric(scalarUpdMetricF(uint64(diff)*piecefunc.DecimalUnit)) * ancestor.Metric(weight) / ancestor.Metric(totalWeight)
 }
 
-func updMetric(median, cur, upd idx.Event, validatorIdx idx.Validator, validators *pos.Validators) ancestor.Metric {
-	if upd <= median || upd <= cur {
+func updMetric(thresholdValue, cur, upd idx.Event, validatorIdx idx.Validator, validators *pos.Validators) ancestor.Metric {
+	if upd <= thresholdValue || upd <= cur {
 		return 0
 	}
 	weight := validators.GetWeightByIdx(validatorIdx)
-	if median < cur {
-		return scalarUpdMetric(upd-median, weight, validators.TotalWeight()) - scalarUpdMetric(cur-median, weight, validators.TotalWeight())
+	if thresholdValue < cur {
+		return scalarUpdMetric(upd-thresholdValue, weight, validators.TotalWeight()) - scalarUpdMetric(cur-thresholdValue, weight, validators.TotalWeight())
 	}
-	return scalarUpdMetric(upd-median, weight, validators.TotalWeight())
+	return scalarUpdMetric(upd-thresholdValue, weight, validators.TotalWeight())
 }
 
 func (em *Emitter) isAllowedToEmit() bool {

--- a/gossip/emitter/hooks.go
+++ b/gossip/emitter/hooks.go
@@ -76,14 +76,14 @@ func (em *Emitter) OnNewEpoch(newValidators *pos.Validators, newEpoch idx.Epoch)
 		em.fcIndexer = ancestor.NewFCIndexer(newValidators, em.world.DagIndex(), em.config.Validator.ID)
 	} else {
 		em.quorumIndexer = ancestor.NewQuorumIndexer(newValidators, vecmt2dagidx.Wrap(em.world.DagIndex()),
-			func(median, current, update idx.Event, validatorIdx idx.Validator) ancestor.Metric {
-				return updMetric(median, current, update, validatorIdx, newValidators)
+			func(thresholdValue, current, update idx.Event, validatorIdx idx.Validator) ancestor.Metric {
+				return updMetric(thresholdValue, current, update, validatorIdx, newValidators)
 			})
 		em.fcIndexer = nil
 	}
 	em.quorumIndexer = ancestor.NewQuorumIndexer(newValidators, vecmt2dagidx.Wrap(em.world.DagIndex()),
-		func(median, current, update idx.Event, validatorIdx idx.Validator) ancestor.Metric {
-			return updMetric(median, current, update, validatorIdx, newValidators)
+		func(thresholdValue, current, update idx.Event, validatorIdx idx.Validator) ancestor.Metric {
+			return updMetric(thresholdValue, current, update, validatorIdx, newValidators)
 		})
 	em.payloadIndexer = ancestor.NewPayloadIndexer(PayloadIndexerSize)
 }

--- a/utils/wthreshold/wthreshold.go
+++ b/utils/wthreshold/wthreshold.go
@@ -1,0 +1,24 @@
+package wthreshold
+
+import (
+	"github.com/0xsoniclabs/consensus/inter/pos"
+)
+
+type WeightedValue interface {
+	Weight() pos.Weight
+}
+
+// FindThresholdValue iterates through a slice of WeightedValues, accumulating total weight
+// and returns the first WeightedValue with which the total weight exceeds a given threshold.
+// If cumulative weight of all values is less than the threshold, panic.
+func FindThresholdValue(values []WeightedValue, threshold pos.Weight) WeightedValue {
+	// Calculate weighted threshold value
+	var totalWeight pos.Weight
+	for _, value := range values {
+		totalWeight += value.Weight()
+		if totalWeight >= threshold {
+			return value
+		}
+	}
+	panic("invalid threshold value")
+}

--- a/utils/wthreshold/wthreshold_test.go
+++ b/utils/wthreshold/wthreshold_test.go
@@ -1,0 +1,114 @@
+package wthreshold
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/consensus/inter/pos"
+)
+
+type testWeightedValue struct {
+	weight pos.Weight
+	value  string
+}
+
+func (twv testWeightedValue) Weight() pos.Weight {
+	return twv.weight
+}
+
+func TestFindWeightedThresholdValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		values    []WeightedValue
+		threshold pos.Weight
+		want      string
+		panic     bool
+	}{
+		{
+			name: "simple case",
+			values: []WeightedValue{
+				testWeightedValue{weight: 1, value: "test1"},
+				testWeightedValue{weight: 2, value: "test2"},
+				testWeightedValue{weight: 3, value: "test3"},
+			},
+			threshold: 2,
+			want:      "test2",
+			panic:     false,
+		},
+		{
+			name: "first element",
+			values: []WeightedValue{
+				testWeightedValue{weight: 5, value: "test4"},
+				testWeightedValue{weight: 2, value: "test5"},
+				testWeightedValue{weight: 3, value: "test6"},
+			},
+			threshold: 3,
+			want:      "test4",
+			panic:     false,
+		},
+		{
+			name: "last element",
+			values: []WeightedValue{
+				testWeightedValue{weight: 1, value: "test7"},
+				testWeightedValue{weight: 2, value: "test8"},
+				testWeightedValue{weight: 3, value: "test9"},
+			},
+			threshold: 6,
+			want:      "test9",
+			panic:     false,
+		},
+		{
+			name: "exact threshold",
+			values: []WeightedValue{
+				testWeightedValue{weight: 1, value: "test10"},
+				testWeightedValue{weight: 2, value: "test11"},
+				testWeightedValue{weight: 3, value: "test12"},
+			},
+			threshold: 3,
+			want:      "test11",
+			panic:     false,
+		},
+		{
+			name: "panic case",
+			values: []WeightedValue{
+				testWeightedValue{weight: 1, value: "test13"},
+				testWeightedValue{weight: 2, value: "test14"},
+			},
+			threshold: 4,
+			panic:     true,
+		},
+		{
+			name:      "empty values",
+			values:    []WeightedValue{},
+			threshold: 1,
+			panic:     true,
+		},
+		{
+			name: "zero weight",
+			values: []WeightedValue{
+				testWeightedValue{weight: 0, value: "test15"},
+				testWeightedValue{weight: 2, value: "test16"},
+			},
+			threshold: 1,
+			want:      "test16",
+			panic:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.panic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("FindThresholdValue() did not panic as expected")
+					}
+				}()
+				FindThresholdValue(tt.values, tt.threshold)
+			} else {
+				result := FindThresholdValue(tt.values, tt.threshold).(testWeightedValue).value
+				if result != tt.want {
+					t.Errorf("FindThresholdValue() = %v, want %v", result, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR migrates the `wmedian` utils from the `consensus` repository into the `sonic` repository (and renames it to the more appropriate `wthreshold` package, along with updating all relevant references, since it's not really a median) since they are only used here and adds testing for 100% coverage.

`wthreshold` exposes the `FindThresholdValue` function which iterates through a slice of `WeightedValues`, accumulating total weight and returns the first `WeightedValue` with which the total weight exceeds a given threshold - please see code comments - this function is required for gossip functionality.

Verification:

![image](https://github.com/user-attachments/assets/926ec0a7-d452-46d3-9332-4db777c7dfd8)
