### PR TITLE
Add coverage check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,4 +15,4 @@ ignore:
   - "tests/"
   - "**/*_mock.go"
   - "**/*_test.go"
-  - "**/*_mock_test.go"
+  - "**/*.pb.go"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,5 +6,13 @@ coverage:
   status:
     patch:
       default:
-        target: 80% # target coverage of the changes
+        target: 80% # coverage of the changes
         threshold: 1% # allow the coverage to drop by <threshold>%
+    project:
+      default:
+        target: 80% # coverage of the project
+ignore:
+  - "tests/"
+  - "**/*_mock.go"
+  - "**/*_test.go"
+  - "**/*_mock_test.go"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+# default coverage setting
+coverage:
+  range: 50..80 # below 50 is red, between 50-80 is yellow and above 80 is green
+  round: down
+  precision: 2
+  status:
+    patch:
+      default:
+        target: 80% # target coverage of the changes
+        threshold: 1% # allow the coverage to drop by <threshold>%

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24"
+
+      - name: Test
+        run: go test -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: 0xsoniclabs/sonic


### PR DESCRIPTION
This PR introduce coverage check to Sonic client. The coverage rule can be set in `.codecov.yml` file. The current settings are simple rules which should be fine-tuned by repo owners.