### PR TITLE
Add test to check revision is forwarded correctly

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -78,6 +78,8 @@ type IntegrationTestNetOptions struct {
 	// will not be saved into the toml file, modifications will be ignored.
 	// Zero value means no modification.
 	ModifyConfig func(*config.Config)
+	// Accounts to be deployed with the genesis.
+	Accounts []makefakegenesis.Account
 }
 
 // IntegrationTestNet is a in-process test network for integration tests. When
@@ -176,6 +178,8 @@ func StartIntegrationTestNetWithJsonGenesis(
 		effectiveOptions.NumNodes,
 		effectiveOptions.FeatureSet,
 	)
+
+	jsonGenesis.Accounts = append(jsonGenesis.Accounts, effectiveOptions.Accounts...)
 
 	// Speed up the block generation time to reduce test time.
 	jsonGenesis.Rules.Emitter.Interval = inter.Timestamp(time.Millisecond)

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -147,6 +147,10 @@ func StartIntegrationTestNetWithFakeGenesis(
 		t.Fatal("failed to validate and sanitize options: ", err)
 	}
 
+	if len(effectiveOptions.Accounts) != 0 {
+		t.Fatal("fake genesis does not support custom accounts")
+	}
+
 	net, err := startIntegrationTestNet(
 		t,
 		t.TempDir(),

--- a/tests/revision_forward_test.go
+++ b/tests/revision_forward_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/tosca/go/tosca/vm"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransaction_DelegationDesignationAddressAccessIsConsideredInAllegro(t *testing.T) {
+	gas := uint64(21_000) // transaction base
+	gas += 7 * 3          // 7 push instructions
+	gas += 2_600          // cold access to recipient
+	gas += 10             // gas in recursive call (is fully consumed due to failed execution)
+
+	tests := map[string]struct {
+		featureSet opera.FeatureSet
+		gas        uint64
+	}{
+		"Sonic": {
+			featureSet: opera.SonicFeatures,
+			gas:        gas,
+		},
+		"Allegro": {
+			featureSet: opera.AllegroFeatures,
+			gas:        gas + 2_600, // cold access to recipient billed in interpreter
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
+				FeatureSet: test.featureSet,
+				Accounts:   accountsToDeploy(),
+			})
+
+			client, err := net.GetClient()
+			require.NoError(t, err)
+			defer client.Close()
+
+			sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
+
+			gasPrice, err := client.SuggestGasPrice(context.Background())
+			require.NoError(t, err)
+
+			chainId, err := client.ChainID(context.Background())
+			require.NoError(t, err)
+
+			recipient := common.HexToAddress("0x44")
+			txData := &types.AccessListTx{
+				ChainID:    chainId,
+				Nonce:      0,
+				GasPrice:   gasPrice,
+				Gas:        test.gas + 1, // +1 to ensure there was no error which consumed the gas
+				To:         &recipient,
+				Value:      big.NewInt(0),
+				Data:       []byte{},
+				AccessList: types.AccessList{},
+			}
+			tx := signTransaction(t, chainId, txData, sender)
+
+			receipt, err := net.Run(tx)
+			require.NoError(t, err)
+
+			require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+			require.Equal(t, test.gas, receipt.GasUsed)
+		})
+	}
+}
+
+func accountsToDeploy() []makefakegenesis.Account {
+	// account 0x42 code: single invalid instruction (0xee)
+	// account 0x43 code: delegation designation to 0x42: 0xef0100...042
+	// account 0x44 code: code that calls 0x43
+
+	account42 := makefakegenesis.Account{
+		Name:    "account42",
+		Address: common.HexToAddress("0x42"),
+		Code:    []byte{0xee},
+		Nonce:   1,
+	}
+
+	account43 := makefakegenesis.Account{
+		Name:    "account43",
+		Address: common.HexToAddress("0x43"),
+		Code:    append([]byte{0xef, 0x01, 0x00}, common.HexToAddress("0x42").Bytes()...),
+		Nonce:   1,
+	}
+
+	code44 := []byte{
+		byte(vm.PUSH1), 0x00, // retSize
+		byte(vm.PUSH1), 0x00, // retOffset
+		byte(vm.PUSH1), 0x00, // argSize
+		byte(vm.PUSH1), 0x00, // argOffset
+		byte(vm.PUSH1), 0x00, // value
+		byte(vm.PUSH20),
+	}
+	code44 = append(code44, common.HexToAddress("0x43").Bytes()...) // address
+	code44 = append(code44,
+		byte(vm.PUSH1), 0x0a, // gas
+		byte(vm.CALL), // call
+		byte(vm.STOP), // return
+	)
+
+	account44 := makefakegenesis.Account{
+		Name:    "account44",
+		Address: common.HexToAddress("0x44"),
+		Code:    code44,
+		Nonce:   1,
+	}
+
+	return []makefakegenesis.Account{account42, account43, account44}
+}

--- a/tests/revision_forward_test.go
+++ b/tests/revision_forward_test.go
@@ -25,11 +25,11 @@ func TestTransaction_DelegationDesignationAddressAccessIsConsideredInAllegro(t *
 	}{
 		"Sonic": {
 			featureSet: opera.SonicFeatures,
-			gas:        gas,
+			gas:        gas, // delegate designator ignored, no address access.
 		},
 		"Allegro": {
 			featureSet: opera.AllegroFeatures,
-			gas:        gas + 2_600, // cold access to recipient billed in interpreter
+			gas:        gas + 2_600, // cold access to delegate billed in interpreter.
 		},
 	}
 


### PR DESCRIPTION
To ensure the revision is forward correctly to the interpreter an integration test is added. This checks that the access cost for the delegation designation address is taken into account if Prague is enabled. 