### PR TITLE
Track the nonce of a session sponsor explicitly

### DIFF
--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -2,7 +2,6 @@ package app_test
 
 import (
 	"crypto/ecdsa"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"math/big"
@@ -353,10 +352,6 @@ func generateNBlocks(t *testing.T, net *tests.IntegrationTestNet, n int) {
 
 func createAccount(t *testing.T, net *tests.IntegrationTestNet) {
 	t.Helper()
-
-	var addr common.Address
-	_, err := rand.Read(addr[:])
-	require.NoError(t, err)
 
 	receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(100))
 	require.NoError(t, err)


### PR DESCRIPTION
This change should fix flaky tests resulting into problems like this:
```
15:26:52  --- FAIL: TestSonicTool_heal_ExecutesWithoutErrors (10.17s)
15:26:52      app_test.go:173: 
15:26:52          	Error Trace:	/home/jenkins/workspace/Request_Tests_0xSonicLabs_PR-174/cmd/sonictool/app/app_test.go:362
15:26:52          	            				/home/jenkins/workspace/Request_Tests_0xSonicLabs_PR-174/cmd/sonictool/app/app_test.go:350
15:26:52          	            				/home/jenkins/workspace/Request_Tests_0xSonicLabs_PR-174/cmd/sonictool/app/app_test.go:173
15:26:52          	Error:      	Received unexpected error:
15:26:52          	            	failed to send transaction: replacement transaction underpriced
15:26:52          	Test:       	TestSonicTool_heal_ExecutesWithoutErrors
```

The cause for this flakyness seems to be that nonces for the session account are requested from the server through RPC queries targeting the archive state [here](https://github.com/0xsoniclabs/sonic/blob/fc3ec8fc790601e591512d943b93648a5255e2ac/ethapi/api.go#L1626). However, the archive state may be lagging behind, resulting in an out-dated nonce value.

By tracking it explicitly, this problem can be circumvented.