### PR TITLE
Integration tests: Add better tooling to construct valid transactions.

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -35,6 +35,8 @@ import (
 // It provides the methods to launch transactions and queries against the network.
 // Additionally, it provides the methods to endow accounts with funds.
 type IntegrationTestNetSession interface {
+	// GetFeatureSet returns the feature set the network has been started with.
+	GetFeatureSet() opera.FeatureSet
 
 	// EndowAccount sends a requested amount of tokens to the given account. This is
 	// mainly intended to provide funds to accounts for testing purposes.
@@ -634,6 +636,10 @@ type contractDeployer[T any] func(*bind.TransactOpts, bind.ContractBackend) (com
 type Session struct {
 	net     *IntegrationTestNet
 	account Account
+}
+
+func (s *Session) GetFeatureSet() opera.FeatureSet {
+	return s.net.options.FeatureSet
 }
 
 // EndowAccount sends a requested amount of tokens to the given account. This is

--- a/tests/integration_test_tools_test.go
+++ b/tests/integration_test_tools_test.go
@@ -1,0 +1,457 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+// signTransaction is a testing helper that signs a transaction with the
+// key from the provided account
+func signTransaction(
+	t *testing.T,
+	chainId *big.Int,
+	payload types.TxData,
+	from *Account,
+) *types.Transaction {
+	t.Helper()
+	res, err := types.SignTx(
+		types.NewTx(payload),
+		types.NewPragueSigner(chainId),
+		from.PrivateKey)
+	require.NoError(t, err)
+	return res
+}
+
+// setTransactionDefaults defaults the transaction common fields to meaningful values
+//
+// If left zeroed: It configures the nonce of the transaction to be the current nonce of the sender account
+// If left zeroed: It configures the gas price of the transaction to be the suggested gas price
+// If left zeroed: It configures the gas of the transaction to be the minimum gas required to execute the transaction
+// Filled gas is a static minimum value, it does not account for the gas costs of the contract opcodes.
+//
+// Notice that this function is generic, returning the same type as the input, this
+// allows further manual configuration of the transaction fields after the defaults are set.
+func setTransactionDefaults[T types.TxData](
+	t *testing.T,
+	net IntegrationTestNetSession,
+	txPayload T,
+	sender *Account,
+) T {
+	t.Helper()
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// use a types.Transaction type to access polymorphic getters
+	tmpTx := types.NewTx(txPayload)
+	nonce := tmpTx.Nonce()
+	if tmpTx.Nonce() == 0 {
+		var err error
+		nonce, err = client.NonceAt(context.Background(), sender.Address(), nil)
+		require.NoError(t, err)
+	}
+
+	gasPrice := tmpTx.GasPrice()
+	if gasPrice == nil || gasPrice.Sign() == 0 {
+		var err error
+		gasPrice, err = client.SuggestGasPrice(context.Background())
+		require.NoError(t, err)
+	}
+
+	gas := tmpTx.Gas()
+	if gas == 0 {
+		gas = computeMinimumGas(t, net, txPayload)
+	}
+
+	switch tx := types.TxData(txPayload).(type) {
+	case *types.LegacyTx:
+		tx.Nonce = nonce
+		tx.Gas = gas
+		tx.GasPrice = gasPrice
+	case *types.AccessListTx:
+		tx.Nonce = nonce
+		tx.Gas = gas
+		tx.GasPrice = big.NewInt(500e9)
+	case *types.DynamicFeeTx:
+		tx.Nonce = nonce
+		tx.Gas = gas
+		tx.GasFeeCap = gasPrice
+	case *types.BlobTx:
+		tx.Nonce = nonce
+		tx.Gas = gas
+		tx.GasFeeCap = uint256.MustFromBig(gasPrice)
+	case *types.SetCodeTx:
+		tx.Nonce = nonce
+		tx.Gas = gas
+		tx.GasFeeCap = uint256.MustFromBig(gasPrice)
+	default:
+		t.Fatalf("unexpected transaction type: %T", tx)
+	}
+
+	return txPayload
+}
+
+// ComputeMinimumGas computes the minimum gas required to execute a transaction,
+// this accounts for all gas costs except for the contract opcodes gas costs.
+func computeMinimumGas(t *testing.T, session IntegrationTestNetSession, tx types.TxData) uint64 {
+
+	var data []byte
+	var authList []types.AccessTuple
+	var authorizations []types.SetCodeAuthorization
+	var isCreate bool
+	switch tx := tx.(type) {
+	case *types.LegacyTx:
+		data = tx.Data
+		isCreate = tx.To == nil
+	case *types.AccessListTx:
+		data = tx.Data
+		authList = tx.AccessList
+		isCreate = tx.To == nil
+	case *types.DynamicFeeTx:
+		data = tx.Data
+		authList = tx.AccessList
+		isCreate = tx.To == nil
+	case *types.BlobTx:
+		data = tx.Data
+		authList = tx.AccessList
+		isCreate = false
+	case *types.SetCodeTx:
+		data = tx.Data
+		authList = tx.AccessList
+		authorizations = tx.AuthList
+		isCreate = false
+	default:
+		t.Fatalf("unexpected transaction type: %T", tx)
+	}
+
+	minimumGas, err := core.IntrinsicGas(data, authList, authorizations, isCreate, true, true, true)
+	require.NoError(t, err)
+
+	if session.GetFeatureSet() >= opera.AllegroFeatures {
+		floorDataGas, err := core.FloorDataGas(data)
+		require.NoError(t, err)
+		minimumGas = max(minimumGas, floorDataGas)
+	}
+
+	return minimumGas
+}
+
+func TestIntegrationTestNet_setTransactionDefaults(t *testing.T) {
+
+	net := StartIntegrationTestNet(t,
+		IntegrationTestNetOptions{
+			FeatureSet: opera.AllegroFeatures})
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	chainId, err := client.ChainID(context.Background())
+	require.NoError(t, err)
+
+	type modificationFunction func(t *testing.T, tx *types.TxData)
+
+	transactionType := func(txType byte) modificationFunction {
+		return func(t *testing.T, tx *types.TxData) {
+			switch txType {
+			case types.LegacyTxType:
+				*tx = &types.LegacyTx{}
+			case types.AccessListTxType:
+				*tx = &types.AccessListTx{}
+			case types.DynamicFeeTxType:
+				*tx = &types.DynamicFeeTx{}
+			case types.BlobTxType:
+				*tx = &types.BlobTx{}
+			case types.SetCodeTxType:
+				*tx = &types.SetCodeTx{}
+			default:
+				t.Fatalf("unexpected transaction type: %d", txType)
+			}
+		}
+	}
+
+	noData := func() modificationFunction {
+		return func(t *testing.T, tx *types.TxData) {}
+	}
+
+	withData := func(size, zeroes int) modificationFunction {
+
+		makeData := func(t *testing.T, size, numZeroes int) []byte {
+			if zeroes > size {
+				t.Fatalf("zeroes %d > size %d", zeroes, size)
+			}
+			if zeroes < 1 {
+				// please add one 0, so that init-code starts with STOP
+				t.Fatalf("zeroes %d < 1", zeroes)
+			}
+			data := make([]byte, size)
+			for i := numZeroes; i < size; i++ {
+				data[i] = 1
+			}
+			return data
+		}
+
+		return func(t *testing.T, tx *types.TxData) {
+			switch tx := (*tx).(type) {
+			case *types.LegacyTx:
+				tx.Data = makeData(t, size, zeroes)
+			case *types.AccessListTx:
+				tx.Data = makeData(t, size, zeroes)
+			case *types.DynamicFeeTx:
+				tx.Data = makeData(t, size, zeroes)
+			case *types.BlobTx:
+				tx.Data = makeData(t, size, zeroes)
+			case *types.SetCodeTx:
+				tx.Data = makeData(t, size, zeroes)
+			default:
+				t.Fatalf("unexpected transaction type: %T", tx)
+			}
+		}
+	}
+
+	noAccessList := func() modificationFunction {
+		return func(t *testing.T, tx *types.TxData) {}
+	}
+
+	withAccessList := func(accounts, keysPerAccount int) modificationFunction {
+
+		makeAccessList := func(t *testing.T, accounts, keysPerAccount int) []types.AccessTuple {
+			accessList := make([]types.AccessTuple, accounts)
+			for i := range accessList {
+				accessList[i] = types.AccessTuple{
+					Address:     NewAccount().Address(),
+					StorageKeys: make([]common.Hash, keysPerAccount),
+				}
+				for j := range accessList[i].StorageKeys {
+					accessList[i].StorageKeys[j] = common.BigToHash(big.NewInt(int64(j)))
+				}
+			}
+			return accessList
+		}
+		return func(t *testing.T, tx *types.TxData) {
+			switch tx := (*tx).(type) {
+			case *types.LegacyTx:
+				// ignore
+			case *types.AccessListTx:
+				tx.AccessList = makeAccessList(t, accounts, keysPerAccount)
+			case *types.DynamicFeeTx:
+				tx.AccessList = makeAccessList(t, accounts, keysPerAccount)
+			case *types.BlobTx:
+				tx.AccessList = makeAccessList(t, accounts, keysPerAccount)
+			case *types.SetCodeTx:
+				tx.AccessList = makeAccessList(t, accounts, keysPerAccount)
+			default:
+				t.Fatalf("unexpected transaction type: %T", tx)
+			}
+		}
+	}
+	withAuthorizations := func(chainId *big.Int, accounts int) modificationFunction {
+		makeAuthList := func(t *testing.T, chainId *big.Int, accounts int) []types.SetCodeAuthorization {
+			authList := make([]types.SetCodeAuthorization, accounts)
+			for i := range authList {
+				account := NewAccount()
+
+				auth, err := types.SignSetCode(account.PrivateKey,
+					types.SetCodeAuthorization{
+						ChainID: *uint256.MustFromBig(chainId),
+						Address: common.BigToAddress(big.NewInt(int64(i))),
+						Nonce:   0,
+					})
+				require.NoError(t, err)
+				authList[i] = auth
+			}
+			return authList
+		}
+
+		return func(t *testing.T, tx *types.TxData) {
+			switch tx := (*tx).(type) {
+			case *types.LegacyTx:
+				// ignore
+			case *types.AccessListTx:
+				// ignore
+			case *types.DynamicFeeTx:
+				// ignore
+			case *types.BlobTx:
+				// ignore
+			case *types.SetCodeTx:
+				tx.AuthList = makeAuthList(t, chainId, accounts)
+			default:
+				t.Fatalf("unexpected transaction type: %T", tx)
+			}
+		}
+	}
+
+	withoutTo := func() modificationFunction {
+		return func(t *testing.T, tx *types.TxData) {
+			switch tx := (*tx).(type) {
+			case *types.LegacyTx:
+				tx.To = nil
+			case *types.AccessListTx:
+				tx.To = nil
+			case *types.DynamicFeeTx:
+				tx.To = nil
+			case *types.BlobTx, *types.SetCodeTx:
+				// ignore without to
+			default:
+				t.Fatalf("unexpected transaction type: %T", tx)
+			}
+		}
+	}
+
+	withTo := func(address common.Address) modificationFunction {
+		return func(t *testing.T, tx *types.TxData) {
+			switch tx := (*tx).(type) {
+			case *types.LegacyTx:
+				tx.To = &address
+			case *types.AccessListTx:
+				tx.To = &address
+			case *types.DynamicFeeTx:
+				tx.To = &address
+			case *types.BlobTx:
+				tx.To = address
+			case *types.SetCodeTx:
+				tx.To = address
+			default:
+				t.Fatalf("unexpected transaction type: %T", tx)
+			}
+		}
+	}
+
+	t.Run("filled transactions can be executed", func(t *testing.T) {
+
+		tests := generateTestDataBasedOnModificationCombinations(
+			func() types.TxData { return nil },
+			[][]modificationFunction{
+				// Transaction type
+				{
+					transactionType(types.LegacyTxType),
+					transactionType(types.AccessListTxType),
+					transactionType(types.DynamicFeeTxType),
+					transactionType(types.BlobTxType),
+					transactionType(types.SetCodeTxType),
+				},
+				// Data
+				{noData(), withData(100, 1)},
+				// To
+				{withoutTo(), withTo(NewAccount().Address())},
+				// AccessList
+				{noAccessList(), withAccessList(1, 1), withAccessList(8, 4)},
+				// Authorizations (for transactions that require them, one minimum)
+				{withAuthorizations(chainId, 1), withAuthorizations(chainId, 8)},
+			},
+			func(tc types.TxData, pieces []modificationFunction) types.TxData {
+				for _, piece := range pieces {
+					piece(t, &tc)
+				}
+				return tc
+			},
+		)
+
+		nonce, err := client.NonceAt(t.Context(), net.GetSessionSponsor().Address(), nil)
+		require.NoError(t, err)
+
+		pending := []common.Hash{}
+
+		for tx := range tests {
+			switch tx := tx.(type) {
+			case *types.LegacyTx:
+				tx.Nonce = nonce
+			case *types.AccessListTx:
+				tx.Nonce = nonce
+			case *types.DynamicFeeTx:
+				tx.Nonce = nonce
+			case *types.BlobTx:
+				tx.Nonce = nonce
+			case *types.SetCodeTx:
+				tx.Nonce = nonce
+			default:
+				t.Fatalf("unexpected transaction type: %T", tx)
+			}
+			nonce++
+
+			txData := setTransactionDefaults(t, net, tx, net.GetSessionSponsor())
+			tx := signTransaction(t, chainId, txData, net.GetSessionSponsor())
+
+			// the filled values suffice to get the transaction accepted and executed
+			err := client.SendTransaction(t.Context(), tx)
+			require.NoError(t, err)
+			pending = append(pending, tx.Hash())
+		}
+
+		for _, txHash := range pending {
+			receipt, err := net.GetReceipt(txHash)
+			require.NoError(t, err)
+			require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+		}
+	})
+
+	t.Run("zero nonce is defaulted", func(t *testing.T) {
+		// this generation is tested isolated because the previous test case
+		// utilizes manual nonce setting to issue multiple transactions asynchronously
+
+		// account has a non-zero nonce
+		receipt, err := net.EndowAccount(common.Address{}, big.NewInt(1))
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+		txData := setTransactionDefaults(t, net, &types.LegacyTx{}, net.GetSessionSponsor())
+		tx := signTransaction(t, chainId, txData, net.GetSessionSponsor())
+
+		nonce, err := client.NonceAt(t.Context(), net.GetSessionSponsor().Address(), nil)
+		require.NoError(t, err)
+
+		require.Equal(t, nonce, tx.Nonce())
+	})
+
+	t.Run("non-zero nonce is not defaulted", func(t *testing.T) {
+
+		// endowments modify the account nonce
+		receipt, err := net.EndowAccount(common.Address{}, big.NewInt(1))
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+		receipt, err = net.EndowAccount(common.Address{}, big.NewInt(1))
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+		txData := setTransactionDefaults(t, net, &types.LegacyTx{
+			Nonce: 1,
+		}, net.GetSessionSponsor())
+		tx := signTransaction(t, chainId, txData, net.GetSessionSponsor())
+
+		// the filled values suffice to get the transaction accepted and executed
+		_, err = net.Run(tx)
+		require.ErrorContains(t, err, "nonce too low")
+	})
+
+	t.Run("non-zero gas is not defaulted ", func(t *testing.T) {
+
+		txData := setTransactionDefaults(t, net, &types.LegacyTx{
+			Gas: 1,
+		}, net.GetSessionSponsor())
+		tx := signTransaction(t, chainId, txData, net.GetSessionSponsor())
+
+		// the filled values suffice to get the transaction accepted and executed
+		_, err := net.Run(tx)
+		require.ErrorContains(t, err, " intrinsic gas too low")
+	})
+
+	t.Run("non-zero gas-price is not defaulted ", func(t *testing.T) {
+
+		txData := setTransactionDefaults(t, net, &types.LegacyTx{
+			GasPrice: big.NewInt(1),
+		}, net.GetSessionSponsor())
+		tx := signTransaction(t, chainId, txData, net.GetSessionSponsor())
+
+		// the filled values suffice to get the transaction accepted and executed
+		_, err := net.Run(tx)
+		require.ErrorContains(t, err, "underpriced")
+	})
+}

--- a/tests/integration_test_tools_test.go
+++ b/tests/integration_test_tools_test.go
@@ -32,10 +32,14 @@ func signTransaction(
 
 // setTransactionDefaults defaults the transaction common fields to meaningful values
 //
-// If left zeroed: It configures the nonce of the transaction to be the current nonce of the sender account
-// If left zeroed: It configures the gas price of the transaction to be the suggested gas price
-// If left zeroed: It configures the gas of the transaction to be the minimum gas required to execute the transaction
-// Filled gas is a static minimum value, it does not account for the gas costs of the contract opcodes.
+//   - If nonce is zeroed: It configures the nonce of the transaction to be the
+//     current nonce of the sender account
+//   - If gas price or gas fee cap is zeroed: It configures the gas price of the
+//     transaction to be the suggested gas price
+//   - If gas is zeroed: It configures the gas of the transaction to be the
+//     minimum gas required to execute the transaction
+//     Filled gas is a static minimum value, it does not account for the gas
+//     costs of the contract opcodes.
 //
 // Notice that this function is generic, returning the same type as the input, this
 // allows further manual configuration of the transaction fields after the defaults are set.

--- a/tests/integration_test_tools_test.go
+++ b/tests/integration_test_tools_test.go
@@ -55,14 +55,12 @@ func setTransactionDefaults[T types.TxData](
 	tmpTx := types.NewTx(txPayload)
 	nonce := tmpTx.Nonce()
 	if tmpTx.Nonce() == 0 {
-		var err error
 		nonce, err = client.NonceAt(context.Background(), sender.Address(), nil)
 		require.NoError(t, err)
 	}
 
 	gasPrice := tmpTx.GasPrice()
 	if gasPrice == nil || gasPrice.Sign() == 0 {
-		var err error
 		gasPrice, err = client.SuggestGasPrice(context.Background())
 		require.NoError(t, err)
 	}

--- a/tests/transaction_store_test.go
+++ b/tests/transaction_store_test.go
@@ -132,18 +132,3 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 			}))
 	}
 }
-
-func signTransaction(
-	t *testing.T,
-	chainId *big.Int,
-	payload types.TxData,
-	from *Account,
-) *types.Transaction {
-	t.Helper()
-	res, err := types.SignTx(
-		types.NewTx(payload),
-		types.NewPragueSigner(chainId),
-		from.PrivateKey)
-	require.NoError(t, err)
-	return res
-}


### PR DESCRIPTION
This PR introduces new function to fill in common fields in the transactions used for testing.
The goal is to reduce boilerplate code needed to configure nonce, gas, and gas price. While preserving the capacity to define any other field. 

The design works around the Geth inner transaction types, use these structs to configure payloads.
The reason why `setTransactionDefaults` and `signTransaction` are two separate symbols is to allow users to modify transaction payload after defaults are set (e.g. nonce override) 
The name `setTransactionDefaults` is inspired by the RPC function `SetDefaults` which provides a similar functionality.

This PR enables refactor of https://github.com/0xsoniclabs/sonic-admin/issues/101
Later changes will merge this new tools with the already existing `txFactory` object