### PR TITLE
Fix rpc response when block not found

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1747,19 +1747,15 @@ func (s *PublicTransactionPoolAPI) GetBlockReceipts(ctx context.Context, blockNr
 	if blockNr, ok := blockNrOrHash.Number(); ok {
 		number = blockNr
 		header, err = s.b.HeaderByNumber(ctx, number)
-		if err != nil {
+		if header == nil || err != nil {
 			return nil, err
 		}
 	} else if blockHash, ok := blockNrOrHash.Hash(); ok {
 		header, err = s.b.HeaderByHash(ctx, blockHash)
-		if err != nil {
+		if header == nil || err != nil {
 			return nil, err
 		}
 		number = rpc.BlockNumber(header.Number.Uint64())
-	}
-
-	if header == nil {
-		return nil, fmt.Errorf("block not found")
 	}
 
 	receipts, err := s.b.GetReceiptsByNumber(ctx, number)

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -837,27 +837,27 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 // * When blockNr is -2 the pending chain head is returned.
 func (s *PublicBlockChainAPI) GetHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*evmcore.EvmHeaderJson, error) {
 	header, err := s.b.HeaderByNumber(ctx, number)
-	if header != nil && err == nil {
-		receipts, err := s.getBlockReceipts(ctx, rpc.BlockNumber(header.Number.Uint64()))
-		if err != nil {
-			return nil, err
-		}
-		return header.ToJson(receipts), nil
+	if header == nil || err != nil {
+		return nil, err
 	}
-	return nil, err
+	return s.getHeaderWithReceipts(ctx, header, rpc.BlockNumber(header.Number.Uint64()))
 }
 
 // GetHeaderByHash returns the requested header by hash.
 func (s *PublicBlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.Hash) (*evmcore.EvmHeaderJson, error) {
 	header, err := s.b.HeaderByHash(ctx, hash)
-	if header != nil && err == nil {
-		receipts, err := s.getBlockReceipts(ctx, rpc.BlockNumber(header.Number.Uint64()))
-		if err != nil {
-			return nil, err
-		}
-		return header.ToJson(receipts), nil
+	if header == nil || err != nil {
+		return nil, err
 	}
-	return nil, err
+	return s.getHeaderWithReceipts(ctx, header, rpc.BlockNumber(header.Number.Uint64()))
+}
+
+func (s *PublicBlockChainAPI) getHeaderWithReceipts(ctx context.Context, header *evmcore.EvmHeader, blkNumber rpc.BlockNumber) (*evmcore.EvmHeaderJson, error) {
+	receipts, err := s.getBlockReceipts(ctx, blkNumber)
+	if receipts == nil || err != nil {
+		return nil, err
+	}
+	return header.ToJson(receipts), nil
 }
 
 func (s *PublicBlockChainAPI) getBlockReceipts(ctx context.Context, blkNumber rpc.BlockNumber) (types.Receipts, error) {

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -411,7 +411,7 @@ func TestBlockOverrides(t *testing.T) {
 
 }
 
-func TestReturnNil(t *testing.T) {
+func TestGetTransactionReceiptReturnsNilNotError(t *testing.T) {
 
 	txHash := common.Hash{1}
 

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -416,7 +416,6 @@ func TestGetTransactionReceiptReturnsNilNotError(t *testing.T) {
 	txHash := common.Hash{1}
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockBackend := NewMockBackend(ctrl)
 	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(&types.Transaction{}, uint64(0), uint64(0), nil)
 	mockBackend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(nil, nil)

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -411,6 +411,26 @@ func TestBlockOverrides(t *testing.T) {
 
 }
 
+func TestReturnNil(t *testing.T) {
+
+	txHash := common.Hash{1}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockBackend := NewMockBackend(ctrl)
+	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(&types.Transaction{}, uint64(0), uint64(0), nil)
+	mockBackend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).Return(nil, nil)
+	mockBackend.EXPECT().ChainConfig().Return(&params.ChainConfig{}).AnyTimes()
+
+	api := NewPublicTransactionPoolAPI(
+		mockBackend,
+		&AddrLocker{},
+	)
+	receiptsRes, err := api.GetTransactionReceipt(context.Background(), txHash)
+	require.NoError(t, err)
+	require.Nil(t, receiptsRes)
+}
+
 // Custom matcher to compare vm.BlockContext values
 type BlockContextMatcher struct {
 	expected *vm.BlockContext

--- a/ethapi/block_overrides.go
+++ b/ethapi/block_overrides.go
@@ -78,7 +78,10 @@ func (context *chainContext) GetHeader(hash common.Hash, number uint64) *evmcore
 	// This method is called to get the hash for a block number when executing the BLOCKHASH
 	// opcode. Hence no need to search for non-canonical blocks.
 	header, err := context.b.HeaderByNumber(context.ctx, rpc.BlockNumber(number))
-	if header == nil || err != nil || header.Hash != hash {
+	if header == nil || err != nil {
+		return nil
+	}
+	if header.Hash != hash {
 		return nil
 	}
 	return header

--- a/ethapi/block_overrides.go
+++ b/ethapi/block_overrides.go
@@ -78,7 +78,7 @@ func (context *chainContext) GetHeader(hash common.Hash, number uint64) *evmcore
 	// This method is called to get the hash for a block number when executing the BLOCKHASH
 	// opcode. Hence no need to search for non-canonical blocks.
 	header, err := context.b.HeaderByNumber(context.ctx, rpc.BlockNumber(number))
-	if err != nil || header.Hash != hash {
+	if header == nil || err != nil || header.Hash != hash {
 		return nil
 	}
 	return header

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -82,11 +82,8 @@ func (b *EthAPIBackend) ResolveRpcBlockNumberOrHash(ctx context.Context, blockNr
 // HeaderByNumber returns evm block header by its number, or nil if not exists.
 func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*evmcore.EvmHeader, error) {
 	blk, err := b.BlockByNumber(ctx, number)
-	if err != nil {
+	if blk == nil || err != nil {
 		return nil, err
-	}
-	if blk == nil {
-		return nil, fmt.Errorf("block %v not found", number)
 	}
 	return blk.Header(), err
 }


### PR DESCRIPTION
This PR fixes an issue, when error was returned instead of nil, when block was not found.
It is related to [this issue](https://github.com/0xsoniclabs/sonic-admin/issues/116) where problem is decribed