### PR TITLE
Add configurable variable for RPC simulation with EVM

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -231,6 +231,9 @@ func gossipConfigWithFlags(ctx *cli.Context, src gossip.Config) gossip.Config {
 	if ctx.IsSet(flags.StructLogLimitFlag.Name) {
 		cfg.StructLogLimit = ctx.GlobalInt(flags.StructLogLimitFlag.Name)
 	}
+	if ctx.GlobalIsSet(flags.RPCEVMSimulationFlag.Name) {
+		cfg.RPCEVMSimulation = true
+	}
 	return cfg
 }
 

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -330,6 +330,10 @@ var (
 		Name:  "exitwhensynced.epoch",
 		Usage: "Exits after synchronisation reaches the required epoch",
 	}
+	RPCEVMSimulationFlag = cli.BoolFlag{
+		Name:  "rpc.evmsimulation",
+		Usage: "EVM is used for RPC transaction simulation",
+	}
 
 	// Validator
 	ValidatorIDFlag = cli.UintFlag{

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -379,6 +379,7 @@ func TestBlockOverrides(t *testing.T) {
 	mockBackend.EXPECT().RPCGasCap().Return(uint64(10000000)).AnyTimes()
 	mockBackend.EXPECT().ChainConfig().Return(&params.ChainConfig{}).AnyTimes()
 	mockBackend.EXPECT().RPCEVMTimeout().Return(time.Duration(0)).AnyTimes()
+	mockBackend.EXPECT().RPCEVMSimulation().Return(false).AnyTimes()
 	setExpectedStateCalls(mockState)
 
 	expectedBlockCtx := &vm.BlockContext{
@@ -613,7 +614,7 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 		timeout := time.Duration(time.Second)
 		gasCap := uint64(10000000)
 
-		result, err := DoCall(t.Context(), backend, txArgs, blockNrOrHash, stateOverrides, blockOverrides, timeout, gasCap)
+		result, err := DoCall(t.Context(), backend, txArgs, blockNrOrHash, stateOverrides, blockOverrides, timeout, gasCap, false)
 		require.NoError(t, err)
 		require.False(t, result.Failed())
 	}

--- a/ethapi/backend.go
+++ b/ethapi/backend.go
@@ -61,6 +61,7 @@ type Backend interface {
 	RPCGasCap() uint64            // global gas cap for eth_call over rpc: DoS protection
 	RPCEVMTimeout() time.Duration // global timeout for eth_call over rpc: DoS protection
 	RPCTxFeeCap() float64         // global tx fee cap for all transaction related APIs
+	RPCEVMSimulation() bool       // EVM used for RPC transaction simulation
 	UnprotectedAllowed() bool     // allows only for EIP155 transactions.
 	CalcBlockExtApi() bool
 

--- a/ethapi/mock_backend.go
+++ b/ethapi/mock_backend.go
@@ -501,6 +501,20 @@ func (mr *MockBackendMockRecorder) Progress() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Progress", reflect.TypeOf((*MockBackend)(nil).Progress))
 }
 
+// RPCEVMSimulation mocks base method.
+func (m *MockBackend) RPCEVMSimulation() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RPCEVMSimulation")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// RPCEVMSimulation indicates an expected call of RPCEVMSimulation.
+func (mr *MockBackendMockRecorder) RPCEVMSimulation() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCEVMSimulation", reflect.TypeOf((*MockBackend)(nil).RPCEVMSimulation))
+}
+
 // RPCEVMTimeout mocks base method.
 func (m *MockBackend) RPCEVMTimeout() time.Duration {
 	m.ctrl.T.Helper()

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -95,6 +95,9 @@ type (
 		StructLogLimit int
 
 		RPCBlockExt bool
+
+		// RPCEVMSimulation when set, EVM is used for simulation in eth_call function
+		RPCEVMSimulation bool
 	}
 
 	StoreCacheConfig struct {
@@ -205,6 +208,8 @@ func DefaultConfig(scale cachescale.Func) Config {
 
 		MaxResponseSize: 25 * 1024 * 1024,
 		StructLogLimit:  2000,
+
+		RPCEVMSimulation: false,
 	}
 	sessionCfg := cfg.Protocol.DagStreamLeecher.Session
 	cfg.Protocol.DagProcessor.EventsBufferLimit.Num = idx.Event(sessionCfg.ParallelChunksDownload)*

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -467,6 +467,9 @@ func (b *EthAPIBackend) RPCEVMTimeout() time.Duration {
 func (b *EthAPIBackend) RPCTxFeeCap() float64 {
 	return b.svc.config.RPCTxFeeCap
 }
+func (b *EthAPIBackend) RPCEVMSimulation() bool {
+	return b.svc.config.RPCEVMSimulation
+}
 
 func (b *EthAPIBackend) EvmLogIndex() topicsdb.Index {
 	return b.svc.store.evm.EvmLogs


### PR DESCRIPTION
This PR adds an configurable flag to select, if EVM should be used for transaction simulation with `eth_call` RPC function