### PR TITLE
Fix originatedFees in epoch sealing - fixes 0xsoniclabs/sonic-admin#122

### DIFF
--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -48,7 +48,8 @@ type (
 
 		WithdrawalsHash *common.Hash
 
-		BaseFee *big.Int
+		BaseFee     *big.Int
+		BlobBaseFee *big.Int // TODO issue #147
 
 		PrevRandao common.Hash // == mixHash/mixDigest
 

--- a/gossip/blockproc/drivermodule/driver_txs_test.go
+++ b/gossip/blockproc/drivermodule/driver_txs_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 	"go.uber.org/mock/gomock"
 	"math/big"
 	"testing"
@@ -18,6 +21,9 @@ const GasUsed = 40
 const GasFeeCap = 100
 const GasTip = 3
 const BaseFee = 50
+const BlobGasUsed = 2 * params.BlobTxBlobGasPerBlob
+const BlobFeeCap = 6
+const BlobBaseFee = 4
 const EffectiveGasPrice = 53
 
 func TestReceiptRewardWithoutFixEnabled(t *testing.T) {
@@ -52,7 +58,7 @@ func TestReceiptRewardWithoutFixEnabled(t *testing.T) {
 		TxHash:  tx.Hash(),
 		GasUsed: GasUsed,
 	}
-	listener.OnNewReceipt(tx, receipt, idx.ValidatorID(1), big.NewInt(BaseFee))
+	listener.OnNewReceipt(tx, receipt, idx.ValidatorID(1), big.NewInt(BaseFee), big.NewInt(BlobBaseFee))
 
 	originated := bs.ValidatorStates[es.Validators.GetIdx(1)].Originated.Uint64()
 	if originated != OrigOriginated+GasUsed*GasFeeCap {
@@ -93,11 +99,55 @@ func TestReceiptRewardWithFixEnabled(t *testing.T) {
 		TxHash:  tx.Hash(),
 		GasUsed: GasUsed,
 	}
-	listener.OnNewReceipt(tx, receipt, idx.ValidatorID(1), big.NewInt(BaseFee))
+	listener.OnNewReceipt(tx, receipt, idx.ValidatorID(1), big.NewInt(BaseFee), big.NewInt(BlobBaseFee))
 
 	originated := bs.ValidatorStates[es.Validators.GetIdx(1)].Originated.Uint64()
 	if originated != OrigOriginated+GasUsed*EffectiveGasPrice {
 		t.Errorf("Originated increment not GasUsed*EffectiveGasPrice: expected %d, actual %d",
 			OrigOriginated+GasUsed*EffectiveGasPrice, originated)
+	}
+}
+
+func TestReceiptRewardWithBlobsAndFixEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	module := drivermodule.NewDriverTxListenerModule()
+
+	blockCtx := iblockproc.BlockCtx{}
+	bs := iblockproc.BlockState{
+		ValidatorStates: []iblockproc.ValidatorBlockState{{
+			Originated: big.NewInt(OrigOriginated),
+		}},
+	}
+	valsBuilder := pos.NewBuilder()
+	valsBuilder.Set(1, 100)
+
+	rules := opera.MainNetRules()
+	rules.Upgrades.Allegro = true // enable fix
+
+	es := iblockproc.EpochState{
+		Validators: valsBuilder.Build(),
+		Rules:      rules,
+	}
+	stateDb := state.NewMockStateDB(ctrl)
+	listener := module.Start(blockCtx, bs, es, stateDb)
+
+	tx := types.NewTx(&types.BlobTx{
+		GasTipCap:  uint256.NewInt(GasTip),
+		GasFeeCap:  uint256.NewInt(GasFeeCap),
+		BlobFeeCap: uint256.NewInt(BlobFeeCap),
+		BlobHashes: make([]common.Hash, 2),
+	})
+	receipt := &types.Receipt{
+		TxHash:      tx.Hash(),
+		GasUsed:     GasUsed,
+		BlobGasUsed: BlobGasUsed,
+	}
+	listener.OnNewReceipt(tx, receipt, idx.ValidatorID(1), big.NewInt(BaseFee), big.NewInt(BlobBaseFee))
+
+	originated := bs.ValidatorStates[es.Validators.GetIdx(1)].Originated.Uint64()
+	if originated != OrigOriginated+GasUsed*EffectiveGasPrice+BlobGasUsed*BlobBaseFee {
+		t.Errorf("Originated increment not GasUsed*EffectiveGasPrice+BlobGasUsed*BlobBaseFee: expected %d, actual %d",
+			OrigOriginated+GasUsed*EffectiveGasPrice+BlobGasUsed*BlobBaseFee, originated)
 	}
 }

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -16,7 +16,7 @@ import (
 
 type TxListener interface {
 	OnNewLog(*types.Log)
-	OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int)
+	OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int)
 	Finalize() iblockproc.BlockState
 	Update(bs iblockproc.BlockState, es iblockproc.EpochState)
 }

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -336,7 +336,7 @@ func consensusCallbackBeginBlockFn(
 						if creator != 0 && es.Validators.Get(creator) == 0 {
 							creator = 0
 						}
-						txListener.OnNewReceipt(evmBlock.Transactions[i], r, creator, evmBlock.BaseFee)
+						txListener.OnNewReceipt(evmBlock.Transactions[i], r, creator, evmBlock.BaseFee, evmBlock.BlobBaseFee)
 					}
 					bs = txListener.Finalize() // TODO: refactor to not mutate the bs
 					bs.FinalizedStateRoot = hash.Hash(evmBlock.Root)


### PR DESCRIPTION
Fixes 0xsoniclabs/sonic-admin#122, fix is enabled by Allegro hardfork.

Update: Since receive.EffectiveGasPrice is not initialized in this part of the code, calculation from baseFee was added.

Successfully tested on local fakenet - originatedFees matches with EffectiveGasPrice in the receipt after this fix.