### PR TITLE
base fee deep copy allegro

### DIFF
--- a/opera/rules.go
+++ b/opera/rules.go
@@ -420,7 +420,14 @@ func DefaultGasPowerRules() GasPowerRules {
 func (r Rules) Copy() Rules {
 	cp := r
 	cp.Economy.MinGasPrice = new(big.Int).Set(r.Economy.MinGasPrice)
-	cp.Economy.MinBaseFee = new(big.Int).Set(r.Economy.MinBaseFee)
+
+	// there is a bug in pre-Allegro versions that MinBaseFee is not deep copied.
+	// Since switching to deep-copy is not possible in a network running combination
+	// of Allegro and pre-Allegro versions, we need to enable this fix only when Allegro is applied.
+	if cp.Upgrades.Allegro {
+		cp.Economy.MinBaseFee = new(big.Int).Set(r.Economy.MinBaseFee)
+	}
+
 	return cp
 }
 

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -169,7 +169,7 @@ func TestRules_Copy_CopiesAreDisjoint(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Create a deep copy of the original rules
-			original := MainNetRules()
+			original := FakeNetRules(AllegroFeatures)
 			copied := original.Copy()
 
 			// Apply the update to the copied rules
@@ -180,5 +180,16 @@ func TestRules_Copy_CopiesAreDisjoint(t *testing.T) {
 				t.Errorf("original and copied rules are the same: got %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestRules_MinBaseFee_NoCopy_PreAllegro(t *testing.T) {
+	original := FakeNetRules(SonicFeatures)
+	copied := original.Copy()
+
+	copied.Economy.MinBaseFee.SetInt64(2 * copied.Economy.MinBaseFee.Int64())
+
+	if got, want := original.Economy.MinBaseFee.Int64(), copied.Economy.MinBaseFee.Int64(); got != want {
+		t.Errorf("original and copied rules must be the same - shallow copy for preAllegro: got %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
This PR updates copy of `MinBaseFee` to be deep copied for `Allegro` update only.  This prevent situation when a network runs pre-Allegro updated, but already running old and new version of the client. 

To prevent network issues, this enables deep copy of this property only when Allegro is enabled, which is possible only when majority of nodes is updated as well. 