### PR TITLE
Use GETH for eth_call simulation with large code in state override

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1020,7 +1020,7 @@ func (diff *StateOverride) CodeTooBig() bool {
 	}
 	for _, account := range *diff {
 		// Check account(contract) code length.
-		if account.Code != nil && len(*account.Code) > math.MaxUint16 {
+		if account.Code != nil && len(*account.Code) > params.MaxCodeSize {
 			return true
 		}
 	}

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1014,7 +1014,7 @@ func (diff *StateOverride) Apply(state state.StateDB) error {
 	return nil
 }
 
-func (diff *StateOverride) CodeTooBig() bool {
+func (diff *StateOverride) HasCodesExceedingOnChainLimit() bool {
 	if diff == nil {
 		return false
 	}
@@ -1056,7 +1056,7 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 		return nil, err
 	}
 	vmConfig := opera.DefaultVMConfig
-	if overrides.CodeTooBig() {
+	if overrides.HasCodesExceedingOnChainLimit() {
 		// Use geth as VM for computation
 		vmConfig.Tracer = &tracing.Hooks{}
 	}

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1014,6 +1014,19 @@ func (diff *StateOverride) Apply(state state.StateDB) error {
 	return nil
 }
 
+func (diff *StateOverride) CodeTooBig() bool {
+	if diff == nil {
+		return false
+	}
+	for _, account := range *diff {
+		// Check account(contract) code length.
+		if account.Code != nil && len(*account.Code) > math.MaxUint16 {
+			return true
+		}
+	}
+	return false
+}
+
 func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, blockOverrides *BlockOverrides, timeout time.Duration, globalGasCap uint64) (*core.ExecutionResult, error) {
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
 
@@ -1043,6 +1056,11 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 		return nil, err
 	}
 	vmConfig := opera.DefaultVMConfig
+	if overrides.CodeTooBig() {
+		// Use geth as VM for computation
+		vmConfig.Tracer = &tracing.Hooks{}
+	}
+
 	var blockCtx *vm.BlockContext
 	if blockOverrides != nil {
 		bctx := getBlockContext(ctx, b, header)

--- a/tests/eth_call_test.go
+++ b/tests/eth_call_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -9,18 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEthCall_CodeLargerThanMaxInitCodeSizeIsNotAccepted(t *testing.T) {
+func TestEthCall_CodeLargerThanMaxInitCodeSizeIsAccepted(t *testing.T) {
 	tests := map[string]struct {
 		codeSize int
-		err      error
 	}{
-		"max code size": {
+		"max code size lfvm": {
 			math.MaxUint16, // max code size supported by the LFVM
-			nil,
 		},
-		"max code size + 1": {
-			math.MaxUint16 + 1,
-			fmt.Errorf("max code size exceeded"),
+		"max code size lfvm + 1": {
+			math.MaxUint16 + 1, // will be processed by GETH
 		},
 	}
 	net := StartIntegrationTestNet(t)
@@ -51,11 +47,7 @@ func TestEthCall_CodeLargerThanMaxInitCodeSizeIsNotAccepted(t *testing.T) {
 
 			var res interface{}
 			err = rpcClient.Call(&res, "eth_call", txArguments, requestedBlock, stateOverrides)
-			if test.err == nil {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, test.err.Error())
-			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/tests/eth_call_test.go
+++ b/tests/eth_call_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,11 +13,17 @@ func TestEthCall_CodeLargerThanMaxInitCodeSizeIsAccepted(t *testing.T) {
 	tests := map[string]struct {
 		codeSize int
 	}{
+		"max code size": {
+			params.MaxCodeSize,
+		},
+		"max code size + 1": {
+			params.MaxCodeSize + 1,
+		},
 		"max code size lfvm": {
 			math.MaxUint16, // max code size supported by the LFVM
 		},
 		"max code size lfvm + 1": {
-			math.MaxUint16 + 1, // will be processed by GETH
+			math.MaxUint16 + 1,
 		},
 	}
 	net := StartIntegrationTestNet(t)


### PR DESCRIPTION
This PR modifies `eth_call` RPC function when there is contract code in account state override largen then the maximum allowed code for `LFVM` interpreter. In this case it uses `GETH` interpreter to simulate `eth_call`.