### PR TITLE
Fix stopping of TxPool background worker during service shutdown

### DIFF
--- a/gossip/dummy_tx_pool.go
+++ b/gossip/dummy_tx_pool.go
@@ -177,3 +177,5 @@ func (p *dummyTxPool) Delete(needle common.Hash) {
 	}
 	p.pool = notErased
 }
+
+func (p *dummyTxPool) Stop() {}

--- a/gossip/protocol.go
+++ b/gossip/protocol.go
@@ -131,6 +131,8 @@ type TxPool interface {
 	Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	ContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	GasPrice() *big.Int
+
+	Stop()
 }
 
 // handshakeData is the network packet for the initial handshake message

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -592,6 +592,9 @@ func (s *Service) WaitBlockEnd() {
 // Stop method invoked when the node terminates the service.
 func (s *Service) Stop() error {
 	defer log.Info("Fantom service stopped")
+
+	s.txpool.Stop()
+
 	s.verWatcher.Stop()
 	for _, em := range s.emitters {
 		em.Stop()


### PR DESCRIPTION
This PR fixes a node-shutdown issue seen in some integration tests by reporting an access to some `nil` pointer, like this:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xfeea5d]

goroutine 4868 [running]:
github.com/Fantom-foundation/lachesis-base/utils/wlru.(*Cache).Get(0x0, {0x1b15800, 0xc016d96850})
	/home/herbert/go/pkg/mod/github.com/!fantom-foundation/lachesis-base-sonic@v0.0.0-20250212122819-abaef8bb9abb/utils/wlru/wlru.go:50 +0x1d
github.com/0xsoniclabs/sonic/gossip.(*Store).GetBlock(0xc000328dc8, 0x5)
	/home/herbert/coding/soniclabs/sonic/gossip/store_block.go:60 +0x3f
github.com/0xsoniclabs/sonic/gossip.(*EvmStateReader).getBlock(0xc00536a3a8, {0x1e, 0x25, 0x88, 0xe, 0xc0, 0x3e, 0x9e, 0x26, 0xd8, ...}, ...)
	/home/herbert/coding/soniclabs/sonic/gossip/evm_state_reader.go:86 +0x3d
github.com/0xsoniclabs/sonic/gossip.(*EvmStateReader).GetBlock(0xc00543bbc0?, {0x1e, 0x25, 0x88, 0xe, 0xc0, 0x3e, 0x9e, 0x26, 0xd8, ...}, ...)
	/home/herbert/coding/soniclabs/sonic/gossip/evm_state_reader.go:82 +0x2b
github.com/0xsoniclabs/sonic/evmcore.(*TxPool).reset(0xc04dc73000, 0xc01c1d4300, 0xc02ceeb100)
	/home/herbert/coding/soniclabs/sonic/evmcore/tx_pool.go:1461 +0x1f5
github.com/0xsoniclabs/sonic/evmcore.(*TxPool).runReorg(0xc04dc73000, 0xc005cf1e28?, 0xc0052f5310, 0x0, 0xc01b1eaf30)
	/home/herbert/coding/soniclabs/sonic/evmcore/tx_pool.go:1376 +0x205
created by github.com/0xsoniclabs/sonic/evmcore.(*TxPool).scheduleReorgLoop in goroutine 96
	/home/herbert/coding/soniclabs/sonic/evmcore/tx_pool.go:1306 +0x18a
```

The reason is that the TxPool was not properly stopped during the shutdown. This can lead to a situation where the background-reorg worker is still active while the DB is shut down, leading to the observed issue.