### PR TITLE
Add `ValidateTxWithNetworkRules`

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -674,6 +674,14 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	opts := validationOptions{
+		currentState: pool.currentState,
+		minTip:       pool.gasPrice,
+		locals:       pool.locals,
+		isLocal:      local,
+		signer:       pool.signer,
+	}
+
+	netOpts := networkOptions{
 		istanbul:       pool.istanbul,
 		shanghai:       pool.shanghai,
 		eip1559:        pool.eip1559,
@@ -681,15 +689,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		eip4844:        pool.eip4844,
 		eip7623:        pool.eip7623,
 		eip7702:        pool.eip7702,
-		currentState:   pool.currentState,
-		currentMaxGas:  pool.currentMaxGas,
 		currentBaseFee: pool.chain.GetCurrentBaseFee(),
-		minTip:         pool.gasPrice,
-		locals:         pool.locals,
-		isLocal:        local,
-		signer:         pool.signer,
+		currentMaxGas:  pool.currentMaxGas,
 	}
-	err := validateTx(tx, opts)
+
+	err := validateTx(tx, opts, netOpts)
 	if err != nil {
 		return err
 	}

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -497,9 +497,9 @@ func TestEIP4844Transactions(t *testing.T) {
 		err    error
 	}{
 		{"empty blob tx before cancun", nil, false, ErrTxTypeNotSupported},
-		{"blob tx before cancun", common.Address{1}.Bytes(), false, ErrTxTypeNotSupported},
+		{"blob tx before cancun", common.Address{1}.Bytes(), false, ErrOversizedData},
 		{"empty blob tx", nil, true, nil},
-		{"blob tx with data", common.Address{1}.Bytes(), true, ErrTxTypeNotSupported},
+		{"blob tx with data", common.Address{1}.Bytes(), true, ErrOversizedData},
 	}
 
 	for _, test := range tests {
@@ -518,7 +518,7 @@ func TestEIP4844Transactions(t *testing.T) {
 			}
 
 			_, err = pool.add(tx, false)
-			if err != test.err {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("expected error %v, got %v", test.err, err)
 			}
 		})
@@ -584,7 +584,7 @@ func TestEIP7702Transactions_InvalidTransactionsReturnAnError(t *testing.T) {
 			tx := pricedSetCodeTxWithAuth(0, 250000, uint256.NewInt(1000), uint256.NewInt(1), key, test.authorizations)
 
 			_, err := pool.add(tx, false)
-			if err != test.expectedErr {
+			if !errors.Is(err, test.expectedErr) {
 				t.Fatalf("expected error %v, got %v", test.expectedErr, err)
 			}
 		})
@@ -872,20 +872,18 @@ func TestInvalidTransactions(t *testing.T) {
 	tx := transaction(0, 100, key)
 	from, _ := deriveSender(tx)
 
-	testAddBalance(pool, from, big.NewInt(1))
-	if err := pool.AddRemote(tx); !errors.Is(err, ErrInsufficientFunds) {
-		t.Error("expected", ErrInsufficientFunds)
-	}
-
-	balance := new(big.Int).Add(tx.Value(), new(big.Int).Mul(new(big.Int).SetUint64(tx.Gas()), tx.GasPrice()))
-	testAddBalance(pool, from, balance)
 	if err := pool.AddRemote(tx); !errors.Is(err, ErrIntrinsicGas) {
 		t.Error("expected", ErrIntrinsicGas, "got", err)
 	}
 
+	tx = transaction(0, 100000, key)
+	testAddBalance(pool, from, big.NewInt(1))
+	if err := pool.AddRemote(tx); !errors.Is(err, ErrInsufficientFunds) {
+		t.Errorf("expected %v, but got: %v", ErrInsufficientFunds, err)
+	}
+
 	testSetNonce(pool, from, 1)
 	testAddBalance(pool, from, big.NewInt(0xffffffffffffff))
-	tx = transaction(0, 100000, key)
 	if err := pool.AddRemote(tx); !errors.Is(err, ErrNonceTooLow) {
 		t.Error("expected", ErrNonceTooLow)
 	}

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -16,52 +16,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// getTestTransactionsOption returns a set of options to adjust the validation of transactions
+// so that it would accept all types of transactions, considering them as local transactions
+// with a min tip of 1, current base fee of 1, and a current max gas of 100_000.
+func getTestTransactionsOption() (validationOptions, networkOptions) {
+	return validationOptions{
+			minTip:  big.NewInt(1),
+			isLocal: true,
+			signer:  types.NewPragueSigner(big.NewInt(1)),
+		}, networkOptions{
+			eip2718:        true,
+			eip1559:        true,
+			shanghai:       true,
+			eip4844:        true,
+			eip7623:        true,
+			eip7702:        true,
+			currentBaseFee: big.NewInt(1),
+			currentMaxGas:  100_000,
+		}
+}
+
 func TestValidateTx_BeforeEip2718_RejectsNonLegacyTransactions(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		if _, ok := tx.(*types.LegacyTx); ok {
 			continue // Skip legacy transactions
 		}
 		t.Run(name, func(t *testing.T) {
-			err := validateTx(types.NewTx(tx), validationOptions{eip2718: false})
-			require.ErrorIs(t, ErrTxTypeNotSupported, err)
+			opt, netOpts := getTestTransactionsOption()
+			netOpts.eip2718 = false
+			err := validateTx(types.NewTx(tx), opt, netOpts)
+			require.ErrorContains(t, err, "network validation failed")
 		})
-	}
-}
-
-// getTestTransactionsOption returns a set of options to adjust the validation of transactions
-// so that it would accept all types of transactions, considering them as local transactions
-// with a min tip of 1, current base fee of 1, and a current max gas of 100_000.
-func getTestTransactionsOption() validationOptions {
-	return validationOptions{
-		eip2718:        true,
-		eip1559:        true,
-		shanghai:       true,
-		eip4844:        true,
-		eip7623:        true,
-		eip7702:        true,
-		currentMaxGas:  100_000,
-		currentBaseFee: big.NewInt(1),
-		minTip:         big.NewInt(1),
-		isLocal:        true,
-		signer:         types.NewPragueSigner(big.NewInt(1)),
 	}
 }
 
 func TestValidateTx_RejectsTxBasedOnTypeAndActiveRevision(t *testing.T) {
 	tests := map[string]struct {
 		tx        *types.Transaction
-		configure func(validationOptions) validationOptions
+		configure func(networkOptions) networkOptions
 	}{
 		"accessList tx before eip2718": {
 			tx: types.NewTx(&types.AccessListTx{}),
-			configure: func(opts validationOptions) validationOptions {
+			configure: func(opts networkOptions) networkOptions {
 				opts.eip2718 = false
 				return opts
 			},
 		},
 		"dynamic fee tx before eip1559": {
 			tx: types.NewTx(&types.DynamicFeeTx{}),
-			configure: func(opts validationOptions) validationOptions {
+			configure: func(opts networkOptions) networkOptions {
 				opts.eip2718 = true
 				opts.eip1559 = false
 				return opts
@@ -69,7 +72,7 @@ func TestValidateTx_RejectsTxBasedOnTypeAndActiveRevision(t *testing.T) {
 		},
 		"blob tx before eip4844": {
 			tx: types.NewTx(makeBlobTx(nil, nil)),
-			configure: func(opts validationOptions) validationOptions {
+			configure: func(opts networkOptions) networkOptions {
 				opts.eip2718 = true
 				opts.eip4844 = false
 				return opts
@@ -77,7 +80,7 @@ func TestValidateTx_RejectsTxBasedOnTypeAndActiveRevision(t *testing.T) {
 		},
 		"setCode tx before eip7702": {
 			tx: types.NewTx(&types.SetCodeTx{}),
-			configure: func(opts validationOptions) validationOptions {
+			configure: func(opts networkOptions) networkOptions {
 				opts.eip2718 = true
 				opts.eip7702 = false
 				return opts
@@ -86,20 +89,23 @@ func TestValidateTx_RejectsTxBasedOnTypeAndActiveRevision(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := validateTx(test.tx, test.configure(getTestTransactionsOption()))
-			require.Equal(t, ErrTxTypeNotSupported, err)
+			validateOpts, netOpts := getTestTransactionsOption()
+			err := validateTx(test.tx, validateOpts, test.configure(netOpts))
+			require.ErrorContains(t, err, "network validation failed")
 		})
 	}
 }
+
+const intrinsicGasForTest = 53_000
 
 func TestValidateTx_Nonce_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("older nonce/%v", name), func(t *testing.T) {
 			// setup validation context
-			opt := getTestTransactionsOption()
+			opt, netOpts := getTestTransactionsOption()
 
 			// set up to reach nonce check
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
 
 			// set nonce lower than the current account nonce
 			currentNonce := uint64(2)
@@ -112,7 +118,7 @@ func TestValidateTx_Nonce_RejectsTxWith(t *testing.T) {
 			opt.currentState = testDb
 
 			// validate transaction
-			err := validateTx(signedTx, opt)
+			err := validateTx(signedTx, opt, netOpts)
 			require.ErrorIs(t, err, ErrNonceTooLow)
 		})
 	}
@@ -125,7 +131,8 @@ func TestValidateTx_Value_RejectsTxWith(t *testing.T) {
 				t.Skip("blob and setCode transactions cannot have negative value because they use uint256 Value")
 			}
 			setValueToNegative(t, tx)
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			opt, netOpts := getTestTransactionsOption()
+			err := validateTx(types.NewTx(tx), opt, netOpts)
 			require.ErrorIs(t, err, ErrNegativeValue)
 		})
 	}
@@ -141,7 +148,8 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 				t.Skip("blob and setCode transactions cannot have gas price larger than uint256")
 			}
 			setGasPriceOrFeeCap(t, tx, extremelyLargeN)
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			opt, netOpts := getTestTransactionsOption()
+			err := validateTx(types.NewTx(tx), opt, netOpts)
 			require.ErrorIs(t, err, ErrFeeCapVeryHigh)
 		})
 	}
@@ -149,8 +157,8 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("gas price lower than base fee/%v", name), func(t *testing.T) {
 			// setup validation context
-			opt := getTestTransactionsOption()
-			opt.currentBaseFee = big.NewInt(2)
+			opt, netOpts := getTestTransactionsOption()
+			netOpts.currentBaseFee = big.NewInt(2)
 
 			// gas fee cap should be higher than current gas price
 			setGasPriceOrFeeCap(t, tx, big.NewInt(1))
@@ -159,8 +167,8 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 			_, signedTx := signTxForTest(t, tx)
 
 			// validate transaction
-			err := validateTx(signedTx, opt)
-			require.ErrorIs(t, err, ErrUnderpriced)
+			err := validateTx(signedTx, opt, netOpts)
+			require.ErrorContains(t, err, "network validation failed")
 		})
 	}
 
@@ -175,8 +183,8 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 
 			// set gas tip cap too large
 			setEffectiveTip(t, tx, extremelyLargeN)
-
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			opt, netOpts := getTestTransactionsOption()
+			err := validateTx(types.NewTx(tx), opt, netOpts)
 
 			if _, ok := tx.(*types.DynamicFeeTx); ok {
 				require.ErrorIs(t, err, ErrTipVeryHigh)
@@ -195,7 +203,7 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 		t.Run(fmt.Sprintf("gas tip lower than pool min tip/%v", name), func(t *testing.T) {
 
 			// setup validation context
-			opt := getTestTransactionsOption()
+			opt, netOpts := getTestTransactionsOption()
 			opt.isLocal = false
 			opt.minTip = big.NewInt(2)
 
@@ -206,13 +214,17 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 
 			// --- needed for execution up to relevant check ---
 			setGasPriceOrFeeCap(t, tx, lowTipCap)
+
 			// sign txs with sender
-			_, signedTx := signTxForTest(t, tx)
+			address, signedTx := signTxForTest(t, tx)
 			opt.locals = newAccountSet(opt.signer)
+			testDb := newTestTxPoolStateDb()
+			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
+			opt.currentState = testDb
 			// --- needed for execution up to relevant check ---
 
 			// validate transaction
-			err := validateTx(signedTx, opt)
+			err := validateTx(signedTx, opt, netOpts)
 			require.ErrorIs(t, err, ErrUnderpriced)
 		})
 	}
@@ -224,16 +236,15 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 			setGasPriceOrFeeCap(t, tx, big.NewInt(1))
 			setEffectiveTip(t, tx, big.NewInt(2))
 
-			setGas(t, tx, 53000)
 			address, signedTx := signTxForTest(t, tx)
-			opt := getTestTransactionsOption()
+			opt, netOpts := getTestTransactionsOption()
 			opt.locals = newAccountSet(opt.signer)
 
 			testDb := newTestTxPoolStateDb()
 			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
 			opt.currentState = testDb
 
-			err := validateTx(signedTx, opt)
+			err := validateTx(signedTx, opt, netOpts)
 			if isLegacyOrAccessList(tx) {
 				// legacy and access list transactions use the same field for
 				// gas fee and gas tip, so no error will be produced.
@@ -248,26 +259,26 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("current max gas lower than tx gas/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
-			opt.currentMaxGas = 1
+			opt, netOpts := getTestTransactionsOption()
+			netOpts.currentMaxGas = 1
 
 			setGas(t, tx, 2)
 
-			err := validateTx(types.NewTx(tx), opt)
-			require.ErrorIs(t, err, ErrGasLimit)
+			err := validateTx(types.NewTx(tx), opt, netOpts)
+			require.ErrorContains(t, err, "network validation failed")
 		})
 	}
 
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("tx gas lower than intrinsic gas/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+			opt, netOpts := getTestTransactionsOption()
 
 			// setup tx to fail intrinsic gas calculation
-			setGas(t, tx, getIntrinsicGasForTest(t, tx, &opt)-1)
+			setGas(t, tx, getIntrinsicGasForTest(t, tx, &netOpts)-1)
 
 			// --- needed for execution up to relevant check ---
 			// set tx for execution
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
 			// sign txs with sender
 			address, signedTx := signTxForTest(t, tx)
 			// setup enough balance
@@ -277,15 +288,15 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 			// ---
 
 			// validate transaction
-			err := validateTx(signedTx, opt)
-			require.ErrorIs(t, err, ErrIntrinsicGas)
+			err := validateTx(signedTx, opt, netOpts)
+			require.ErrorContains(t, err, "network validation failed")
 		})
 	}
 
 	// EIP-7623
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("gas lower than floor data gas/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+			opt, netOpts := getTestTransactionsOption()
 
 			// setup tx to fail intrinsic gas calculation
 			someData := make([]byte, txSlotSize)
@@ -293,11 +304,11 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 			floorDataGas, err := core.FloorDataGas(someData)
 			require.NoError(t, err)
 			setGas(t, tx, floorDataGas-1)
-			opt.currentMaxGas = floorDataGas
+			netOpts.currentMaxGas = floorDataGas
 
 			// --- needed for execution up to relevant check ---
 			// set tx for execution
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
 			// sign txs with sender
 			address, signedTx := signTxForTest(t, tx)
 			// setup enough balance
@@ -307,15 +318,15 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 			// ---
 
 			// validate transaction
-			err = validateTx(signedTx, opt)
-			require.ErrorIs(t, err, ErrFloorDataGas)
+			err = validateTx(signedTx, opt, netOpts)
+			require.ErrorContains(t, err, "network validation failed")
 		})
 	}
 
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("floor data gas not checked before eip7623/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
-			opt.eip7623 = false
+			opt, netOpts := getTestTransactionsOption()
+			netOpts.eip7623 = false
 
 			// setup tx to fail intrinsic gas calculation
 			someData := make([]byte, txSlotSize)
@@ -323,11 +334,11 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 			floorDataGas, err := core.FloorDataGas(someData)
 			require.NoError(t, err)
 			setGas(t, tx, floorDataGas-1)
-			opt.currentMaxGas = floorDataGas
+			netOpts.currentMaxGas = floorDataGas
 
 			// --- needed for execution up to relevant check ---
 			// set tx for execution
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
 			// sign txs with sender
 			address, signedTx := signTxForTest(t, tx)
 			// setup enough balance
@@ -337,7 +348,7 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 			// ---
 
 			// validate transaction
-			err = validateTx(signedTx, opt)
+			err = validateTx(signedTx, opt, netOpts)
 			require.NoError(t, err)
 
 		})
@@ -350,8 +361,8 @@ func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
 		t.Run(fmt.Sprintf("oversized data/%v", name), func(t *testing.T) {
 
 			setData(t, types.TxData(tx), oversizedData)
-
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			opt, netOpts := getTestTransactionsOption()
+			err := validateTx(types.NewTx(tx), opt, netOpts)
 			require.Equal(t, ErrOversizedData, err)
 		})
 	}
@@ -366,8 +377,8 @@ func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
 
 			setData(t, types.TxData(tx), maxInitCode)
 			setReceiverToNil(t, tx)
-
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			opt, netOpts := getTestTransactionsOption()
+			err := validateTx(types.NewTx(tx), opt, netOpts)
 			require.ErrorIs(t, err, ErrMaxInitCodeSizeExceeded)
 		})
 	}
@@ -377,24 +388,24 @@ func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
 			if isBlobOrSetCode(tx) {
 				t.Skip("blob and setCode transactions cannot be used to initialize a contract")
 			}
-			opt := getTestTransactionsOption()
-			opt.shanghai = false
-			opt.eip4844 = false
-			opt.eip7623 = false
+			opt, netOpts := getTestTransactionsOption()
+			netOpts.shanghai = false
+			netOpts.eip4844 = false
+			netOpts.eip7623 = false
 			// needs extra gas to allow big data to be afforded.
-			opt.currentMaxGas = 249_612
+			netOpts.currentMaxGas = 249_612
 
 			setData(t, types.TxData(tx), maxInitCode)
 			setReceiverToNil(t, tx)
 
-			setGasPriceOrFeeCap(t, tx, opt.currentBaseFee)
-			setGas(t, tx, opt.currentMaxGas) // enough gas
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
+			setGas(t, tx, netOpts.currentMaxGas) // enough gas
 			address, signedTx := signTxForTest(t, tx)
 			testDb := newTestTxPoolStateDb()
-			testDb.balances[address] = uint256.NewInt(opt.currentMaxGas*opt.currentBaseFee.Uint64() + 1)
+			testDb.balances[address] = uint256.NewInt(netOpts.currentMaxGas*netOpts.currentBaseFee.Uint64() + 1)
 			opt.currentState = testDb
 
-			err := validateTx(signedTx, opt)
+			err := validateTx(signedTx, opt, netOpts)
 			require.NoError(t, err)
 		})
 	}
@@ -404,16 +415,25 @@ func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
 func TestValidateTx_Signer_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("invalid signature/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+			opt, netOpts := getTestTransactionsOption()
 			opt.signer = types.HomesteadSigner{}
+
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
+
 			setSignatureValues(t, tx, big.NewInt(1), big.NewInt(2), big.NewInt(3))
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			err := validateTx(types.NewTx(tx), opt, netOpts)
 			require.ErrorIs(t, err, ErrInvalidSender)
 		})
 	}
 
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("invalid signer/%v", name), func(t *testing.T) {
+			opt, netOpts := getTestTransactionsOption()
+
+			// provide enough gas to reach sender check
+			setGas(t, tx, intrinsicGasForTest)
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
+
 			// sign txs with sender
 			key, err := crypto.GenerateKey()
 			require.NoError(t, err)
@@ -422,7 +442,7 @@ func TestValidateTx_Signer_RejectsTxWith(t *testing.T) {
 			require.NoError(t, err)
 
 			// validate transaction
-			err = validateTx(signedTx, getTestTransactionsOption())
+			err = validateTx(signedTx, opt, netOpts)
 			require.ErrorIs(t, err, ErrInvalidSender)
 		})
 	}
@@ -432,13 +452,13 @@ func TestValidateTx_Balance_RejectsTxWhen(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("insufficient balance/%v", name), func(t *testing.T) {
 			// setup validation context
-			opt := getTestTransactionsOption()
+			opt, netOpts := getTestTransactionsOption()
 			setValue(t, tx, big.NewInt(42))
 
 			// --- needed for execution up to relevant check ---
 			// setup transaction enough gas and fee cap to reach balance check
-			setGasPriceOrFeeCap(t, tx, opt.currentBaseFee)
-			setGas(t, tx, opt.currentMaxGas)
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
+			setGas(t, tx, netOpts.currentMaxGas)
 
 			// sign txs with sender
 			address, signedTx := signTxForTest(t, tx)
@@ -449,15 +469,15 @@ func TestValidateTx_Balance_RejectsTxWhen(t *testing.T) {
 			// balance = gas * fee cap + value
 			zero := uint256.NewInt(0)
 			txCost := zero.Mul(
-				uint256.NewInt(opt.currentMaxGas),
-				uint256.MustFromBig(opt.currentBaseFee),
+				uint256.NewInt(netOpts.currentMaxGas),
+				uint256.MustFromBig(netOpts.currentBaseFee),
 			)
 			txCost = zero.Add(txCost, uint256.MustFromBig(signedTx.Value()))
 			testDb.balances[address] = zero.Sub(txCost, uint256.NewInt(1))
 			opt.currentState = testDb
 
 			// validate transaction
-			err := validateTx(signedTx, opt)
+			err := validateTx(signedTx, opt, netOpts)
 			require.ErrorIs(t, err, ErrInsufficientFunds)
 		})
 	}
@@ -468,14 +488,16 @@ func TestValidateTx_Blobs_RejectsTxWith(t *testing.T) {
 
 	t.Run("blob tx with non-empty blob hashes", func(t *testing.T) {
 		tx := types.NewTx(makeBlobTx([]common.Hash{{0x01}}, nil))
-		err := validateTx(tx, getTestTransactionsOption())
+		opt, netOpts := getTestTransactionsOption()
+		err := validateTx(tx, opt, netOpts)
 		require.ErrorIs(t, err, ErrTxTypeNotSupported)
 	})
 
 	t.Run("blob tx with non-empty sidecar", func(t *testing.T) {
 		tx := types.NewTx(makeBlobTx(nil,
 			&types.BlobTxSidecar{Commitments: []kzg4844.Commitment{{0x01}}}))
-		err := validateTx(tx, getTestTransactionsOption())
+		opt, netOpts := getTestTransactionsOption()
+		err := validateTx(tx, opt, netOpts)
 		require.ErrorIs(t, err, ErrTxTypeNotSupported)
 	})
 }
@@ -483,7 +505,8 @@ func TestValidateTx_Blobs_RejectsTxWith(t *testing.T) {
 func TestValidateTx_AuthorizationList_RejectsTxWith(t *testing.T) {
 	t.Run("setCode tx with empty authorization list", func(t *testing.T) {
 		tx := types.NewTx(&types.SetCodeTx{})
-		err := validateTx(tx, getTestTransactionsOption())
+		opt, netOpts := getTestTransactionsOption()
+		err := validateTx(tx, opt, netOpts)
 		require.ErrorIs(t, err, ErrEmptyAuthorizations)
 	})
 }
@@ -538,12 +561,149 @@ func TestValidateTx_Success(t *testing.T) {
 			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
 			testDb.nonces[address] = 0
 
-			opts := getTestTransactionsOption()
+			opts, netOpts := getTestTransactionsOption()
 			opts.currentState = testDb
 
 			// Validate the transaction
-			err := validateTx(signedTx, opts)
+			err := validateTx(signedTx, opts, netOpts)
 			require.NoError(t, err)
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Network Checks Tests
+
+func TestNetworkChecks_BeforeEip2718_RejectsNonLegacyTransactions(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		if _, ok := tx.(*types.LegacyTx); ok {
+			continue // Skip legacy transactions
+		}
+		t.Run(name, func(t *testing.T) {
+			_, netOpts := getTestTransactionsOption()
+			netOpts.eip2718 = false
+			err := ValidateTxWithNetworkRules(types.NewTx(tx), netOpts)
+			require.ErrorIs(t, err, ErrTxTypeNotSupported)
+		})
+	}
+}
+
+func TestNetworkChecks_RejectsTxBasedOnTypeAndActiveRevision(t *testing.T) {
+	tests := map[string]struct {
+		tx        *types.Transaction
+		configure func(networkOptions) networkOptions
+	}{
+		"accessList tx before eip2718": {
+			tx: types.NewTx(&types.AccessListTx{}),
+			configure: func(opts networkOptions) networkOptions {
+				opts.eip2718 = false
+				return opts
+			},
+		},
+		"dynamic fee tx before eip1559": {
+			tx: types.NewTx(&types.DynamicFeeTx{}),
+			configure: func(opts networkOptions) networkOptions {
+				opts.eip2718 = true
+				opts.eip1559 = false
+				return opts
+			},
+		},
+		"blob tx before eip4844": {
+			tx: types.NewTx(makeBlobTx(nil, nil)),
+			configure: func(opts networkOptions) networkOptions {
+				opts.eip2718 = true
+				opts.eip4844 = false
+				return opts
+			},
+		},
+		"setCode tx before eip7702": {
+			tx: types.NewTx(&types.SetCodeTx{}),
+			configure: func(opts networkOptions) networkOptions {
+				opts.eip2718 = true
+				opts.eip7702 = false
+				return opts
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, netOpts := getTestTransactionsOption()
+			err := ValidateTxWithNetworkRules(test.tx, test.configure(netOpts))
+			require.ErrorIs(t, err, ErrTxTypeNotSupported)
+		})
+	}
+}
+
+func TestNetworkChecks_GasPriceAndTip_RejectsTxWith(t *testing.T) {
+	// extremelyLargeN := new(big.Int).Lsh(big.NewInt(1), 256)
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("gas price lower than base fee/%v", name), func(t *testing.T) {
+			// setup validation context
+			opt, netOpts := getTestTransactionsOption()
+			netOpts.currentBaseFee = big.NewInt(2)
+
+			// gas fee cap should be higher than current gas price
+			setGasPriceOrFeeCap(t, tx, big.NewInt(1))
+
+			// validate transaction
+			err := validateTx(types.NewTx(tx), opt, netOpts)
+			require.ErrorIs(t, err, ErrUnderpriced)
+		})
+	}
+}
+
+func TestNetworkChecks_Gas_RejectsTxWith(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("current max gas lower than tx gas/%v", name), func(t *testing.T) {
+			_, netOpts := getTestTransactionsOption()
+			netOpts.currentMaxGas = 1
+
+			setGas(t, tx, 2)
+
+			err := ValidateTxWithNetworkRules(types.NewTx(tx), netOpts)
+			require.ErrorIs(t, err, ErrGasLimit)
+		})
+	}
+
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("tx gas lower than intrinsic gas/%v", name), func(t *testing.T) {
+			_, netOpts := getTestTransactionsOption()
+
+			// setup tx to fail intrinsic gas calculation
+			setGas(t, tx, getIntrinsicGasForTest(t, tx, &netOpts)-1)
+
+			// --- needed for execution up to relevant check ---
+			// set tx for execution
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
+			// ---
+
+			// validate transaction
+			err := ValidateTxWithNetworkRules(types.NewTx(tx), netOpts)
+			require.ErrorIs(t, err, ErrIntrinsicGas)
+		})
+	}
+
+	// // EIP-7623
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("gas lower than floor data gas/%v", name), func(t *testing.T) {
+			_, netOpts := getTestTransactionsOption()
+
+			// setup tx to fail intrinsic gas calculation
+			someData := make([]byte, txSlotSize)
+			setData(t, tx, someData)
+			floorDataGas, err := core.FloorDataGas(someData)
+			require.NoError(t, err)
+			setGas(t, tx, floorDataGas-1)
+			netOpts.currentMaxGas = floorDataGas
+
+			// --- needed for execution up to relevant check ---
+			// set tx for execution
+			setGasPriceOrFeeCap(t, tx, netOpts.currentBaseFee)
+			// ---
+
+			// validate transaction
+			err = ValidateTxWithNetworkRules(types.NewTx(tx), netOpts)
+			require.ErrorIs(t, err, ErrFloorDataGas)
 		})
 	}
 }
@@ -554,11 +714,12 @@ func TestValidateTx_Success(t *testing.T) {
 // getTxsOfAllTypes returns a list of all transaction types for testing.
 func getTxsOfAllTypes() map[string]types.TxData {
 	return map[string]types.TxData{
-		"Legacy":     &types.LegacyTx{},
-		"AccessList": &types.AccessListTx{},
-		"DynamicFee": &types.DynamicFeeTx{},
+		"Legacy":     &types.LegacyTx{Gas: intrinsicGasForTest},
+		"AccessList": &types.AccessListTx{Gas: intrinsicGasForTest},
+		"DynamicFee": &types.DynamicFeeTx{Gas: intrinsicGasForTest},
 		"Blob":       makeBlobTx(nil, nil),
-		"SetCode":    &types.SetCodeTx{AuthList: []types.SetCodeAuthorization{{}}},
+		"SetCode": &types.SetCodeTx{Gas: intrinsicGasForTest,
+			AuthList: []types.SetCodeAuthorization{{}}},
 	}
 }
 
@@ -750,7 +911,7 @@ func setSignatureValues(t *testing.T, tx types.TxData, v, r, s *big.Int) {
 	}
 }
 
-func getIntrinsicGasForTest(t *testing.T, tx types.TxData, opt *validationOptions) uint64 {
+func getIntrinsicGasForTest(t *testing.T, tx types.TxData, netOpts *networkOptions) uint64 {
 	transaction := types.NewTx(tx)
 	intrGas, err := core.IntrinsicGas(
 		transaction.Data(),
@@ -758,8 +919,8 @@ func getIntrinsicGasForTest(t *testing.T, tx types.TxData, opt *validationOption
 		transaction.SetCodeAuthorizations(),
 		transaction.To() == nil, // is contract creation
 		true,                    // is homestead
-		opt.istanbul,            // is eip-2028 (transactional data gas cost reduction)
-		opt.shanghai,            // is eip-3860 (limit and meter init-code )
+		netOpts.istanbul,        // is eip-2028 (transactional data gas cost reduction)
+		netOpts.shanghai,        // is eip-3860 (limit and meter init-code )
 	)
 	require.NoError(t, err)
 	return intrGas
@@ -780,6 +941,7 @@ func isBlobOrSetCode(tx types.TxData) bool {
 // blobTx
 func makeBlobTx(hashes []common.Hash, sidecar *types.BlobTxSidecar) types.TxData {
 	return &types.BlobTx{
+		Gas:        intrinsicGasForTest,
 		BlobHashes: hashes,
 		Sidecar:    sidecar,
 	}

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -49,11 +49,11 @@ func testBlobTx_WithBlobsIsRejected(t *testing.T, ctxt *testContext) {
 
 	// attempt to run tx
 	_, err = ctxt.net.Run(tx)
-	require.ErrorContains(err, "transaction type not supported")
+	require.ErrorContains(err, "oversized data")
 
 	// repeat same tx (regression against reported repeated tx issue)
 	_, err = ctxt.net.Run(tx)
-	require.ErrorContains(err, "transaction type not supported")
+	require.ErrorContains(err, "oversized data")
 }
 
 func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, ctxt *testContext) {


### PR DESCRIPTION
This PR does the first of a series of refactors in `validateTx` from the `TxPool`. 

In order to isolate and tests the verifications related to the network rules, the previous `validateOptions` is split into `validateOptions` and `networkOptions`. This way it can be individually tested:
- Revision and tx types compatibility (including revision dependent checks such as max init code size, empty blobs and non-empty auth list)
- GasPrice (GasFee) over network's BaseFee
- Gas less or equal than current max gas in the block

Note to reviewer:  changes to `tx_pool_test.go` and `tests/blob_tx_test.go` are only necessary because now the check for tx size is done before checking for tx type.