### PR TITLE
Add Multiplexer Provider

### DIFF
--- a/scc/light_client/light_client_test.go
+++ b/scc/light_client/light_client_test.go
@@ -25,15 +25,15 @@ func TestLightClient_NewLightClient_ReportsInvalidConfig(t *testing.T) {
 
 	tests := map[string]Config{
 		"emptyStringProvider": {
-			Url:     &url.URL{},
+			Url:     []*url.URL{},
 			Genesis: scc.NewCommittee(member),
 		},
 		"invalidUrl": {
-			Url:     &url.URL{Host: "not-a-url"},
+			Url:     []*url.URL{{Host: "not-a-url"}},
 			Genesis: scc.NewCommittee(member),
 		},
 		"emptyGenesisCommittee": {
-			Url:     &url.URL{Scheme: "http", Host: "localhost:4242"},
+			Url:     []*url.URL{{Scheme: "http", Host: "localhost:4242"}},
 			Genesis: scc.NewCommittee(),
 		},
 	}
@@ -151,9 +151,9 @@ func TestLightClientState_Sync_UpdatesStateToHead(t *testing.T) {
 		Return([]cert.CommitteeCertificate{committeeCert1}, nil)
 
 	// sync
-	url, _ := url.Parse("http://localhost:4242")
+	u, _ := url.Parse("http://localhost:4242")
 	config := Config{
-		Url:     url,
+		Url:     []*url.URL{u},
 		Genesis: scc.NewCommittee(member),
 	}
 	c, err := NewLightClient(config)
@@ -181,9 +181,9 @@ func makeMember(key bls.PrivateKey) scc.Member {
 func testConfig() Config {
 	key := bls.NewPrivateKey()
 	// error is ignored because constant string is a url
-	url, _ := url.Parse("http://localhost:4242")
+	u, _ := url.Parse("http://localhost:4242")
 	return Config{
-		Url:     url,
+		Url:     []*url.URL{u},
 		Genesis: scc.NewCommittee(makeMember(key)),
 	}
 }

--- a/scc/light_client/multiplexer.go
+++ b/scc/light_client/multiplexer.go
@@ -73,7 +73,7 @@ func (m *multiplexer) getBlockCertificates(first idx.Block, maxResults uint64) (
 	})
 }
 
-// tryAll executes a function on each provider in sequence until one returns nil error.
+// tryAll executes a function on each provider in sequence until one returns a nil error.
 //
 // This function is a generic helper that iterates over a list of providers,
 // calling the given function on each. If any function call succeeds, it immediately
@@ -84,7 +84,7 @@ func (m *multiplexer) getBlockCertificates(first idx.Block, maxResults uint64) (
 //
 // Parameters:
 //   - ps: A slice of provider instances to be tried.
-//   - fn: A function that takes a provider and returns a result of type T and an error.
+//   - fn: A function that takes a provider and returns a result of type C and an error.
 //
 // Returns:
 //   - C: The result of the first successful function execution.

--- a/scc/light_client/multiplexer.go
+++ b/scc/light_client/multiplexer.go
@@ -1,0 +1,104 @@
+package light_client
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+)
+
+// multiplexer is a provider that distributes requests across multiple providers.
+// It attempts to retrieve data by calling each provider in sequence until one
+// successfully fulfills the request.
+type multiplexer struct {
+	providers []provider
+}
+
+// newMultiplexer creates a new multiplexer instance.
+//
+// Parameters:
+//   - providers: A list of provider instances to be used by the multiplexer.
+//
+// Returns:
+//   - *multiplexer: A pointer to a new multiplexer instance.
+//   - error: Returns an error if no providers are given.
+func newMultiplexer(providers ...provider) (*multiplexer, error) {
+	if len(providers) == 0 {
+		return nil, errors.New("no providers provided")
+	}
+	return &multiplexer{providers: providers}, nil
+}
+
+// Close closes all the providers in the Multiplexer.
+// Closing an already closed provider has no effect.
+func (m *multiplexer) close() {
+	for _, p := range m.providers {
+		p.close()
+	}
+}
+
+// getCommitteeCertificates returns up to `maxResults` consecutive committee
+// certificates starting from the given period.
+//
+// Parameters:
+// - first: The starting period for which to retrieve committee certificates.
+// - maxResults: The maximum number of committee certificates to retrieve.
+//
+// Returns:
+//   - []cert.CommitteeCertificate: A slice of committee certificates.
+//   - error: Not nil if the provider failed to obtain the requested certificates.
+func (m *multiplexer) getCommitteeCertificates(first scc.Period, maxResults uint64) ([]cert.CommitteeCertificate, error) {
+	return tryAll(m.providers, func(p provider) ([]cert.CommitteeCertificate, error) {
+		return p.getCommitteeCertificates(first, maxResults)
+	})
+}
+
+// getBlockCertificates returns up to `maxResults` consecutive block
+// certificates starting from the given block number.
+//
+// Parameters:
+//   - number: The starting block number for which to retrieve the block certificate.
+//     Can be LatestBlock to retrieve the latest certificates.
+//   - maxResults: The maximum number of block certificates to retrieve.
+//
+// Returns:
+//   - cert.BlockCertificate: The block certificates for the given block number
+//     and the following blocks.
+//   - error: Not nil if the provider failed to obtain the requested certificates.
+func (m *multiplexer) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert.BlockCertificate, error) {
+	return tryAll(m.providers, func(p provider) ([]cert.BlockCertificate, error) {
+		return p.getBlockCertificates(first, maxResults)
+	})
+}
+
+// tryAll executes a function on each provider in sequence until one succeeds.
+//
+// This function is a generic helper that iterates over a list of providers,
+// calling the given function on each. If any function call succeeds, it immediately
+// returns the result. If all calls fail, it aggregates the errors and returns them.
+//
+// Type Parameters:
+//   - C: The type of the result returned by the function.
+//
+// Parameters:
+//   - ps: A slice of provider instances to be tried.
+//   - fn: A function that takes a provider and returns a result of type T and an error.
+//
+// Returns:
+//   - C: The result of the first successful function execution.
+//   - error: Nil if at least one execution of fn returned without error.
+//     The joined error of all failed attempts if all attempts failed.
+func tryAll[C any](ps []provider, fn func(provider) (C, error)) (C, error) {
+	var errs []error
+	for _, p := range ps {
+		res, err := fn(p)
+		if err == nil {
+			return res, nil
+		}
+		errs = append(errs, err)
+	}
+	var c C
+	return c, errors.Join(fmt.Errorf("all providers failed: "), errors.Join(errs...))
+}

--- a/scc/light_client/multiplexer.go
+++ b/scc/light_client/multiplexer.go
@@ -11,7 +11,7 @@ import (
 
 // multiplexer is a provider that distributes requests across multiple providers.
 // It attempts to retrieve data by calling each provider in sequence until one
-// successfully fulfills the request.
+// returns a nil error.
 type multiplexer struct {
 	providers []provider
 }
@@ -73,7 +73,7 @@ func (m *multiplexer) getBlockCertificates(first idx.Block, maxResults uint64) (
 	})
 }
 
-// tryAll executes a function on each provider in sequence until one succeeds.
+// tryAll executes a function on each provider in sequence until one returns nil error.
 //
 // This function is a generic helper that iterates over a list of providers,
 // calling the given function on each. If any function call succeeds, it immediately

--- a/scc/light_client/multiplexer_test.go
+++ b/scc/light_client/multiplexer_test.go
@@ -1,0 +1,83 @@
+package light_client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/scc"
+	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestMultiplexer_Close_closesAllProviders(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	prov1 := NewMockprovider(ctrl)
+	prov1.EXPECT().close().Times(1)
+
+	prov2 := NewMockprovider(ctrl)
+	prov2.EXPECT().close().Times(1)
+
+	m, err := newMultiplexer(prov1, prov2)
+	require.NoError(t, err)
+	m.close()
+}
+
+func TestMultiplexer_tryAllProviders_TriesAllProvidersOnFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	p1 := NewMockprovider(ctrl)
+	p1.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1)
+
+	p2 := NewMockprovider(ctrl)
+	p2.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1)
+
+	m, err := newMultiplexer(p1, p2)
+	require.NoError(t, err)
+	_, err = tryAll(m.providers, func(p provider) ([]cert.BlockCertificate, error) {
+		return p.getBlockCertificates(idx.Block(0), uint64(1))
+	})
+	require.ErrorContains(t, err, "all providers failed")
+}
+
+func TestMultiplexer_tryAllProviders_ReturnsFirstSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	p1 := NewMockprovider(ctrl)
+	p1.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).Return([]cert.BlockCertificate{}, nil).Times(1)
+
+	p2 := NewMockprovider(ctrl)
+
+	m, err := newMultiplexer(p1, p2)
+	require.NoError(t, err)
+	_, err = tryAll(m.providers, func(p provider) ([]cert.BlockCertificate, error) {
+		return p.getBlockCertificates(idx.Block(0), uint64(1))
+	})
+	require.NoError(t, err)
+}
+
+func TestMultiplexer_GetCertificates_PropagatesError(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	p1 := NewMockprovider(ctrl)
+	p2 := NewMockprovider(ctrl)
+
+	m, err := newMultiplexer(p1, p2)
+	require.NoError(err)
+
+	// fail to get block certificates
+	p1.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1)
+	p2.EXPECT().getBlockCertificates(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1)
+
+	_, err = m.getBlockCertificates(idx.Block(0), uint64(1))
+	require.ErrorContains(err, "all providers failed")
+
+	// fail to get committee certificates
+	p1.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1)
+	p2.EXPECT().getCommitteeCertificates(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).Times(1)
+
+	_, err = m.getCommitteeCertificates(scc.Period(0), uint64(1))
+	require.ErrorContains(err, "all providers failed")
+}


### PR DESCRIPTION
This PR introduces the `Multiplexer` type, which implements the `Provider` interface while also wrapping a number of existing `Provider`s and automatically iterating through them when they try fetch certificate and return a non `nil` error. It follows the Decorator Pattern, ensuring that multiplexing logic is separate from core provider implementations.

A multiplexer provider is also used in the `LightClient` and the `Config` struct is adapted to reflect this, containing now a list of providers and failing when this list in empty, or if any of the provided ones are invalid.