### PR TITLE
Add fuzzer for scrambler 

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -26,6 +26,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/verwatcher"
 	"github.com/0xsoniclabs/sonic/gossip/emitter"
 	"github.com/0xsoniclabs/sonic/gossip/evmstore"
+	"github.com/0xsoniclabs/sonic/gossip/scrambler"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -274,7 +275,7 @@ func consensusCallbackBeginBlockFn(
 					}
 
 					signer := gsignercache.Wrap(types.MakeSigner(chainCfg, new(big.Int).SetUint64(number), uint64(blockCtx.Time)))
-					orderedTxs := getExecutionOrder(unorderedTxs, signer, es.Rules.Upgrades.Sonic)
+					orderedTxs := scrambler.GetExecutionOrder(unorderedTxs, signer, es.Rules.Upgrades.Sonic)
 
 					for i, receipt := range evmProcessor.Execute(orderedTxs) {
 						if receipt != nil { // < nil if skipped

--- a/gossip/scrambler/tx_scrambler.go
+++ b/gossip/scrambler/tx_scrambler.go
@@ -1,12 +1,13 @@
-package gossip
+package scrambler
 
 import (
 	"bytes"
 	"cmp"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"slices"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // ScramblerEntry stores meta information about transaction for sorting and filtering them.
@@ -43,11 +44,11 @@ func (tx *scramblerTransaction) Sender() common.Address {
 	return tx.sender
 }
 
-// getExecutionOrder returns correct order of the transactions.
+// GetExecutionOrder returns correct order of the transactions.
 // If Sonic is enabled, the tx scrambler is used, otherwise the
 // order stays unchanged. If signer is unable to derive sender for
 // a transaction, this transaction is not excluded from the final list.
-func getExecutionOrder(unorderedTxs types.Transactions, signer types.Signer, isSonic bool) types.Transactions {
+func GetExecutionOrder(unorderedTxs types.Transactions, signer types.Signer, isSonic bool) types.Transactions {
 	// Don't use scrambler if Sonic is not enabled
 	if !isSonic {
 		return unorderedTxs
@@ -130,8 +131,8 @@ func sortTransactionsWithSameSender(entries []ScramblerEntry) {
 func scrambleTransactions(list []ScramblerEntry, salt [32]byte) {
 	var aX, bX [32]byte
 	slices.SortFunc(list, func(a, b ScramblerEntry) int {
-		aX = xorBytes32(a.Hash(), salt)
-		bX = xorBytes32(b.Hash(), salt)
+		aX = XorBytes32(a.Hash(), salt)
+		bX = XorBytes32(b.Hash(), salt)
 		return bytes.Compare(aX[:], bX[:])
 	})
 }
@@ -157,7 +158,7 @@ func analyseEntryList(entries []ScramblerEntry) ([]ScramblerEntry, [32]byte, boo
 			hasDuplicateAddresses = true
 		}
 		seenAddresses[sender] = struct{}{}
-		salt = xorBytes32(salt, entry.Hash())
+		salt = XorBytes32(salt, entry.Hash())
 		uniqueList = append(uniqueList, entry)
 		seenHashes[entry.Hash()] = struct{}{}
 
@@ -166,7 +167,7 @@ func analyseEntryList(entries []ScramblerEntry) ([]ScramblerEntry, [32]byte, boo
 	return uniqueList, salt, hasDuplicateAddresses
 }
 
-func xorBytes32(a, b [32]byte) (dst [32]byte) {
+func XorBytes32(a, b [32]byte) (dst [32]byte) {
 	for i := 0; i < 32; i++ {
 		dst[i] = a[i] ^ b[i]
 	}

--- a/gossip/scrambler/tx_scrambler.go
+++ b/gossip/scrambler/tx_scrambler.go
@@ -131,8 +131,8 @@ func sortTransactionsWithSameSender(entries []ScramblerEntry) {
 func scrambleTransactions(list []ScramblerEntry, salt [32]byte) {
 	var aX, bX [32]byte
 	slices.SortFunc(list, func(a, b ScramblerEntry) int {
-		aX = XorBytes32(a.Hash(), salt)
-		bX = XorBytes32(b.Hash(), salt)
+		aX = xorBytes32(a.Hash(), salt)
+		bX = xorBytes32(b.Hash(), salt)
 		return bytes.Compare(aX[:], bX[:])
 	})
 }
@@ -158,7 +158,7 @@ func analyseEntryList(entries []ScramblerEntry) ([]ScramblerEntry, [32]byte, boo
 			hasDuplicateAddresses = true
 		}
 		seenAddresses[sender] = struct{}{}
-		salt = XorBytes32(salt, entry.Hash())
+		salt = xorBytes32(salt, entry.Hash())
 		uniqueList = append(uniqueList, entry)
 		seenHashes[entry.Hash()] = struct{}{}
 
@@ -167,7 +167,7 @@ func analyseEntryList(entries []ScramblerEntry) ([]ScramblerEntry, [32]byte, boo
 	return uniqueList, salt, hasDuplicateAddresses
 }
 
-func XorBytes32(a, b [32]byte) (dst [32]byte) {
+func xorBytes32(a, b [32]byte) (dst [32]byte) {
 	for i := 0; i < 32; i++ {
 		dst[i] = a[i] ^ b[i]
 	}

--- a/gossip/scrambler/tx_scrambler_fuzz_test.go
+++ b/gossip/scrambler/tx_scrambler_fuzz_test.go
@@ -1,0 +1,201 @@
+package scrambler_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"math"
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/scrambler"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzScrambler(f *testing.F) {
+
+	signer := types.NewPragueSigner(big.NewInt(1))
+
+	// generate 256 account keys
+	accountKeys := make([]*ecdsa.PrivateKey, 256)
+	for i := range 256 {
+		key, err := crypto.GenerateKey()
+		require.NoError(f, err)
+		accountKeys[i] = key
+	}
+	maxMetaTransactionEncodedSize := sizeOfEncodedMetaTransaction(f)
+
+	f.Add(encodeTxList(f, []metaTransaction{}))
+	f.Add(encodeTxList(f, []metaTransaction{
+		{SenderAccount: 0, Nonce: 0, GasPrice: 0},
+		{SenderAccount: 0, Nonce: 1, GasPrice: 0},
+		{SenderAccount: 0, Nonce: 2, GasPrice: 0},
+	}))
+	f.Add(encodeTxList(f, []metaTransaction{
+		{SenderAccount: 0, Nonce: 0, GasPrice: 1},
+		{SenderAccount: 1, Nonce: 0, GasPrice: 10_000},
+		{SenderAccount: 255, Nonce: 3, GasPrice: 10_000_000_000},
+	}))
+
+	f.Fuzz(func(t *testing.T, encoded []byte) {
+
+		// Bind the input to some reasonable size.
+		// metaTransactions serialization size is variable, use worst case scenario
+		if len(encoded) > 10_000*maxMetaTransactionEncodedSize {
+			t.Skip("input too large")
+		}
+
+		stream := rlp.NewStream(bytes.NewReader(encoded), 0)
+
+		metaTxs := make([]metaTransaction, 0)
+		if err := stream.Decode(&metaTxs); err != nil {
+			t.Skip("invalid input", err)
+		}
+		if containsDuplicates(metaTxs) {
+			// the scrambler takes as a precondition that transactions cannot be duplicated
+			t.Skip("contains duplicates")
+		}
+
+		txs := make([]*types.Transaction, 0, len(metaTxs))
+		for _, metaTx := range metaTxs {
+
+			key := accountKeys[metaTx.SenderAccount]
+			tx, err := types.SignTx(types.NewTx(&types.LegacyTx{
+				Nonce:    metaTx.Nonce,
+				GasPrice: big.NewInt(int64(metaTx.GasPrice)),
+			}), signer, key)
+			require.NoError(t, err)
+
+			txs = append(txs, tx)
+		}
+
+		ordered := scrambler.GetExecutionOrder(txs, signer, true)
+
+		scrambledOrderIsReproducible(t, ordered, signer)
+	})
+}
+
+func sizeOfEncodedMetaTransaction(t testing.TB) int {
+	bytes, err := rlp.EncodeToBytes(metaTransaction{
+		SenderAccount: 0xff,
+		Nonce:         math.MaxUint64,
+		GasPrice:      math.MaxUint64,
+	})
+	require.NoError(t, err)
+	return len(bytes)
+}
+
+// scrambledOrderIsReproducible is a naive implementation that checks if the scrambler order is
+// reproducible.
+// It is meant to be used by tests only.
+func scrambledOrderIsReproducible(t testing.TB, ordered types.Transactions, signer types.Signer) {
+	t.Helper()
+
+	testList := slices.Clone(ordered)
+
+	// shuffle the list, but in a deterministic way
+	slices.SortFunc(testList, func(a, b *types.Transaction) int {
+		return bytes.Compare(a.Hash().Bytes(), b.Hash().Bytes())
+	})
+
+	reOrdered := scrambler.GetExecutionOrder(testList, signer, true)
+	if expected, got := len(reOrdered), len(ordered); expected != got {
+		t.Fatalf("scrambler did not produce same number of transactions; expected %d, got %d", expected, got)
+	}
+	for i := range reOrdered {
+		if reOrdered[i].Hash() != ordered[i].Hash() {
+			t.Errorf("transactions are not sorted")
+			for i, tx := range ordered {
+				sender, _ := types.Sender(signer, tx)
+				t.Logf("tx[%d]: hash %s sender %s nonce: %d gasprice, %d", i, tx.Hash().Hex(), sender.Hex(), tx.Nonce(), tx.GasPrice())
+			}
+		}
+	}
+}
+
+func containsDuplicates(txs []metaTransaction) bool {
+	seen := make(map[uint8]map[uint64]struct{})
+	for _, tx := range txs {
+		if _, ok := seen[tx.SenderAccount]; !ok {
+			seen[tx.SenderAccount] = make(map[uint64]struct{})
+		}
+		if _, ok := seen[tx.SenderAccount][tx.Nonce]; ok {
+			return true
+		}
+		seen[tx.SenderAccount][tx.Nonce] = struct{}{}
+	}
+	return false
+}
+
+func TestContainsDuplicates_DetectsCollisionsOfSenderAndNonce(t *testing.T) {
+	tests := map[string]struct {
+		txs                []metaTransaction
+		expectedDuplicates bool
+	}{
+		"empty": {
+			txs:                []metaTransaction{},
+			expectedDuplicates: false,
+		},
+		"no duplicates, different sender": {
+			txs: []metaTransaction{
+				{SenderAccount: 0, Nonce: 0},
+				{SenderAccount: 1, Nonce: 0},
+			},
+		},
+		"no duplicates, same sender": {
+			txs: []metaTransaction{
+				{SenderAccount: 0, Nonce: 0},
+				{SenderAccount: 0, Nonce: 1},
+			},
+		},
+		"contains duplicates": {
+			txs: []metaTransaction{
+				{SenderAccount: 0, Nonce: 0},
+				{SenderAccount: 0, Nonce: 0},
+			},
+			expectedDuplicates: true,
+		},
+		"contains duplicates, interleaved sender": {
+			txs: []metaTransaction{
+				{SenderAccount: 0, Nonce: 0},
+				{SenderAccount: 1, Nonce: 0},
+				{SenderAccount: 0, Nonce: 0},
+			},
+			expectedDuplicates: true,
+		},
+		"contains duplicates, interleaved nonce": {
+			txs: []metaTransaction{
+				{SenderAccount: 0, Nonce: 0},
+				{SenderAccount: 0, Nonce: 1},
+				{SenderAccount: 0, Nonce: 0},
+			},
+			expectedDuplicates: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.expectedDuplicates, containsDuplicates(test.txs))
+		})
+	}
+
+}
+
+// metaTransaction is a simplified representation of a transaction with the
+// fields relevant for hte scrambler.
+// It can be encoded and decoded using RLP, and this is used for the fuzzing
+// to easily generate lists of transactions.
+type metaTransaction struct {
+	SenderAccount uint8
+	Nonce         uint64
+	GasPrice      uint64
+}
+
+func encodeTxList(t testing.TB, txs []metaTransaction) []byte {
+	buf := new(bytes.Buffer)
+	require.NoError(t, rlp.Encode(buf, txs))
+	return buf.Bytes()
+}

--- a/gossip/scrambler/tx_scrambler_fuzz_test.go
+++ b/gossip/scrambler/tx_scrambler_fuzz_test.go
@@ -78,6 +78,9 @@ func FuzzScrambler(f *testing.F) {
 	})
 }
 
+// sizeOfEncodedMetaTransaction returns the size of the encoded metaTransaction,
+// this is used to avoid hardcoding the maximum size of one input, to be able
+// to create an upper bound for the generated fuzz data.
 func sizeOfEncodedMetaTransaction(t testing.TB) int {
 	bytes, err := rlp.EncodeToBytes(metaTransaction{
 		SenderAccount: 0xff,
@@ -185,7 +188,7 @@ func TestContainsDuplicates_DetectsCollisionsOfSenderAndNonce(t *testing.T) {
 }
 
 // metaTransaction is a simplified representation of a transaction with the
-// fields relevant for hte scrambler.
+// fields relevant for the scrambler.
 // It can be encoded and decoded using RLP, and this is used for the fuzzing
 // to easily generate lists of transactions.
 type metaTransaction struct {

--- a/gossip/scrambler/tx_scrambler_test.go
+++ b/gossip/scrambler/tx_scrambler_test.go
@@ -1,7 +1,6 @@
 package scrambler
 
 import (
-	"bytes"
 	"cmp"
 	"errors"
 	"fmt"
@@ -138,48 +137,6 @@ func TestTxScrambler_ScrambleTransactions_ScrambleIsDeterministic(t *testing.T) 
 			if slices.CompareFunc(res1, res2, compareFunc) != 0 {
 				t.Error("scramble is not deterministic")
 			}
-		}
-	}
-}
-
-func TestTxScrambler_ScrambleTransactions_OrderCanBeVerified(t *testing.T) {
-
-	const txCount = 100
-	const iterations = 100
-
-	testInput := make([]ScramblerEntry, 0, txCount)
-	for i := range txCount {
-		testInput = append(testInput, &dummyScramblerEntry{
-			hash:   common.Hash{byte(i)},
-			sender: common.Address{byte(i)},
-			nonce:  uint64(i),
-		})
-	}
-
-	for range iterations {
-		salt := createRandomSalt()
-		scrambleTransactions(testInput, salt)
-
-		orderFunc := func(a, b ScramblerEntry) int {
-			if a.Sender() == b.Sender() {
-				// ordered by nonce, gas price, hash
-				if res := cmp.Compare(a.Nonce(), b.Nonce()); res != 0 {
-					return res
-				}
-				if res := a.GasPrice().Cmp(b.GasPrice()); res != 0 {
-					return res
-				}
-				return a.Hash().Cmp(b.Hash())
-			}
-
-			aX := XorBytes32(a.Hash(), salt)
-			bX := XorBytes32(b.Hash(), salt)
-			return bytes.Compare(aX[:], bX[:])
-		}
-
-		// check that the order is correct
-		if !slices.IsSortedFunc(testInput, orderFunc) {
-			t.Errorf("scrambled transactions are not sorted, salt: %x %v", salt, testInput)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a fuzzing test for the public interface of the scrambler.

The fuzzer generates lists of transactions to be scrambled, shuffled and scrambled again to test reproducibility of the sorting algorithm. 

This PR moves the scrambler into its own package, this is done because fuzzing requires all tests from the package to pass before it can start.  This change reduces gossip package size, and it can be done because the scrambler does not depend on any other member of gossip. 
