### PR TITLE
Introduce new event version using protobuffer payload

### DIFF
--- a/inter/event.go
+++ b/inter/event.go
@@ -267,6 +267,7 @@ func (e *MutableEventPayload) SetEpochVote(v LlrEpochVote) {
 
 func (e *MutableEventPayload) SetPayload(payload Payload) {
 	e.payload = payload
+	e.payloadHash = payload.Hash()
 }
 
 func calcEventID(h hash.Hash) (id [24]byte) {

--- a/inter/event.go
+++ b/inter/event.go
@@ -62,12 +62,13 @@ type EventPayloadI interface {
 }
 
 var emptyPayloadHash1 = CalcPayloadHash(&MutableEventPayload{extEventData: extEventData{version: 1}})
+var emptyPayloadHash3 = CalcPayloadHash(&MutableEventPayload{extEventData: extEventData{version: 3}})
 
 func EmptyPayloadHash(version uint8) hash.Hash {
 	if version == 1 {
 		return emptyPayloadHash1
 	} else if version == 3 {
-		return (&Payload{}).Hash()
+		return emptyPayloadHash3
 	} else {
 		return hash.Hash(types.EmptyRootHash)
 	}

--- a/inter/event_serializer.go
+++ b/inter/event_serializer.go
@@ -251,6 +251,11 @@ func (e *EventPayload) MarshalCSER(w *cser.Writer) error {
 	if e.AnyBlockVotes() != (len(e.blockVotes.Votes) != 0) {
 		return ErrSerMalformedEvent
 	}
+	if e.Version() == 3 {
+		if e.AnyBlockVotes() || e.AnyEpochVote() || e.AnyMisbehaviourProofs() || e.AnyTxs() {
+			return ErrSerMalformedEvent
+		}
+	}
 	err := e.Event.MarshalCSER(w)
 	if err != nil {
 		return err

--- a/inter/event_test.go
+++ b/inter/event_test.go
@@ -56,3 +56,21 @@ func TestCalcMisbehaviourProofsHash(t *testing.T) {
 
 	require.Equal(t, "85834ef7fc1d75d65832b1f9b45b43c4f5677811bb2d384208553d32ab49def1", hex.EncodeToString(CalcMisbehaviourProofsHash(v).Bytes()))
 }
+
+func TestEvent_Version3_PayloadHashMatchesHashOfPayload(t *testing.T) {
+	require := require.New(t)
+
+	for turn := range Turn(2) {
+		payload := Payload{
+			LastSeenProposalTurn: turn,
+		}
+
+		builder := MutableEventPayload{}
+		builder.SetVersion(3)
+		builder.SetPayload(payload)
+		event := builder.Build()
+
+		require.Equal(CalcPayloadHash(event), event.PayloadHash())
+		require.Equal(payload.Hash(), event.PayloadHash())
+	}
+}


### PR DESCRIPTION
This PR integrates the new `Payload` type into a new version for the Lachesis `Event` type.

This modification adds support for proposals to be annotated to events, thereby enabling the forwarding of proposals through the network as well as retaining them in the event database.