### PR TITLE
Remove eip-2537 test skipping

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -42,9 +42,6 @@ var (
 )
 
 func initMatcher(st *tests.TestMatcher) {
-	// The EIP-2537 test cases are out of date and have not been updated by ethereum.
-	st.SkipLoad(`^stEIP2537/`)
-
 	// EOF is not yet supported by sonic.
 	st.SkipLoad(`^stEOF/`)
 }


### PR DESCRIPTION
With the release of  [ethereum/tests v17.0](https://github.com/ethereum/tests/releases/tag/v17.0) the out dated eip-2537 tests got removed, they no longer need to be skipped in the test runner. 
Solves [#109](https://github.com/0xsoniclabs/sonic-admin/issues/109).