### PR TITLE
Add algorithm to select proposer for each turn

### DIFF
--- a/inter/proposer_selection.go
+++ b/inter/proposer_selection.go
@@ -1,0 +1,65 @@
+package inter
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+)
+
+// Turn is the turn number of a proposal. Turns are used to orchestrate the
+// sequence of block proposals in the consensus protocol. Turns are processed
+// in order. A turn ends with a proposer making a proposal or a timeout.
+type Turn uint32
+
+// GetProposer returns the designated proposer for a given turn.
+// The proposer is determined through deterministic sampling of validators
+// proportional to the validator's stake.
+func GetProposer(
+	validators *pos.Validators,
+	turn Turn,
+) (idx.ValidatorID, error) {
+
+	// The selection of the proposer for a given round is conducted as follows:
+	//  1. f := sha256(turn) / 2^256
+	//  2. limit := f * total_weight
+	//  3. from the list of validators sorted by their stake, find the first
+	//     validator whose cumulative weight is greater than or equal to limit.
+
+	// -- Preconditions --
+	ids := validators.SortedIDs()
+	if len(ids) == 0 {
+		return 0, fmt.Errorf("no validators")
+	}
+
+	// Note that we use big.Rat to preserve precision in the division.
+	// limit := (sha256(turn) * total_weight) / 2^256
+	data := make([]byte, 0, 4)
+	data = binary.BigEndian.AppendUint32(data, uint32(turn))
+	hash := sha256.Sum256(data)
+	limit := new(big.Rat).Quo(
+		new(big.Rat).SetInt(
+			new(big.Int).Mul(
+				new(big.Int).SetBytes(hash[:]),
+				big.NewInt(int64(validators.TotalWeight())),
+			),
+		),
+		new(big.Rat).SetInt(new(big.Int).Lsh(big.NewInt(1), 256)),
+	)
+
+	// Find the first validator whose cumulative weight is greater than or equal
+	// to the limit.
+	res := ids[0]
+	cumulated := big.NewRat(0, 1)
+	for i, weight := range validators.SortedWeights() {
+		cumulated.Num().Add(cumulated.Num(), big.NewInt(int64(weight)))
+		if cumulated.Cmp(limit) >= 0 {
+			res = ids[i]
+			break
+		}
+	}
+	return res, nil
+}

--- a/inter/proposer_selection.go
+++ b/inter/proposer_selection.go
@@ -50,8 +50,8 @@ func GetProposer(
 		new(big.Rat).SetInt(new(big.Int).Lsh(big.NewInt(1), 256)),
 	)
 
-	// Find the first validator whose cumulative weight is greater than or equal
-	// to the limit.
+	// Walk through the validators sorted by their stake (and ID as a tiebreaker)
+	// and accumulate their weights until we reach the limit calculated above.
 	res := ids[0]
 	cumulated := big.NewRat(0, 1)
 	for i, weight := range validators.SortedWeights() {

--- a/inter/proposer_selection.go
+++ b/inter/proposer_selection.go
@@ -10,11 +10,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 )
 
-// Turn is the turn number of a proposal. Turns are used to orchestrate the
-// sequence of block proposals in the consensus protocol. Turns are processed
-// in order. A turn ends with a proposer making a proposal or a timeout.
-type Turn uint32
-
 // GetProposer returns the designated proposer for a given turn.
 // The proposer is determined through deterministic sampling of validators
 // proportional to the validator's stake.

--- a/inter/proposer_selection_test.go
+++ b/inter/proposer_selection_test.go
@@ -1,0 +1,65 @@
+package inter
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetProposer_IsDeterministic(t *testing.T) {
+	require := require.New(t)
+
+	builder := pos.ValidatorsBuilder{}
+	builder.Set(1, 10)
+	builder.Set(2, 20)
+	builder.Set(3, 30)
+	validators := builder.Build()
+
+	for turn := range Turn(5) {
+		a, err := GetProposer(validators, turn)
+		require.NoError(err)
+		b, err := GetProposer(validators, turn)
+		require.NoError(err)
+		require.Equal(a, b, "proposer selection is not deterministic")
+	}
+}
+
+func TestGetProposer_EmptyValidatorSet_Fails(t *testing.T) {
+	require := require.New(t)
+
+	builder := pos.ValidatorsBuilder{}
+	validators := builder.Build()
+
+	_, err := GetProposer(validators, 0)
+	require.ErrorContains(err, "no validators")
+}
+
+func TestGetProposer_ProposersAreSelectedProportionalToStake(t *testing.T) {
+	require := require.New(t)
+
+	builder := pos.ValidatorsBuilder{}
+	builder.Set(1, 10)
+	builder.Set(2, 20)
+	builder.Set(3, 30)
+	builder.Set(4, 40)
+	validators := builder.Build()
+
+	const Samples = 100000
+	counters := map[idx.ValidatorID]int{}
+	for turn := range Turn(Samples) {
+		proposer, err := GetProposer(validators, turn)
+		require.NoError(err)
+		counters[proposer]++
+	}
+
+	tolerance := float64(Samples / 100) // 1% tolerance
+	for id, idx := range validators.Idxs() {
+		expected := int(Samples * validators.GetWeightByIdx(idx) / validators.TotalWeight())
+		require.InDelta(
+			counters[id], expected, tolerance,
+			"validator %d is not selected proportional to stake", id,
+		)
+	}
+}

--- a/inter/proposer_selection_test.go
+++ b/inter/proposer_selection_test.go
@@ -1,6 +1,7 @@
 package inter
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -26,6 +27,53 @@ func TestGetProposer_IsDeterministic(t *testing.T) {
 	}
 }
 
+func TestGetProposer_EqualStakes_SelectionIsDeterministic(t *testing.T) {
+	require := require.New(t)
+
+	builder := pos.ValidatorsBuilder{}
+	builder.Set(1, 10)
+	builder.Set(2, 10)
+	validators1 := builder.Build()
+
+	builder = pos.ValidatorsBuilder{}
+	builder.Set(2, 10)
+	builder.Set(1, 10)
+	validators2 := builder.Build()
+
+	const N = 50
+	want := []idx.ValidatorID{}
+	for turn := range Turn(N) {
+		got, err := GetProposer(validators1, turn)
+		require.NoError(err)
+		want = append(want, got)
+	}
+
+	for range 10 {
+		for turn := range Turn(N) {
+			got, err := GetProposer(validators2, turn)
+			require.NoError(err)
+			require.Equal(got, want[turn], "proposer selection is not deterministic")
+		}
+	}
+}
+
+func TestGetProposer_ZeroStake_IsIgnored(t *testing.T) {
+	require := require.New(t)
+
+	builder := pos.ValidatorsBuilder{}
+	builder.Set(1, 0)
+	builder.Set(2, 1)
+	validators := builder.Build()
+
+	require.Len(validators.Idxs(), 1, "validator with zero stake should be ignored")
+
+	for turn := range Turn(50) {
+		a, err := GetProposer(validators, turn)
+		require.NoError(err)
+		require.Equal(idx.ValidatorID(2), a, "unexpected proposer")
+	}
+}
+
 func TestGetProposer_EmptyValidatorSet_Fails(t *testing.T) {
 	require := require.New(t)
 
@@ -37,7 +85,6 @@ func TestGetProposer_EmptyValidatorSet_Fails(t *testing.T) {
 }
 
 func TestGetProposer_ProposersAreSelectedProportionalToStake(t *testing.T) {
-	require := require.New(t)
 
 	builder := pos.ValidatorsBuilder{}
 	builder.Set(1, 10)
@@ -46,20 +93,38 @@ func TestGetProposer_ProposersAreSelectedProportionalToStake(t *testing.T) {
 	builder.Set(4, 40)
 	validators := builder.Build()
 
-	const Samples = 100000
-	counters := map[idx.ValidatorID]int{}
-	for turn := range Turn(Samples) {
-		proposer, err := GetProposer(validators, turn)
-		require.NoError(err)
-		counters[proposer]++
+	tests := []struct {
+		samples   int
+		tolerance float32 // in percent
+	}{
+		{samples: 1, tolerance: 100},
+		{samples: 10, tolerance: 20},
+		{samples: 50, tolerance: 10},
+		{samples: 100, tolerance: 3},
+		{samples: 1_000, tolerance: 1.5},
+		{samples: 10_000, tolerance: 0.6},
+		{samples: 100_000, tolerance: 0.25},
 	}
 
-	tolerance := float64(Samples / 100) // 1% tolerance
-	for id, idx := range validators.Idxs() {
-		expected := int(Samples * validators.GetWeightByIdx(idx) / validators.TotalWeight())
-		require.InDelta(
-			counters[id], expected, tolerance,
-			"validator %d is not selected proportional to stake", id,
-		)
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("samples=%v", test.samples), func(t *testing.T) {
+			require := require.New(t)
+			t.Parallel()
+			counters := map[idx.ValidatorID]int{}
+			for turn := range Turn(test.samples) {
+				proposer, err := GetProposer(validators, turn)
+				require.NoError(err)
+				counters[proposer]++
+			}
+
+			tolerance := float64(test.samples) * float64(test.tolerance) / 100
+			for id, idx := range validators.Idxs() {
+				expected := int(pos.Weight(test.samples) * validators.GetWeightByIdx(idx) / validators.TotalWeight())
+				require.InDelta(
+					counters[id], expected, tolerance,
+					"validator %d is not selected proportional to stake", id,
+				)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR introduces the algorithm used to select validators allowed to propose blocks from a list of validators.

The selection algorithm is selecting validators proportionally to their stake. Thus, a valdiator A with twice the stake of validator B will get selected twice as often for being a proposer for turns.