### PR TITLE
network rule validation

### DIFF
--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	maxAdvanceEpochs = 1 << 16
+	internalTransactionsGasLimit = opera.MinimumMaxBlockGas / 2
+	maxAdvanceEpochs             = 1 << 16
 )
 
 type DriverTxListenerModule struct{}
@@ -66,7 +67,7 @@ func InternalTxBuilder(statedb state.StateDB) func(calldata []byte, addr common.
 		if nonce == math.MaxUint64 {
 			nonce = statedb.GetNonce(common.Address{})
 		}
-		tx := types.NewTransaction(nonce, addr, common.Big0, 500_000_000, common.Big0, calldata)
+		tx := types.NewTransaction(nonce, addr, common.Big0, internalTransactionsGasLimit, common.Big0, calldata)
 		nonce++
 		return tx
 	}

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	internalTransactionsGasLimit = opera.MinimumMaxBlockGas / 10
+	internalTransactionsGasLimit = 500_000_000
 	maxAdvanceEpochs             = 1 << 16
 )
 

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+    // internalTransactionsGasLimit is the gas limit for internal transactions like epoch sealing. This constant MUST NOT be changed, as doing so will cause a network fork.
 	internalTransactionsGasLimit = 500_000_000
 	maxAdvanceEpochs             = 1 << 16
 )

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	internalTransactionsGasLimit = opera.MinimumMaxBlockGas / 2
+	internalTransactionsGasLimit = opera.MinimumMaxBlockGas / 10
 	maxAdvanceEpochs             = 1 << 16
 )
 

--- a/integration/makefakegenesis/json_test.go
+++ b/integration/makefakegenesis/json_test.go
@@ -19,3 +19,33 @@ func TestJsonGenesis_AcceptsGenesisWithoutCommittee(t *testing.T) {
 	_, err := ApplyGenesisJson(genesis)
 	require.NoError(t, err)
 }
+
+func TestJsonGenesis_Network_Rules_Validated_Allegro_Only(t *testing.T) {
+	tests := map[string]struct {
+		featureSet opera.FeatureSet
+		assert     func(t *testing.T, err error)
+	}{
+		"sonic": {
+			featureSet: opera.SonicFeatures,
+			assert: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		"allegro": {
+			featureSet: opera.AllegroFeatures,
+			assert: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "LLR upgrade is not supported")
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			genesis := GenerateFakeJsonGenesis(1, test.featureSet)
+			genesis.Rules.Upgrades.Llr = true // LLR is not supported in Allegro and Sonic
+			_, err := ApplyGenesisJson(genesis)
+			test.assert(t, err)
+		})
+	}
+}

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -175,6 +175,10 @@ func (b *GenesisBuilder) FinalizeBlockZero(
 		return common.Hash{}, common.Hash{}, errors.New("block zero already finalized")
 	}
 
+	if err := rules.Validate(); err != nil {
+		return common.Hash{}, common.Hash{}, fmt.Errorf("invalid rules: %w", err)
+	}
+
 	// construct state root of initial state
 	b.tmpStateDB.EndBlock(0)
 	genesisStateRoot := b.tmpStateDB.GetStateHash()

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -175,8 +175,10 @@ func (b *GenesisBuilder) FinalizeBlockZero(
 		return common.Hash{}, common.Hash{}, errors.New("block zero already finalized")
 	}
 
-	if err := rules.Validate(); err != nil {
-		return common.Hash{}, common.Hash{}, fmt.Errorf("invalid rules: %w", err)
+	if rules.Upgrades.Allegro {
+		if err := rules.Validate(); err != nil {
+			return common.Hash{}, common.Hash{}, fmt.Errorf("invalid rules: %w", err)
+		}
 	}
 
 	// construct state root of initial state

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -2,15 +2,19 @@ package opera
 
 import "encoding/json"
 
-func UpdateRules(src Rules, diff []byte) (res Rules, err error) {
+func UpdateRules(src Rules, diff []byte) (Rules, error) {
 	changed := src.Copy()
-	err = json.Unmarshal(diff, &changed)
+	err := json.Unmarshal(diff, &changed)
 	if err != nil {
-		return src, err
+		return Rules{}, err
 	}
 	// protect readonly fields
-	res = changed
-	res.NetworkID = src.NetworkID
-	res.Name = src.Name
-	return
+	changed.NetworkID = src.NetworkID
+	changed.Name = src.Name
+
+	// check validity of the new rules
+	if err = changed.Validate(); err != nil {
+		return Rules{}, err
+	}
+	return changed, nil
 }

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -13,8 +13,10 @@ func UpdateRules(src Rules, diff []byte) (Rules, error) {
 	changed.Name = src.Name
 
 	// check validity of the new rules
-	if err = changed.Validate(); err != nil {
-		return Rules{}, err
+	if changed.Upgrades.CheckRuleChanges {
+		if err = changed.Validate(); err != nil {
+			return Rules{}, err
+		}
 	}
 	return changed, nil
 }

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -5,16 +5,16 @@ import "encoding/json"
 func UpdateRules(src Rules, diff []byte) (Rules, error) {
 	changed := src.Copy()
 	if err := json.Unmarshal(diff, &changed); err != nil {
-	if err != nil {
 		return Rules{}, err
 	}
+
 	// protect readonly fields
 	changed.NetworkID = src.NetworkID
 	changed.Name = src.Name
 
 	// check validity of the new rules
 	if changed.Upgrades.Allegro {
-		if err = changed.Validate(); err != nil {
+		if err := changed.Validate(); err != nil {
 			return Rules{}, err
 		}
 	}

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 func UpdateRules(src Rules, diff []byte) (Rules, error) {
 	changed := src.Copy()
-	err := json.Unmarshal(diff, &changed)
+	if err := json.Unmarshal(diff, &changed); err != nil {
 	if err != nil {
 		return Rules{}, err
 	}

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -13,7 +13,7 @@ func UpdateRules(src Rules, diff []byte) (Rules, error) {
 	changed.Name = src.Name
 
 	// check validity of the new rules
-	if changed.Upgrades.CheckRuleChanges {
+	if changed.Upgrades.Allegro {
 		if err = changed.Validate(); err != nil {
 			return Rules{}, err
 		}

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -14,15 +14,13 @@ func TestUpdateRules(t *testing.T) {
 
 	base := MainNetRules()
 
-	got, err := UpdateRules(base, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":5000000000}}`))
-	require.NoError(err)
-
 	exp := base.Copy()
 	exp.Dag.MaxParents = 5
 	exp.Economy.MinGasPrice = big.NewInt(7)
 	exp.Economy.MinBaseFee = big.NewInt(1e9)
-	exp.Blocks.MaxBlockGas = 1000
-	got, err := UpdateRules(exp, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":2000000000}}`))
+	exp.Blocks.MaxBlockGas = 5000000000
+
+	got, err := UpdateRules(exp, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":5000000000}}`))
 	require.NoError(err)
 	require.Equal(exp.String(), got.String(), "should not be able to change readonly fields")
 
@@ -69,20 +67,9 @@ func TestUpdateRules_ValidityCheckIsConductedIfCheckIsEnabledInUpdatedRuleSet(t 
 func TestUpdateRules_CanUpdateHardForks(t *testing.T) {
 	require := require.New(t)
 
-	rules := Rules{
-		Economy: EconomyRules{
-			MinGasPrice: big.NewInt(1),
-			MinBaseFee:  big.NewInt(2),
-		},
-		Upgrades: Upgrades{
-			Berlin:  true,
-			London:  false,
-			Sonic:   true,
-			Allegro: false,
-		},
-	}
+	rules := FakeNetRules(SonicFeatures)
 
-	got, err := UpdateRules(rules, []byte(`{"Upgrades":{"Berlin":true,"London":true,"Sonic":true,"Allegro":true}}`))
+	got, err := UpdateRules(rules, []byte(`{"Upgrades":{"Allegro":true}}`))
 	require.NoError(err)
 	require.Equal(Upgrades{
 		Berlin:  true,

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -18,9 +18,9 @@ func TestUpdateRules(t *testing.T) {
 	exp.Economy.MinGasPrice = big.NewInt(7)
 	exp.Economy.MinBaseFee = big.NewInt(1e9)
 	exp.Blocks.MaxBlockGas = 1000
-	got, err := UpdateRules(exp, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":1000}}`))
+	got, err := UpdateRules(exp, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":2000000000}}`))
 	require.NoError(err)
-	require.Equal(exp.String(), got.String(), "mutate fields")
+	require.Equal(exp.String(), got.String(), "mutate fields") // < this test checks nothing; todo: fix
 
 	exp.Dag.MaxParents = 0
 	got, err = UpdateRules(exp, []byte(`{"Name":"xxx","NetworkID":1,"Dag":{"MaxParents":0}}`))

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -1,6 +1,7 @@
 package opera
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -34,6 +35,35 @@ func TestUpdateRules(t *testing.T) {
 
 	_, err = UpdateRules(exp, []byte(`{"Dag":{"MaxParents":1}}`))
 	require.Error(err, "should fail on invalid rules")
+}
+
+func TestUpdateRules_ValidityCheckIsConductedIfCheckIsEnabledInUpdatedRuleSet(t *testing.T) {
+	for _, enabledBefore := range []bool{true, false} {
+		for _, enabledAfter := range []bool{true, false} {
+			for _, validUpdate := range []bool{true, false} {
+				t.Run(fmt.Sprintf("before=%t,after=%t,valid=%t", enabledBefore, enabledAfter, validUpdate), func(t *testing.T) {
+					require := require.New(t)
+
+					base := MainNetRules()
+					base.Upgrades.CheckRuleChanges = enabledBefore
+
+					maxParents := 1
+					if validUpdate {
+						maxParents = 5
+					}
+
+					update := fmt.Sprintf(`{"Dag":{"MaxParents":%d}, "Upgrades":{"CheckRuleChanges":%t}}`, maxParents, enabledAfter)
+
+					_, err := UpdateRules(base, []byte(update))
+					if enabledAfter && !validUpdate {
+						require.Error(err)
+					} else {
+						require.NoError(err)
+					}
+				})
+			}
+		}
+	}
 }
 
 func TestUpdateRules_CanUpdateHardForks(t *testing.T) {

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -52,7 +52,7 @@ func TestUpdateRules_ValidityCheckIsConductedIfCheckIsEnabledInUpdatedRuleSet(t 
 						maxParents = 5
 					}
 
-					update := fmt.Sprintf(`{"Dag":{"MaxParents":%d}, "Upgrades":{"CheckRuleChanges":%t}}`, maxParents, enabledAfter)
+					update := fmt.Sprintf(`{"Dag":{"MaxParents":%d}, "Upgrades":{"Allegro":%t}}`, maxParents, enabledAfter)
 
 					_, err := UpdateRules(base, []byte(update))
 					if enabledAfter && !validUpdate {
@@ -82,12 +82,12 @@ func TestUpdateRules_CanUpdateHardForks(t *testing.T) {
 		},
 	}
 
-	got, err := UpdateRules(rules, []byte(`{"Upgrades":{"Berlin":false,"London":true,"Sonic":false,"Allegro":true}}`))
+	got, err := UpdateRules(rules, []byte(`{"Upgrades":{"Berlin":true,"London":true,"Sonic":true,"Allegro":true}}`))
 	require.NoError(err)
 	require.Equal(Upgrades{
-		Berlin:  false,
+		Berlin:  true,
 		London:  true,
-		Sonic:   false,
+		Sonic:   true,
 		Allegro: true,
 	}, got.Upgrades)
 }

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -11,28 +11,29 @@ import (
 func TestUpdateRules(t *testing.T) {
 	require := require.New(t)
 
-	var exp Rules
-	exp.Epochs.MaxEpochGas = 99
+	base := MainNetRules()
 
+	got, err := UpdateRules(base, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":2000000000}}`))
+	require.NoError(err)
+
+	exp := base.Copy()
 	exp.Dag.MaxParents = 5
 	exp.Economy.MinGasPrice = big.NewInt(7)
 	exp.Economy.MinBaseFee = big.NewInt(1e9)
 	exp.Blocks.MaxBlockGas = 1000
 	got, err := UpdateRules(exp, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":2000000000}}`))
 	require.NoError(err)
-	require.Equal(exp.String(), got.String(), "mutate fields") // < this test checks nothing; todo: fix
-
-	exp.Dag.MaxParents = 0
-	got, err = UpdateRules(exp, []byte(`{"Name":"xxx","NetworkID":1,"Dag":{"MaxParents":0}}`))
-	require.NoError(err)
-	require.Equal(exp.String(), got.String(), "readonly fields")
+	require.Equal(exp.String(), got.String(), "should not be able to change readonly fields")
 
 	got, err = UpdateRules(exp, []byte(`{}`))
 	require.NoError(err)
-	require.Equal(exp.String(), got.String(), "empty diff")
+	require.Equal(exp.String(), got.String(), "empty diff changed the rules")
 
 	_, err = UpdateRules(exp, []byte(`}{`))
-	require.Error(err)
+	require.Error(err, "should fail on invalid json")
+
+	_, err = UpdateRules(exp, []byte(`{"Dag":{"MaxParents":1}}`))
+	require.Error(err, "should fail on invalid rules")
 }
 
 func TestUpdateRules_CanUpdateHardForks(t *testing.T) {

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -45,7 +45,7 @@ func TestUpdateRules_ValidityCheckIsConductedIfCheckIsEnabledInUpdatedRuleSet(t 
 					require := require.New(t)
 
 					base := MainNetRules()
-					base.Upgrades.CheckRuleChanges = enabledBefore
+					base.Upgrades.Allegro = enabledBefore
 
 					maxParents := 1
 					if validUpdate {

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -14,7 +14,7 @@ func TestUpdateRules(t *testing.T) {
 
 	base := MainNetRules()
 
-	got, err := UpdateRules(base, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":2000000000}}`))
+	got, err := UpdateRules(base, []byte(`{"Dag":{"MaxParents":5},"Economy":{"MinGasPrice":7},"Blocks":{"MaxBlockGas":5000000000}}`))
 	require.NoError(err)
 
 	exp := base.Copy()

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -370,7 +370,7 @@ func DefaultEmitterRules() EmitterRules {
 func DefaultEpochsRules() EpochsRules {
 	return EpochsRules{
 		MaxEpochGas:      defaultTargetGasRate * 300, // ~5 minute epoch
-		MaxEpochDuration: inter.Timestamp(4 * time.Hour),
+		MaxEpochDuration: inter.Timestamp(1 * time.Hour),
 	}
 }
 

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -313,12 +313,7 @@ func MainNetRules() Rules {
 			MaxBlockGas:             MinimumMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(1 * time.Minute),
 		},
-		Upgrades: Upgrades{
-			Berlin: true,
-			London: true,
-			Llr:    false,
-			Sonic:  true,
-		},
+		Upgrades: DefaultUpgrades(),
 	}
 }
 
@@ -349,6 +344,16 @@ func DefaultEconomyRules() EconomyRules {
 		LongGasPower:     DefaultGasPowerRules(),
 	}
 	return rules
+}
+
+func DefaultUpgrades() Upgrades {
+	return Upgrades{
+		Berlin:           true,
+		London:           true,
+		Llr:              false,
+		Sonic:            true,
+		CheckRuleChanges: true,
+	}
 }
 
 // FakeEconomyRules returns fakenet economy

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -438,7 +438,7 @@ func (r Rules) Copy() Rules {
 // they do not risk stalling the network or preventing future rule updates.
 //
 // Note: the validation is very liberal to allow a maximum flexibility in the rules.
-// The merely check for the most critical configuration errors that may lead to network
+// It merely checks for the most critical configuration errors that may lead to network
 // stalls or rule update issues. However, many valid configurations may still result
 // in undesirable network behavior. Rule-setters need to be aware of the implications
 // of their choices and should always test their rules in a controlled environment.

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -313,7 +313,6 @@ func MainNetRules() Rules {
 			MaxBlockGas:             MinimumMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(1 * time.Minute),
 		},
-		Upgrades: DefaultUpgrades(),
 	}
 }
 
@@ -344,16 +343,6 @@ func DefaultEconomyRules() EconomyRules {
 		LongGasPower:     DefaultGasPowerRules(),
 	}
 	return rules
-}
-
-func DefaultUpgrades() Upgrades {
-	return Upgrades{
-		Berlin:           true,
-		London:           true,
-		Llr:              false,
-		Sonic:            true,
-		CheckRuleChanges: true,
-	}
 }
 
 // FakeEconomyRules returns fakenet economy

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -313,6 +313,7 @@ func MainNetRules() Rules {
 			MaxBlockGas:             MinimumMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(1 * time.Minute),
 		},
+		Upgrades: AllegroFeatures.ToUpgrades(),
 	}
 }
 

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -444,6 +444,15 @@ func (r Rules) Copy() Rules {
 	return cp
 }
 
+// Validate checks the rules for consistency and safety. Rules are considered safe if
+// they do not risk stalling the network or preventing future rule updates.
+//
+// Note: the validation is very liberal to allow a maximum flexibility in the rules.
+// The merely check for the most critical configuration errors that may lead to network
+// stalls or rule update issues. However, many valid configurations may still result
+// in undesirable network behavior. Rule-setters need to be aware of the implications
+// of their choices and should always test their rules in a controlled environment.
+// This validation is not a substitute for proper testing.
 func (r Rules) Validate() error {
 	return validate(r)
 }

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -28,7 +28,7 @@ const (
 	sonicBit               = 1 << 3
 	allegroBit             = 1 << 4
 
-	MinimumMaxBlockGas          = 1_000_000_000 // < must be large enough to allow internal transactions to seal blocks
+	MinimumMaxBlockGas          = 5_000_000_000 // < must be large enough to allow internal transactions to seal blocks
 	MaximumMaxBlockGas          = math.MaxInt64 // < should fit into 64-bit signed integers to avoid parsing errors in third-party libraries
 	defaultTargetGasRate        = 15_000_000    // 15 MGas/s
 	defaultEventEmitterInterval = 600 * time.Millisecond

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -313,6 +313,12 @@ func MainNetRules() Rules {
 			MaxBlockGas:             MinimumMaxBlockGas,
 			MaxEmptyBlockSkipPeriod: inter.Timestamp(1 * time.Minute),
 		},
+		Upgrades: Upgrades{
+			Berlin: true,
+			London: true,
+			Llr:    false,
+			Sonic:  true,
+		},
 	}
 }
 

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -13,7 +13,7 @@ func validate(rules Rules) error {
 		validateDagRules(rules.Dag),
 		validateEmitterRules(rules.Emitter),
 		validateEpochsRules(rules.Epochs),
-		validateBlockRules(rules.Blocks),
+		validateBlocksRules(rules.Blocks),
 		validateEconomyRules(rules.Economy),
 		validateUpgrades(rules.Upgrades),
 	)
@@ -72,14 +72,14 @@ func validateEpochsRules(rules EpochsRules) error {
 	return errors.Join(issues...)
 }
 
-func validateBlockRules(rules BlocksRules) error {
+func validateBlocksRules(rules BlocksRules) error {
 	var issues []error
 
 	if rules.MaxBlockGas < MinimumMaxBlockGas {
-		issues = append(issues, errors.New("MaxBlockGas is too low"))
+		issues = append(issues, errors.New("Blocks.MaxBlockGas is too low"))
 	}
 	if rules.MaxBlockGas > MaximumMaxBlockGas {
-		issues = append(issues, errors.New("MaxBlockGas is too high"))
+		issues = append(issues, errors.New("Blocks.MaxBlockGas is too high"))
 	}
 
 	// The empty-block skip period is not restricted. There are no too low or too high values.
@@ -140,7 +140,11 @@ func validateGasRules(rules GasRules) error {
 		issues = append(issues, errors.New("Gas.MaxEventGas is too low"))
 	}
 
-	if rules.MaxEventGas-rules.EventGas < upperBoundForRuleChangeGasCosts {
+	if rules.EventGas > rules.MaxEventGas {
+		issues = append(issues, errors.New("Gas.EventGas is too high"))
+	}
+
+	if rules.MaxEventGas < upperBoundForRuleChangeGasCosts+rules.EventGas {
 		issues = append(issues, errors.New("Gas.EventGas is too high"))
 	}
 

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -1,0 +1,162 @@
+package opera
+
+import (
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/Fantom-foundation/go-opera/inter"
+)
+
+var (
+	maxMinimumGasPrice = new(big.Int).SetUint64(1000 * 1e9) // 1000 Gwei
+)
+
+func validate(rules Rules) error {
+	return errors.Join(
+		validateDagRules(rules.Dag),
+		validateEmitterRules(rules.Emitter),
+		validateEpochsRules(rules.Epochs),
+		validateBlockRules(rules.Blocks),
+		validateEconomyRules(rules.Economy),
+		validateUpgrades(rules.Upgrades),
+	)
+}
+
+func validateDagRules(rules DagRules) error {
+	var issues []error
+
+	if rules.MaxParents < 2 {
+		issues = append(issues, errors.New("Dag.MaxParents is too low"))
+	}
+
+	if rules.MaxExtraData > 1<<20 { // 1 MB
+		issues = append(issues, errors.New("Dag.MaxExtraData is too high"))
+	}
+
+	return errors.Join(issues...)
+}
+
+func validateEmitterRules(rules EmitterRules) error {
+
+	var issues []error
+	if rules.Interval < inter.Timestamp(100*time.Millisecond) {
+		issues = append(issues, errors.New("Emitter.Interval is too low"))
+	}
+	if rules.Interval > inter.Timestamp(10*time.Second) {
+		issues = append(issues, errors.New("Emitter.Interval is too high"))
+	}
+
+	if rules.StallThreshold < inter.Timestamp(10*time.Second) {
+		issues = append(issues, errors.New("Emitter.StallThreshold is too low"))
+	}
+
+	if rules.StalledInterval < inter.Timestamp(10*time.Second) {
+		issues = append(issues, errors.New("Emitter.StalledInterval is too low"))
+	}
+	if rules.StalledInterval > inter.Timestamp(1*time.Minute) {
+		issues = append(issues, errors.New("Emitter.StalledInterval is too high"))
+	}
+
+	return errors.Join(issues...)
+}
+
+func validateEpochsRules(rules EpochsRules) error {
+	var issues []error
+
+	// MaxEpochGas is not restricted. If it is too low, we will have an epoch per block, which is
+	// not great performance-wise, but it is not invalid. If it is too high, the time limit will
+	// eventually end a long epoch.
+
+	if rules.MaxEpochDuration > inter.Timestamp(24*time.Hour) {
+		issues = append(issues, errors.New("Epochs.MaxEpochDuration is too high"))
+	}
+
+	return errors.Join(issues...)
+}
+
+func validateBlockRules(rules BlocksRules) error {
+	var issues []error
+
+	if rules.MaxBlockGas < MinimumMaxBlockGas {
+		issues = append(issues, errors.New("MaxBlockGas is too low"))
+	}
+	if rules.MaxBlockGas > MaximumMaxBlockGas {
+		issues = append(issues, errors.New("MaxBlockGas is too high"))
+	}
+
+	// The empty-block skip period is not restricted. There are no too low or too high values.
+
+	return errors.Join(issues...)
+}
+
+func validateEconomyRules(rules EconomyRules) error {
+	var issues []error
+
+	if rules.MinGasPrice == nil {
+		issues = append(issues, errors.New("MinGasPrice is nil"))
+	} else {
+		if rules.MinGasPrice.Sign() < 0 {
+			issues = append(issues, errors.New("MinGasPrice is negative"))
+		}
+		if rules.MinGasPrice.Cmp(maxMinimumGasPrice) > 0 {
+			issues = append(issues, errors.New("MinGasPrice is too high"))
+		}
+	}
+
+	if rules.MinBaseFee == nil {
+		issues = append(issues, errors.New("MinBaseFee is nil"))
+	} else {
+		if rules.MinBaseFee.Sign() < 0 {
+			issues = append(issues, errors.New("MinBaseFee is negative"))
+		}
+		if rules.MinBaseFee.Cmp(maxMinimumGasPrice) > 0 {
+			issues = append(issues, errors.New("MinBaseFee is too high"))
+		}
+	}
+
+	// TODO: check BlockMissedSlack
+
+	issues = append(issues, validateGasRules(rules.Gas))
+	issues = append(issues, validateGasPowerRules("Economy.ShortGasPower", rules.ShortGasPower))
+	issues = append(issues, validateGasPowerRules("Economy.LongGasPower", rules.LongGasPower))
+
+	return errors.Join(issues...)
+}
+
+func validateGasRules(rules GasRules) error {
+	var issues []error
+
+	// TODO: implement
+
+	return errors.Join(issues...)
+}
+
+func validateGasPowerRules(prefix string, rules GasPowerRules) error {
+	var issues []error
+
+	// TODO: implement
+
+	return errors.Join(issues...)
+}
+
+func validateUpgrades(upgrade Upgrades) error {
+	var issues []error
+
+	if upgrade.Llr {
+		issues = append(issues, errors.New("LLR upgrade is not supported"))
+	}
+
+	if upgrade.Sonic && !upgrade.London {
+		issues = append(issues, errors.New("Sonic upgrade requires London"))
+	}
+	if upgrade.London && !upgrade.Berlin {
+		issues = append(issues, errors.New("London upgrade requires Berlin"))
+	}
+
+	if !upgrade.Sonic {
+		issues = append(issues, errors.New("Sonic upgrade is required"))
+	}
+
+	return errors.Join(issues...)
+}

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -40,9 +40,6 @@ func validateDagRules(rules DagRules) error {
 func validateEmitterRules(rules EmitterRules) error {
 
 	var issues []error
-	if rules.Interval < inter.Timestamp(100*time.Millisecond) {
-		issues = append(issues, errors.New("Emitter.Interval is too low"))
-	}
 	if rules.Interval > inter.Timestamp(10*time.Second) {
 		issues = append(issues, errors.New("Emitter.Interval is too high"))
 	}

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -2,10 +2,9 @@ package opera
 
 import (
 	"errors"
+	"github.com/0xsoniclabs/sonic/inter"
 	"math/big"
 	"time"
-
-	"github.com/Fantom-foundation/go-opera/inter"
 )
 
 func validate(rules Rules) error {

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -43,10 +43,6 @@ func validateEmitterRules(rules EmitterRules) error {
 		issues = append(issues, errors.New("Emitter.Interval is too high"))
 	}
 
-	if rules.Interval < inter.Timestamp(100*time.Millisecond) {
-		issues = append(issues, errors.New("Emitter.Interval is too low"))
-	}
-
 	if rules.StallThreshold < inter.Timestamp(10*time.Second) {
 		issues = append(issues, errors.New("Emitter.StallThreshold is too low"))
 	}

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -44,7 +44,7 @@ func validateEmitterRules(rules EmitterRules) error {
 	}
 
 	if rules.Interval < inter.Timestamp(100*time.Millisecond) {
-		issues = append(issues, errors.New("Emitter.Interval is too high"))
+		issues = append(issues, errors.New("Emitter.Interval is too low"))
 	}
 
 	if rules.StallThreshold < inter.Timestamp(10*time.Second) {

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -68,7 +68,7 @@ func validateEpochsRules(rules EpochsRules) error {
 	// not great performance-wise, but it is not invalid. If it is too high, the time limit will
 	// eventually end a long epoch.
 
-	if rules.MaxEpochDuration > inter.Timestamp(24*time.Hour) {
+	if rules.MaxEpochDuration > inter.Timestamp(1*time.Hour) {
 		issues = append(issues, errors.New("Epochs.MaxEpochDuration is too high"))
 	}
 

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -195,5 +195,9 @@ func validateUpgrades(upgrade Upgrades) error {
 		issues = append(issues, errors.New("Sonic upgrade is required"))
 	}
 
+	if !upgrade.Allegro {
+		issues = append(issues, errors.New("Allegro upgrade is required"))
+	}
+
 	return errors.Join(issues...)
 }

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -43,6 +43,10 @@ func validateEmitterRules(rules EmitterRules) error {
 		issues = append(issues, errors.New("Emitter.Interval is too high"))
 	}
 
+	if rules.Interval < inter.Timestamp(100*time.Millisecond) {
+		issues = append(issues, errors.New("Emitter.Interval is too high"))
+	}
+
 	if rules.StallThreshold < inter.Timestamp(10*time.Second) {
 		issues = append(issues, errors.New("Emitter.StallThreshold is too low"))
 	}
@@ -182,6 +186,14 @@ func validateUpgrades(upgrade Upgrades) error {
 
 	if upgrade.Llr {
 		issues = append(issues, errors.New("LLR upgrade is not supported"))
+	}
+
+	if !upgrade.London {
+		issues = append(issues, errors.New("London upgrade is required"))
+	}
+	
+	if !upgrade.Berlin {
+		issues = append(issues, errors.New("Berlin upgrade is required"))
 	}
 
 	if upgrade.Sonic && !upgrade.London {

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -102,13 +102,6 @@ func validateEconomyRules(rules EconomyRules) error {
 
 	if rules.MinGasPrice == nil {
 		issues = append(issues, errors.New("MinGasPrice is nil"))
-	} else {
-		if rules.MinGasPrice.Sign() < 0 {
-			issues = append(issues, errors.New("MinGasPrice is negative"))
-		}
-		if rules.MinGasPrice.Cmp(maxMinimumGasPrice) > 0 {
-			issues = append(issues, errors.New("MinGasPrice is too high"))
-		}
 	}
 
 	if rules.MinBaseFee == nil {

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -122,6 +122,19 @@ func validateEconomyRules(rules EconomyRules) error {
 		}
 	}
 
+	if rules.ShortGasPower.StartupAllocPeriod != rules.LongGasPower.StartupAllocPeriod {
+		issues = append(issues, errors.New("ShortGasPower.StartupAllocPeriod and LongGasPower.StartupAllocPeriod differ"))
+	}
+	if rules.ShortGasPower.MaxAllocPeriod != rules.LongGasPower.MaxAllocPeriod {
+		issues = append(issues, errors.New("ShortGasPower.MaxAllocPeriod and LongGasPower.MaxAllocPeriod differ"))
+	}
+	if rules.ShortGasPower.AllocPerSec != rules.LongGasPower.AllocPerSec {
+		issues = append(issues, errors.New("ShortGasPower.AllocPerSec and LongGasPower.AllocPerSec differ"))
+	}
+	if rules.ShortGasPower.MinStartupGas != rules.LongGasPower.MinStartupGas {
+		issues = append(issues, errors.New("ShortGasPower.MinStartupGas and LongGasPower.MinStartupGas differ"))
+	}
+
 	// There are deliberately no checks for the BlockMissedSlack. This can be set to any value.
 
 	issues = append(issues, validateGasRules(rules.Gas))
@@ -191,7 +204,7 @@ func validateUpgrades(upgrade Upgrades) error {
 	if !upgrade.London {
 		issues = append(issues, errors.New("London upgrade is required"))
 	}
-	
+
 	if !upgrade.Berlin {
 		issues = append(issues, errors.New("Berlin upgrade is required"))
 	}

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -1,0 +1,19 @@
+package opera
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultRulesAreValid(t *testing.T) {
+	rules := map[string]Rules{
+		"mainnet": MainNetRules(),
+		"fakenet": FakeNetRules(),
+	}
+	for name, r := range rules {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, r.Validate())
+		})
+	}
+}

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -1,8 +1,12 @@
 package opera
 
 import (
+	"math"
+	"math/big"
 	"testing"
+	"time"
 
+	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,5 +19,450 @@ func TestDefaultRulesAreValid(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, r.Validate())
 		})
+	}
+}
+
+func TestValidate_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules Rules
+		issue string
+	}{
+		"dag rules issue": {
+			rules: Rules{Dag: DagRules{MaxParents: 1}},
+			issue: "Dag.MaxParents is too low",
+		},
+		"emitter rules issue": {
+			rules: Rules{Emitter: EmitterRules{Interval: inter.Timestamp(11 * time.Second)}},
+			issue: "Emitter.Interval is too high",
+		},
+		"epochs rules issue": {
+			rules: Rules{Epochs: EpochsRules{MaxEpochDuration: inter.Timestamp(24*time.Hour) + 1}},
+			issue: "Epochs.MaxEpochDuration is too high",
+		},
+		"blocks rules issue": {
+			rules: Rules{Blocks: BlocksRules{MaxBlockGas: 0}},
+			issue: "Blocks.MaxBlockGas is too low",
+		},
+		"economy rules issue": {
+			rules: Rules{Economy: EconomyRules{Gas: GasRules{MaxEventGas: 1}}},
+			issue: "Gas.MaxEventGas is too low",
+		},
+		"upgrades issue": {
+			rules: Rules{Upgrades: Upgrades{Llr: true}},
+			issue: "LLR upgrade is not supported",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := test.rules.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestDagRulesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules DagRules
+		issue string
+	}{
+		"zero parents are not enough": {
+			rules: DagRules{MaxParents: 0},
+			issue: "MaxParents is too low",
+		},
+		"one parent is not enough": {
+			rules: DagRules{MaxParents: 1},
+			issue: "MaxParents is too low",
+		},
+		"zero free parents are not enough": {
+			rules: DagRules{MaxFreeParents: 0},
+			issue: "MaxFreeParents is too low",
+		},
+		"one free parent is not enough": {
+			rules: DagRules{MaxFreeParents: 1},
+			issue: "MaxFreeParents is too low",
+		},
+		"too much extra data": {
+			rules: DagRules{MaxExtraData: 1<<20 + 1},
+			issue: "MaxExtraData is too high",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateDagRules(test.rules)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestDagRulesValidation_AcceptsValidRules(t *testing.T) {
+	rules := []DagRules{
+		{MaxParents: 2, MaxFreeParents: 2, MaxExtraData: 0},
+		{MaxParents: 2, MaxFreeParents: 2, MaxExtraData: 1 << 20},
+		{MaxParents: 10, MaxFreeParents: 10, MaxExtraData: 1 << 20},
+	}
+
+	for _, test := range rules {
+		require.NoError(t, validateDagRules(test))
+	}
+}
+
+func TestEmitterRulesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules EmitterRules
+		issue string
+	}{
+		"more than 10 seconds emitter times is too high": {
+			rules: EmitterRules{Interval: inter.Timestamp(10*time.Second) + 1},
+			issue: "Interval is too high",
+		},
+		"hour long emitter times is too high": {
+			rules: EmitterRules{Interval: inter.Timestamp(10 * time.Hour)},
+			issue: "Interval is too high",
+		},
+		"stall threshold must be at least 10 seconds": {
+			rules: EmitterRules{StallThreshold: inter.Timestamp(10*time.Second) - 1},
+			issue: "StallThreshold is too low",
+		},
+		"stall interval must be at least 10 seconds": {
+			rules: EmitterRules{StallThreshold: inter.Timestamp(10*time.Second) - 1},
+			issue: "StallThreshold is too low",
+		},
+		"stall intervals of more than 1 minute are too high": {
+			rules: EmitterRules{StalledInterval: inter.Timestamp(1*time.Minute) + 1},
+			issue: "StalledInterval is too high",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateEmitterRules(test.rules)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestEmitterRulesValidation_AcceptsValidRules(t *testing.T) {
+	rules := []EmitterRules{
+		{
+			Interval:        inter.Timestamp(10 * time.Second),
+			StallThreshold:  inter.Timestamp(10 * time.Second),
+			StalledInterval: inter.Timestamp(10 * time.Second),
+		},
+		{
+			Interval:        inter.Timestamp(10 * time.Millisecond),
+			StallThreshold:  inter.Timestamp(10 * time.Second),
+			StalledInterval: inter.Timestamp(1 * time.Minute),
+		},
+		{
+			Interval:        inter.Timestamp(0),
+			StallThreshold:  inter.Timestamp(1 * time.Hour),
+			StalledInterval: inter.Timestamp(30 * time.Second),
+		},
+	}
+
+	for _, test := range rules {
+		require.NoError(t, validateEmitterRules(test))
+	}
+}
+
+func TestEpochsRulesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules EpochsRules
+		issue string
+	}{
+		"more than day long epochs are too high": {
+			rules: EpochsRules{MaxEpochDuration: inter.Timestamp(24*time.Hour) + 1},
+			issue: "MaxEpochDuration is too high",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateEpochsRules(test.rules)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestEpochsRulesValidation_AcceptsValidRules(t *testing.T) {
+	rules := []EpochsRules{
+		{MaxEpochDuration: inter.Timestamp(24 * time.Hour)},
+		{MaxEpochDuration: inter.Timestamp(1 * time.Hour)},
+		{MaxEpochDuration: inter.Timestamp(0)},
+	}
+
+	for _, test := range rules {
+		require.NoError(t, validateEpochsRules(test))
+	}
+}
+
+func TestBlocksRulesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules BlocksRules
+		issue string
+	}{
+		"no block gas": {
+			rules: BlocksRules{MaxBlockGas: 0},
+			issue: "MaxBlockGas is too low",
+		},
+		"max block gas less than minimum is too low": {
+			rules: BlocksRules{MaxBlockGas: MinimumMaxBlockGas - 1},
+			issue: "MaxBlockGas is too low",
+		},
+		"max block gas more than maximum is too high": {
+			rules: BlocksRules{MaxBlockGas: MaximumMaxBlockGas + 1},
+			issue: "MaxBlockGas is too high",
+		},
+		"uint64 max block gas": {
+			rules: BlocksRules{MaxBlockGas: math.MaxUint64},
+			issue: "MaxBlockGas is too high",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateBlocksRules(test.rules)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestBlocksRulesValidation_AcceptsValidRules(t *testing.T) {
+	rules := []BlocksRules{
+		{MaxBlockGas: MinimumMaxBlockGas},
+		{MaxBlockGas: MaximumMaxBlockGas},
+		{MaxBlockGas: MaximumMaxBlockGas / 2},
+	}
+
+	for _, test := range rules {
+		require.NoError(t, validateBlocksRules(test))
+	}
+}
+
+func TestGasRulesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules GasRules
+		issue string
+	}{
+		"zero max event gas is too low": {
+			rules: GasRules{MaxEventGas: 0},
+			issue: "MaxEventGas is too low",
+		},
+		"zero event gas is too low": {
+			rules: GasRules{EventGas: 0},
+			issue: "EventGas is too low",
+		},
+		"less than rule-update gas is too low": {
+			rules: GasRules{MaxEventGas: upperBoundForRuleChangeGasCosts - 1},
+			issue: "MaxEventGas is too low",
+		},
+		"too high event gas costs": {
+			rules: GasRules{EventGas: 1},
+			issue: "EventGas is too high",
+		},
+		"insufficient capacity for rule update": {
+			rules: GasRules{MaxEventGas: upperBoundForRuleChangeGasCosts, EventGas: 1},
+			issue: "EventGas is too high",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateGasRules(test.rules)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestGasRulesValidation_AcceptsValidRules(t *testing.T) {
+	rules := []GasRules{
+		{MaxEventGas: upperBoundForRuleChangeGasCosts, EventGas: 0},
+		{MaxEventGas: upperBoundForRuleChangeGasCosts + 10, EventGas: 10},
+		{MaxEventGas: upperBoundForRuleChangeGasCosts + 15, EventGas: 10},
+		{MaxEventGas: 1000 * upperBoundForRuleChangeGasCosts, EventGas: 10000},
+	}
+
+	for _, test := range rules {
+		require.NoError(t, validateGasRules(test))
+	}
+}
+
+func TestEconomyRulesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules EconomyRules
+		issue string
+	}{
+		"min gas price must not be nil": {
+			rules: EconomyRules{MinGasPrice: nil},
+			issue: "MinGasPrice is nil",
+		},
+		"negative min gas price is too low": {
+			rules: EconomyRules{MinGasPrice: big.NewInt(-1)},
+			issue: "MinGasPrice is negative",
+		},
+		"too high min gas price is too high": {
+			rules: EconomyRules{MinGasPrice: new(big.Int).Add(maxMinimumGasPrice, big.NewInt(1))},
+			issue: "MinGasPrice is too high",
+		},
+		"min base fee must not be nil": {
+			rules: EconomyRules{MinBaseFee: nil},
+			issue: "MinBaseFee is nil",
+		},
+		"negative min base fee is too low": {
+			rules: EconomyRules{MinBaseFee: big.NewInt(-1)},
+			issue: "MinBaseFee is negative",
+		},
+		"too high min base fee is too high": {
+			rules: EconomyRules{MinBaseFee: new(big.Int).Add(maxMinimumGasPrice, big.NewInt(1))},
+			issue: "MinBaseFee is too high",
+		},
+		"too low event gas": {
+			rules: EconomyRules{Gas: GasRules{MaxEventGas: 1}},
+			issue: "MaxEventGas is too low",
+		},
+		"too low short-gas allocation per second": {
+			rules: EconomyRules{ShortGasPower: GasPowerRules{AllocPerSec: 1}},
+			issue: "ShortGasPower.AllocPerSec is too low",
+		},
+		"too low long-gas allocation per second": {
+			rules: EconomyRules{LongGasPower: GasPowerRules{AllocPerSec: 1}},
+			issue: "LongGasPower.AllocPerSec is too low",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateEconomyRules(test.rules)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestEconomyRulesValidation_AcceptsValidRules(t *testing.T) {
+	valid := EconomyRules{
+		Gas: GasRules{
+			MaxEventGas: upperBoundForRuleChangeGasCosts,
+		},
+		MinGasPrice: big.NewInt(0),
+		MinBaseFee:  big.NewInt(0),
+		ShortGasPower: GasPowerRules{
+			AllocPerSec:        10 * upperBoundForRuleChangeGasCosts,
+			MaxAllocPeriod:     inter.Timestamp(time.Second),
+			StartupAllocPeriod: inter.Timestamp(time.Second),
+		},
+		LongGasPower: GasPowerRules{
+			AllocPerSec:        12 * upperBoundForRuleChangeGasCosts,
+			MaxAllocPeriod:     inter.Timestamp(2 * time.Second),
+			StartupAllocPeriod: inter.Timestamp(3 * time.Second),
+		},
+	}
+
+	require.NoError(t, validateEconomyRules(valid))
+}
+
+func TestGasPowerRulesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		rules GasPowerRules
+		issue string
+	}{
+		"zero gas allocation per second is too low": {
+			rules: GasPowerRules{AllocPerSec: 0},
+			issue: "AllocPerSec is too low",
+		},
+		"too low allocation per second": {
+			rules: GasPowerRules{AllocPerSec: 10*upperBoundForRuleChangeGasCosts - 1},
+			issue: "AllocPerSec is too low",
+		},
+		"no allocation period is too low": {
+			rules: GasPowerRules{MaxAllocPeriod: 0},
+			issue: "AllocPeriod is too low",
+		},
+		"less than a second allocation period is too low": {
+			rules: GasPowerRules{MaxAllocPeriod: inter.Timestamp(time.Second) - 1},
+			issue: "AllocPeriod is too low",
+		},
+		"more than a minute allocation period is too high": {
+			rules: GasPowerRules{MaxAllocPeriod: inter.Timestamp(time.Minute) + 1},
+			issue: "AllocPeriod is too high",
+		},
+		"less than a second startup period is too low": {
+			rules: GasPowerRules{StartupAllocPeriod: inter.Timestamp(time.Second) - 1},
+			issue: "StartupAllocPeriod is too low",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateGasPowerRules("", test.rules)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestGasPowerRulesValidation_AcceptsValidRules(t *testing.T) {
+	sec := inter.Timestamp(time.Second)
+	min := inter.Timestamp(time.Minute)
+	rules := []GasPowerRules{
+		{AllocPerSec: 10 * upperBoundForRuleChangeGasCosts, MaxAllocPeriod: 1 * sec, StartupAllocPeriod: 1 * sec},
+		{AllocPerSec: 10 * upperBoundForRuleChangeGasCosts, MaxAllocPeriod: 1 * min, StartupAllocPeriod: 1 * sec},
+		{AllocPerSec: 10 * upperBoundForRuleChangeGasCosts, MaxAllocPeriod: 1 * min, StartupAllocPeriod: 1 * min},
+		{AllocPerSec: math.MaxUint64, MaxAllocPeriod: 1 * min, StartupAllocPeriod: 1 * min},
+	}
+
+	for _, test := range rules {
+		require.NoError(t, validateGasPowerRules("", test))
+	}
+}
+
+func TestUpgradesValidation_DetectsIssues(t *testing.T) {
+	issues := map[string]struct {
+		upgrade Upgrades
+		issue   string
+	}{
+		"LLR upgrade is not supported": {
+			upgrade: Upgrades{Llr: true},
+			issue:   "LLR upgrade is not supported",
+		},
+		"Sonic upgrade requires London": {
+			upgrade: Upgrades{Sonic: true},
+			issue:   "Sonic upgrade requires London",
+		},
+		"London upgrade requires Berlin": {
+			upgrade: Upgrades{London: true},
+			issue:   "London upgrade requires Berlin",
+		},
+		"Sonic upgrade is required": {
+			upgrade: Upgrades{},
+			issue:   "Sonic upgrade is required",
+		},
+	}
+
+	for name, test := range issues {
+		t.Run(name, func(t *testing.T) {
+			err := validateUpgrades(test.upgrade)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.issue)
+		})
+	}
+}
+
+func TestUpgradesValidation_AcceptsValidRules(t *testing.T) {
+	upgrades := []Upgrades{
+		{Berlin: true, London: true, Sonic: true},
+		{Berlin: true, London: true, Sonic: true, CheckRuleChanges: true},
+	}
+
+	for _, test := range upgrades {
+		require.NoError(t, validateUpgrades(test))
 	}
 }

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -119,6 +119,10 @@ func TestEmitterRulesValidation_DetectsIssues(t *testing.T) {
 			rules: EmitterRules{Interval: inter.Timestamp(10*time.Second) + 1},
 			issue: "Interval is too high",
 		},
+		"less than 100 milliseconds emitter times is too low": {
+			rules: EmitterRules{Interval: inter.Timestamp(100*time.Millisecond) - 1},
+			issue: "Interval is too high",
+		},
 		"hour long emitter times is too high": {
 			rules: EmitterRules{Interval: inter.Timestamp(10 * time.Hour)},
 			issue: "Interval is too high",
@@ -429,6 +433,14 @@ func TestUpgradesValidation_DetectsIssues(t *testing.T) {
 		upgrade Upgrades
 		issue   string
 	}{
+		"Berlin upgrade is required": {
+			upgrade: Upgrades{},
+			issue:   "Berlin upgrade is required",
+		},
+		"London upgrade is required": {
+			upgrade: Upgrades{},
+			issue:   "London upgrade is required",
+		},
 		"LLR upgrade is not supported": {
 			upgrade: Upgrades{Llr: true},
 			issue:   "LLR upgrade is not supported",

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -199,7 +199,6 @@ func TestEpochsRulesValidation_DetectsIssues(t *testing.T) {
 
 func TestEpochsRulesValidation_AcceptsValidRules(t *testing.T) {
 	rules := []EpochsRules{
-		{MaxEpochDuration: inter.Timestamp(24 * time.Hour)},
 		{MaxEpochDuration: inter.Timestamp(1 * time.Hour)},
 		{MaxEpochDuration: inter.Timestamp(0)},
 	}

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -122,7 +122,7 @@ func TestEmitterRulesValidation_DetectsIssues(t *testing.T) {
 		},
 		"less than 100 milliseconds emitter times is too low": {
 			rules: EmitterRules{Interval: inter.Timestamp(100*time.Millisecond) - 1},
-			issue: "Interval is too high",
+			issue: "Interval is too low",
 		},
 		"hour long emitter times is too high": {
 			rules: EmitterRules{Interval: inter.Timestamp(10 * time.Hour)},

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -120,10 +120,6 @@ func TestEmitterRulesValidation_DetectsIssues(t *testing.T) {
 			rules: EmitterRules{Interval: inter.Timestamp(10*time.Second) + 1},
 			issue: "Interval is too high",
 		},
-		"less than 100 milliseconds emitter times is too low": {
-			rules: EmitterRules{Interval: inter.Timestamp(100*time.Millisecond) - 1},
-			issue: "Interval is too low",
-		},
 		"hour long emitter times is too high": {
 			rules: EmitterRules{Interval: inter.Timestamp(10 * time.Hour)},
 			issue: "Interval is too high",

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -1,19 +1,19 @@
 package opera
 
 import (
+	"github.com/0xsoniclabs/sonic/inter"
 	"math"
 	"math/big"
 	"testing"
 	"time"
 
-	"github.com/Fantom-foundation/go-opera/inter"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultRulesAreValid(t *testing.T) {
 	rules := map[string]Rules{
 		"mainnet": MainNetRules(),
-		"fakenet": FakeNetRules(),
+		"fakenet": FakeNetRules(AllegroFeatures),
 	}
 	for name, r := range rules {
 		t.Run(name, func(t *testing.T) {
@@ -459,7 +459,7 @@ func TestUpgradesValidation_DetectsIssues(t *testing.T) {
 func TestUpgradesValidation_AcceptsValidRules(t *testing.T) {
 	upgrades := []Upgrades{
 		{Berlin: true, London: true, Sonic: true},
-		{Berlin: true, London: true, Sonic: true, CheckRuleChanges: true},
+		{Berlin: true, London: true, Sonic: true, Allegro: true},
 	}
 
 	for _, test := range upgrades {

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -445,6 +445,10 @@ func TestUpgradesValidation_DetectsIssues(t *testing.T) {
 			upgrade: Upgrades{},
 			issue:   "Sonic upgrade is required",
 		},
+		"Allegro upgrade is required": {
+			upgrade: Upgrades{},
+			issue:   "Allegro upgrade is required",
+		},
 	}
 
 	for name, test := range issues {

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -1,6 +1,7 @@
 package opera
 
 import (
+	"fmt"
 	"github.com/0xsoniclabs/sonic/inter"
 	"math"
 	"math/big"
@@ -158,19 +159,21 @@ func TestEmitterRulesValidation_AcceptsValidRules(t *testing.T) {
 			StalledInterval: inter.Timestamp(10 * time.Second),
 		},
 		{
-			Interval:        inter.Timestamp(10 * time.Millisecond),
+			Interval:        inter.Timestamp(100 * time.Millisecond),
 			StallThreshold:  inter.Timestamp(10 * time.Second),
 			StalledInterval: inter.Timestamp(1 * time.Minute),
 		},
 		{
-			Interval:        inter.Timestamp(0),
+			Interval:        inter.Timestamp(3 * time.Second),
 			StallThreshold:  inter.Timestamp(1 * time.Hour),
 			StalledInterval: inter.Timestamp(30 * time.Second),
 		},
 	}
 
-	for _, test := range rules {
-		require.NoError(t, validateEmitterRules(test))
+	for i, test := range rules {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			require.NoError(t, validateEmitterRules(test))
+		})
 	}
 }
 
@@ -308,14 +311,6 @@ func TestEconomyRulesValidation_DetectsIssues(t *testing.T) {
 			rules: EconomyRules{MinGasPrice: nil},
 			issue: "MinGasPrice is nil",
 		},
-		"negative min gas price is too low": {
-			rules: EconomyRules{MinGasPrice: big.NewInt(-1)},
-			issue: "MinGasPrice is negative",
-		},
-		"too high min gas price is too high": {
-			rules: EconomyRules{MinGasPrice: new(big.Int).Add(maxMinimumGasPrice, big.NewInt(1))},
-			issue: "MinGasPrice is too high",
-		},
 		"min base fee must not be nil": {
 			rules: EconomyRules{MinBaseFee: nil},
 			issue: "MinBaseFee is nil",
@@ -404,9 +399,9 @@ func TestEconomyRulesValidation_AcceptsValidRules(t *testing.T) {
 			StartupAllocPeriod: inter.Timestamp(time.Second),
 		},
 		LongGasPower: GasPowerRules{
-			AllocPerSec:        12 * upperBoundForRuleChangeGasCosts,
-			MaxAllocPeriod:     inter.Timestamp(2 * time.Second),
-			StartupAllocPeriod: inter.Timestamp(3 * time.Second),
+			AllocPerSec:        10 * upperBoundForRuleChangeGasCosts,
+			MaxAllocPeriod:     inter.Timestamp(time.Second),
+			StartupAllocPeriod: inter.Timestamp(time.Second),
 		},
 	}
 
@@ -514,7 +509,6 @@ func TestUpgradesValidation_DetectsIssues(t *testing.T) {
 
 func TestUpgradesValidation_AcceptsValidRules(t *testing.T) {
 	upgrades := []Upgrades{
-		{Berlin: true, London: true, Sonic: true},
 		{Berlin: true, London: true, Sonic: true, Allegro: true},
 	}
 

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -188,7 +188,7 @@ func StartIntegrationTestNetWithJsonGenesis(
 	jsonGenesis.Accounts = append(jsonGenesis.Accounts, effectiveOptions.Accounts...)
 
 	// Speed up the block generation time to reduce test time.
-	jsonGenesis.Rules.Emitter.Interval = inter.Timestamp(time.Millisecond)
+	jsonGenesis.Rules.Emitter.Interval = inter.Timestamp(100 * time.Millisecond)
 
 	encoded, err := json.MarshalIndent(jsonGenesis, "", "  ")
 	if err != nil {

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -188,7 +188,7 @@ func StartIntegrationTestNetWithJsonGenesis(
 	jsonGenesis.Accounts = append(jsonGenesis.Accounts, effectiveOptions.Accounts...)
 
 	// Speed up the block generation time to reduce test time.
-	jsonGenesis.Rules.Emitter.Interval = inter.Timestamp(100 * time.Millisecond)
+	jsonGenesis.Rules.Emitter.Interval = inter.Timestamp(time.Millisecond)
 
 	encoded, err := json.MarshalIndent(jsonGenesis, "", "  ")
 	if err != nil {


### PR DESCRIPTION
This PR introduces a network rule verification infrastructure and adds support for validating rule changes on the network.

The rule verification code covers basic rule properties by constraining the domain of various rule parameters. The main goal of those constraints is to prevent an accidental network stall. These validation steps are to be considered a last line of defense to safe-guard the network lifelines. However, they are necessarily incomplete. Any change of network rules should be tested extensively before being applied on production networks.

To facilitate a safe roll-out, the validation step is ignored by default. Only a rule-update will enable this features. To prevent a network split, the validation features should only be updated once sufficient (ideally all) nodes on the network have been updated to support this feature.

This PR follows-up on https://github.com/Fantom-foundation/Sonic/pull/383