### PR TITLE
Add `make integration-cover-all` target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 */*.test
 */*.out
 fuzzing/
+coverage/
 
 # Build output
 build

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 */*.test
 */*.out
 fuzzing/
-coverage/
 
 # Build output
 build

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,18 @@ fuzz:
 	go run github.com/dvyukov/go-fuzz/go-fuzz-build -o=./fuzzing/gossip-fuzz.zip ./gossip && \
 	go run github.com/dvyukov/go-fuzz/go-fuzz -workdir=./fuzzing -bin=./fuzzing/gossip-fuzz.zip
 
+.PHONY: integration-coverage
+integration-coverage: DATE=$(shell date +"%Y-%m-%d-%T")
+integration-coverage: export GOCOVERDIR=./coverage/${DATE}
+integration-coverage: 
+	@mkdir -p ${GOCOVERDIR} ;\
+	go test ./tests/ -coverpkg=${PACKAGES} -coverprofile=${GOCOVERDIR}/cover.out ;\
+	go tool cover -html ${GOCOVERDIR}/cover.out -o ${GOCOVERDIR}/coverage.html ;\
+	echo "Coverage report generated in ${GOCOVERDIR}/coverage.html"
+
+.PHONY: integration-cover-all
+integration-cover-all: PACKAGES=./...
+integration-cover-all: integration-coverage
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,12 @@ fuzz:
 
 .PHONY: integration-coverage
 integration-coverage: DATE=$(shell date +"%Y-%m-%d-%T")
-integration-coverage: export GOCOVERDIR=./coverage/${DATE}
+integration-coverage: export GOCOVERDIR=./build/coverage/${DATE}
 integration-coverage: 
 	@mkdir -p ${GOCOVERDIR} ;\
-	go test ./tests/ -coverpkg=${PACKAGES} -coverprofile=${GOCOVERDIR}/cover.out ;\
-	go tool cover -html ${GOCOVERDIR}/cover.out -o ${GOCOVERDIR}/coverage.html ;\
-	echo "Coverage report generated in ${GOCOVERDIR}/coverage.html"
+	go test ./tests/ -coverpkg=${PACKAGES} -coverprofile=${GOCOVERDIR}/integration-cover.out ;\
+	go tool cover -html ${GOCOVERDIR}/integration-cover.out -o ${GOCOVERDIR}/integration-coverage.html ;\
+	echo "Coverage report generated in ${GOCOVERDIR}/integration-coverage.html"
 
 .PHONY: integration-cover-all
 integration-cover-all: PACKAGES=./...


### PR DESCRIPTION
This PR adds a new target to our Makefile, `integration-cover-all`. 

This new target will:
- create a new folder (`./coverage/{current-date}`)
- run the integrations tests (`go test ./tests/`) and produce a coverage report on all packages in `github.com/0xsoniclabs/sonic/`.
- the raw report will be in `./coverage/{current-date}/cover.out` and a friendlier human readable html report will be in  `./coverage/{current-date}/coverage.html`

The folder where all reports will be generated is included in `.gitignore` as to prevent uploading them by mistake. 