### PR TITLE
Integration tests: Allow use of custom configuration in test nodes.

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -104,6 +104,7 @@ func initFlags() {
 		flags.ExitWhenEpochFlag,
 		flags.LightKDFFlag,
 		flags.ConfigFileFlag,
+		flags.DumpConfigFileFlag,
 		flags.ValidatorIDFlag,
 		flags.ValidatorPubkeyFlag,
 		flags.ValidatorPasswordFlag,
@@ -257,6 +258,13 @@ func lachesisMainInternal(
 		return fmt.Errorf("failed to initialize the node: %w", err)
 	}
 	defer nodeClose()
+
+	if ctx.GlobalIsSet(flags.DumpConfigFileFlag.Name) {
+		// At this point the node is fully configured,
+		// if the dump-config flag is set, dump the config into the file and exit
+		outputConfigFile := ctx.GlobalString(flags.DumpConfigFileFlag.Name)
+		return config.SaveAllConfigs(outputConfigFile, cfg)
+	}
 
 	if err := startNode(ctx, node); err != nil {
 		return fmt.Errorf("failed to start the node: %w", err)

--- a/config/config.go
+++ b/config/config.go
@@ -78,7 +78,7 @@ func (c *Config) AppConfigs() integration.Configs {
 	}
 }
 
-func loadAllConfigs(file string, cfg *Config) (err error) {
+func LoadAllConfigs(file string, cfg *Config) (err error) {
 	f, err := os.Open(file)
 	if err != nil {
 		return fmt.Errorf("failed to open config file %s: %w", file, err)
@@ -94,6 +94,17 @@ func loadAllConfigs(file string, cfg *Config) (err error) {
 		return fmt.Errorf("TOML config file error: %v.\n"+
 			"Use 'dumpconfig' command to get an example config file.\n"+
 			"If node was recently upgraded and a previous network config file is used, then check updates for the config file.", err)
+	}
+	return nil
+}
+
+func SaveAllConfigs(file string, cfg *Config) error {
+	encoded, err := TomlSettings.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to encode config to TOML: %w", err)
+	}
+	if err := os.WriteFile(file, encoded, 0644); err != nil {
+		return fmt.Errorf("failed to write config file %s: %w", file, err)
 	}
 	return nil
 }
@@ -337,7 +348,7 @@ func MakeAllConfigsFromFile(ctx *cli.Context, configFile string) (*Config, error
 
 	// Load config file (medium priority)
 	if configFile != "" {
-		if err := loadAllConfigs(configFile, &cfg); err != nil {
+		if err := LoadAllConfigs(configFile, &cfg); err != nil {
 			return &cfg, err
 		}
 	}

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -269,6 +269,10 @@ var (
 		Name:  "config",
 		Usage: "TOML configuration file",
 	}
+	DumpConfigFileFlag = cli.StringFlag{
+		Name:  "dump-config",
+		Usage: "wite configuration in TOML file and exit",
+	}
 	CacheFlag = cli.IntFlag{
 		Name:  "cache",
 		Usage: "Megabytes of memory allocated to internal caching",

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -527,16 +527,12 @@ func (n *IntegrationTestNet) GetHeaders() ([]*types.Header, error) {
 //
 // A typical use case would look as follows:
 //
-//	net, err := StartIntegrationTestNet(t.TempDir())
-//	if err != nil {
-//	    ...
-//	}
-//	t.Cleanup(func(){net.Stop()})
-//	t.Run("test_case",, func(t *testing.T) {
-//			t.Parallel()
-//			session := net.SpawnSession(t)
-//	        < use session instead of net of the rest of the test >
-//	})
+//	 net := StartIntegrationTestNet(t)
+//		t.Run("test_case",, func(t *testing.T) {
+//				t.Parallel()
+//				session := net.SpawnSession(t)
+//		        < use session instead of net of the rest of the test >
+//		})
 func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSession {
 	t.Helper()
 	n.sessionsMutex.Lock()

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -17,6 +17,7 @@ import (
 
 	sonicd "github.com/0xsoniclabs/sonic/cmd/sonicd/app"
 	sonictool "github.com/0xsoniclabs/sonic/cmd/sonictool/app"
+	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
 	"github.com/0xsoniclabs/sonic/inter"
@@ -70,6 +71,13 @@ type IntegrationTestNetOptions struct {
 	NumNodes int
 	// ClientExtraArguments specifies additional arguments to be passed to the client.
 	ClientExtraArguments []string
+	// ModifyConfig allows the caller to modify the configuration of the nodes
+	// on the integration test network. This modified configuration will be saved
+	// as a toml file and loaded by the nodes when they are started.
+	// Please read carefully the config type declaration, config fields with tag `-`
+	// will not be saved into the toml file, modifications will be ignored.
+	// Zero value means no modification.
+	ModifyConfig func(*config.Config)
 }
 
 // IntegrationTestNet is a in-process test network for integration tests. When
@@ -93,8 +101,8 @@ type IntegrationTestNetOptions struct {
 // integration test networks can also be used for automated integration and
 // regression tests for client code.
 type IntegrationTestNet struct {
-	extraClientArguments []string
-	nodes                []integrationTestNode
+	options IntegrationTestNetOptions
+	nodes   []integrationTestNode
 
 	sessionsMutex sync.Mutex
 	Session
@@ -203,7 +211,7 @@ func startIntegrationTestNet(
 	options IntegrationTestNetOptions,
 ) (*IntegrationTestNet, error) {
 	net := &IntegrationTestNet{
-		extraClientArguments: options.ClientExtraArguments,
+		options: options,
 		Session: Session{
 			account: Account{evmcore.FakeKey(1)},
 		},
@@ -311,8 +319,24 @@ func (n *IntegrationTestNet) start() error {
 				"--ipcpath", fmt.Sprintf("%s/sonic.ipc", tmp),
 			},
 				// append extra arguments
-				n.extraClientArguments...,
+				n.options.ClientExtraArguments...,
 			)
+
+			if n.options.ModifyConfig != nil {
+				configFile := filepath.Join(tmp, "config.toml")
+				if err := sonicd.RunWithArgs(append(args, "--dump-config", configFile), nil); err != nil {
+					panic(fmt.Sprint("Failed to dump config file:", err))
+				}
+				var loadedConfig config.Config
+				if err := config.LoadAllConfigs(configFile, &loadedConfig); err != nil {
+					panic(fmt.Sprint("Failed to load default config file:", err))
+				}
+				n.options.ModifyConfig(&loadedConfig)
+				if err := config.SaveAllConfigs(configFile, &loadedConfig); err != nil {
+					panic(fmt.Sprint("Failed to save modified config file:", err))
+				}
+				args = append(args, "--config", configFile)
+			}
 
 			control := &sonicd.AppControl{
 				NodeIdAnnouncement:   nodeIds[i],


### PR DESCRIPTION
This PR adds a mechanism to change the configuration of the integration test net nodes. This is required because some flags are not exposed via command line flags. 

The changes here presented compromises in the following:
- The configuration is saved from a constructed node, instead of saving the configuration loaded directly. This is done this way because the initialization of the node contains accesses to the command line arguments at several stages of initialization. Making quite difficult to identify when is the configuration complete. This code aims to reduce code changes in that section while introducing the new feature. 
- Not every configuration field can be modified using this mechanism. The configuration structure contains both, non-serializable objects, and explicitly ignored objects. This means that modifications may not be propagated into the integration test net node. 

This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/124