### PR TITLE
Modify RPC callbacks to execute EIP-2935 History Storage Contract.

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1062,6 +1062,11 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 		evm.Cancel()
 	}()
 
+	// execute EIP-2935 HistoryStorage contract.
+	if evm.ChainConfig().IsPrague(header.Number, uint64(header.Time.Unix())) {
+		evmcore.ProcessParentBlockHash(header.ParentHash, evm)
+	}
+
 	// Execute the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
 	result, err := core.ApplyMessage(evm, msg, gp)
@@ -2317,6 +2322,11 @@ func stateAtTransaction(ctx context.Context, block *evmcore.EvmBlock, txIndex in
 	if err != nil {
 		statedb.Release()
 		return nil, nil, err
+	}
+
+	// execute EIP-2935 HistoryStorage contract.
+	if vmenv.ChainConfig().IsPrague(block.Number, uint64(block.Time.Unix())) {
+		evmcore.ProcessParentBlockHash(block.ParentHash, vmenv)
 	}
 
 	// Recompute transactions up to the target index.

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1049,7 +1049,7 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 		blockOverrides.apply(&bctx)
 		blockCtx = &bctx
 	}
-	evm, vmError, err := b.GetEVM(ctx, msg, state, header, &vmConfig, blockCtx)
+	evm, vmError, err := b.GetEVM(ctx, state, header, &vmConfig, blockCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -1519,7 +1519,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		config := opera.DefaultVMConfig
 		config.Tracer = tracer.Hooks()
 		config.NoBaseFee = true
-		vmenv, _, err := b.GetEVM(ctx, msg, statedb, header, &config, nil)
+		vmenv, _, err := b.GetEVM(ctx, statedb, header, &config, nil)
 		if err != nil {
 			statedb.Release()
 			return nil, 0, nil, err
@@ -2167,7 +2167,7 @@ func (api *PublicDebugAPI) traceTx(ctx context.Context, tx *types.Transaction, m
 
 	loggingStateDB := evmstore.WrapStateDbWithLogger(statedb, tracer.Hooks)
 
-	vmenv, _, err := api.b.GetEVM(ctx, message, loggingStateDB, blockHeader, &evmconfig, blockCtx)
+	vmenv, _, err := api.b.GetEVM(ctx, loggingStateDB, blockHeader, &evmconfig, blockCtx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get EVM for tracing: %w", err)
 	}
@@ -2310,6 +2310,15 @@ func stateAtTransaction(ctx context.Context, block *evmcore.EvmBlock, txIndex in
 		return nil, statedb, nil
 	}
 
+	// Use default config for replaying transactions with possible no base fee
+	cfg := opera.DefaultVMConfig
+	cfg.NoBaseFee = true
+	vmenv, _, err := b.GetEVM(ctx, statedb, block.Header(), &cfg, nil)
+	if err != nil {
+		statedb.Release()
+		return nil, nil, err
+	}
+
 	// Recompute transactions up to the target index.
 	signer := gsignercache.Wrap(types.MakeSigner(b.ChainConfig(), block.Number, uint64(block.Time.Unix())))
 	for idx, tx := range block.Transactions {
@@ -2322,16 +2331,6 @@ func stateAtTransaction(ctx context.Context, block *evmcore.EvmBlock, txIndex in
 			return msg, statedb, nil
 		}
 
-		// Use default config for replaying transactions with possible no base fee
-		cfg := opera.DefaultVMConfig
-		cfg.NoBaseFee = true
-
-		// Not yet the searched for transaction, execute on top of the current state
-		vmenv, _, err := b.GetEVM(ctx, msg, statedb, block.Header(), &cfg, nil)
-		if err != nil {
-			statedb.Release()
-			return nil, nil, err
-		}
 		statedb.SetTxContext(tx.Hash(), idx)
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 			statedb.Release()

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
@@ -596,6 +598,325 @@ func TestTransactionJSONSerialization(t *testing.T) {
 	}
 }
 
+func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
+
+	senderKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	sender := crypto.PubkeyToAddress(senderKey.PublicKey)
+	recipient := common.Address{0x2}
+
+	executeDoCall := func(t *testing.T, backend Backend, txArgs TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash) {
+		var stateOverrides *StateOverride
+		var blockOverrides *BlockOverrides
+		timeout := time.Duration(time.Second)
+		gasCap := uint64(10000000)
+
+		result, err := DoCall(t.Context(), backend, txArgs, blockNrOrHash, stateOverrides, blockOverrides, timeout, gasCap)
+		require.NoError(t, err)
+		require.False(t, result.Failed())
+	}
+
+	executeStateAtTransaction := func(t *testing.T, backend Backend, txArgs TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash) {
+		block := backend.CurrentBlock()
+
+		// modify block for test: add historical transactions
+		block.Transactions = []*types.Transaction{
+
+			// first transaction will be replayed
+			signTransaction(t,
+				big.NewInt(250),
+				&types.LegacyTx{
+					To:       &recipient,
+					Gas:      150_000,
+					GasPrice: big.NewInt(10000000),
+				},
+				senderKey),
+
+			// second transaction does not matter, we are querying state before
+			// it being executed
+			types.NewTx(&types.LegacyTx{}),
+		}
+
+		// querying state at tx 1 requires executing tx 0
+		_, _, err := stateAtTransaction(t.Context(), block, 1, backend)
+		require.NoError(t, err)
+	}
+	executeTraceReplayBlock := func(t *testing.T, backend Backend, txArgs TransactionArgs, blockOrHash rpc.BlockNumberOrHash) {
+		api := PublicTxTraceAPI{b: backend}
+		block := backend.CurrentBlock()
+
+		tx1 := signTransaction(t,
+			big.NewInt(250),
+			&types.LegacyTx{
+				To:       &recipient,
+				Gas:      150_000,
+				GasPrice: big.NewInt(10000000),
+				Nonce:    0,
+			},
+			senderKey)
+
+		tx2 := signTransaction(t,
+			big.NewInt(250),
+			&types.LegacyTx{
+				To:       &recipient,
+				Gas:      150_000,
+				GasPrice: big.NewInt(10000000),
+				Nonce:    1,
+			},
+			senderKey)
+
+		block.Transactions = []*types.Transaction{tx1, tx2}
+		txHash := tx2.Hash()
+		_, err := api.replayBlock(t.Context(), block, &txHash, &[]hexutil.Uint{hexutil.Uint(0)})
+		require.NoError(t, err)
+	}
+
+	expectedCallsFromTxCall := func(mockState *state.MockStateDB) {
+		mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		mockState.EXPECT().Release().AnyTimes()
+		mockState.EXPECT().Snapshot()
+		mockState.EXPECT().GetBalance(sender).Return(uint256.NewInt(1e18))
+		mockState.EXPECT().GetNonce(sender).Return(uint64(0))
+		mockState.EXPECT().SetNonce(sender, uint64(1), gomock.Any())
+		mockState.EXPECT().Exist(recipient).Return(true)
+		mockState.EXPECT().GetCode(recipient).Return([]byte{}).Times(2)
+		mockState.EXPECT().AddBalance(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockState.EXPECT().SubBalance(sender, gomock.Any(), gomock.Any()).Times(2)
+		mockState.EXPECT().GetRefund().Return(uint64(0)).Times(2)
+	}
+
+	expectedCallsFromHistoryStorageContract := func(mockState *state.MockStateDB) {
+		mockState.EXPECT().Snapshot()
+		mockState.EXPECT().AddAddressToAccessList(params.HistoryStorageAddress)
+		mockState.EXPECT().GetCode(params.HistoryStorageAddress).Return(params.HistoryStorageCode).Times(2)
+		mockState.EXPECT().GetCodeHash(params.HistoryStorageAddress).Return(common.Hash{})
+		mockState.EXPECT().AddRefund(gomock.Any()).Times(2)
+		mockState.EXPECT().SlotInAccessList(params.HistoryStorageAddress, gomock.Any())
+		mockState.EXPECT().AddSlotToAccessList(params.HistoryStorageAddress, gomock.Any())
+		mockState.EXPECT().GetState(params.HistoryStorageAddress, gomock.Any())
+		mockState.EXPECT().SubRefund(gomock.Any())
+		mockState.EXPECT().Exist(params.HistoryStorageAddress).Return(true)
+		mockState.EXPECT().SubBalance(params.SystemAddress, uint256.NewInt(0), gomock.Any())
+		mockState.EXPECT().GetRefund().Return(uint64(0))
+		mockState.EXPECT().Finalise(true)
+	}
+
+	tests := map[string]struct {
+		features          opera.FeatureSet
+		extraSetupBackend func(*MockBackend)
+		setupStateDb      func(*state.MockStateDB)
+		call              func(*testing.T, Backend, TransactionArgs, rpc.BlockNumberOrHash)
+	}{
+		"DoCall sonic": {
+			features:     opera.SonicFeatures,
+			setupStateDb: expectedCallsFromTxCall,
+			call:         executeDoCall,
+		},
+		"DoCall allegro": {
+			features: opera.AllegroFeatures,
+			setupStateDb: func(mockState *state.MockStateDB) {
+				expectedCallsFromHistoryStorageContract(mockState)
+				expectedCallsFromTxCall(mockState)
+			},
+			call: executeDoCall,
+		},
+		"StateAtTransaction sonic": {
+			features: opera.SonicFeatures,
+			setupStateDb: func(mockState *state.MockStateDB) {
+				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+				mockState.EXPECT().GetCode(sender).Return([]byte{})
+				mockState.EXPECT().GetNonce(sender).Return(uint64(0))
+				mockState.EXPECT().EndTransaction()
+
+				expectedCallsFromTxCall(mockState)
+			},
+			call: executeStateAtTransaction,
+		},
+		"StateAtTransaction allegro": {
+			features: opera.AllegroFeatures,
+			setupStateDb: func(mockState *state.MockStateDB) {
+				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+				mockState.EXPECT().GetCode(sender).Return([]byte{})
+				mockState.EXPECT().GetNonce(sender).Return(uint64(0))
+				mockState.EXPECT().EndTransaction()
+
+				expectedCallsFromHistoryStorageContract(mockState)
+				expectedCallsFromTxCall(mockState)
+			},
+			call: executeStateAtTransaction,
+		},
+		"trace_replayBlock sonic": {
+			features: opera.SonicFeatures,
+			extraSetupBackend: func(mockBackend *MockBackend) {
+				mockBackend.EXPECT().GetReceiptsByNumber(gomock.Any(), gomock.Any()).
+					Return(types.Receipts{
+						{Status: types.ReceiptStatusSuccessful},
+						{Status: types.ReceiptStatusSuccessful},
+					}, nil)
+				mockBackend.EXPECT().RPCEVMTimeout()
+			},
+			setupStateDb: func(mockState *state.MockStateDB) {
+				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+				mockState.EXPECT().GetCode(sender).Return([]byte{})
+				mockState.EXPECT().GetNonce(sender).Return(uint64(0))
+				expectedCallsFromTxCall(mockState)
+				mockState.EXPECT().EndTransaction()
+
+				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+				mockState.EXPECT().GetNonce(sender).Return(uint64(1)).Times(2)
+				mockState.EXPECT().GetCode(sender).Return([]byte{})
+				mockState.EXPECT().GetBalance(sender).Return(uint256.NewInt(1e18))
+				mockState.EXPECT().SubBalance(sender, gomock.Any(), gomock.Any())
+
+				mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockState.EXPECT().SetNonce(sender, uint64(2), gomock.Any())
+				mockState.EXPECT().GetCode(recipient).Return([]byte{})
+				mockState.EXPECT().Snapshot()
+				mockState.EXPECT().Exist(recipient)
+				mockState.EXPECT().GetRefund().Times(2)
+				mockState.EXPECT().EndTransaction().Times(2)
+				mockState.EXPECT().TxIndex()
+			},
+			call: executeTraceReplayBlock,
+		},
+		"trace_replayBlock allegro": {
+			features: opera.AllegroFeatures,
+			extraSetupBackend: func(mockBackend *MockBackend) {
+				mockBackend.EXPECT().GetReceiptsByNumber(gomock.Any(), gomock.Any()).
+					Return(types.Receipts{
+						{Status: types.ReceiptStatusSuccessful},
+						{Status: types.ReceiptStatusSuccessful},
+					}, nil)
+				mockBackend.EXPECT().RPCEVMTimeout()
+			},
+			setupStateDb: func(mockState *state.MockStateDB) {
+				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+				mockState.EXPECT().GetCode(sender).Return([]byte{})
+				mockState.EXPECT().GetNonce(sender).Return(uint64(0))
+				expectedCallsFromHistoryStorageContract(mockState)
+				expectedCallsFromTxCall(mockState)
+				mockState.EXPECT().EndTransaction()
+
+				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+				mockState.EXPECT().GetNonce(sender).Return(uint64(1)).Times(2)
+				mockState.EXPECT().GetCode(sender).Return([]byte{})
+				mockState.EXPECT().GetBalance(sender).Return(uint256.NewInt(1e18))
+				mockState.EXPECT().SubBalance(sender, gomock.Any(), gomock.Any())
+
+				mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockState.EXPECT().SetNonce(sender, uint64(2), gomock.Any())
+				mockState.EXPECT().GetCode(recipient).Return([]byte{})
+				mockState.EXPECT().Snapshot()
+				mockState.EXPECT().Exist(recipient)
+				mockState.EXPECT().GetRefund().Times(2)
+				mockState.EXPECT().EndTransaction().Times(2)
+				mockState.EXPECT().TxIndex()
+			},
+			call: executeTraceReplayBlock,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			ctrl := gomock.NewController(t)
+
+			blockOrHash := rpc.BlockNumberOrHashWithNumber(0)
+
+			header := evmcore.EvmHeader{
+				// return any block but 0, 0 is genesis and has special semantics
+				Number:  big.NewInt(1),
+				BaseFee: big.NewInt(10000000),
+			}
+
+			mockState := state.NewMockStateDB(ctrl)
+			require.NotNil(t, test.setupStateDb, "setupStateDb must be defined")
+			test.setupStateDb(mockState)
+
+			backend := NewMockBackend(ctrl)
+			backend.EXPECT().StateAndHeaderByNumberOrHash(gomock.Any(), blockOrHash).
+				Return(mockState, &header, nil).AnyTimes()
+			backend.EXPECT().GetEVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(makeTestEVM(test.features)).AnyTimes()
+			backend.EXPECT().CurrentBlock().AnyTimes().Return(&evmcore.EvmBlock{EvmHeader: header})
+			backend.EXPECT().ChainConfig().AnyTimes().Return(makeChainConfig(test.features))
+			backend.EXPECT().SuggestGasTipCap(gomock.Any(), gomock.Any()).AnyTimes().Return(big.NewInt(1))
+			backend.EXPECT().MinGasPrice().AnyTimes().Return(big.NewInt(1))
+			backend.EXPECT().RPCGasCap().AnyTimes().Return(uint64(10000000))
+			backend.EXPECT().MaxGasLimit().AnyTimes().Return(uint64(10000000))
+			backend.EXPECT().StateAndHeaderByNumberOrHash(gomock.Any(), gomock.Any()).
+				Return(mockState, &header, nil).AnyTimes()
+			if test.extraSetupBackend != nil {
+				test.extraSetupBackend(backend)
+			}
+
+			// every test uses the same transaction
+			nonce := hexutil.Uint64(0)
+			gas := hexutil.Uint64(150_000)
+			gasFeeCap := hexutil.Big(*big.NewInt(10000000))
+			txArgs := TransactionArgs{
+				From:         &sender,
+				To:           &recipient,
+				Nonce:        &nonce,
+				Gas:          &gas,
+				MaxFeePerGas: &gasFeeCap,
+			}
+
+			test.call(t, backend, txArgs, blockOrHash)
+		})
+	}
+}
+
+// makeChainConfig allows to create a chain config with a given set of features
+func makeChainConfig(features opera.FeatureSet) *params.ChainConfig {
+	chainConfig := opera.MainNetRules().EvmChainConfig(
+		[]opera.UpgradeHeight{})
+
+	if features == opera.SonicFeatures {
+		chainConfig = opera.MainNetRules().EvmChainConfig(
+			[]opera.UpgradeHeight{
+				{Upgrades: opera.SonicFeatures.ToUpgrades(), Height: 0},
+			})
+	} else if features == opera.AllegroFeatures {
+		chainConfig = opera.MainNetRules().EvmChainConfig(
+			[]opera.UpgradeHeight{
+				{Upgrades: opera.SonicFeatures.ToUpgrades(), Height: 0},
+				{Upgrades: opera.AllegroFeatures.ToUpgrades(), Height: 1},
+			})
+	}
+	return chainConfig
+}
+
+// makeTestEVM allows to create an evm instance to use in tests with a given set of features
+func makeTestEVM(features opera.FeatureSet) func(
+	ctx context.Context,
+	statedb vm.StateDB,
+	header *evmcore.EvmHeader,
+	vmConfig *vm.Config,
+	blockContext *vm.BlockContext,
+) (*vm.EVM, func() error, error) {
+
+	return func(ctx context.Context, statedb vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
+
+		chainConfig := makeChainConfig(features)
+
+		if blockContext == nil {
+			ethHeader := header.EthHeader()
+			chainContext := &FakeChainContext{
+				header:      ethHeader,
+				chainConfig: chainConfig,
+			}
+			author := common.Address{}
+			tmp := core.NewEVMBlockContext(ethHeader, chainContext, &author)
+			blockContext = &tmp
+		}
+
+		evm := vm.NewEVM(*blockContext, statedb, chainConfig, *vmConfig)
+		return evm, func() error { return nil }, nil
+	}
+}
+
 func signTransaction(
 	t *testing.T,
 	chainId *big.Int,
@@ -694,4 +1015,24 @@ func rpcTransactionToTransaction(t *testing.T, tx *RPCTransaction) *types.Transa
 		t.Error("unsupported transaction type ", tx.Type)
 		return nil
 	}
+}
+
+// fakeChainContext is a fake implementation of evm.ChainContext
+// to use in tests
+type FakeChainContext struct {
+	header      *types.Header
+	chainConfig *params.ChainConfig
+}
+
+func (fcc *FakeChainContext) Engine() consensus.Engine {
+	// currently not used in tests, if needed: engine will have to be faked
+	return nil
+}
+
+func (fcc *FakeChainContext) GetHeader(common.Hash, uint64) *types.Header {
+	return fcc.header
+}
+
+func (fcc *FakeChainContext) Config() *params.ChainConfig {
+	return fcc.chainConfig
 }

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -703,6 +703,28 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 		mockState.EXPECT().Finalise(true)
 	}
 
+	expectedTraceReplayBlock := func(mockState *state.MockStateDB) {
+		mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+		mockState.EXPECT().GetCode(sender).Return([]byte{})
+		mockState.EXPECT().GetNonce(sender).Return(uint64(0))
+		mockState.EXPECT().EndTransaction()
+
+		mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+		mockState.EXPECT().GetNonce(sender).Return(uint64(1)).Times(2)
+		mockState.EXPECT().GetCode(sender).Return([]byte{})
+		mockState.EXPECT().GetBalance(sender).Return(uint256.NewInt(1e18))
+		mockState.EXPECT().SubBalance(sender, gomock.Any(), gomock.Any())
+
+		mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+		mockState.EXPECT().SetNonce(sender, uint64(2), gomock.Any())
+		mockState.EXPECT().GetCode(recipient).Return([]byte{})
+		mockState.EXPECT().Snapshot()
+		mockState.EXPECT().Exist(recipient)
+		mockState.EXPECT().GetRefund().Times(2)
+		mockState.EXPECT().EndTransaction().Times(2)
+		mockState.EXPECT().TxIndex()
+	}
+
 	tests := map[string]struct {
 		features          opera.FeatureSet
 		extraSetupBackend func(*MockBackend)
@@ -758,26 +780,9 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 				mockBackend.EXPECT().RPCEVMTimeout()
 			},
 			setupStateDb: func(mockState *state.MockStateDB) {
-				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
-				mockState.EXPECT().GetCode(sender).Return([]byte{})
-				mockState.EXPECT().GetNonce(sender).Return(uint64(0))
 				expectedCallsFromTxCall(mockState)
-				mockState.EXPECT().EndTransaction()
 
-				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
-				mockState.EXPECT().GetNonce(sender).Return(uint64(1)).Times(2)
-				mockState.EXPECT().GetCode(sender).Return([]byte{})
-				mockState.EXPECT().GetBalance(sender).Return(uint256.NewInt(1e18))
-				mockState.EXPECT().SubBalance(sender, gomock.Any(), gomock.Any())
-
-				mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mockState.EXPECT().SetNonce(sender, uint64(2), gomock.Any())
-				mockState.EXPECT().GetCode(recipient).Return([]byte{})
-				mockState.EXPECT().Snapshot()
-				mockState.EXPECT().Exist(recipient)
-				mockState.EXPECT().GetRefund().Times(2)
-				mockState.EXPECT().EndTransaction().Times(2)
-				mockState.EXPECT().TxIndex()
+				expectedTraceReplayBlock(mockState)
 			},
 			call: executeTraceReplayBlock,
 		},
@@ -792,27 +797,9 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 				mockBackend.EXPECT().RPCEVMTimeout()
 			},
 			setupStateDb: func(mockState *state.MockStateDB) {
-				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
-				mockState.EXPECT().GetCode(sender).Return([]byte{})
-				mockState.EXPECT().GetNonce(sender).Return(uint64(0))
 				expectedCallsFromHistoryStorageContract(mockState)
 				expectedCallsFromTxCall(mockState)
-				mockState.EXPECT().EndTransaction()
-
-				mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
-				mockState.EXPECT().GetNonce(sender).Return(uint64(1)).Times(2)
-				mockState.EXPECT().GetCode(sender).Return([]byte{})
-				mockState.EXPECT().GetBalance(sender).Return(uint256.NewInt(1e18))
-				mockState.EXPECT().SubBalance(sender, gomock.Any(), gomock.Any())
-
-				mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mockState.EXPECT().SetNonce(sender, uint64(2), gomock.Any())
-				mockState.EXPECT().GetCode(recipient).Return([]byte{})
-				mockState.EXPECT().Snapshot()
-				mockState.EXPECT().Exist(recipient)
-				mockState.EXPECT().GetRefund().Times(2)
-				mockState.EXPECT().EndTransaction().Times(2)
-				mockState.EXPECT().TxIndex()
+				expectedTraceReplayBlock(mockState)
 			},
 			call: executeTraceReplayBlock,
 		},

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -255,7 +255,7 @@ func TestEstimateGas(t *testing.T) {
 	mockBackend.EXPECT().StateAndHeaderByNumberOrHash(any, blkNr).Return(mockState, mockHeader, nil).AnyTimes()
 	mockBackend.EXPECT().RPCGasCap().Return(uint64(10000000))
 	mockBackend.EXPECT().MaxGasLimit().Return(uint64(10000000))
-	mockBackend.EXPECT().GetEVM(any, any, any, any, any, any).DoAndReturn(getEvmFunc(mockState)).AnyTimes()
+	mockBackend.EXPECT().GetEVM(any, any, any, any, any).DoAndReturn(getEvmFunc(mockState)).AnyTimes()
 	setExpectedStateCalls(mockState)
 
 	api := NewPublicBlockChainAPI(mockBackend)
@@ -278,7 +278,7 @@ func TestReplayTransactionOnEmptyBlock(t *testing.T) {
 	mockBackend.EXPECT().BlockByNumber(any, any).Return(block, nil)
 	mockBackend.EXPECT().StateAndHeaderByNumberOrHash(any, any).Return(mockState, nil, nil).AnyTimes()
 	mockBackend.EXPECT().RPCGasCap().Return(uint64(10000000)).AnyTimes()
-	mockBackend.EXPECT().GetEVM(any, any, any, any, any, any).DoAndReturn(getEvmFunc(mockState)).AnyTimes()
+	mockBackend.EXPECT().GetEVM(any, any, any, any, any).DoAndReturn(getEvmFunc(mockState)).AnyTimes()
 	mockBackend.EXPECT().ChainConfig().Return(&params.ChainConfig{}).AnyTimes()
 	setExpectedStateCalls(mockState)
 
@@ -349,7 +349,7 @@ func TestReplayInternalTransaction(t *testing.T) {
 	mockBackend.EXPECT().StateAndHeaderByNumberOrHash(any, any).Return(mockState, nil, nil).AnyTimes()
 	mockBackend.EXPECT().RPCGasCap().Return(uint64(10000000)).AnyTimes()
 	mockBackend.EXPECT().GetTransaction(any, any).Return(types.NewTx(internalTx), block.NumberU64(), txIndex, nil).AnyTimes()
-	mockBackend.EXPECT().GetEVM(any, any, any, any, noBaseFeeMatcher{expected: true}, any).DoAndReturn(getEvmFuncWithParameters(mockState, chainConfig, &blockCtx, vmConfig)).AnyTimes()
+	mockBackend.EXPECT().GetEVM(any, any, any, noBaseFeeMatcher{expected: true}, any).DoAndReturn(getEvmFuncWithParameters(mockState, chainConfig, &blockCtx, vmConfig)).AnyTimes()
 	mockBackend.EXPECT().ChainConfig().Return(chainConfig).AnyTimes()
 	setExpectedStateCalls(mockState)
 
@@ -387,7 +387,7 @@ func TestBlockOverrides(t *testing.T) {
 	}
 
 	// Check that the correct block context is used when creating EVM instance
-	mockBackend.EXPECT().GetEVM(any, any, any, any, any, BlockContextMatcher{expectedBlockCtx}).DoAndReturn(getEvmFunc(mockState)).AnyTimes()
+	mockBackend.EXPECT().GetEVM(any, any, any, any, BlockContextMatcher{expectedBlockCtx}).DoAndReturn(getEvmFunc(mockState)).AnyTimes()
 
 	blockOverrides := &BlockOverrides{
 		Number:  (*hexutil.Big)(big.NewInt(5)),
@@ -464,8 +464,8 @@ func getTxArgs(t *testing.T) TransactionArgs {
 	}
 }
 
-func getEvmFunc(mockState *state.MockStateDB) func(interface{}, interface{}, interface{}, interface{}, interface{}, interface{}) (*vm.EVM, func() error, error) {
-	return func(interface{}, interface{}, interface{}, interface{}, interface{}, interface{}) (*vm.EVM, func() error, error) {
+func getEvmFunc(mockState *state.MockStateDB) func(any, any, any, any, any) (*vm.EVM, func() error, error) {
+	return func(any, any, any, any, any) (*vm.EVM, func() error, error) {
 		blockCtx := vm.BlockContext{
 			Transfer: vm.TransferFunc(func(sd vm.StateDB, a1, a2 common.Address, i *uint256.Int) {}),
 		}
@@ -473,8 +473,8 @@ func getEvmFunc(mockState *state.MockStateDB) func(interface{}, interface{}, int
 	}
 }
 
-func getEvmFuncWithParameters(mockState *state.MockStateDB, chainConfig *params.ChainConfig, blockContext *vm.BlockContext, vmConfig vm.Config) func(interface{}, interface{}, interface{}, interface{}, interface{}, interface{}) (*vm.EVM, func() error, error) {
-	return func(interface{}, interface{}, interface{}, interface{}, interface{}, interface{}) (*vm.EVM, func() error, error) {
+func getEvmFuncWithParameters(mockState *state.MockStateDB, chainConfig *params.ChainConfig, blockContext *vm.BlockContext, vmConfig vm.Config) func(any, any, any, any, any) (*vm.EVM, func() error, error) {
+	return func(any, any, any, any, any) (*vm.EVM, func() error, error) {
 		return vm.NewEVM(*blockContext, mockState, chainConfig, vmConfig), func() error { return nil }, nil
 	}
 }

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -642,6 +642,7 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 		_, _, err := stateAtTransaction(t.Context(), block, 1, backend)
 		require.NoError(t, err)
 	}
+
 	executeTraceReplayBlock := func(t *testing.T, backend Backend, txArgs TransactionArgs, blockOrHash rpc.BlockNumberOrHash) {
 		api := PublicTxTraceAPI{b: backend}
 		block := backend.CurrentBlock()
@@ -822,7 +823,7 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 
-			blockOrHash := rpc.BlockNumberOrHashWithNumber(0)
+			blockOrHash := rpc.BlockNumberOrHashWithNumber(1)
 
 			header := evmcore.EvmHeader{
 				// return any block but 0, 0 is genesis and has special semantics

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -870,22 +870,21 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 
 // makeChainConfig allows to create a chain config with a given set of features
 func makeChainConfig(features opera.FeatureSet) *params.ChainConfig {
-	chainConfig := opera.MainNetRules().EvmChainConfig(
-		[]opera.UpgradeHeight{})
-
-	if features == opera.SonicFeatures {
-		chainConfig = opera.MainNetRules().EvmChainConfig(
+	switch features {
+	case opera.SonicFeatures:
+		return opera.MainNetRules().EvmChainConfig(
 			[]opera.UpgradeHeight{
 				{Upgrades: opera.SonicFeatures.ToUpgrades(), Height: 0},
 			})
-	} else if features == opera.AllegroFeatures {
-		chainConfig = opera.MainNetRules().EvmChainConfig(
+	case opera.AllegroFeatures:
+		return opera.MainNetRules().EvmChainConfig(
 			[]opera.UpgradeHeight{
 				{Upgrades: opera.SonicFeatures.ToUpgrades(), Height: 0},
 				{Upgrades: opera.AllegroFeatures.ToUpgrades(), Height: 1},
 			})
+	default:
+		panic(fmt.Errorf("unsupported featureSet %v", features))
 	}
-	return chainConfig
 }
 
 // makeTestEVM allows to create an evm instance to use in tests with a given set of features

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	notify "github.com/ethereum/go-ethereum/event"
@@ -73,7 +72,7 @@ type Backend interface {
 	ResolveRpcBlockNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (idx.Block, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*evmcore.EvmBlock, error)
 	GetReceiptsByNumber(ctx context.Context, number rpc.BlockNumber) (types.Receipts, error)
-	GetEVM(ctx context.Context, msg *core.Message, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error)
+	GetEVM(ctx context.Context, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error)
 	MinGasPrice() *big.Int
 	MaxGasLimit() uint64
 

--- a/ethapi/mock_backend.go
+++ b/ethapi/mock_backend.go
@@ -27,7 +27,6 @@ import (
 	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
 	accounts "github.com/ethereum/go-ethereum/accounts"
 	common "github.com/ethereum/go-ethereum/common"
-	core "github.com/ethereum/go-ethereum/core"
 	types "github.com/ethereum/go-ethereum/core/types"
 	vm "github.com/ethereum/go-ethereum/core/vm"
 	event "github.com/ethereum/go-ethereum/event"
@@ -218,9 +217,9 @@ func (mr *MockBackendMockRecorder) GetDowntime(ctx, vid any) *gomock.Call {
 }
 
 // GetEVM mocks base method.
-func (m *MockBackend) GetEVM(ctx context.Context, msg *core.Message, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
+func (m *MockBackend) GetEVM(ctx context.Context, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEVM", ctx, msg, state, header, vmConfig, blockContext)
+	ret := m.ctrl.Call(m, "GetEVM", ctx, state, header, vmConfig, blockContext)
 	ret0, _ := ret[0].(*vm.EVM)
 	ret1, _ := ret[1].(func() error)
 	ret2, _ := ret[2].(error)
@@ -228,9 +227,9 @@ func (m *MockBackend) GetEVM(ctx context.Context, msg *core.Message, state vm.St
 }
 
 // GetEVM indicates an expected call of GetEVM.
-func (mr *MockBackendMockRecorder) GetEVM(ctx, msg, state, header, vmConfig, blockContext any) *gomock.Call {
+func (mr *MockBackendMockRecorder) GetEVM(ctx, state, header, vmConfig, blockContext any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEVM", reflect.TypeOf((*MockBackend)(nil).GetEVM), ctx, msg, state, header, vmConfig, blockContext)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEVM", reflect.TypeOf((*MockBackend)(nil).GetEVM), ctx, state, header, vmConfig, blockContext)
 }
 
 // GetEpochBlockState mocks base method.

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -247,6 +247,10 @@ func (s *PublicTxTraceAPI) replayBlock(ctx context.Context, block *evmcore.EvmBl
 				return nil, fmt.Errorf("cannot initialize vm for transaction %s, error: %s", tx.Hash().String(), err.Error())
 			}
 
+			if vmenv.ChainConfig().IsPrague(block.Number, uint64(block.Time.Unix())) {
+				evmcore.ProcessParentBlockHash(block.ParentHash, vmenv)
+			}
+
 			res, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.GasLimit))
 			failed := false
 			if err != nil {

--- a/ethapi/tx_trace.go
+++ b/ethapi/tx_trace.go
@@ -242,7 +242,7 @@ func (s *PublicTxTraceAPI) replayBlock(ctx context.Context, block *evmcore.EvmBl
 			vmConfig.NoBaseFee = true
 			vmConfig.Tracer = nil
 
-			vmenv, _, err := s.b.GetEVM(ctx, msg, state, block.Header(), &vmConfig, nil)
+			vmenv, _, err := s.b.GetEVM(ctx, state, block.Header(), &vmConfig, nil)
 			if err != nil {
 				return nil, fmt.Errorf("cannot initialize vm for transaction %s, error: %s", tx.Hash().String(), err.Error())
 			}
@@ -305,7 +305,7 @@ func (s *PublicTxTraceAPI) traceTx(
 	// this makes sure resources are cleaned up.
 	defer cancel()
 
-	vmenv, _, err := b.GetEVM(ctx, msg, state, header, &cfg, nil)
+	vmenv, _, err := b.GetEVM(ctx, state, header, &cfg, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot initialize vm for transaction %s, error: %s", tx.Hash().String(), err.Error())
 	}

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/core"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -328,7 +327,7 @@ func (b *EthAPIBackend) GetLogs(ctx context.Context, block common.Hash) ([][]*ty
 	return logs, nil
 }
 
-func (b *EthAPIBackend) GetEVM(ctx context.Context, msg *core.Message, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
+func (b *EthAPIBackend) GetEVM(ctx context.Context, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 
 	if vmConfig == nil {


### PR DESCRIPTION

Issue https://github.com/0xsoniclabs/sonic-admin/issues/128 describes a list of RPC methods which can execute a transaction in the RPC.
All these methods are calling one of the following internal routines: 
- `DoCall`, executes one transaction in a read-only mode. It is used by `DoEstimateGas` which ends up being used in many rpc methods.
- `StateAtTransaction`, executes a subset of one block transactions and returns the intermediate state. Used in debug and tracing methods.
- trace: `replayBlock`, similar to the previous, executes a subset of transactions included in a block. Used by other trace methods.
- `AccessList`, this is a tracing tool that helps pre-filling the access list for a transaction. This function exists 1:1 in [geth](https://github.com/ethereum/go-ethereum/blob/a775e68421595d9c3807e68cce7ff2037991a781/internal/ethapi/api.go#L1139), but it hasn't been upgraded with the history storage semantics (it should happen [here](https://github.com/ethereum/go-ethereum/blob/a775e68421595d9c3807e68cce7ff2037991a781/internal/ethapi/api.go#L1224C1-L1224C82)). 

Therefore, only  `DoCall`,  `StateAtTransaction`, and `replayBlock` have been instrumented with the new semantics. 

The methodology has been to locate all calls to `core.ApplyMessage` from the RPC, as this is the entry point to the processor. 

Unit testing checks that the side effect state calls, happening as a result of the invocation of the History Storage contract, happen only when `Allegro` is enabled. 
This test does not check that the RPC state access is read-only, as this is in a much larger scope (that applies to the complete RPC usage of the state by any callback) 
