### PR TITLE
Add `GetBalance` to `LightClient`

### DIFF
--- a/scc/light_client/light_client.go
+++ b/scc/light_client/light_client.go
@@ -89,13 +89,12 @@ func (c *LightClient) getAccountProof(address common.Address) (carmen.WitnessPro
 // the balance could not be proven or there was any error
 // in getting or verifying the proof.
 func (c *LightClient) GetBalance(address common.Address) (*uint256.Int, error) {
-	if !c.state.hasSynced {
-		return nil, fmt.Errorf("light client has not yet synced")
-	}
 	proof, err := c.getAccountProof(address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get account proof: %w", err)
 	}
+	// it is safe to use the state.headRoot here because if the state had not been synced,
+	// getAccountProof would have returned an error earlier.
 	value, proven, err := proof.GetBalance(carmen.Hash(c.state.headRoot),
 		carmen.Address(address))
 	if err != nil {

--- a/scc/light_client/light_client.go
+++ b/scc/light_client/light_client.go
@@ -5,8 +5,11 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
 )
 
 // LightClient is the main entry point for the light client.
@@ -18,7 +21,7 @@ type LightClient struct {
 }
 
 // Config is used to configure the LightClient.
-// It requires a list of urls for the certificate providers and an initial committee.
+// It requires a list of URLs for the certificate providers and an initial committee.
 type Config struct {
 	Url     []*url.URL
 	Genesis scc.Committee
@@ -28,7 +31,7 @@ type Config struct {
 }
 
 // NewLightClient creates a new LightClient with the given config.
-// Returns an error if the config does not contain a valid provider url or committee.
+// Returns an error if the config does not contain a valid provider URL or committee.
 func NewLightClient(config Config) (*LightClient, error) {
 	if err := config.Genesis.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid committee provided: %w", err)
@@ -53,7 +56,7 @@ func NewLightClient(config Config) (*LightClient, error) {
 }
 
 // Close closes the light client provider.
-// Closing an already closed client has no effect
+// Closing an already closed client has no effect.
 func (c *LightClient) Close() {
 	c.provider.close()
 }
@@ -63,4 +66,79 @@ func (c *LightClient) Close() {
 // with the network.
 func (c *LightClient) Sync() (idx.Block, error) {
 	return c.state.sync(c.provider)
+}
+
+// getAccountProof retrieves and verifies the proof for the given address.
+// It first ensures the client is synchronized before querying for the proof.
+// Returns an error if synchronization fails, if the proof cannot be obtained.
+func (c *LightClient) getAccountProof(address common.Address) (carmen.WitnessProof, error) {
+	// always sync before querying
+	_, err := c.Sync()
+	if err != nil {
+		return nil, fmt.Errorf("failed to sync: %w", err)
+	}
+	proof, err := c.provider.getAccountProof(address, LatestBlock)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get account proof: %w", err)
+	}
+	if proof == nil {
+		return nil, fmt.Errorf("nil account proof for address %v", address)
+	}
+	return proof, nil
+}
+
+// GetBalance returns the balance of the given address.
+// It returns an error if the balance could not be proven or there was any error
+// in getting or verifying the proof.
+func (c *LightClient) GetBalance(address common.Address) (*uint256.Int, error) {
+	balance, err := getInfoFromProof(address, c, "balance",
+		func(
+			proof carmen.WitnessProof,
+			address common.Address,
+			rootHash common.Hash,
+		) (carmen.Amount, bool, error) {
+			return proof.GetBalance(carmen.Hash(rootHash), carmen.Address(address))
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	balanceInt := balance.Uint256()
+	return &balanceInt, nil
+}
+
+// getInfoFromProof runs a function `f` that takes a proof, the provided address
+// and the provided state root hash, to retrieve a value of type T.
+//
+// If the proof is missing, invalid, or does not confirm the requested information,
+// an error is returned.
+//
+// Parameters:
+// - address: The address whose data is being queried.
+// - c: The LightClient instance handling the request.
+// - valueName: A string representing the type of value being retrieved (e.g., "balance").
+// - f: A function that takes (proof, address, rootHash) and returns (T, proven, error).
+//
+// Returns:
+// - The requested value of type T if proven successfully, otherwise an error.
+func getInfoFromProof[T any](address common.Address, c *LightClient, valueName string,
+	f func(carmen.WitnessProof, common.Address, common.Hash) (T, bool, error)) (T, error) {
+	var zeroValue T
+	proof, err := c.getAccountProof(address)
+	if err != nil {
+		return zeroValue, fmt.Errorf("failed to get account proof: %w", err)
+	}
+	// it is safe to ignore the hasSynced flag here because if there was an error
+	// during sync, it would have triggered an early return.
+	rootHash, _ := c.state.stateRoot()
+	value, proven, err := f(proof, address, rootHash)
+	if err != nil {
+		return zeroValue, fmt.Errorf("failed to get %v from proof: %w", valueName, err)
+	}
+	if !proven {
+		return zeroValue,
+			fmt.Errorf("%v could not be proven from the proof and state root hash",
+				valueName)
+	}
+	return value, err
 }

--- a/scc/light_client/light_client_test.go
+++ b/scc/light_client/light_client_test.go
@@ -123,43 +123,20 @@ func TestLightClientState_Sync_UpdatesStateToHead(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	prov := NewMockprovider(ctrl)
 
-	// setup block for period 1.
-	blockNumber := idx.Block(scc.BLOCKS_PER_PERIOD*1 + 1)
-	blockCert := cert.NewCertificate(
-		cert.NewBlockStatement(0, blockNumber, common.Hash{0x1}, common.Hash{0x2}))
-
-	// setup committee certificate for period 1.
+	// Setup test data
 	key := bls.NewPrivateKey()
-	member := makeMember(key)
-	committeeCert1 := cert.NewCertificate(cert.CommitteeStatement{
-		Period:    1,
-		Committee: scc.NewCommittee(member),
-	})
+	blockCert, blockNumber := setupBlockCertificate(t, key)
+	committeeCert := setupCommitteeCertificate(t, key)
 
-	// member signs the certificates
-	err := committeeCert1.Add(scc.MemberId(0), cert.Sign(committeeCert1.Subject(), key))
-	require.NoError(err)
-	err = blockCert.Add(scc.MemberId(0), cert.Sign(blockCert.Subject(), key))
+	// Mock provider calls
+	mockProviderResponses(prov, blockCert, committeeCert)
+
+	// Create and configure LightClient
+	client, err := setupLightClient(prov, key)
 	require.NoError(err)
 
-	// provider calls
-	prov.EXPECT().
-		getBlockCertificates(LatestBlock, uint64(1)).
-		Return([]cert.BlockCertificate{blockCert}, nil)
-	prov.EXPECT().
-		getCommitteeCertificates(scc.Period(1), uint64(1)).
-		Return([]cert.CommitteeCertificate{committeeCert1}, nil)
-
-	// sync
-	u, _ := url.Parse("http://localhost:4242")
-	config := Config{
-		Url:     []*url.URL{u},
-		Genesis: scc.NewCommittee(member),
-	}
-	c, err := NewLightClient(config)
-	require.NoError(err)
-	c.provider = prov
-	head, err := c.Sync()
+	// Perform sync
+	head, err := client.Sync()
 	require.NoError(err)
 
 	// check state
@@ -186,4 +163,65 @@ func testConfig() Config {
 		Url:     []*url.URL{u},
 		Genesis: scc.NewCommittee(makeMember(key)),
 	}
+}
+
+// setupBlockCertificate creates a block certificate for the second block of
+// period 1 and signs it with the given key.
+// Returns the block certificate and the block number.
+func setupBlockCertificate(t *testing.T, key bls.PrivateKey) (cert.BlockCertificate, idx.Block) {
+	blockNumber := idx.Block(scc.BLOCKS_PER_PERIOD*1 + 1)
+	blockCert := cert.NewCertificate(
+		cert.NewBlockStatement(0, blockNumber, common.Hash{0x1}, common.Hash{0x2}),
+	)
+
+	// Sign certificate
+	err := blockCert.Add(scc.MemberId(0), cert.Sign(blockCert.Subject(), key))
+	require.NoError(t, err)
+
+	return blockCert, blockNumber
+}
+
+// setupCommitteeCertificate creates a committee certificate for period 1 and
+// signs it with the given key.
+// Returns the committee certificate.
+func setupCommitteeCertificate(t *testing.T, key bls.PrivateKey) cert.CommitteeCertificate {
+	member := makeMember(key)
+	committeeCert := cert.NewCertificate(cert.CommitteeStatement{
+		Period:    1,
+		Committee: scc.NewCommittee(member),
+	})
+
+	// Sign certificate
+	err := committeeCert.Add(scc.MemberId(0), cert.Sign(committeeCert.Subject(), key))
+	require.NoError(t, err)
+
+	return committeeCert
+}
+
+// mockProviderResponses mocks the provider responses for block and committee certificates
+func mockProviderResponses(prov *Mockprovider, blockCert cert.BlockCertificate, committeeCert cert.CommitteeCertificate) {
+	prov.EXPECT().
+		getBlockCertificates(LatestBlock, uint64(1)).
+		Return([]cert.BlockCertificate{blockCert}, nil)
+
+	prov.EXPECT().
+		getCommitteeCertificates(scc.Period(1), uint64(1)).
+		Return([]cert.CommitteeCertificate{committeeCert}, nil)
+}
+
+// setupLightClient creates a LightClient with a committee member based on
+// the given key and a used the given provider for the client.
+func setupLightClient(prov *Mockprovider, key bls.PrivateKey) (*LightClient, error) {
+	u, _ := url.Parse("http://localhost:4242")
+	config := Config{
+		Url:     []*url.URL{u},
+		Genesis: scc.NewCommittee(makeMember(key)),
+	}
+	client, err := NewLightClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	client.provider = prov
+	return client, nil
 }

--- a/scc/light_client/light_client_test.go
+++ b/scc/light_client/light_client_test.go
@@ -5,11 +5,13 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/sonic/scc"
 	"github.com/0xsoniclabs/sonic/scc/bls"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -143,6 +145,140 @@ func TestLightClientState_Sync_UpdatesStateToHead(t *testing.T) {
 	require.Equal(blockNumber, head)
 }
 
+func TestLightClient_getAccountProof_ReportsErrorOnSyncFailure(t *testing.T) {
+	// setup
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	prov := NewMockprovider(ctrl)
+
+	// expect
+	prov.EXPECT().getBlockCertificates(LatestBlock, uint64(1)).
+		Return(nil, fmt.Errorf("failed to sync"))
+
+	// build client
+	c, err := NewLightClient(testConfig())
+	require.NoError(err)
+	c.provider = prov
+
+	// check
+	_, err = c.getAccountProof(common.Address{0x01})
+	require.ErrorContains(err, "failed to sync")
+}
+
+func TestLightClient_getAccountProof_ReportsErrorsFrom(t *testing.T) {
+	require := require.New(t)
+	address := common.Address{0x01}
+
+	tests := map[string]struct {
+		mockProvider func(*Mockprovider)
+		expectedErr  string
+	}{
+		"ProviderError": {
+			mockProvider: func(prov *Mockprovider) {
+				prov.EXPECT().getAccountProof(address, idx.Block(LatestBlock)).
+					Return(nil, fmt.Errorf("some error"))
+			},
+			expectedErr: "failed to get account proof",
+		},
+		"NilProof": {
+			mockProvider: func(prov *Mockprovider) {
+				prov.EXPECT().getAccountProof(address, idx.Block(LatestBlock)).
+					Return(nil, nil)
+			},
+			expectedErr: "nil account proof",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, prov := setupForTestSync(t)
+			tt.mockProvider(prov)
+			_, err := client.getAccountProof(address)
+			require.ErrorContains(err, tt.expectedErr)
+		})
+	}
+}
+
+func TestLightClient_getAccountProof_ReturnsProof(t *testing.T) {
+	require := require.New(t)
+	client, prov := setupForTestSync(t)
+
+	want := carmen.CreateWitnessProofFromNodes()
+	prov.EXPECT().getAccountProof(common.Address{0x01}, idx.Block(LatestBlock)).
+		Return(want, nil)
+
+	got, err := client.getAccountProof(common.Address{0x01})
+	require.NoError(err)
+	require.Equal(want, got)
+}
+
+func TestLightClient_GetBalance_PropagatesErrorFrom(t *testing.T) {
+	tests := map[string]struct {
+		mockExpect  func(*Mockprovider, *carmen.MockWitnessProof)
+		expectedErr string
+	}{
+		"getAccountProof": {
+			mockExpect: func(prov *Mockprovider, _ *carmen.MockWitnessProof) {
+				prov.EXPECT().getAccountProof(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("some error"))
+			},
+			expectedErr: "failed to get account proof",
+		},
+		"proofGetBalance": {
+			mockExpect: func(prov *Mockprovider, proof *carmen.MockWitnessProof) {
+				prov.EXPECT().getAccountProof(gomock.Any(), idx.Block(LatestBlock)).
+					Return(proof, nil)
+				proof.EXPECT().GetBalance(gomock.Any(), gomock.Any()).
+					Return(carmen.NewAmountFromUint256(uint256.NewInt(0)), false, fmt.Errorf("some error"))
+			},
+			expectedErr: "failed to get balance from proof",
+		},
+		"balanceNotProven": {
+			mockExpect: func(prov *Mockprovider, proof *carmen.MockWitnessProof) {
+				prov.EXPECT().getAccountProof(gomock.Any(), idx.Block(LatestBlock)).
+					Return(proof, nil)
+				proof.EXPECT().GetBalance(gomock.Any(), gomock.Any()).
+					Return(carmen.NewAmountFromUint256(uint256.NewInt(0)), false, nil)
+			},
+			expectedErr: "balance could not be proven",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			client, prov := setupForTestSync(t)
+			proof := carmen.NewMockWitnessProof(ctrl)
+
+			tt.mockExpect(prov, proof)
+
+			_, err := client.GetBalance(common.Address{0x01})
+			require.ErrorContains(err, tt.expectedErr)
+		})
+	}
+}
+
+func TestLightClient_GetBalance_ReturnsBalance(t *testing.T) {
+	require := require.New(t)
+	client, prov := setupForTestSync(t)
+	ctrl := gomock.NewController(t)
+	wantBalance := uint256.NewInt(42)
+
+	proof := carmen.NewMockWitnessProof(ctrl)
+	proof.EXPECT().GetBalance(gomock.Any(), carmen.Address{0x01}).
+		Return(carmen.NewAmountFromUint256(wantBalance), true, nil)
+
+	// setup rpc provider to return proof
+	prov.EXPECT().getAccountProof(common.Address{0x01}, idx.Block(LatestBlock)).
+		Return(proof, nil)
+
+	// get balance function receives the proof and uses the state root to verify
+	balance, err := client.GetBalance(common.Address{0x01})
+	require.NoError(err)
+	require.Equal(wantBalance, balance)
+}
+
 /////////////////////////////////////////////////////
 // Helper functions for testing
 /////////////////////////////////////////////////////
@@ -224,4 +360,22 @@ func setupLightClient(prov *Mockprovider, key bls.PrivateKey) (*LightClient, err
 
 	client.provider = prov
 	return client, nil
+}
+
+// setupForTestSync sets up a light client and the necessary mocks for a
+// successful sync test.
+// - sets up a mock provider that will return valid block/committee certificates
+// Returns the client
+func setupForTestSync(t *testing.T) (*LightClient, *Mockprovider) {
+	ctrl := gomock.NewController(t)
+	prov := NewMockprovider(ctrl)
+
+	key := bls.NewPrivateKey()
+	blockCert, _ := setupBlockCertificate(t, key)
+	committeeCert := setupCommitteeCertificate(t, key)
+	client, err := setupLightClient(prov, key)
+	require.NoError(t, err)
+
+	mockProviderResponses(prov, blockCert, committeeCert)
+	return client, prov
 }


### PR DESCRIPTION
This PR adds the method `GetBalance` to the `LightClient` enabling it to ask for the balance of a given account, verifying it with the known state root certificate. 
This PR:
- adds the method `getAccountProof` which given an account, returns the witness proof for it, using the corresponding provider method.
- adds the method `GetBalance` which given an address, returns it's balance or an error. uses `getAccoutProof` to get a proof for the state's current head and the given address (of an account), and then validate it using the state's root hash.
