### PR TITLE
Add `getAccountProof` to providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/0xsoniclabs/sonic
 go 1.24.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff
+	github.com/0xsoniclabs/carmen/go v0.0.0-20250318153505-712d1a76e929
 	github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff h1:ItY2JgmM0lH/kLHRGOHh7sEAB6w/lT5qv/xkkS5zO6o=
-github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff/go.mod h1:/u6oDZBv6eyPs9K7Ug5D4aL9l1Q7N43BnWEUPsvKmYw=
+github.com/0xsoniclabs/carmen/go v0.0.0-20250318153505-712d1a76e929 h1:byQDSYyUE0AIxd+WZEFna2paBftg4hQSyQDHru5vQ3Q=
+github.com/0xsoniclabs/carmen/go v0.0.0-20250318153505-712d1a76e929/go.mod h1:/u6oDZBv6eyPs9K7Ug5D4aL9l1Q7N43BnWEUPsvKmYw=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809 h1:MtKV0hC7b58vimXYzmNRBNZJw1ovewt5GbanzPgl68k=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809/go.mod h1:9SAhGia6ukqZnvwJ3npNEmQDFjusZ/vXgbU1Z7J1vhw=
 github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc h1:3JvCgp/G+0VQCz74vXKjH475/JvCM7r1Kny0wzUN7TI=

--- a/scc/light_client/multiplexer.go
+++ b/scc/light_client/multiplexer.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // multiplexer is a provider that distributes requests across multiple providers.
@@ -70,6 +72,22 @@ func (m *multiplexer) getCommitteeCertificates(first scc.Period, maxResults uint
 func (m *multiplexer) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert.BlockCertificate, error) {
 	return tryAll(m.providers, func(p provider) ([]cert.BlockCertificate, error) {
 		return p.getBlockCertificates(first, maxResults)
+	})
+}
+
+// getAccountProof returns the account proof corresponding to the
+// given address at the given height.
+//
+// Parameters:
+//   - address: The address of the account.
+//   - height: The block height of the state.
+//
+// Returns:
+//   - WitnessProof: witness proof for the given account.
+//   - error: Not nil if the provider failed to obtain the requested account proof.
+func (m *multiplexer) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
+	return tryAll(m.providers, func(p provider) (carmen.WitnessProof, error) {
+		return p.getAccountProof(address, height)
 	})
 }
 

--- a/scc/light_client/multiplexer_test.go
+++ b/scc/light_client/multiplexer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -89,4 +90,12 @@ func TestMultiplexer_GetCertificates_PropagatesError(t *testing.T) {
 	require.ErrorContains(err, "all providers failed")
 	require.ErrorContains(err, "error3")
 	require.ErrorContains(err, "error4")
+
+	p1.EXPECT().getAccountProof(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error5")).Times(1)
+	p2.EXPECT().getAccountProof(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error6")).Times(1)
+
+	_, err = m.getAccountProof(common.Address{0x01}, idx.Block(0))
+	require.ErrorContains(err, "all providers failed")
+	require.ErrorContains(err, "error5")
+	require.ErrorContains(err, "error6")
 }

--- a/scc/light_client/provider.go
+++ b/scc/light_client/provider.go
@@ -41,7 +41,7 @@ type provider interface {
 	//   - error: Not nil if the provider failed to obtain the requested certificates.
 	getBlockCertificates(first idx.Block, maxResults uint64) ([]cert.BlockCertificate, error)
 
-	// GetAccountProof returns the account info corresponding to the
+	// GetAccountProof returns the account proof corresponding to the
 	// given address at the given height.
 	//
 	// Parameters:
@@ -49,8 +49,8 @@ type provider interface {
 	// - height: The block height of the state.
 	//
 	// Returns:
-	// - WitnessProof: witness proof for the account info.
-	// - error: Not nil if the provider failed to obtain the requested account info.
+	// - WitnessProof: witness proof for the account proof.
+	// - error: Not nil if the provider failed to obtain the requested account proof.
 	getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error)
 
 	// close closes the Provider.

--- a/scc/light_client/provider.go
+++ b/scc/light_client/provider.go
@@ -3,9 +3,11 @@ package light_client
 import (
 	"math"
 
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 //go:generate mockgen -source=provider.go -package=light_client -destination=provider_mock.go
@@ -38,6 +40,18 @@ type provider interface {
 	//     and the following blocks.
 	//   - error: Not nil if the provider failed to obtain the requested certificates.
 	getBlockCertificates(first idx.Block, maxResults uint64) ([]cert.BlockCertificate, error)
+
+	// GetAccountProof returns the account info corresponding to the
+	// given address at the given height.
+	//
+	// Parameters:
+	// - address: The address of the account.
+	// - height: The block height of the state.
+	//
+	// Returns:
+	// - WitnessProof: witness proof for the account info.
+	// - error: Not nil if the provider failed to obtain the requested account info.
+	getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error)
 
 	// close closes the Provider.
 	// Closing an already closed provider has no effect

--- a/scc/light_client/provider_mock.go
+++ b/scc/light_client/provider_mock.go
@@ -12,9 +12,11 @@ package light_client
 import (
 	reflect "reflect"
 
+	carmen "github.com/0xsoniclabs/carmen/go/carmen"
 	scc "github.com/0xsoniclabs/sonic/scc"
 	cert "github.com/0xsoniclabs/sonic/scc/cert"
 	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
+	common "github.com/ethereum/go-ethereum/common"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,6 +54,21 @@ func (m *Mockprovider) close() {
 func (mr *MockproviderMockRecorder) close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "close", reflect.TypeOf((*Mockprovider)(nil).close))
+}
+
+// getAccountProof mocks base method.
+func (m *Mockprovider) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getAccountProof", address, height)
+	ret0, _ := ret[0].(carmen.WitnessProof)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getAccountProof indicates an expected call of getAccountProof.
+func (mr *MockproviderMockRecorder) getAccountProof(address, height any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getAccountProof", reflect.TypeOf((*Mockprovider)(nil).getAccountProof), address, height)
 }
 
 // getBlockCertificates mocks base method.

--- a/scc/light_client/retry.go
+++ b/scc/light_client/retry.go
@@ -99,7 +99,7 @@ func (r retryProvider) getBlockCertificates(first idx.Block, maxResults uint64) 
 // - height: The block height of the state.
 //
 // Returns:
-// - AccountInfo: The AccountInfo of the account at the given height.
+// - AccountProof: The proof of the account at the given height.
 // - error: Not nil if the provider failed to obtain the requested account proof.
 func (r retryProvider) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
 	return retry(r.maxRetries, r.timeout, func() (carmen.WitnessProof, error) {

--- a/scc/light_client/retry.go
+++ b/scc/light_client/retry.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // retryProvider is used to wrap another provider and add a retry mechanism.
@@ -86,6 +88,22 @@ func (r retryProvider) getCommitteeCertificates(first scc.Period, maxResults uin
 func (r retryProvider) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert.BlockCertificate, error) {
 	return retry(r.maxRetries, r.timeout, func() ([]cert.BlockCertificate, error) {
 		return r.provider.getBlockCertificates(first, maxResults)
+	})
+}
+
+// GetAccountProof returns the account info corresponding to the
+// given address at the given height.
+//
+// Parameters:
+// - address: The address of the account.
+// - height: The block height of the state.
+//
+// Returns:
+// - AccountInfo: The AccountInfo of the account at the given height.
+// - error: Not nil if the provider failed to obtain the requested account info.
+func (r retryProvider) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
+	return retry(r.maxRetries, r.timeout, func() (carmen.WitnessProof, error) {
+		return r.provider.getAccountProof(address, height)
 	})
 }
 

--- a/scc/light_client/retry.go
+++ b/scc/light_client/retry.go
@@ -91,7 +91,7 @@ func (r retryProvider) getBlockCertificates(first idx.Block, maxResults uint64) 
 	})
 }
 
-// GetAccountProof returns the account info corresponding to the
+// GetAccountProof returns the account proof corresponding to the
 // given address at the given height.
 //
 // Parameters:
@@ -100,7 +100,7 @@ func (r retryProvider) getBlockCertificates(first idx.Block, maxResults uint64) 
 //
 // Returns:
 // - AccountInfo: The AccountInfo of the account at the given height.
-// - error: Not nil if the provider failed to obtain the requested account info.
+// - error: Not nil if the provider failed to obtain the requested account proof.
 func (r retryProvider) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
 	return retry(r.maxRetries, r.timeout, func() (carmen.WitnessProof, error) {
 		return r.provider.getAccountProof(address, height)

--- a/scc/light_client/server.go
+++ b/scc/light_client/server.go
@@ -3,10 +3,14 @@ package light_client
 import (
 	"fmt"
 
+	"github.com/0xsoniclabs/carmen/go/carmen"
+	"github.com/0xsoniclabs/carmen/go/common/immutable"
 	"github.com/0xsoniclabs/sonic/ethapi"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -172,4 +176,45 @@ func (s server) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert
 		certs[i] = res.ToCertificate()
 	}
 	return certs, nil
+}
+
+// GetAccountProof returns the account info corresponding to the
+// given address at the given height.
+//
+// Parameters:
+// - address: The address of the account.
+// - height: The block height of the state.
+//
+// Returns:
+// - AccountInfo: The AccountInfo of the account at the given height.
+// - error: Not nil if the provider failed to obtain the requested account info.
+func (s server) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
+	heightString := fmt.Sprintf("0x%x", height)
+	if height == LatestBlock {
+		heightString = "latest"
+	}
+	var result struct {
+		AccountProof []string
+	}
+	err := s.client.Call(
+		&result,
+		"eth_getProof",
+		fmt.Sprintf("%v", address),
+		[]string{fmt.Sprintf("%v", common.Hash{})},
+		heightString,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// decode elements for the proof.
+	elements := []carmen.Bytes{}
+	for _, element := range result.AccountProof {
+		data, err := hexutil.Decode(element)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode proof element: %v", err)
+		}
+		elements = append(elements, immutable.NewBytes(data))
+	}
+	return carmen.CreateWitnessProofFromNodes(elements...), nil
 }

--- a/scc/light_client/server.go
+++ b/scc/light_client/server.go
@@ -178,7 +178,7 @@ func (s server) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert
 	return certs, nil
 }
 
-// GetAccountProof returns the account info corresponding to the
+// GetAccountProof returns the account proof corresponding to the
 // given address at the given height.
 //
 // Parameters:
@@ -187,7 +187,7 @@ func (s server) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert
 //
 // Returns:
 // - AccountInfo: The AccountInfo of the account at the given height.
-// - error: Not nil if the provider failed to obtain the requested account info.
+// - error: Not nil if the provider failed to obtain the requested account proof.
 func (s server) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
 	heightString := fmt.Sprintf("0x%x", height)
 	if height == LatestBlock {

--- a/scc/light_client/server.go
+++ b/scc/light_client/server.go
@@ -186,7 +186,7 @@ func (s server) getBlockCertificates(first idx.Block, maxResults uint64) ([]cert
 // - height: The block height of the state.
 //
 // Returns:
-// - AccountInfo: The AccountInfo of the account at the given height.
+// - AccountProof: The proof of the account at the given height.
 // - error: Not nil if the provider failed to obtain the requested account proof.
 func (s server) getAccountProof(address common.Address, height idx.Block) (carmen.WitnessProof, error) {
 	heightString := fmt.Sprintf("0x%x", height)
@@ -200,7 +200,7 @@ func (s server) getAccountProof(address common.Address, height idx.Block) (carme
 		&result,
 		"eth_getProof",
 		fmt.Sprintf("%v", address),
-		[]string{fmt.Sprintf("%v", common.Hash{})},
+		[]string{},
 		heightString,
 	)
 	if err != nil {
@@ -216,5 +216,9 @@ func (s server) getAccountProof(address common.Address, height idx.Block) (carme
 		}
 		elements = append(elements, immutable.NewBytes(data))
 	}
-	return carmen.CreateWitnessProofFromNodes(elements...), nil
+	proof := carmen.CreateWitnessProofFromNodes(elements...)
+	if !proof.IsValid() {
+		return nil, fmt.Errorf("invalid proof")
+	}
+	return proof, nil
 }

--- a/scc/light_client/server_test.go
+++ b/scc/light_client/server_test.go
@@ -2,11 +2,13 @@ package light_client
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -329,4 +331,78 @@ func TestServer_GetCertificates_ReturnsCertificates(t *testing.T) {
 	blockCerts, err := server.getBlockCertificates(0, 2)
 	require.NoError(err)
 	require.Len(blockCerts, 2)
+}
+
+func TestBlockQuery_GetAccountProof_PropagatesClientError(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := NewMockrpcClient(ctrl)
+	server, err := newServerFromClient(client)
+	require.NoError(err)
+
+	someError := fmt.Errorf("some error")
+	addr := common.Address{0x1}
+	client.EXPECT().Call(
+		gomock.Any(), // any result variable
+		"eth_getProof",
+		fmt.Sprintf("%v", addr),
+		gomock.Any(), // any storage key
+		"latest").
+		Return(someError)
+
+	_, err = server.getAccountProof(addr, math.MaxUint64)
+	require.ErrorIs(err, someError)
+}
+
+func TestBlockQuery_GetAccountProof_FailsToDecodeAddressProof(t *testing.T) {
+	// setup
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := NewMockrpcClient(ctrl)
+	server, err := newServerFromClient(client)
+	require.NoError(err)
+	// expexted error
+	addr := common.Address{0x1}
+	client.EXPECT().Call(
+		gomock.Any(),
+		"eth_getProof",
+		fmt.Sprintf("%v", addr),
+		gomock.Any(),
+		"latest").DoAndReturn(
+		func(result *struct {
+			AccountProof []string
+		}, method string, args ...interface{}) error {
+			// invalid proof
+			result.AccountProof = []string{"invalid"}
+			return nil
+		})
+
+	got, err := server.getAccountProof(addr, math.MaxUint64)
+	require.ErrorContains(err, "failed to decode proof element")
+	require.Nil(got)
+}
+
+func TestBlockQuery_GetAccountProof_ReturnsAccountProof(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := NewMockrpcClient(ctrl)
+	server, err := newServerFromClient(client)
+	require.NoError(err)
+	addr := common.Address{0x1}
+	client.EXPECT().Call(
+		gomock.Any(),
+		"eth_getProof",
+		fmt.Sprintf("%v", addr),
+		gomock.Any(),
+		"latest").DoAndReturn(
+		func(result *struct {
+			AccountProof []string
+		}, method string, args ...interface{}) error {
+			result.AccountProof = []string{"0x01", "0x02"}
+			return nil
+		})
+
+	got, err := server.getAccountProof(addr, math.MaxUint64)
+	require.NoError(err)
+	require.NotNil(got)
 }


### PR DESCRIPTION
This PR adds the `getAccountProof` function  to the interface and the different provider implementations. To enable unit testing  of this method a mock witness proof was needed from the `carmen` package, hence the update for this dependency.
`GetAccountProof` method takes an account address and a block height and returns the witness proof for it, which can be used to validate relevant information regarding that account at that height of the chain.