### PR TITLE
Reject gapped tx from delegated account

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -94,6 +94,10 @@ var (
 	// than some meaningful limit a user might use. This is not a consensus error
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
+
+	// ErrOutOfOrderTxFromDelegated is returned when the transaction with gapped
+	// nonce received from the accounts with delegation or pending delegation.
+	ErrOutOfOrderTxFromDelegated = errors.New("gapped-nonce tx from delegated accounts")
 )
 
 var (
@@ -798,32 +802,39 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	return pool.validateAuth(tx)
 }
 
+// checkDelegationLimit determines if the tx sender is delegated or has a
+// pending delegation, and if so, ensures they have at most one in-flight
+// **executable** transaction, e.g. disallow stacked and gapped transactions
+// from the account.
+func (pool *TxPool) checkDelegationLimit(tx *types.Transaction) error {
+	from, _ := types.Sender(pool.signer, tx) // validated
+
+	// early return if the sender has neither delegation nor pending delegation.
+	if pool.currentState.GetCodeHash(from) == types.EmptyCodeHash && len(pool.all.auths[from]) == 0 {
+		return nil
+	}
+	pending := pool.pending[from]
+	if pending == nil {
+		// Transaction with gapped nonce is not supported for delegated accounts
+		if pool.pendingNonces.get(from) != tx.Nonce() {
+			return ErrOutOfOrderTxFromDelegated
+		}
+		return nil
+	}
+	// Transaction replacement is supported
+	if pending.Contains(tx.Nonce()) {
+		return nil
+	}
+	return ErrInflightTxLimitReached
+}
+
 // validateAuth verifies that the transaction complies with code authorization
 // restrictions brought by SetCode transaction type.
 func (pool *TxPool) validateAuth(tx *types.Transaction) error {
-	from, _ := types.Sender(pool.signer, tx) // validated
 	// Allow at most one in-flight tx for delegated accounts or those with a
 	// pending authorization.
-	if pool.currentState.GetCodeHash(from) != types.EmptyCodeHash || len(pool.all.auths[from]) != 0 {
-		var (
-			count  int
-			exists bool
-		)
-		pending := pool.pending[from]
-		if pending != nil {
-			count += pending.Len()
-			exists = pending.Contains(tx.Nonce())
-		}
-		queue := pool.queue[from]
-		if queue != nil {
-			count += queue.Len()
-			exists = exists || queue.Contains(tx.Nonce())
-		}
-		// Replace the existing in-flight transaction for delegated accounts
-		// are still supported
-		if count >= 1 && !exists {
-			return ErrInflightTxLimitReached
-		}
+	if err := pool.checkDelegationLimit(tx); err != nil {
+		return err
 	}
 	// Authorities cannot conflict with any pending or queued transactions.
 	if auths := tx.SetCodeAuthorizations(); len(auths) > 0 {

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -619,6 +619,11 @@ func TestSetCodeTransactions(t *testing.T) {
 			test: func(t *testing.T, pool *TxPool) {
 				db.codeHashes[addrA] = common.BytesToHash([]byte{0xaa})
 
+				// Send gapped transaction, it should be rejected.
+				if err := pool.addRemoteSync(pricedTransaction(2, 100000, big.NewInt(1), keyA)); !errors.Is(err, ErrOutOfOrderTxFromDelegated) {
+					t.Fatalf("error mismatch: want %v, have %v", ErrOutOfOrderTxFromDelegated, err)
+				}
+
 				// first transaction is accepted
 				if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), keyA)); err != nil {
 					t.Fatalf("failed to add remote transaction: %v", err)


### PR DESCRIPTION
This PR updates the transaction validation logic to ensure proper ordering of transactions with authorization.

The previous check rejected a transaction if all the following conditions match:
- The sender had a delegation or pending delegation.
- There was at least one queued or pending transaction from the same sender.
- None of those transactions had the same nonce as the incoming transaction.

This approach led to an issue where:
- If a transaction with a higher nonce than expected was accepted first, and later a transaction with the expected nonce arrived, the latter would be rejected.
- This happened due to the "at most one in-flight transaction" policy introduced in https://github.com/0xsoniclabs/sonic/pull/74.
- As a result, the first transaction (with the higher nonce) would be stuck.

*New Behavior*
The updated check ensures that delegated transactions are accepted in the correct execution order.
This prevents transactions from getting stuck while maintaining execution order integrity.

This PR addresses https://github.com/0xsoniclabs/sonic-admin/issues/137