### PR TITLE
Update for consensus test library and eventcheck removal

### DIFF
--- a/emitter/emission_sim_test.go
+++ b/emitter/emission_sim_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/0xsoniclabs/consensus/consensus"
 	"github.com/0xsoniclabs/consensus/consensus/consensusengine"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 
 	"github.com/0xsoniclabs/sonic/emitter/ancestor"
 )
@@ -44,7 +45,7 @@ type cityLatency struct {
 type QITestEvents []*QITestEvent
 
 type QITestEvent struct {
-	consensus.TestEvent
+	consensustest.TestEvent
 	creationTime int
 }
 
@@ -175,13 +176,13 @@ func simulate(weights []consensus.Weight, QIParentCount int, randParentCount int
 	headsAll := make([]consensus.Events, numValidators)
 
 	//setup nodes
-	nodes := consensus.GenNodes(numValidators)
+	nodes := consensustest.GenNodes(numValidators)
 	validators := consensus.ArrayToValidators(nodes, weights)
 
-	var input *consensusengine.EventStore
+	var input *consensustest.TestEventSource
 	var lch *consensusengine.CoreLachesis
 	var dagIndexer ancestor.DagIndex
-	inputs := make([]consensusengine.EventStore, numValidators)
+	inputs := make([]consensustest.TestEventSource, numValidators)
 	lchs := make([]consensusengine.CoreLachesis, numValidators)
 	fcIndexers := make([]*ancestor.FCIndexer, numValidators)
 	for i := 0; i < numValidators; i++ {
@@ -495,7 +496,7 @@ func updateHeads(newEvent consensus.Event, heads *consensus.Events) {
 	*heads = append(*heads, newEvent) //add newEvent to heads
 }
 
-func processEvent(input consensusengine.EventStore, lchs *consensusengine.CoreLachesis, e *QITestEvent, fcIndexer *ancestor.FCIndexer, heads *consensus.Events, self consensus.ValidatorID, time int) (frame consensus.Frame) {
+func processEvent(input consensustest.TestEventSource, lchs *consensusengine.CoreLachesis, e *QITestEvent, fcIndexer *ancestor.FCIndexer, heads *consensus.Events, self consensus.ValidatorID, time int) (frame consensus.Frame) {
 	input.SetEvent(e)
 
 	lchs.DagIndexer.Add(e)

--- a/eventcheck/ban.go
+++ b/eventcheck/ban.go
@@ -1,7 +1,7 @@
 package eventcheck
 
 import (
-	base "github.com/0xsoniclabs/consensus/eventcheck"
+	base "github.com/0xsoniclabs/sonic/eventcheck/base"
 
 	"github.com/0xsoniclabs/sonic/eventcheck/epochcheck"
 )

--- a/eventcheck/base/all.go
+++ b/eventcheck/base/all.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package eventcheck
+
+import (
+	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/sonic/eventcheck/base/basiccheck"
+	"github.com/0xsoniclabs/sonic/eventcheck/base/epochcheck"
+	"github.com/0xsoniclabs/sonic/eventcheck/base/parentscheck"
+)
+
+// Checkers is collection of all the checkers
+type Checkers struct {
+	Basiccheck   *basiccheck.Checker
+	Epochcheck   *epochcheck.Checker
+	Parentscheck *parentscheck.Checker
+}
+
+// Validate runs all the checks except Lachesis-related
+func (v *Checkers) Validate(e consensus.Event, parents consensus.Events) error {
+	if err := v.Basiccheck.Validate(e); err != nil {
+		return err
+	}
+	if err := v.Epochcheck.Validate(e); err != nil {
+		return err
+	}
+	if err := v.Parentscheck.Validate(e, parents); err != nil {
+		return err
+	}
+	return nil
+}

--- a/eventcheck/base/all_test.go
+++ b/eventcheck/base/all_test.go
@@ -1,0 +1,310 @@
+// Copyright (c) 2025 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package eventcheck
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
+	"github.com/0xsoniclabs/sonic/eventcheck/base/basiccheck"
+	"github.com/0xsoniclabs/sonic/eventcheck/base/epochcheck"
+	"github.com/0xsoniclabs/sonic/eventcheck/base/parentscheck"
+)
+
+type testReader struct{}
+
+func (tr *testReader) GetEpochValidators() (*consensus.Validators, consensus.Epoch) {
+	vb := consensus.NewBuilder()
+	vb.Set(1, 1)
+	return vb.Build(), 1
+}
+
+func TestBasicEventValidation(t *testing.T) {
+	var tests = []struct {
+		e       consensus.Event
+		wantErr error
+	}{
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(1)
+			e.SetLamport(1)
+			e.SetEpoch(1)
+			e.SetFrame(1)
+			return e
+		}(), nil},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(0)
+			e.SetLamport(1)
+			e.SetEpoch(1)
+			e.SetFrame(1)
+			return e
+		}(), basiccheck.ErrNotInited},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(1)
+			e.SetEpoch(1)
+			e.SetFrame(1)
+			return e
+		}(), basiccheck.ErrNoParents},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(math.MaxInt32 - 1)
+			e.SetLamport(1)
+			e.SetEpoch(1)
+			e.SetFrame(1)
+			return e
+		}(), basiccheck.ErrHugeValue},
+	}
+
+	for _, tt := range tests {
+		basicCheck := basiccheck.New()
+		assert.Equal(t, tt.wantErr, basicCheck.Validate(tt.e))
+	}
+}
+
+func TestEpochEventValidation(t *testing.T) {
+	var tests = []struct {
+		e       consensus.Event
+		wantErr error
+	}{
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetEpoch(1)
+			e.SetCreator(1)
+			return e
+		}(), nil},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetEpoch(2)
+			e.SetCreator(1)
+			return e
+		}(), epochcheck.ErrNotRelevant},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetEpoch(1)
+			e.SetCreator(2)
+			return e
+		}(), epochcheck.ErrAuth},
+	}
+
+	for _, tt := range tests {
+		tr := new(testReader)
+		epochCheck := epochcheck.New(tr)
+		assert.Equal(t, tt.wantErr, epochCheck.Validate(tt.e))
+	}
+}
+
+func TestParentsEventValidation(t *testing.T) {
+	var tests = []struct {
+		e         consensus.Event
+		pe        consensus.Events
+		wantErr   error
+		wantPanic bool
+	}{
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(2)
+			e.SetCreator(1)
+			selfParent := &consensustest.TestEvent{}
+			selfParent.SetLamport(1)
+			selfParent.SetID([24]byte{1})
+			e.SetParents(consensus.EventHashes{selfParent.ID()})
+			return e
+		}(),
+			func() consensus.Events {
+				e := &consensustest.TestEvent{}
+				e.SetSeq(1)
+				e.SetLamport(1)
+				e.SetCreator(1)
+				e.SetID([24]byte{1})
+				return consensus.Events{e}
+			}(),
+			nil, false},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(2)
+			e.SetCreator(1)
+			selfParent := &consensustest.TestEvent{}
+			selfParent.SetLamport(1)
+			selfParent.SetID([24]byte{2})
+			e.SetParents(consensus.EventHashes{selfParent.ID()})
+			return e
+		}(),
+			func() consensus.Events {
+				e := &consensustest.TestEvent{}
+				e.SetSeq(1)
+				e.SetLamport(1)
+				e.SetCreator(1)
+				e.SetID([24]byte{1})
+				return consensus.Events{e}
+			}(),
+			parentscheck.ErrWrongSelfParent, false},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(1)
+			e.SetParents(consensus.EventHashes{e.ID()})
+			return e
+		}(),
+			func() consensus.Events {
+				e := &consensustest.TestEvent{}
+				e.SetSeq(1)
+				e.SetLamport(1)
+				return consensus.Events{e}
+			}(),
+			parentscheck.ErrWrongLamport, false},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(1)
+			e.SetLamport(2)
+			e.SetParents(consensus.EventHashes{e.ID()})
+			return e
+		}(),
+			func() consensus.Events {
+				e := &consensustest.TestEvent{}
+				e.SetSeq(1)
+				e.SetLamport(1)
+				return consensus.Events{e}
+			}(),
+			parentscheck.ErrWrongSelfParent, false},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(2)
+			selfParent := &consensustest.TestEvent{}
+			selfParent.SetLamport(1)
+			selfParent.SetID([24]byte{1})
+			e.SetParents(consensus.EventHashes{selfParent.ID()})
+			return e
+		}(),
+			func() consensus.Events {
+				e := &consensustest.TestEvent{}
+				e.SetSeq(2)
+				e.SetLamport(1)
+				e.SetID([24]byte{1})
+				return consensus.Events{e}
+			}(),
+			parentscheck.ErrWrongSeq, false},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(1)
+			return e
+		}(),
+			nil,
+			parentscheck.ErrWrongSeq, false},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(1)
+			e.SetLamport(1)
+			e.SetParents(consensus.EventHashes{e.ID()})
+			return e
+		}(),
+			nil,
+			nil, true},
+	}
+
+	for _, tt := range tests {
+		parentsCheck := parentscheck.New()
+		if tt.wantPanic {
+			assert.Panics(t, func() {
+				err := parentsCheck.Validate(tt.e, tt.pe)
+				if err != nil {
+					return
+				}
+			})
+		} else {
+			assert.Equal(t, tt.wantErr, parentsCheck.Validate(tt.e, tt.pe))
+		}
+	}
+}
+
+func TestAllEventValidation(t *testing.T) {
+	var tests = []struct {
+		e       consensus.Event
+		pe      consensus.Events
+		wantErr error
+	}{
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(2)
+			e.SetParents(consensus.EventHashes{e.ID()})
+			return e
+		}(),
+			nil,
+			basiccheck.ErrNotInited},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(1)
+			e.SetLamport(1)
+			e.SetEpoch(1)
+			e.SetFrame(1)
+			return e
+		}(),
+			nil,
+			epochcheck.ErrAuth},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(2)
+			e.SetLamport(2)
+			e.SetCreator(1)
+			e.SetEpoch(1)
+			e.SetFrame(1)
+			e.SetParents(consensus.EventHashes{e.ID()})
+			return e
+		}(),
+			func() consensus.Events {
+				e := &consensustest.TestEvent{}
+				e.SetSeq(1)
+				e.SetLamport(1)
+				return consensus.Events{e}
+			}(),
+			parentscheck.ErrWrongSelfParent},
+		{func() consensus.Event {
+			e := &consensustest.TestEvent{}
+			e.SetSeq(1)
+			e.SetLamport(2)
+			e.SetCreator(1)
+			e.SetEpoch(1)
+			e.SetFrame(1)
+			e.SetParents(consensus.EventHashes{e.ID()})
+			return e
+		}(),
+			func() consensus.Events {
+				e := &consensustest.TestEvent{}
+				e.SetSeq(1)
+				e.SetLamport(1)
+				return consensus.Events{e}
+			}(),
+			nil},
+	}
+
+	tr := new(testReader)
+
+	checkers := Checkers{
+		Basiccheck:   basiccheck.New(),
+		Epochcheck:   epochcheck.New(tr),
+		Parentscheck: parentscheck.New(),
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.wantErr, checkers.Validate(tt.e, tt.pe))
+	}
+}

--- a/eventcheck/base/epochcheck/epoch_check.go
+++ b/eventcheck/base/epochcheck/epoch_check.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package epochcheck
+
+import (
+	"errors"
+
+	"github.com/0xsoniclabs/consensus/consensus"
+)
+
+var (
+	// ErrNotRelevant indicates the event's epoch isn't equal to current epoch.
+	ErrNotRelevant = errors.New("event is too old or too new")
+	// ErrAuth indicates that event's creator isn't authorized to create events in current epoch.
+	ErrAuth = errors.New("event creator isn't a validator")
+)
+
+// Reader returns currents epoch and its validators group.
+type Reader interface {
+	GetEpochValidators() (*consensus.Validators, consensus.Epoch)
+}
+
+// Checker which require only current epoch info
+type Checker struct {
+	reader Reader
+}
+
+func New(reader Reader) *Checker {
+	return &Checker{
+		reader: reader,
+	}
+}
+
+// Validate event
+func (v *Checker) Validate(e consensus.Event) error {
+	// check epoch first, because validators group is returned only for the current epoch
+	validators, epoch := v.reader.GetEpochValidators()
+	if e.Epoch() != epoch {
+		return ErrNotRelevant
+	}
+	if !validators.Exists(e.Creator()) {
+		return ErrAuth
+	}
+	return nil
+}

--- a/eventcheck/base/noban.go
+++ b/eventcheck/base/noban.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package eventcheck
+
+import (
+	"errors"
+)
+
+var (
+	ErrAlreadyConnectedEvent = errors.New("event is connected already")
+	ErrSpilledEvent          = errors.New("event is spilled")
+	ErrDuplicateEvent        = errors.New("event is duplicated")
+)

--- a/eventcheck/base/parentscheck/parents_check.go
+++ b/eventcheck/base/parentscheck/parents_check.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 Fantom Foundation
+//
+// Use of this software is governed by the Business Source License included
+// in the LICENSE file and at fantom.foundation/bsl11.
+//
+// Change Date: 2028-4-16
+//
+// On the date above, in accordance with the Business Source License, use of
+// this software will be governed by the GNU Lesser General Public License v3.
+
+package parentscheck
+
+import (
+	"errors"
+
+	"github.com/0xsoniclabs/consensus/consensus"
+)
+
+var (
+	ErrWrongSeq        = errors.New("event has wrong sequence time")
+	ErrWrongLamport    = errors.New("event has wrong Lamport time")
+	ErrWrongSelfParent = errors.New("event is missing self-parent")
+)
+
+// Checker performs checks, which require the parents list
+type Checker struct{}
+
+// New checker which performs checks, which require the parents list
+func New() *Checker {
+	return &Checker{}
+}
+
+// Validate event
+func (v *Checker) Validate(e consensus.Event, parents consensus.Events) error {
+	if len(e.Parents()) != len(parents) {
+		panic("parentscheck: expected event's parents as an argument")
+	}
+
+	// double parents are checked by basiccheck
+
+	// lamport
+	maxLamport := consensus.Lamport(0)
+	for _, p := range parents {
+		maxLamport = consensus.MaxLamport(maxLamport, p.Lamport())
+	}
+	if e.Lamport() != maxLamport+1 {
+		return ErrWrongLamport
+	}
+
+	// self-parent
+	for i, p := range parents {
+		if (p.Creator() == e.Creator()) != e.IsSelfParent(e.Parents()[i]) {
+			return ErrWrongSelfParent
+		}
+	}
+
+	// seq
+	if (e.Seq() == 1) != (e.SelfParent() == nil) {
+		return ErrWrongSeq
+	}
+	if e.SelfParent() != nil {
+		selfParent := parents[0]
+		if !e.IsSelfParent(selfParent.ID()) {
+			// sanity check, self-parent is always first, it's how it's stored
+			return ErrWrongSelfParent
+		}
+		if e.Seq() != selfParent.Seq()+1 {
+			return ErrWrongSeq
+		}
+	}
+
+	return nil
+}

--- a/eventcheck/basiccheck/basic_check.go
+++ b/eventcheck/basiccheck/basic_check.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"math"
 
-	base "github.com/0xsoniclabs/consensus/eventcheck/basiccheck"
+	base "github.com/0xsoniclabs/sonic/eventcheck/base/basiccheck"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/0xsoniclabs/sonic/evmcore"

--- a/eventcheck/epochcheck/epoch_check.go
+++ b/eventcheck/epochcheck/epoch_check.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/0xsoniclabs/consensus/consensus"
 
-	base "github.com/0xsoniclabs/consensus/eventcheck/epochcheck"
+	base "github.com/0xsoniclabs/sonic/eventcheck/base/epochcheck"
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/0xsoniclabs/sonic/inter"

--- a/eventcheck/gaspowercheck/gas_power_check.go
+++ b/eventcheck/gaspowercheck/gas_power_check.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/0xsoniclabs/consensus/consensus"
 
-	"github.com/0xsoniclabs/consensus/eventcheck/epochcheck"
+	"github.com/0xsoniclabs/sonic/eventcheck/base/epochcheck"
 
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"

--- a/eventcheck/parentscheck/parents_check.go
+++ b/eventcheck/parentscheck/parents_check.go
@@ -3,7 +3,7 @@ package parentscheck
 import (
 	"errors"
 
-	base "github.com/0xsoniclabs/consensus/eventcheck/parentscheck"
+	base "github.com/0xsoniclabs/sonic/eventcheck/base/parentscheck"
 
 	"github.com/0xsoniclabs/sonic/inter"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/0xsoniclabs/cacheutils v0.0.0-20250320134355-5a9aa4df3861
 	github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff
-	github.com/0xsoniclabs/consensus v0.0.0-20250325140549-abcb2a8137a0
+	github.com/0xsoniclabs/consensus v0.0.0-20250402102031-cbd390dcb623
 	github.com/0xsoniclabs/kvdb v0.0.0-20250224113306-fe6d2ca29563
 	github.com/0xsoniclabs/tosca v0.0.0-20250221124739-3aac4e7427dc
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff h1:ItY2JgmM0
 github.com/0xsoniclabs/carmen/go v0.0.0-20250113102336-97f8b8616eff/go.mod h1:/u6oDZBv6eyPs9K7Ug5D4aL9l1Q7N43BnWEUPsvKmYw=
 github.com/0xsoniclabs/consensus v0.0.0-20250325140549-abcb2a8137a0 h1:EVZG0B+78kKnqS8Xx+HxAYnC/jjmeLy5r3SJt2iIrCM=
 github.com/0xsoniclabs/consensus v0.0.0-20250325140549-abcb2a8137a0/go.mod h1:yGWxvaPp4jRoAPFWntTe6QKzG9m9XwbCIRk6oreTCBg=
+github.com/0xsoniclabs/consensus v0.0.0-20250402102031-cbd390dcb623 h1:Cufi0K/SGctwz5dsYc8swJAckCKUuxeQ/WN8zTcl/PA=
+github.com/0xsoniclabs/consensus v0.0.0-20250402102031-cbd390dcb623/go.mod h1:yGWxvaPp4jRoAPFWntTe6QKzG9m9XwbCIRk6oreTCBg=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809 h1:MtKV0hC7b58vimXYzmNRBNZJw1ovewt5GbanzPgl68k=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250210213022-86eca3554809/go.mod h1:9SAhGia6ukqZnvwJ3npNEmQDFjusZ/vXgbU1Z7J1vhw=
 github.com/0xsoniclabs/kvdb v0.0.0-20250224113306-fe6d2ca29563 h1:jx+6rC5/buNABHcuxfL2gdd7zbqvHMMN2u+RdEJO/FY=

--- a/gossip/basestream/basestreamseeder/seeder_test.go
+++ b/gossip/basestream/basestreamseeder/seeder_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 
 	"github.com/stretchr/testify/require"
 
@@ -63,7 +64,7 @@ func testSeederResponsesOrder(t *testing.T, maxPeers int, maxEvents int) {
 
 	events := make(consensus.Events, maxEvents)
 	for i := range events {
-		e := &consensus.TestEvent{}
+		e := &consensustest.TestEvent{}
 		e.SetEpoch(consensus.Epoch(i / 10))
 		e.SetLamport(consensus.Lamport(i / 2))
 		var rID [24]byte

--- a/gossip/basiccheck_test.go
+++ b/gossip/basiccheck_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/0xsoniclabs/consensus/consensus"
 
-	lbasiccheck "github.com/0xsoniclabs/consensus/eventcheck/basiccheck"
+	lbasiccheck "github.com/0xsoniclabs/sonic/eventcheck/base/basiccheck"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 

--- a/gossip/dagordering/event_buffer.go
+++ b/gossip/dagordering/event_buffer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/0xsoniclabs/consensus/consensus"
 
 	"github.com/0xsoniclabs/cacheutils/wlru"
-	"github.com/0xsoniclabs/consensus/eventcheck"
+	eventcheck "github.com/0xsoniclabs/sonic/eventcheck/base"
 )
 
 type (

--- a/gossip/dagordering/ordering_test.go
+++ b/gossip/dagordering/ordering_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 )
 
 func TestEventsBuffer(t *testing.T) {
@@ -19,11 +20,11 @@ func TestEventsBuffer(t *testing.T) {
 
 func testEventsBuffer(t *testing.T, try int64) {
 	t.Helper()
-	nodes := consensus.GenNodes(5)
+	nodes := consensustest.GenNodes(5)
 
 	var ordered consensus.Events
 	r := rand.New(rand.NewSource(try)) // nolint:gosec
-	_ = consensus.ForEachRandEvent(nodes, 10, 3, r, consensus.ForEachEvent{
+	_ = consensustest.ForEachRandEvent(nodes, 10, 3, r, consensustest.ForEachEvent{
 		Process: func(e consensus.Event, name string) {
 			ordered = append(ordered, e)
 		},
@@ -106,11 +107,11 @@ func TestEventsBufferReleasing(t *testing.T) {
 
 func testEventsBufferReleasing(t *testing.T, maxEvents int, try int64) {
 	t.Helper()
-	nodes := consensus.GenNodes(5)
+	nodes := consensustest.GenNodes(5)
 	eventsPerNode := 1 + rand.Intn(maxEvents)/5 // nolint:gosec
 
 	var ordered consensus.Events
-	_ = consensus.ForEachRandEvent(nodes, eventsPerNode, 3, rand.New(rand.NewSource(try)), consensus.ForEachEvent{ // nolint:gosec
+	_ = consensustest.ForEachRandEvent(nodes, eventsPerNode, 3, rand.New(rand.NewSource(try)), consensustest.ForEachEvent{ // nolint:gosec
 		Process: func(e consensus.Event, name string) {
 			ordered = append(ordered, e)
 		},

--- a/gossip/dagprocessor/processor.go
+++ b/gossip/dagprocessor/processor.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/0xsoniclabs/consensus/consensus"
 
-	"github.com/0xsoniclabs/consensus/eventcheck"
+	eventcheck "github.com/0xsoniclabs/sonic/eventcheck/base"
 	"github.com/0xsoniclabs/sonic/gossip/dagordering"
 	"github.com/0xsoniclabs/sonic/utils/datasemaphore"
 	"github.com/0xsoniclabs/sonic/utils/workers"

--- a/gossip/dagprocessor/processor_test.go
+++ b/gossip/dagprocessor/processor_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 
 	"github.com/0xsoniclabs/cacheutils/cachescale"
 	"github.com/0xsoniclabs/sonic/utils/datasemaphore"
@@ -48,10 +49,10 @@ func shuffleEventsIntoChunks(inEvents consensus.Events) []consensus.Events {
 
 func testProcessor(t *testing.T) {
 	t.Helper()
-	nodes := consensus.GenNodes(5)
+	nodes := consensustest.GenNodes(5)
 
 	var ordered consensus.Events
-	_ = consensus.ForEachRandEvent(nodes, 10, 3, nil, consensus.ForEachEvent{
+	_ = consensustest.ForEachRandEvent(nodes, 10, 3, nil, consensustest.ForEachEvent{
 		Process: func(e consensus.Event, name string) {
 			ordered = append(ordered, e)
 		},
@@ -171,10 +172,10 @@ func TestProcessorReleasing(t *testing.T) {
 
 func testProcessorReleasing(t *testing.T, maxEvents int, try int64) {
 	t.Helper()
-	nodes := consensus.GenNodes(5)
+	nodes := consensustest.GenNodes(5)
 
 	var ordered consensus.Events
-	_ = consensus.ForEachRandEvent(nodes, 10, 3, rand.New(rand.NewSource(try)), consensus.ForEachEvent{ // nolint:gosec
+	_ = consensustest.ForEachRandEvent(nodes, 10, 3, rand.New(rand.NewSource(try)), consensustest.ForEachEvent{ // nolint:gosec
 		Process: func(e consensus.Event, name string) {
 			ordered = append(ordered, e)
 		},

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -121,7 +121,7 @@ func (em *Emitter) isMyTxTurn(txHash common.Hash, sender common.Address, account
 	}
 
 	// generate seed for generating the validators sequence for the tx
-	roundsHash := consensus.Of(sender.Bytes(), byteutils.Uint64ToBigEndian(accountNonce/TxTurnNonces), epoch.Bytes())
+	roundsHash := consensus.EventHashFromBytes(sender.Bytes(), byteutils.Uint64ToBigEndian(accountNonce/TxTurnNonces), epoch.Bytes())
 
 	// generate the validators sequence for the tx
 	rounds := utils.WeightedPermutation(int(validators.Len()), validators.SortedWeights(), roundsHash)

--- a/gossip/prevrandao_test.go
+++ b/gossip/prevrandao_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 )
 
 func TestComputePrevRandao_ComputationIsDeterministic(t *testing.T) {
-	events := consensus.FakeEvents(5)
+	events := consensustest.FakeEventHashes(5)
 	randao1 := computePrevRandao(events)
 	rand.Shuffle(len(events), func(i, j int) {
 		events[i], events[j] = events[j], events[i]

--- a/gossip/protocols/dag/dagstream/dagstreamleecher/leecher_test.go
+++ b/gossip/protocols/dag/dagstream/dagstreamleecher/leecher_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 
 	"github.com/stretchr/testify/require"
 
@@ -73,7 +74,7 @@ func testLeecherNoDeadlocks(t *testing.T, maxPeers int) {
 		select {
 		case req := <-requests:
 			if rand.IntN(10) != 0 {
-				err := leecher.NotifyChunkReceived(req.request.Session.ID, consensus.FakeEvent(), rand.IntN(5) == 0)
+				err := leecher.NotifyChunkReceived(req.request.Session.ID, consensustest.FakeEventHash(), rand.IntN(5) == 0)
 				if !terminated {
 					require.NoError(t, err)
 				}

--- a/inter/event.go
+++ b/inter/event.go
@@ -207,7 +207,7 @@ func CalcMisbehaviourProofsHash(mps []MisbehaviourProof) consensus.Hash {
 
 func CalcPayloadHash(e EventPayloadI) consensus.Hash {
 	if e.Version() == 1 {
-		return consensus.Of(consensus.Of(CalcTxHash(e.Txs()).Bytes(), CalcMisbehaviourProofsHash(e.MisbehaviourProofs()).Bytes()).Bytes(), consensus.Of(e.EpochVote().Hash().Bytes(), e.BlockVotes().Hash().Bytes()).Bytes())
+		return consensus.EventHashFromBytes(consensus.EventHashFromBytes(CalcTxHash(e.Txs()).Bytes(), CalcMisbehaviourProofsHash(e.MisbehaviourProofs()).Bytes()).Bytes(), consensus.EventHashFromBytes(e.EpochVote().Hash().Bytes(), e.BlockVotes().Hash().Bytes()).Bytes())
 	} else {
 		return CalcTxHash(e.Txs())
 	}
@@ -259,7 +259,7 @@ func calcEventID(h consensus.Hash) (id [24]byte) {
 }
 
 func calcEventHashes(ser []byte, e EventI) (locator consensus.Hash, base consensus.Hash) {
-	base = consensus.Of(ser)
+	base = consensus.EventHashFromBytes(ser)
 	if e.Version() < 1 {
 		return base, base
 	}
@@ -320,7 +320,7 @@ func (e *MutableEventPayload) Build() *EventPayload {
 }
 
 func (l EventLocator) HashToSign() consensus.Hash {
-	return consensus.Of(l.BaseHash.Bytes(), byteutils.Uint16ToBigEndian(l.NetForkID), l.Epoch.Bytes(), l.Seq.Bytes(), l.Lamport.Bytes(), l.Creator.Bytes(), l.PayloadHash.Bytes())
+	return consensus.EventHashFromBytes(l.BaseHash.Bytes(), byteutils.Uint16ToBigEndian(l.NetForkID), l.Epoch.Bytes(), l.Seq.Bytes(), l.Lamport.Bytes(), l.Creator.Bytes(), l.PayloadHash.Bytes())
 }
 
 func (l EventLocator) ID() consensus.EventHash {

--- a/inter/ier/inter_epoch_records.go
+++ b/inter/ier/inter_epoch_records.go
@@ -16,5 +16,5 @@ type LlrIdxFullEpochRecord struct {
 }
 
 func (er LlrFullEpochRecord) Hash() consensus.Hash {
-	return consensus.Of(er.BlockState.Hash().Bytes(), er.EpochState.Hash().Bytes())
+	return consensus.EventHashFromBytes(er.BlockState.Hash().Bytes(), er.EpochState.Hash().Bytes())
 }

--- a/inter/inter_llr.go
+++ b/inter/inter_llr.go
@@ -63,11 +63,11 @@ func (bvs LlrBlockVotes) Hash() consensus.Hash {
 }
 
 func (bvs LlrSignedBlockVotes) CalcPayloadHash() consensus.Hash {
-	return consensus.Of(bvs.TxsAndMisbehaviourProofsHash.Bytes(), consensus.Of(bvs.EpochVoteHash.Bytes(), bvs.Val.Hash().Bytes()).Bytes())
+	return consensus.EventHashFromBytes(bvs.TxsAndMisbehaviourProofsHash.Bytes(), consensus.EventHashFromBytes(bvs.EpochVoteHash.Bytes(), bvs.Val.Hash().Bytes()).Bytes())
 }
 
 func (ev LlrSignedEpochVote) CalcPayloadHash() consensus.Hash {
-	return consensus.Of(ev.TxsAndMisbehaviourProofsHash.Bytes(), consensus.Of(ev.Val.Hash().Bytes(), ev.BlockVotesHash.Bytes()).Bytes())
+	return consensus.EventHashFromBytes(ev.TxsAndMisbehaviourProofsHash.Bytes(), consensus.EventHashFromBytes(ev.Val.Hash().Bytes(), ev.BlockVotesHash.Bytes()).Bytes())
 }
 
 func (ev LlrSignedEpochVote) Size() uint64 {

--- a/inter/inter_llr_test.go
+++ b/inter/inter_llr_test.go
@@ -13,24 +13,24 @@ var test_block_votes = LlrBlockVotes{
 	Start: 9000,
 	Epoch: 342,
 	Votes: []consensus.Hash{
-		consensus.Of(nil),
+		consensus.EventHashFromBytes(nil),
 	},
 }
 var test_signed_event_locator = SignedEventLocator{
 	Locator: EventLocator{
-		BaseHash:    consensus.Of(nil),
+		BaseHash:    consensus.EventHashFromBytes(nil),
 		NetForkID:   1,
 		Epoch:       42,
 		Seq:         9_000_000,
 		Lamport:     142,
 		Creator:     242,
-		PayloadHash: consensus.Of(nil),
+		PayloadHash: consensus.EventHashFromBytes(nil),
 	},
 	Sig: [64]byte{},
 }
-var test_txs_and_misbehaviour_proofs_hash = consensus.Of(nil)
-var test_epoch_vote_hash = consensus.Of(nil)
-var test_block_votes_hash = consensus.Of(nil)
+var test_txs_and_misbehaviour_proofs_hash = consensus.EventHashFromBytes(nil)
+var test_epoch_vote_hash = consensus.EventHashFromBytes(nil)
+var test_block_votes_hash = consensus.EventHashFromBytes(nil)
 
 var test_llr_signed_block_votes = LlrSignedBlockVotes{
 	Signed:                       test_signed_event_locator,

--- a/topicsdb/topicsdb_test.go
+++ b/topicsdb/topicsdb_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 	"github.com/0xsoniclabs/kvdb/memorydb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -423,21 +424,21 @@ func TestPatternLimit(t *testing.T) {
 		},
 		{
 			pattern: [][]common.Hash{
-				{consensus.FakeHash(1), consensus.FakeHash(1)}, {consensus.FakeHash(2), consensus.FakeHash(2)}, {consensus.FakeHash(3), consensus.FakeHash(4)}},
+				{consensustest.FakeHash(1), consensustest.FakeHash(1)}, {consensustest.FakeHash(2), consensustest.FakeHash(2)}, {consensustest.FakeHash(3), consensustest.FakeHash(4)}},
 			exp: [][]common.Hash{
-				{consensus.FakeHash(1)}, {consensus.FakeHash(2)}, {consensus.FakeHash(3), consensus.FakeHash(4)}},
+				{consensustest.FakeHash(1)}, {consensustest.FakeHash(2)}, {consensustest.FakeHash(3), consensustest.FakeHash(4)}},
 			err: nil,
 		},
 		{
 			pattern: [][]common.Hash{
-				{consensus.FakeHash(1), consensus.FakeHash(2)}, {consensus.FakeHash(3), consensus.FakeHash(4)}, {consensus.FakeHash(5), consensus.FakeHash(6)}},
+				{consensustest.FakeHash(1), consensustest.FakeHash(2)}, {consensustest.FakeHash(3), consensustest.FakeHash(4)}, {consensustest.FakeHash(5), consensustest.FakeHash(6)}},
 			exp: [][]common.Hash{
-				{consensus.FakeHash(1), consensus.FakeHash(2)}, {consensus.FakeHash(3), consensus.FakeHash(4)}, {consensus.FakeHash(5), consensus.FakeHash(6)}},
+				{consensustest.FakeHash(1), consensustest.FakeHash(2)}, {consensustest.FakeHash(3), consensustest.FakeHash(4)}, {consensustest.FakeHash(5), consensustest.FakeHash(6)}},
 			err: nil,
 		},
 		{
-			pattern: append(append(make([][]common.Hash, maxTopicsCount), []common.Hash{consensus.FakeHash(1)}), []common.Hash{consensus.FakeHash(1)}),
-			exp:     append(make([][]common.Hash, maxTopicsCount), []common.Hash{consensus.FakeHash(1)}),
+			pattern: append(append(make([][]common.Hash, maxTopicsCount), []common.Hash{consensustest.FakeHash(1)}), []common.Hash{consensustest.FakeHash(1)}),
+			exp:     append(make([][]common.Hash, maxTopicsCount), []common.Hash{consensustest.FakeHash(1)}),
 			err:     nil,
 		},
 	}
@@ -475,7 +476,7 @@ func TestKvdbThreadsPoolLimit(t *testing.T) {
 
 			topics := make([]common.Hash, threads.GlobalPool.Cap()+1)
 			for i := range topics {
-				topics[i] = consensus.FakeHash(int64(i))
+				topics[i] = consensustest.FakeHash(int64(i))
 			}
 			require.Less(threads.GlobalPool.Cap(), len(topics))
 			qq := make([][]common.Hash, 3)
@@ -514,7 +515,7 @@ func genTestData(count int) (
 
 	topics = make([]common.Hash, period)
 	for i := range topics {
-		topics[i] = consensus.FakeHash(int64(i))
+		topics[i] = consensustest.FakeHash(int64(i))
 	}
 
 	topics4rec = func(rec int) (from, to int) {
@@ -528,8 +529,8 @@ func genTestData(count int) (
 		from, to := topics4rec(i)
 		r := &types.Log{
 			BlockNumber: uint64(i / period),
-			BlockHash:   consensus.FakeHash(int64(i / period)),
-			TxHash:      consensus.FakeHash(int64(i % period)),
+			BlockHash:   consensustest.FakeHash(int64(i / period)),
+			TxHash:      consensustest.FakeHash(int64(i % period)),
 			Index:       uint(i % period),
 			Address:     randAddress(),
 			Topics:      topics[from:to],

--- a/vecmt/index_test.go
+++ b/vecmt/index_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 	"github.com/0xsoniclabs/kvdb/memorydb"
 
 	"github.com/0xsoniclabs/sonic/inter"
@@ -41,7 +42,7 @@ func (e *eventWithCreationTime) CreationTime() inter.Timestamp {
 func BenchmarkIndex_Add(b *testing.B) {
 	b.StopTimer()
 	ordered := make(consensus.Events, 0)
-	nodes, _, _ := consensus.ASCIIschemeForEach(testASCIIScheme, consensus.ForEachEvent{
+	nodes, _, _ := consensustest.ASCIIschemeForEach(testASCIIScheme, consensustest.ForEachEvent{
 		Process: func(e consensus.Event, name string) {
 			ordered = append(ordered, e)
 		},

--- a/vecmt/median_time_test.go
+++ b/vecmt/median_time_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/consensus/consensus"
+	"github.com/0xsoniclabs/consensus/consensus/consensustest"
 
 	"github.com/0xsoniclabs/consensus/vecengine"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestMedianTimeOnIndex(t *testing.T) {
-	nodes := consensus.GenNodes(5)
+	nodes := consensustest.GenNodes(5)
 	weights := []consensus.Weight{5, 4, 3, 2, 1}
 	validators := consensus.ArrayToValidators(nodes, weights)
 
@@ -155,7 +156,7 @@ func testMedianTime(t *testing.T, dagAscii string, weights []consensus.Weight, c
 	assertar := assert.New(t)
 
 	var ordered consensus.Events
-	nodes, _, named := consensus.ASCIIschemeForEach(dagAscii, consensus.ForEachEvent{
+	nodes, _, named := consensustest.ASCIIschemeForEach(dagAscii, consensustest.ForEachEvent{
 		Process: func(e consensus.Event, name string) {
 			ordered = append(ordered, &eventWithCreationTime{e, creationTimes[name]})
 		},


### PR DESCRIPTION
This PR catches up to the most recent consensus version and mainly adapts for changes in 0xsoniclabs/consensus#89 and 0xsoniclabs/consensus#91.

Unit tests pass.