### PR TITLE
Make ChainId field being returned from RPC calls for LegacyTxs

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1383,6 +1383,11 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	}
 
 	switch tx.Type() {
+	case types.LegacyTxType:
+		// if a legacy transaction has an EIP-155 chain id, include it explicitly
+		if id := tx.ChainId(); id.Sign() != 0 {
+			result.ChainID = (*hexutil.Big)(id)
+		}
 	case types.AccessListTxType:
 		copyAccessList(tx, result)
 	case types.DynamicFeeTxType:


### PR DESCRIPTION
Before now, jsonRPC methods, such as eth_getTransactionByHash missed the chainId field in the output. It is not compatible with another popular EVM chains RPC model, such as Ethereum, Polygon, BSC. Only with chainId filled properly one can check the transactions signature because is able to calculate the correct transaction hash.