### PR TITLE
Add fuzzer for `validateTx`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,19 +61,19 @@ integration-coverage:
 integration-cover-all: PACKAGES=./...
 integration-cover-all: integration-coverage
 
-.PHONY: fuzz-validate-cover
-fuzz-validate-cover: PACKAGES=./...,github.com/ethereum/go-ethereum/core/...
-fuzz-validate-cover: DATE=$(shell date +"%Y-%m-%d-%T")
-fuzz-validate-cover: export GOCOVERDIR=./build/coverage/fuzz-validate/${DATE}
-fuzz-validate-cover: SEEDDIR=$$(go env GOCACHE)/fuzz/github.com/0xsoniclabs/sonic/evmcore/FuzzValidateTransaction/
-fuzz-validate-cover: TEMPSEEDDIR=./evmcore/testdata/fuzz/FuzzValidateTransaction/
-fuzz-validate-cover:
+.PHONY: fuzz-txpool-validatetx-cover
+fuzz-txpool-validatetx-cover: PACKAGES=./...,github.com/ethereum/go-ethereum/core/...
+fuzz-txpool-validatetx-cover: DATE=$(shell date +"%Y-%m-%d-%T")
+fuzz-txpool-validatetx-cover: export GOCOVERDIR=./build/coverage/fuzz-validate/${DATE}
+fuzz-txpool-validatetx-cover: SEEDDIR=$$(go env GOCACHE)/fuzz/github.com/0xsoniclabs/sonic/evmcore/FuzzValidateTransaction/
+fuzz-txpool-validatetx-cover: TEMPSEEDDIR=./evmcore/testdata/fuzz/FuzzValidateTransaction/
+fuzz-txpool-validatetx-cover:
 	@mkdir -p ${GOCOVERDIR} ;\
      mkdir -p ${TEMPSEEDDIR} ;\
-	  go test -fuzz=FuzzValidateTransaction -fuzztime=2m ./evmcore/ ;\
+	 go test -fuzz=FuzzValidateTransaction -fuzztime=2m ./evmcore/ ;\
      cp -r ${SEEDDIR}* ${TEMPSEEDDIR} ;\
-     go test -v -run FuzzValidateTransaction -coverprofile=${GOCOVERDIR}/fuzz-validate-cover.out -coverpkg=${PACKAGES} ./evmcore/ ;\
-     go tool cover -html ${GOCOVERDIR}/fuzz-validate-cover.out -o ${GOCOVERDIR}/fuzz-validate-coverage.html ;\
+     go test -v -run FuzzValidateTransaction -coverprofile=${GOCOVERDIR}/fuzz-txpool-validatetx-cover.out -coverpkg=${PACKAGES} ./evmcore/ ;\
+     go tool cover -html ${GOCOVERDIR}/fuzz-txpool-validatetx-cover.out -o ${GOCOVERDIR}/fuzz-txpool-validatetx-coverage.html ;\
      rm -rf ${TEMPSEEDDIR} ;\
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,21 @@ integration-coverage:
 integration-cover-all: PACKAGES=./...
 integration-cover-all: integration-coverage
 
+.PHONY: fuzz-validate-cover
+fuzz-validate-cover: PACKAGES=./...,github.com/ethereum/go-ethereum/core/...
+fuzz-validate-cover: DATE=$(shell date +"%Y-%m-%d-%T")
+fuzz-validate-cover: export GOCOVERDIR=./build/coverage/fuzz-validate/${DATE}
+fuzz-validate-cover: SEEDDIR=$$(go env GOCACHE)/fuzz/github.com/0xsoniclabs/sonic/evmcore/FuzzValidateTransaction/
+fuzz-validate-cover: TEMPSEEDDIR=./evmcore/testdata/fuzz/FuzzValidateTransaction/
+fuzz-validate-cover:
+	@mkdir -p ${GOCOVERDIR} ;\
+     mkdir -p ${TEMPSEEDDIR} ;\
+	  go test -fuzz=FuzzValidateTransaction -fuzztime=2m ./evmcore/ ;\
+     cp -r ${SEEDDIR}* ${TEMPSEEDDIR} ;\
+     go test -v -run FuzzValidateTransaction -coverprofile=${GOCOVERDIR}/fuzz-validate-cover.out -coverpkg=${PACKAGES} ./evmcore/ ;\
+     go tool cover -html ${GOCOVERDIR}/fuzz-validate-cover.out -o ${GOCOVERDIR}/fuzz-validate-coverage.html ;\
+     rm -rf ${TEMPSEEDDIR} ;\
+
 .PHONY: clean
 clean:
 	rm -fr ./build/*

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -1,0 +1,321 @@
+package evmcore
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	testIstanbul = 0x00
+	testBerlin   = 0x01
+	testLondon   = 0x02
+	testShanghai = 0x03
+	testCancun   = 0x04
+	testPrague   = 0x05
+)
+
+// FuzzValidateTransaction fuzzes the validateTx function with randomly generated transactions.
+func FuzzValidateTransaction(f *testing.F) {
+
+	// Seed corpus with a few valid-looking values
+	f.Add(uint8(2), uint64(1), uint64(42_000), int64(1_000), int64(500), int64(0),
+		[]byte("hi"), false,
+		int64(1_000_000_000), int64(10), uint64(50_000), int8(3),
+	)
+
+	f.Fuzz(func(t *testing.T,
+		// transaction values
+		txType uint8, nonce, gas uint64, feeCap, tip, value int64,
+		data []byte, isCreate bool,
+		// block context
+		blockNum, baseFee int64, evmGasPool uint64, revision int8,
+	) {
+
+		if txType > types.SetCodeTxType {
+			// Skip invalid transaction types
+			return
+		}
+		if revision > testPrague {
+			// Skip invalid revisions
+			return
+		}
+		if isCreate && (txType == types.BlobTxType || txType == types.SetCodeTxType) {
+			// Skip invalid transaction types for contract creation
+			return
+		}
+
+		// a full persistent state is not need. ValidateTx needs to see the same state as the processor.
+		ctxt := gomock.NewController(t)
+
+		chainId := big.NewInt(84)
+
+		tx := makeTxOfType(txType, nonce, gas, feeCap, tip, data, value, isCreate, chainId)
+		from, signedTx := signTxForTestWithChainId(t, tx, chainId)
+
+		cost := signedTx.Cost()
+		underCost := new(big.Int).Sub(cost, big.NewInt(1))
+		overCost := new(big.Int).Add(cost, big.NewInt(1))
+
+		for _, stateBalance := range []*big.Int{underCost, cost, overCost} {
+			for _, stateNonce := range []uint64{nonce - 1, nonce, nonce + 1} {
+
+				state := state.NewMockStateDB(ctxt)
+				state.EXPECT().GetBalance(from).Return(uint256.MustFromBig(stateBalance)).AnyTimes()
+				state.EXPECT().GetNonce(from).Return(stateNonce).AnyTimes()
+				stateExpectCalls(state)
+
+				// TODO: fuzz on validation options as well.
+				opt := getTestTransactionsOptionFromRevision(revision, chainId)
+				opt.currentState = state
+				opt.currentMaxGas = uint64(evmGasPool)
+
+				// Validate the transaction
+				validateErr := validateTx(signedTx, opt)
+
+				// create evm to check validateTx is consistent with processor.
+				evm := makeTestEvm(blockNum, baseFee, evmGasPool, state, revision, chainId)
+
+				msg, err := TxAsMessage(
+					signedTx,
+					types.NewPragueSigner(chainId), // use same sender as signTxForTest
+					evm.Context.BaseFee)
+				require.NoError(t, err)
+
+				gp := new(core.GasPool).AddGas(uint64(evmGasPool))
+				var usedGas uint64
+				_, _, _, processorError := applyTransaction(msg, gp, state, big.NewInt(blockNum),
+					signedTx, &usedGas, evm, nil)
+
+				if validateErr == nil {
+					if processorError != validateErr &&
+						// if the nonce is too high this is also acceptable for the validateTx
+						!strings.Contains(processorError.Error(), "nonce too high") {
+						t.Fatalf("\nvalidateTx: %v - applyTx: %v\n", validateErr, processorError)
+					}
+				}
+			}
+		}
+	})
+}
+
+func makeTxOfType(txType uint8, nonce, gas uint64, feeCap, tip int64,
+	data []byte, value int64, isCreate bool, chainId *big.Int) types.TxData {
+
+	feeCapBig := big.NewInt(feeCap)
+	tipBig := big.NewInt(tip)
+
+	to := common.Address{0x42}
+	toPtr := &to
+	if isCreate {
+		// Set to nil
+		toPtr = nil
+	}
+
+	var tx types.TxData
+	switch txType {
+	case types.LegacyTxType:
+		tx = &types.LegacyTx{
+			Nonce:    nonce,
+			Gas:      gas,
+			GasPrice: feeCapBig,
+			To:       toPtr,
+			Value:    big.NewInt(value),
+			Data:     data,
+		}
+	case types.AccessListTxType:
+		tx = &types.AccessListTx{
+			ChainID:    chainId,
+			Nonce:      nonce,
+			Gas:        gas,
+			GasPrice:   feeCapBig,
+			To:         toPtr,
+			Value:      big.NewInt(value),
+			Data:       data,
+			AccessList: types.AccessList{},
+		}
+	case types.DynamicFeeTxType:
+		tx = &types.DynamicFeeTx{
+			ChainID:    chainId,
+			Nonce:      nonce,
+			Gas:        gas,
+			GasFeeCap:  feeCapBig,
+			GasTipCap:  tipBig,
+			To:         toPtr,
+			Value:      big.NewInt(value),
+			Data:       data,
+			AccessList: types.AccessList{},
+		}
+	case types.BlobTxType:
+		tx = &types.BlobTx{
+			ChainID:    uint256.MustFromBig(chainId),
+			Nonce:      nonce,
+			Gas:        gas,
+			GasFeeCap:  uint256.MustFromBig(feeCapBig),
+			GasTipCap:  uint256.MustFromBig(tipBig),
+			To:         to, // cannot be create
+			Value:      uint256.NewInt(uint64(value)),
+			Data:       data,
+			AccessList: types.AccessList{},
+		}
+	case types.SetCodeTxType:
+		tx = &types.SetCodeTx{
+			ChainID:    uint256.MustFromBig(chainId),
+			Gas:        gas,
+			GasFeeCap:  uint256.MustFromBig(feeCapBig),
+			GasTipCap:  uint256.MustFromBig(tipBig),
+			To:         to, // cannot be create
+			Value:      uint256.NewInt(uint64(value)),
+			Data:       data,
+			AccessList: types.AccessList{},
+			AuthList:   []types.SetCodeAuthorization{{}},
+		}
+	}
+	return tx
+}
+
+func stateExpectCalls(state *state.MockStateDB) {
+	// expected calls to the state
+	any := gomock.Any()
+	state.EXPECT().Snapshot().AnyTimes()
+	state.EXPECT().RevertToSnapshot(any).AnyTimes()
+
+	// all accounts are unknown to a new state
+	state.EXPECT().Exist(any).Return(false).AnyTimes()
+	state.EXPECT().CreateAccount(any).AnyTimes()
+	state.EXPECT().CreateContract(any).AnyTimes()
+	state.EXPECT().EndTransaction().AnyTimes()
+	state.EXPECT().TxIndex().Return(4).AnyTimes()
+
+	state.EXPECT().GetCode(any).Return([]byte{}).AnyTimes()
+	state.EXPECT().GetCodeHash(any).Return(common.Hash{}).AnyTimes()
+	state.EXPECT().GetCodeSize(any).Return(0).AnyTimes()
+	state.EXPECT().GetLogs(any, any).Return([]*types.Log{}).AnyTimes()
+	state.EXPECT().GetNonce(any).Return(uint64(1)).AnyTimes()
+	state.EXPECT().GetRefund().Return(uint64(0)).AnyTimes()
+	state.EXPECT().GetState(any, any).Return(common.Hash{}).AnyTimes()
+	state.EXPECT().GetStorageRoot(any).Return(common.Hash{}).AnyTimes()
+
+	state.EXPECT().HasSelfDestructed(any).Return(false).AnyTimes()
+	state.EXPECT().SelfDestruct(any).AnyTimes()
+
+	state.EXPECT().AddBalance(any, any, any).AnyTimes()
+	state.EXPECT().AddLog(any).AnyTimes()
+	state.EXPECT().AddRefund(any).AnyTimes()
+
+	state.EXPECT().SetCode(any, any).Return([]byte{}).AnyTimes()
+	state.EXPECT().SetNonce(any, any, any).AnyTimes()
+	state.EXPECT().SetState(any, any, any).Return(common.Hash{}).AnyTimes()
+
+	state.EXPECT().AddAddressToAccessList(any).AnyTimes()
+	state.EXPECT().Prepare(any, any, any, any, any, any).AnyTimes()
+	state.EXPECT().SubBalance(any, any, any).AnyTimes()
+	state.EXPECT().Witness().AnyTimes()
+}
+
+func makeTestEvm(blockNum, basefee int64, evmGasPrice uint64, state vm.StateDB, revision int8, chainId *big.Int) *vm.EVM {
+
+	chainConfig := &params.ChainConfig{
+		ChainID: chainId,
+	}
+
+	u64One := uint64(1)
+	blockTime := uint64(0)
+
+	switch revision {
+	case testPrague:
+		chainConfig.PragueTime = &u64One
+		fallthrough
+	case testCancun:
+		chainConfig.CancunTime = &u64One
+		fallthrough
+	case testShanghai:
+		chainConfig.ShanghaiTime = &u64One
+		blockTime = 1
+		fallthrough
+	case testLondon:
+		chainConfig.LondonBlock = common.Big0
+		fallthrough
+	case testBerlin:
+		chainConfig.BerlinBlock = common.Big0
+		fallthrough
+	default:
+		chainConfig.IstanbulBlock = common.Big0
+	}
+	random := common.Hash([32]byte{0x42})
+	evm := vm.NewEVM(
+		vm.BlockContext{
+			BlockNumber: big.NewInt(blockNum),
+			Difficulty:  big.NewInt(1),
+			BaseFee:     big.NewInt(basefee),
+			BlobBaseFee: big.NewInt(0),
+			Random:      &random,
+			Time:        blockTime,
+
+			Transfer:    vm.TransferFunc(func(sd vm.StateDB, a1, a2 common.Address, i *uint256.Int) {}),
+			CanTransfer: vm.CanTransferFunc(func(sd vm.StateDB, a1 common.Address, i *uint256.Int) bool { return true }),
+			GetHash:     func(i uint64) common.Hash { return common.Hash{} },
+		},
+		state,
+		chainConfig,
+		vm.Config{},
+	)
+	evm.GasPrice = big.NewInt(int64(evmGasPrice))
+	return evm
+}
+
+// signTxForTest generates a new key, signs the transaction with it, and returns
+// the signer, address, and signed transaction.
+func signTxForTestWithChainId(t *testing.T, tx types.TxData, chainId *big.Int) (common.Address, *types.Transaction) {
+	key, err := crypto.GenerateKey()
+	address := crypto.PubkeyToAddress(key.PublicKey)
+	require.NoError(t, err)
+	signer := types.NewPragueSigner(chainId)
+	signedTx, err := types.SignTx(types.NewTx(tx), signer, key)
+	require.NoError(t, err)
+	return address, signedTx
+}
+
+func getTestTransactionsOptionFromRevision(revision int8, chainId *big.Int) validationOptions {
+	opt := validationOptions{
+		currentMaxGas:  100_000,
+		currentBaseFee: big.NewInt(1),
+		minTip:         big.NewInt(1),
+		isLocal:        true,
+		signer:         types.NewPragueSigner(chainId),
+	}
+
+	switch revision {
+	case testPrague:
+		opt.eip7702 = true
+		opt.eip7623 = true
+		fallthrough
+	case testCancun:
+		opt.eip4844 = true
+		fallthrough
+	case testShanghai:
+		opt.shanghai = true
+		fallthrough
+	case testLondon:
+		opt.eip1559 = true
+		fallthrough
+	case testBerlin:
+		opt.eip2718 = true
+		fallthrough
+	default:
+		opt.istanbul = true
+	}
+
+	return opt
+}

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -102,6 +102,13 @@ func FuzzValidateTransaction(f *testing.F) {
 							state := state.NewMockStateDB(ctxt)
 							state.EXPECT().GetBalance(from).Return(uint256.MustFromBig(stateBalance)).AnyTimes()
 							state.EXPECT().GetNonce(from).Return(stateNonce).AnyTimes()
+							if txType == types.SetCodeTxType {
+								state.EXPECT().GetCode(gomock.Any()).Return([]byte("some code")).AnyTimes()
+							} else {
+								// This must return empty because externally owned accounts cannot have
+								// code prior to the Prague revision.
+								state.EXPECT().GetCode(gomock.Any()).Return([]byte{}).AnyTimes()
+							}
 							stateExpectCalls(state)
 
 							opt := getTestTransactionsOptionFromRevision(revision, chainId,
@@ -240,10 +247,6 @@ func stateExpectCalls(state *state.MockStateDB) {
 	state.EXPECT().CreateContract(any).AnyTimes()
 	state.EXPECT().EndTransaction().AnyTimes()
 	state.EXPECT().TxIndex().Return(4).AnyTimes()
-
-	// This must return empty because externally owned accounts cannot have
-	// code prior to the Prague revision.
-	state.EXPECT().GetCode(any).Return([]byte{}).AnyTimes()
 
 	state.EXPECT().GetCodeHash(any).Return(types.EmptyCodeHash).AnyTimes()
 	state.EXPECT().GetCodeSize(any).Return(0).AnyTimes()

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -469,6 +469,7 @@ func makeTestEvm(blockNum, basefee int64, evmGasPrice uint64, state vm.StateDB, 
 // signTxForTest generates a new key, signs the transaction with it, and returns
 // the signer, address, and signed transaction.
 func signTxForTestWithChainId(t *testing.T, tx types.TxData, chainId *big.Int) (common.Address, *types.Transaction) {
+	t.Helper()
 	key, err := crypto.GenerateKey()
 	address := crypto.PubkeyToAddress(key.PublicKey)
 	require.NoError(t, err)
@@ -486,8 +487,9 @@ func getTestTransactionsOptionFromRevision(revision int8, chainId *big.Int,
 		currentMaxGas:  maxGas,
 		currentBaseFee: big.NewInt(BaseFee),
 		minTip:         big.NewInt(MinTip),
-		isLocal:        true,
-		signer:         types.NewPragueSigner(chainId),
+		// locally submitted transactions have the more relaxed validation version. Therefore we test local true.
+		isLocal: true,
+		signer:  types.NewPragueSigner(chainId),
 	}
 
 	switch revision {

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -200,15 +200,15 @@ func FuzzValidateTransaction(f *testing.F) {
 
 		if txType > types.SetCodeTxType {
 			// Skip invalid transaction types
-			return
+			t.Skip()
 		}
 		if revision > testPrague {
 			// Skip invalid revisions
-			return
+			t.Skip()
 		}
 		if isCreate && (txType == types.BlobTxType || txType == types.SetCodeTxType) {
 			// Skip invalid transaction types for contract creation
-			return
+			t.Skip()
 		}
 
 		// a full persistent state is not need. ValidateTx needs to see the same state as the processor.

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -254,11 +254,8 @@ func FuzzValidateTransaction(f *testing.F) {
 
 		// validateTx should not reject transactions that the processor would accept
 		if processorError != nil && validateErr == nil {
-			// if !errors.Is(validateErr, ErrNegativeValue) &&
 			// if the nonce is too high this is also acceptable for the validateTx
 			if !errorContains(processorError, fmt.Errorf("nonce too high")) {
-				// errors from the processor can be more detailed than errors from validateTx
-
 				if errors.Is(validateErr, ErrUnderpriced) {
 					t.Logf("feeCap: %v, baseFee: %v", feeCap, baseFee)
 				}
@@ -290,8 +287,12 @@ func makeTxOfType(txType uint8, nonce, gas uint64, feeCap, tip int64,
 	}
 
 	accessList := make([]types.AccessTuple, accessListSize)
-	for i := range accessListSize {
-		accessList[i] = types.AccessTuple{}
+	accessTuple := types.AccessTuple{
+		Address:     common.Address{0x42},
+		StorageKeys: []common.Hash{{0x42}},
+	}
+	for i := range accessList {
+		accessList[i] = accessTuple
 	}
 	authList := make([]types.SetCodeAuthorization, authListSize)
 	for j := range authListSize {


### PR DESCRIPTION
This PR adds a fuzzer targets `validateTx` in the TxPool. 

It will generate random values for tx':
- type (legacy, accessList, dynamicFee, blob and setCode)
- nonce
- gas
- gas price (or fee cap)
- gas tip
- value

and then for the block and pool:
- current block number
- base fee
- available gas in current block
- current revision

The objective of this test is not only to create random values to try to trigger panics in `validateTx` but also to ensure that if `validate Tx` approves a transaction, then a processor with the same state and context will also be able to process it.
To ensure this, the latter set of values will be used for both, validate options as well as configuring the evm for the processor.