### PR TITLE
Add Retry provider to handle request failures

### DIFF
--- a/scc/light_client/light_client.go
+++ b/scc/light_client/light_client.go
@@ -22,9 +22,9 @@ type LightClient struct {
 type Config struct {
 	Url     *url.URL
 	Genesis scc.Committee
-	// unless specified only try once without delays
-	Attempts uint
-	Delay    time.Duration
+	// default values try only once without delays
+	Retries uint
+	Delay   time.Duration
 }
 
 // NewLightClient creates a new LightClient with the given config.
@@ -38,7 +38,7 @@ func NewLightClient(config Config) (*LightClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create provider: %w\n", err)
 	}
-	p = newRetry(p, config.Attempts, config.Delay)
+	p = newRetry(p, config.Retries, config.Delay)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create retry provider: %w\n", err)
 	}

--- a/scc/light_client/light_client.go
+++ b/scc/light_client/light_client.go
@@ -22,7 +22,7 @@ type LightClient struct {
 type Config struct {
 	Url     *url.URL
 	Genesis scc.Committee
-	// default values try only once per request with 10 seconds timeout
+	// By default, requests are retried up to 1024 times to reach a 10-second timeout.
 	Retries uint
 	Timeout time.Duration
 }

--- a/scc/light_client/light_client.go
+++ b/scc/light_client/light_client.go
@@ -22,9 +22,9 @@ type LightClient struct {
 type Config struct {
 	Url     *url.URL
 	Genesis scc.Committee
-	// default values try only once without delays
+	// default values try only once per request with 10 seconds timeout
 	Retries uint
-	Delay   time.Duration
+	Timeout time.Duration
 }
 
 // NewLightClient creates a new LightClient with the given config.
@@ -38,10 +38,7 @@ func NewLightClient(config Config) (*LightClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create provider: %w\n", err)
 	}
-	p = newRetry(p, config.Retries, config.Delay)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create retry provider: %w\n", err)
-	}
+	p = newRetry(p, config.Retries, config.Timeout)
 	return &LightClient{
 		state:    *newState(config.Genesis),
 		provider: p,

--- a/scc/light_client/retry.go
+++ b/scc/light_client/retry.go
@@ -102,16 +102,17 @@ func (r retryProvider) getBlockCertificates(first idx.Block, maxResults uint64) 
 func retry[C any](maxRetries uint, timeout time.Duration, fn func() (C, error)) (C, error) {
 	var errs []error
 	now := time.Now()
-	delay := time.Millisecond
-	maxDelay := 128 * time.Millisecond
+	delay := 200 * time.Millisecond
+	maxDelay := time.Second
 	for i := uint(0); i < maxRetries; i++ {
 		result, err := fn()
 		if err == nil {
 			return result, nil
 		}
 		errs = append(errs, err)
-		if delay < maxDelay {
-			delay *= 2
+		delay = 2 * delay
+		if delay > maxDelay {
+			delay = maxDelay
 		}
 		time.Sleep(delay)
 		if time.Since(now) >= timeout {

--- a/scc/light_client/retry.go
+++ b/scc/light_client/retry.go
@@ -1,0 +1,115 @@
+package light_client
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+)
+
+// retryP is a provider that retries requests a certain number of times on failed
+// requests for certificates with a determined wait between retries. It is used
+// to wrap other providers to add a retry mechanism.
+//
+// Fields:
+// - provider: The underlying provider to retry requests on.
+// - attempts: The maximum number of attempt to ask for certificates.
+// - delay: The time to wait between retries.
+type retryP struct {
+	provider provider
+	attempts uint
+	delay    time.Duration
+}
+
+// newRetry creates a new retryP provider with the given provider and maximum
+// number of retries and delay between retries.
+//
+// Parameters:
+// - provider: The underlying provider to wrap with retry logic.
+// - attempts: The maximum number of attempt to ask for certificates.
+// - delay: The time to wait between retries.
+//
+// Returns:
+// - *retryP: A new retryP provider instance.
+func newRetry(provider provider, attempts uint, delay time.Duration) *retryP {
+	return &retryP{
+		provider: provider,
+		attempts: attempts,
+		delay:    delay,
+	}
+}
+
+// Close closes the retryP provider.
+// Closing an already closed provider has no effect.
+func (r *retryP) close() {
+	r.provider.close()
+}
+
+// getCommitteeCertificates returns up to `maxResults` consecutive committee
+// certificates starting from the given period.
+//
+// Parameters:
+// - first: The starting period for which to retrieve committee certificates.
+// - maxResults: The maximum number of committee certificates to retrieve.
+//
+// Returns:
+// - []cert.CommitteeCertificate: A slice of committee certificates.
+// - error: An error if the provider failed to obtain the requested certificates.
+func (r retryP) getCommitteeCertificates(first scc.Period, maxResults uint64) ([]cert.CommitteeCertificate, error) {
+	result, err := retry(r.attempts, r.delay, func() (any, error) {
+		return r.provider.getCommitteeCertificates(first, maxResults)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]cert.CommitteeCertificate), nil
+}
+
+// getBlockCertificates returns up to `maxResults` consecutive block
+// certificates starting from the given block number.
+//
+// Parameters:
+// - first: The starting block number for which to retrieve the block certificate.
+// - maxResults: The maximum number of block certificates to retrieve.
+//
+// Returns:
+//   - []cert.BlockCertificate: The block certificates for the given block number
+//     and the following blocks.
+//   - error: An error if the provider failed to obtain the requested certificates.
+func (r retryP) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert.BlockCertificate, error) {
+	result, err := retry(r.attempts, r.delay, func() (any, error) {
+		return r.provider.getBlockCertificates(first, maxResults)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.([]cert.BlockCertificate), nil
+}
+
+// retry executes the given function for the given number of attempts, waiting
+// the specified delay between attempts.
+//
+// Parameters:
+// - fn: The function to execute and retry if failed.
+//
+// Returns:
+//   - C: The result of the function if it succeeded.
+//   - error: Nil if at least one execution of fn returned without error.
+//     The joined error of all failed attempts if all attempts failed.
+func retry[C any](attempts uint, delay time.Duration, fn func() (C, error)) (C, error) {
+	var errs []error
+	for i := uint(0); i < attempts; i++ {
+		result, err := fn()
+		if err == nil {
+			return result, nil
+		}
+		errs = append(errs, err)
+		time.Sleep(delay)
+	}
+
+	var c C
+	return c, errors.Join(fmt.Errorf("all retries failed: "), errors.Join(errs...))
+}

--- a/scc/light_client/retry_test.go
+++ b/scc/light_client/retry_test.go
@@ -1,0 +1,142 @@
+package light_client
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRetry_NewRetry_CanInitializeFromProvider(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	provider := NewMockprovider(ctrl)
+
+	retry := newRetry(provider, 3, time.Duration(0))
+	require.NotNil(retry)
+}
+
+func TestRetry_Close_ClosesProvider(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	provider := NewMockprovider(ctrl)
+	provider.EXPECT().close().Times(1)
+
+	retry := newRetry(provider, 3, time.Duration(0))
+	retry.close()
+}
+
+func TestRetry_retry_RetriesWhenProviderFails(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+
+	attempts := uint(3)
+
+	provider := NewMockprovider(ctrl)
+	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("provider failed")).Times(int(attempts))
+
+	certs, err := retry(attempts, time.Duration(0), func() (any, error) {
+		return provider.getCommitteeCertificates(scc.Period(1), uint64(1))
+	})
+	require.Error(err)
+	require.Nil(certs)
+}
+
+func TestRetry_retry_WaitsBetweenRetries(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	provider := NewMockprovider(ctrl)
+
+	attempts := uint(3)
+	delay := 200 * time.Millisecond
+
+	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("provider failed")).Times(int(attempts))
+
+	start := time.Now()
+	_, _ = retry(attempts, delay, func() (any, error) {
+		return provider.getCommitteeCertificates(scc.Period(1), uint64(1))
+	})
+	duration := time.Since(start)
+
+	expected := time.Duration(attempts) * delay
+	require.GreaterOrEqual(duration.Milliseconds(), expected.Milliseconds())
+}
+
+func TestRetry_retry_ReturnsResultWhenProviderSucceeds(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	provider := NewMockprovider(ctrl)
+
+	// fail once
+	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("some error")).Times(1)
+	// then succeed
+	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
+		Return([]cert.CommitteeCertificate{{}}, nil).Times(1)
+
+	delay := 200 * time.Millisecond
+
+	start := time.Now()
+	certs, err := retry(3, delay, func() (any, error) {
+		return provider.getCommitteeCertificates(scc.Period(1), uint64(1))
+	})
+	duration := time.Since(start)
+
+	require.NoError(err)
+	require.NotNil(certs)
+	require.Less(duration.Milliseconds(), 2*delay.Milliseconds())
+}
+
+func TestRetry_GetCertificates_PropagatesError(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	provider := NewMockprovider(ctrl)
+
+	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("provider failed")).Times(4)
+
+	retryProvider := newRetry(provider, 4, time.Duration(0))
+	ccerts, err := retryProvider.getCommitteeCertificates(scc.Period(1), uint64(1))
+	require.Error(err)
+	require.Nil(ccerts)
+
+	provider.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).
+		Return(nil, fmt.Errorf("provider failed")).Times(4)
+	bcerts, err := retryProvider.getBlockCertificates(idx.Block(1), uint64(1))
+	require.Error(err)
+	require.Nil(bcerts)
+}
+
+func TestRetry_GetCertificates_ReceivesCertificates(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	provider := NewMockprovider(ctrl)
+
+	committeeCert := []cert.CommitteeCertificate{
+		cert.NewCertificate(cert.NewCommitteeStatement(1, 1, scc.Committee{})),
+	}
+	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
+		Return(committeeCert, nil).Times(1)
+
+	retryProvider := newRetry(provider, 1, time.Duration(0))
+	ccerts, err := retryProvider.getCommitteeCertificates(scc.Period(1), uint64(1))
+	require.NoError(err)
+	require.Equal(committeeCert, ccerts)
+
+	blockCert := []cert.BlockCertificate{
+		cert.NewCertificate(cert.NewBlockStatement(1, 1, common.Hash{}, common.Hash{})),
+	}
+	provider.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).
+		Return(blockCert, nil).Times(1)
+
+	bcerts, err := retryProvider.getBlockCertificates(idx.Block(1), uint64(1))
+	require.NoError(err)
+	require.Equal(blockCert, bcerts)
+}

--- a/scc/light_client/retry_test.go
+++ b/scc/light_client/retry_test.go
@@ -31,6 +31,8 @@ func TestRetry_NewRetry_CorrectlyHandlesZeroTimeout(t *testing.T) {
 	require.Equal(time.Second*10, retry.timeout)
 	retry = newRetry(provider, 3, 1*time.Second)
 	require.Equal(time.Second*1, retry.timeout)
+	retry = newRetry(provider, 0, 1*time.Second)
+	require.Equal(1024, int(retry.maxRetries))
 }
 
 func TestRetry_Close_ClosesProvider(t *testing.T) {
@@ -46,13 +48,13 @@ func TestRetry_retry_RetriesWhenProviderFails(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 
-	retries := uint(3)
+	maxRetries := uint(3)
 
 	provider := NewMockprovider(ctrl)
 	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
-		Return(nil, fmt.Errorf("provider failed")).Times(int(retries + 1))
+		Return(nil, fmt.Errorf("provider failed")).Times(int(maxRetries))
 
-	certs, err := retry(retries, time.Second*10, func() (any, error) {
+	certs, err := retry(maxRetries, time.Second*10, func() (any, error) {
 		return provider.getCommitteeCertificates(scc.Period(1), uint64(1))
 	})
 	require.Error(err)
@@ -64,14 +66,14 @@ func TestRetry_retry_WaitsBetweenRetries(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := NewMockprovider(ctrl)
 
-	retries := uint(3)
+	maxRetries := uint(3)
 	timeout := time.Second * 10
 
 	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
-		Return(nil, fmt.Errorf("provider failed")).Times(int(retries + 1))
+		Return(nil, fmt.Errorf("provider failed")).Times(int(maxRetries))
 
 	start := time.Now()
-	_, _ = retry(retries, timeout, func() (any, error) {
+	_, _ = retry(maxRetries, timeout, func() (any, error) {
 		return provider.getCommitteeCertificates(scc.Period(1), uint64(1))
 	})
 	duration := time.Since(start)
@@ -84,13 +86,13 @@ func TestRetry_retry_ReportsTimeoutError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := NewMockprovider(ctrl)
 
-	retries := uint(3)
+	maxRetries := uint(3)
 	timeout := time.Millisecond * 1
 
 	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
 		Return(nil, fmt.Errorf("provider failed")).AnyTimes()
 
-	_, err := retry(retries, timeout, func() (any, error) {
+	_, err := retry(maxRetries, timeout, func() (any, error) {
 		return provider.getCommitteeCertificates(scc.Period(1), uint64(1))
 	})
 	require.ErrorContains(err, "exceeded timeout")
@@ -121,18 +123,18 @@ func TestRetry_GetCertificates_PropagatesError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	provider := NewMockprovider(ctrl)
 
-	retries := uint(3)
+	maxRetries := uint(3)
 
 	provider.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).
-		Return(nil, fmt.Errorf("provider failed")).Times(int(retries + 1))
+		Return(nil, fmt.Errorf("provider failed")).Times(int(maxRetries))
 
-	retryProvider := newRetry(provider, retries, time.Duration(0))
+	retryProvider := newRetry(provider, maxRetries, time.Duration(0))
 	ccerts, err := retryProvider.getCommitteeCertificates(scc.Period(1), uint64(1))
 	require.Error(err)
 	require.Nil(ccerts)
 
 	provider.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).
-		Return(nil, fmt.Errorf("provider failed")).Times(int(retries) + 1)
+		Return(nil, fmt.Errorf("provider failed")).Times(int(maxRetries))
 	bcerts, err := retryProvider.getBlockCertificates(idx.Block(1), uint64(1))
 	require.Error(err)
 	require.Nil(bcerts)


### PR DESCRIPTION
This PR introduces the `retryProvider` type, which implements the `provider` interface while also wrapping an existing `provider` and automatically retries failed certificate fetch attempts. It follows the Decorator Pattern, ensuring that retry logic is separate from core provider implementations.
Additionally, the `retries` and `timeout` parameters are added to `light_client.Config`.