### PR TITLE
Add execution spec tests

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -29,9 +29,11 @@ import (
 )
 
 var (
-	eipTests          = filepath.Join(".", "testdata", "EIPTests", "StateTests")
-	generalStateTests = filepath.Join(".", "testdata", "GeneralStateTests")
-	execSpecTests     = filepath.Join(".", "execution-spec-tests", "fixtures", "state_tests")
+	testPaths = []string{
+		filepath.Join(".", "testdata", "EIPTests", "StateTests"),
+		filepath.Join(".", "testdata", "GeneralStateTests"),
+		filepath.Join(".", "execution-spec-tests", "fixtures", "state_tests"),
+	}
 
 	unsupportedForks = map[string]struct{}{
 		"ConstantinopleFix": {},
@@ -47,16 +49,22 @@ func initMatcher(st *tests.TestMatcher) {
 	st.SkipLoad(`^stEOF/`)
 }
 
+// TestState runs the state tests from the Ethereum tests and Ethereum execution spec tests.
+// In order to run the Ethereum tests, clone the `ethereum/tests` repository inside this tests directory as `testdata`.
+// As the tests are pre-filled no further steps are needed.
+// For the execution spec tests, clone the `ethereum/execution-spec-tests` repository inside this tests directory.
+// Install the python dependencies (using uv is recommended):
+// `uv sync --all-extras && uv run solc-select use 0.8.24 --always-install`
+// Collect all desired test cases:
+// `uv run fill --collect-only --from Istanbul --to Prague`
+// Fill all state tests (these are the only ones we currently support):
+// `uv run fill --from Istanbul --until Prague -m state_test`
 func TestState(t *testing.T) {
 	t.Parallel()
 
 	st := new(tests.TestMatcher)
 	initMatcher(st)
-	for _, dir := range []string{
-		eipTests,
-		generalStateTests,
-		execSpecTests,
-	} {
+	for _, dir := range testPaths {
 		// If the directory does not exist,
 		// skip it but do not exit test without checking the other directories.
 		dirinfo, err := os.Stat(dir)

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -29,8 +29,9 @@ import (
 )
 
 var (
-	baseDir      = filepath.Join(".", "testdata")
-	stateTestDir = filepath.Join(baseDir, "GeneralStateTests")
+	eipTests          = filepath.Join(".", "testdata", "EIPTests", "StateTests")
+	generalStateTests = filepath.Join(".", "testdata", "GeneralStateTests")
+	execSpecTests     = filepath.Join(".", "execution-spec-tests", "fixtures", "state_tests")
 
 	unsupportedForks = map[string]struct{}{
 		"ConstantinopleFix": {},
@@ -52,9 +53,18 @@ func TestState(t *testing.T) {
 	st := new(tests.TestMatcher)
 	initMatcher(st)
 	for _, dir := range []string{
-		filepath.Join(baseDir, "EIPTests", "StateTests"),
-		stateTestDir,
+		eipTests,
+		generalStateTests,
+		execSpecTests,
 	} {
+		// If the directory does not exist,
+		// skip it but do not exit test without checking the other directories.
+		dirinfo, err := os.Stat(dir)
+		if os.IsNotExist(err) || !dirinfo.IsDir() {
+			t.Logf("Skipping %s as it does not exist, did you clone/fill the tests?\n", dir)
+			continue
+		}
+
 		st.Walk(t, dir, func(t *testing.T, name string, test *tests.StateTest) {
 			execStateTest(t, st, test)
 		})


### PR DESCRIPTION
The ethereum tests are no longer updated for all new eips, therefore the execution spec tests should be generated and ran against sonic to test its block processing and database. This PR extends the ethereum tests runner to also run the execution spec tests when filled.