### PR TITLE
Split `validateTx` in `TxPool` 

### DIFF
--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -105,4 +105,7 @@ var (
 	// signed by an address which already has in-flight transactions known to the
 	// pool.
 	ErrAuthorityReserved = errors.New("authority already reserved")
+
+	// ErrNonEmptyBlobTx is returned if a blob transaction has non-empty blob data.
+	ErrNonEmptyBlobTx = errors.New("non-empty blob transaction are not supported")
 )

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -673,10 +673,11 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	opts := validationOptions{currentState: pool.currentState,
-		minTip:  pool.gasPrice,
-		locals:  pool.locals,
-		isLocal: local,
+	opts := validationOptions{
+		currentState: pool.currentState,
+		minTip:       pool.gasPrice,
+		locals:       pool.locals,
+		isLocal:      local,
 	}
 	netRules := NetworkRulesForValidateTx{
 		istanbul:       pool.istanbul,

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -673,7 +673,12 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	opts := validationOptions{
+	opts := validationOptions{currentState: pool.currentState,
+		minTip:  pool.gasPrice,
+		locals:  pool.locals,
+		isLocal: local,
+	}
+	netRules := NetworkRulesForValidateTx{
 		istanbul:       pool.istanbul,
 		shanghai:       pool.shanghai,
 		eip1559:        pool.eip1559,
@@ -681,15 +686,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		eip4844:        pool.eip4844,
 		eip7623:        pool.eip7623,
 		eip7702:        pool.eip7702,
-		currentState:   pool.currentState,
 		currentMaxGas:  pool.currentMaxGas,
 		currentBaseFee: pool.chain.GetCurrentBaseFee(),
-		minTip:         pool.gasPrice,
-		locals:         pool.locals,
-		isLocal:        local,
 		signer:         pool.signer,
 	}
-	err := validateTx(tx, opts)
+	err := validateTx(tx, opts, netRules)
 	if err != nil {
 		return err
 	}

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -673,7 +673,7 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	opts := validationOptions{
+	opts := poolOptions{
 		currentState: pool.currentState,
 		minTip:       pool.gasPrice,
 		locals:       pool.locals,
@@ -683,7 +683,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		maxGas:  pool.currentMaxGas,
 		baseFee: pool.chain.GetCurrentBaseFee(),
 	}
-	netRules := ActiveEips{
+	netRules := NetworkRules{
 		istanbul: pool.istanbul,
 		shanghai: pool.shanghai,
 		eip1559:  pool.eip1559,
@@ -691,6 +691,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		eip4844:  pool.eip4844,
 		eip7623:  pool.eip7623,
 		eip7702:  pool.eip7702,
+		signer:   pool.signer,
 	}
 	err := validateTx(tx, opts, blockState, netRules)
 	if err != nil {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -679,19 +679,20 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		locals:       pool.locals,
 		isLocal:      local,
 	}
-	netRules := NetworkRulesForValidateTx{
-		istanbul:       pool.istanbul,
-		shanghai:       pool.shanghai,
-		eip1559:        pool.eip1559,
-		eip2718:        pool.eip2718,
-		eip4844:        pool.eip4844,
-		eip7623:        pool.eip7623,
-		eip7702:        pool.eip7702,
-		currentMaxGas:  pool.currentMaxGas,
-		currentBaseFee: pool.chain.GetCurrentBaseFee(),
-		signer:         pool.signer,
+	blockState := blockState{
+		maxGas:  pool.currentMaxGas,
+		baseFee: pool.chain.GetCurrentBaseFee(),
 	}
-	err := validateTx(tx, opts, netRules)
+	netRules := ActiveEips{
+		istanbul: pool.istanbul,
+		shanghai: pool.shanghai,
+		eip1559:  pool.eip1559,
+		eip2718:  pool.eip2718,
+		eip4844:  pool.eip4844,
+		eip7623:  pool.eip7623,
+		eip7702:  pool.eip7702,
+	}
+	err := validateTx(tx, opts, blockState, netRules)
 	if err != nil {
 		return err
 	}

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -549,7 +549,7 @@ func TestEIP7702Transactions_InvalidTransactionsReturnAnError(t *testing.T) {
 		expectedErr    error
 	}{
 		"set code tx before prague": {
-			expectedErr: ErrTxTypeNotSupported,
+			expectedErr: ErrEmptyAuthorizations,
 		},
 		"set code tx with nil authorizations": {
 			pragueTime:  new(uint64),

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -497,9 +497,9 @@ func TestEIP4844Transactions(t *testing.T) {
 		err    error
 	}{
 		{"empty blob tx before cancun", nil, false, ErrTxTypeNotSupported},
-		{"blob tx before cancun", common.Address{1}.Bytes(), false, ErrOversizedData},
+		{"blob tx before cancun", common.Address{1}.Bytes(), false, ErrNonEmptyBlobTx},
 		{"empty blob tx", nil, true, nil},
-		{"blob tx with data", common.Address{1}.Bytes(), true, ErrOversizedData},
+		{"blob tx with data", common.Address{1}.Bytes(), true, ErrNonEmptyBlobTx},
 	}
 
 	for _, test := range tests {

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -497,7 +497,7 @@ func TestEIP4844Transactions(t *testing.T) {
 		err    error
 	}{
 		{"empty blob tx before cancun", nil, false, ErrTxTypeNotSupported},
-		{"blob tx before cancun", common.Address{1}.Bytes(), false, ErrNonEmptyBlobTx},
+		{"blob tx before cancun", common.Address{1}.Bytes(), false, ErrTxTypeNotSupported},
 		{"empty blob tx", nil, true, nil},
 		{"blob tx with data", common.Address{1}.Bytes(), true, ErrNonEmptyBlobTx},
 	}
@@ -549,7 +549,7 @@ func TestEIP7702Transactions_InvalidTransactionsReturnAnError(t *testing.T) {
 		expectedErr    error
 	}{
 		"set code tx before prague": {
-			expectedErr: ErrEmptyAuthorizations,
+			expectedErr: ErrTxTypeNotSupported,
 		},
 		"set code tx with nil authorizations": {
 			pragueTime:  new(uint64),
@@ -972,7 +972,7 @@ func TestTransactionNegativeValue(t *testing.T) {
 	pool, key := setupTxPool()
 	defer pool.Stop()
 
-	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(-1), 100, big.NewInt(1), nil), types.HomesteadSigner{}, key)
+	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(-1), 200_000, big.NewInt(1), nil), types.HomesteadSigner{}, key)
 	from, _ := deriveSender(tx)
 	testAddBalance(pool, from, big.NewInt(1))
 	if err := pool.AddRemote(tx); err != ErrNegativeValue {
@@ -986,7 +986,7 @@ func TestTransactionTipAboveFeeCap(t *testing.T) {
 	pool, key := setupTxPoolWithConfig(eip1559Config)
 	defer pool.Stop()
 
-	tx := dynamicFeeTx(0, 100, big.NewInt(1), big.NewInt(2), key)
+	tx := dynamicFeeTx(0, 200_000, big.NewInt(1), big.NewInt(2), key)
 
 	if err := pool.AddRemote(tx); err != ErrTipAboveFeeCap {
 		t.Error("expected", ErrTipAboveFeeCap, "got", err)
@@ -1002,12 +1002,12 @@ func TestTransactionVeryHighValues(t *testing.T) {
 	veryBigNumber := big.NewInt(1)
 	veryBigNumber.Lsh(veryBigNumber, 300)
 
-	tx := dynamicFeeTx(0, 100, big.NewInt(1), veryBigNumber, key)
+	tx := dynamicFeeTx(0, 200_000, big.NewInt(1), veryBigNumber, key)
 	if err := pool.AddRemote(tx); err != ErrTipVeryHigh {
 		t.Error("expected", ErrTipVeryHigh, "got", err)
 	}
 
-	tx2 := dynamicFeeTx(0, 100, veryBigNumber, big.NewInt(1), key)
+	tx2 := dynamicFeeTx(0, 200_000, veryBigNumber, big.NewInt(1), key)
 	if err := pool.AddRemote(tx2); err != ErrFeeCapVeryHigh {
 		t.Error("expected", ErrFeeCapVeryHigh, "got", err)
 	}

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -116,7 +116,7 @@ func ValidateTxStatic(tx *types.Transaction) error {
 		return ErrTipAboveFeeCap
 	}
 
-	// For now, Sonic only supports Blob transactions without blob data.
+	// Sonic only supports Blob transactions without blob data.
 	if tx.Type() == types.BlobTxType &&
 		(len(tx.BlobHashes()) > 0 || (tx.BlobTxSidecar() != nil && len(tx.BlobTxSidecar().BlobHashes()) > 0)) {
 		return ErrNonEmptyBlobTx
@@ -127,7 +127,7 @@ func ValidateTxStatic(tx *types.Transaction) error {
 		return ErrEmptyAuthorizations
 	}
 
-	// Reject transactions over defined size to prevent DOS attacks
+	// Reject transactions over defined size to prevent DoS attacks
 	if uint64(tx.Size()) > txMaxSize {
 		return ErrOversizedData
 	}

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -94,11 +94,6 @@ func validateTx(
 // It returns an error if any of the checks fail.
 func ValidateTxStatic(tx *types.Transaction) error {
 
-	// Reject transactions over defined size to prevent DOS attacks
-	if uint64(tx.Size()) > txMaxSize {
-		return ErrOversizedData
-	}
-
 	// Transactions can't be negative. This may never happen using RLP decoded
 	// transactions but may occur if you create a transaction using the RPC.
 	if tx.Value().Sign() < 0 {
@@ -121,12 +116,17 @@ func ValidateTxStatic(tx *types.Transaction) error {
 	// For now, Sonic only supports Blob transactions without blob data.
 	if tx.BlobHashes() != nil && (len(tx.BlobHashes()) > 0 ||
 		(tx.BlobTxSidecar() != nil && len(tx.BlobTxSidecar().BlobHashes()) > 0)) {
-		return ErrTxTypeNotSupported
+		return ErrNonEmptyBlobTx
 	}
 
 	// Check non-empty authorization list
 	if tx.SetCodeAuthorizations() != nil && len(tx.SetCodeAuthorizations()) == 0 {
 		return ErrEmptyAuthorizations
+	}
+
+	// Reject transactions over defined size to prevent DOS attacks
+	if uint64(tx.Size()) > txMaxSize {
+		return ErrOversizedData
 	}
 
 	return nil

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -62,12 +62,12 @@ func validateTx(
 	opt validationOptions,
 	netRules NetworkRulesForValidateTx) error {
 
-	if err := ValidateTxStatic(tx); err != nil {
+	err := ValidateTxForNetworkRules(tx, netRules)
+	if err != nil {
 		return err
 	}
 
-	err := ValidateTxForNetworkRules(tx, netRules)
-	if err != nil {
+	if err := ValidateTxStatic(tx); err != nil {
 		return err
 	}
 

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -76,7 +76,6 @@ func validateTx(
 		return err
 	}
 
-	// leave state accesses for last check
 	if err := ValidateTxForState(tx, opt.currentState, from); err != nil {
 		return err
 	}
@@ -231,7 +230,7 @@ func ValidateTxForState(tx *types.Transaction, state TxPoolStateDB, from common.
 	}
 
 	// Transactor should have enough funds to cover the costs
-	// cost == V + GP * G
+	// cost == Value + GasPrice * Gas
 	if utils.Uint256ToBigInt(state.GetBalance(from)).Cmp(tx.Cost()) < 0 {
 		return ErrInsufficientFunds
 	}

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -181,9 +181,7 @@ func ValidateTxForNetwork(tx *types.Transaction, opt NetworkRules) error {
 // - value (must be positive)
 // - gas fee cap and tip cap must be within the 256 bit range
 // - gas fee cap must be greater than or equal to the tip cap
-// - blob transactions must not contain any blob data
 // - set code transactions must not have an empty authorization list
-// - size must be within the defined limit
 //
 // It returns an error if any of the checks fail.
 func ValidateTxStatic(tx *types.Transaction) error {

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -267,7 +267,8 @@ func validateTxForPool(tx *types.Transaction, opt validationOptions,
 		return ErrInvalidSender
 	}
 
-	// tx is local if received from the local RPC or if the sender belongs to the local accounts set
+	// A transaction is local if received from the local RPC or if the sender belongs to the local accounts set.
+	// For local transactions, minimum gas tips are not enforced.
 	local := opt.isLocal || opt.locals.contains(from)
 	if local {
 		return nil
@@ -275,7 +276,7 @@ func validateTxForPool(tx *types.Transaction, opt validationOptions,
 
 	// Drop non-local transactions under our own minimal accepted gas price or tip.
 	if tx.GasTipCapIntCmp(opt.minTip) < 0 {
-		log.Trace("Rejecting underpriced tx: pool.gasPrice", "pool.gasPrice",
+		log.Trace("Rejecting underpriced tx: pool.minTip", "pool.minTip",
 			opt.minTip, "tx.GasTipCap", tx.GasTipCap())
 		return ErrUnderpriced
 	}

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -127,11 +127,6 @@ func ValidateTxStatic(tx *types.Transaction) error {
 		return ErrEmptyAuthorizations
 	}
 
-	// Reject transactions over defined size to prevent DoS attacks
-	if uint64(tx.Size()) > txMaxSize {
-		return ErrOversizedData
-	}
-
 	return nil
 }
 
@@ -260,6 +255,11 @@ func ValidateTxForState(tx *types.Transaction, state TxPoolStateDB,
 // tip is lower than the minimum tip.
 func validateTxForPool(tx *types.Transaction, opt validationOptions,
 	signer types.Signer) error {
+
+	// Reject transactions over defined size to prevent DoS attacks
+	if uint64(tx.Size()) > txMaxSize {
+		return ErrOversizedData
+	}
 
 	// Make sure the transaction is signed properly.
 	from, err := types.Sender(signer, tx)

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -869,33 +869,6 @@ func setValueToNegative(t *testing.T, tx types.TxData) {
 	}
 }
 
-func setSignatureValues(t *testing.T, tx types.TxData, v, r, s *big.Int) {
-	switch tx := tx.(type) {
-	case *types.LegacyTx:
-		tx.V = v
-		tx.R = r
-		tx.S = s
-	case *types.AccessListTx:
-		tx.V = v
-		tx.R = r
-		tx.S = s
-	case *types.DynamicFeeTx:
-		tx.V = v
-		tx.R = r
-		tx.S = s
-	case *types.BlobTx:
-		tx.V = uint256.MustFromBig(v)
-		tx.R = uint256.MustFromBig(r)
-		tx.S = uint256.MustFromBig(s)
-	case *types.SetCodeTx:
-		tx.V = uint256.MustFromBig(v)
-		tx.R = uint256.MustFromBig(r)
-		tx.S = uint256.MustFromBig(s)
-	default:
-		t.Fatalf("unexpected transaction type: %T", tx)
-	}
-}
-
 func getIntrinsicGasForTest(t *testing.T, tx types.TxData, opt NetworkRulesForValidateTx) uint64 {
 	transaction := types.NewTx(tx)
 	intrGas, err := core.IntrinsicGas(

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 // getTestValidationOptions returns a set of options to adjust the validation of transactions
-// so that it would accept all types of transactions, considering them as local transactions
-// with a min tip of 1, current base fee of 1, and a current max gas of 100_000.
+// considering them as local transactions with a min tip of 1.
 func getTestValidationOptions() validationOptions {
 	return validationOptions{
 		minTip:  big.NewInt(1),
@@ -26,6 +25,9 @@ func getTestValidationOptions() validationOptions {
 	}
 }
 
+// getTestNetworkRules returns a set of network rules to adjust the validation of transactions
+// so that it accepts all types of transactions, with a base fee of 1 and a max gas
+// of 100_000. It also sets the signer to a new Prague signer with chain ID 1.
 func getTestNetworkRules() NetworkRulesForValidateTx {
 	return NetworkRulesForValidateTx{
 		eip2718:        true,
@@ -48,7 +50,7 @@ func TestValidateTxStatic_Data_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("oversized data/%v", name), func(t *testing.T) {
 
-			setData(t, types.TxData(tx), oversizedData)
+			setData(t, tx, oversizedData)
 
 			err := ValidateTxStatic(types.NewTx(tx))
 			require.ErrorIs(t, err, ErrOversizedData)
@@ -307,7 +309,7 @@ func TestValidateTxForNetworkRules_Data_RejectsTxWith(t *testing.T) {
 				t.Skip("blob and setCode transactions cannot be used as create")
 			}
 
-			setData(t, types.TxData(tx), maxInitCode)
+			setData(t, tx, maxInitCode)
 			setReceiverToNil(t, tx)
 
 			err := ValidateTxForNetworkRules(types.NewTx(tx), getTestNetworkRules())
@@ -327,7 +329,7 @@ func TestValidateTxForNetworkRules_Data_RejectsTxWith(t *testing.T) {
 			// needs extra gas to allow big data to be afforded.
 			opt.currentMaxGas = 249_612
 
-			setData(t, types.TxData(tx), maxInitCode)
+			setData(t, tx, maxInitCode)
 			setReceiverToNil(t, tx)
 
 			// --- needed for execution up to relevant check ---

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -156,7 +156,7 @@ func TestValidateTxForNetworkRules_BeforeEip2718_RejectsNonLegacyTransactions(t 
 			continue // Skip legacy transactions
 		}
 		t.Run(name, func(t *testing.T) {
-			err := ValidateTxForNetworkRules(types.NewTx(tx),
+			_, err := ValidateTxForNetworkRules(types.NewTx(tx),
 				NetworkRulesForValidateTx{eip2718: false})
 			require.ErrorIs(t, ErrTxTypeNotSupported, err)
 		})
@@ -202,7 +202,7 @@ func TestValidateTxForNetworkRules_RejectsTxBasedOnTypeAndActiveRevision(t *test
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := ValidateTxForNetworkRules(test.tx, test.configure(getTestNetworkRules()))
+			_, err := ValidateTxForNetworkRules(test.tx, test.configure(getTestNetworkRules()))
 			require.Equal(t, ErrTxTypeNotSupported, err)
 		})
 	}
@@ -216,7 +216,7 @@ func TestValidateTxForNetworkRules_Gas_RejectsTxWith(t *testing.T) {
 
 			setGas(t, tx, 2)
 
-			err := ValidateTxForNetworkRules(types.NewTx(tx), opt)
+			_, err := ValidateTxForNetworkRules(types.NewTx(tx), opt)
 			require.ErrorIs(t, err, ErrGasLimit)
 		})
 	}
@@ -231,7 +231,7 @@ func TestValidateTxForNetworkRules_Gas_RejectsTxWith(t *testing.T) {
 			// sign txs with sender
 			_, signedTx := signTxForTest(t, tx)
 
-			err := ValidateTxForNetworkRules(signedTx, opt)
+			_, err := ValidateTxForNetworkRules(signedTx, opt)
 			require.ErrorIs(t, err, ErrUnderpriced)
 		})
 	}
@@ -248,7 +248,7 @@ func TestValidateTxForNetworkRules_Gas_RejectsTxWith(t *testing.T) {
 			_, signedTx := signTxForTest(t, tx)
 			// ---
 
-			err := ValidateTxForNetworkRules(signedTx, opt)
+			_, err := ValidateTxForNetworkRules(signedTx, opt)
 			require.ErrorIs(t, err, ErrIntrinsicGas)
 		})
 	}
@@ -271,7 +271,7 @@ func TestValidateTxForNetworkRules_Gas_RejectsTxWith(t *testing.T) {
 			_, signedTx := signTxForTest(t, tx)
 			// ---
 
-			err = ValidateTxForNetworkRules(signedTx, opt)
+			_, err = ValidateTxForNetworkRules(signedTx, opt)
 			require.ErrorIs(t, err, ErrFloorDataGas)
 		})
 	}
@@ -293,7 +293,7 @@ func TestValidateTxForNetworkRules_Gas_RejectsTxWith(t *testing.T) {
 			_, signedTx := signTxForTest(t, tx)
 			// ---
 
-			err = ValidateTxForNetworkRules(signedTx, opt)
+			_, err = ValidateTxForNetworkRules(signedTx, opt)
 			require.NoError(t, err)
 
 		})
@@ -312,7 +312,7 @@ func TestValidateTxForNetworkRules_Data_RejectsTxWith(t *testing.T) {
 			setData(t, tx, maxInitCode)
 			setReceiverToNil(t, tx)
 
-			err := ValidateTxForNetworkRules(types.NewTx(tx), getTestNetworkRules())
+			_, err := ValidateTxForNetworkRules(types.NewTx(tx), getTestNetworkRules())
 			require.ErrorIs(t, err, ErrMaxInitCodeSizeExceeded)
 		})
 	}
@@ -338,7 +338,7 @@ func TestValidateTxForNetworkRules_Data_RejectsTxWith(t *testing.T) {
 			_, signedTx := signTxForTest(t, tx)
 			// ---
 
-			err := ValidateTxForNetworkRules(signedTx, opt)
+			_, err := ValidateTxForNetworkRules(signedTx, opt)
 			require.NoError(t, err)
 		})
 	}
@@ -350,7 +350,7 @@ func TestValidateTxForNetworkRules_Signer_RejectsTxWith(t *testing.T) {
 			opt := getTestNetworkRules()
 			opt.signer = types.HomesteadSigner{}
 			setSignatureValues(t, tx, big.NewInt(1), big.NewInt(2), big.NewInt(3))
-			err := ValidateTxForNetworkRules(types.NewTx(tx), getTestNetworkRules())
+			_, err := ValidateTxForNetworkRules(types.NewTx(tx), getTestNetworkRules())
 			require.ErrorIs(t, err, ErrInvalidSender)
 		})
 	}
@@ -364,7 +364,7 @@ func TestValidateTxForNetworkRules_Signer_RejectsTxWith(t *testing.T) {
 				types.NewPragueSigner(big.NewInt(2)), key)
 			require.NoError(t, err)
 
-			err = ValidateTxForNetworkRules(signedTx, getTestNetworkRules())
+			_, err = ValidateTxForNetworkRules(signedTx, getTestNetworkRules())
 			require.ErrorIs(t, err, ErrInvalidSender)
 		})
 	}
@@ -375,14 +375,14 @@ func TestValidateTxForNetworkRules_Blobs_RejectsTxWith(t *testing.T) {
 
 	t.Run("blob tx with non-empty blob hashes", func(t *testing.T) {
 		tx := types.NewTx(makeBlobTx([]common.Hash{{0x01}}, nil))
-		err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
+		_, err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
 		require.ErrorIs(t, err, ErrTxTypeNotSupported)
 	})
 
 	t.Run("blob tx with non-empty sidecar", func(t *testing.T) {
 		tx := types.NewTx(makeBlobTx(nil,
 			&types.BlobTxSidecar{Commitments: []kzg4844.Commitment{{0x01}}}))
-		err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
+		_, err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
 		require.ErrorIs(t, err, ErrTxTypeNotSupported)
 	})
 }
@@ -390,7 +390,7 @@ func TestValidateTxForNetworkRules_Blobs_RejectsTxWith(t *testing.T) {
 func TestValidateTxForNetworkRules_AuthorizationList_RejectsTxWith(t *testing.T) {
 	t.Run("setCode tx with empty authorization list", func(t *testing.T) {
 		tx := types.NewTx(&types.SetCodeTx{})
-		err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
+		_, err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
 		require.ErrorIs(t, err, ErrEmptyAuthorizations)
 	})
 }
@@ -406,7 +406,7 @@ func TestValidateTxForNetworkRules_AcceptsTxWith(t *testing.T) {
 			setGas(t, tx, underMaxGas)
 
 			_, signedTx := signTxForTest(t, tx)
-			err := ValidateTxForNetworkRules(signedTx, opt)
+			_, err := ValidateTxForNetworkRules(signedTx, opt)
 			require.NoError(t, err)
 		})
 	}

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -16,122 +16,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateTx_BeforeEip2718_RejectsNonLegacyTransactions(t *testing.T) {
-	for name, tx := range getTxsOfAllTypes() {
-		if _, ok := tx.(*types.LegacyTx); ok {
-			continue // Skip legacy transactions
-		}
-		t.Run(name, func(t *testing.T) {
-			err := validateTx(types.NewTx(tx), validationOptions{eip2718: false})
-			require.ErrorIs(t, ErrTxTypeNotSupported, err)
-		})
+// getTestValidationOptions returns a set of options to adjust the validation of transactions
+// so that it would accept all types of transactions, considering them as local transactions
+// with a min tip of 1, current base fee of 1, and a current max gas of 100_000.
+func getTestValidationOptions() validationOptions {
+	return validationOptions{
+		minTip:  big.NewInt(1),
+		isLocal: true,
 	}
 }
 
-// getTestTransactionsOption returns a set of options to adjust the validation of transactions
-// so that it would accept all types of transactions, considering them as local transactions
-// with a min tip of 1, current base fee of 1, and a current max gas of 100_000.
-func getTestTransactionsOption() validationOptions {
-	return validationOptions{
+func getTestNetworkRules() NetworkRulesForValidateTx {
+	return NetworkRulesForValidateTx{
 		eip2718:        true,
 		eip1559:        true,
 		shanghai:       true,
 		eip4844:        true,
 		eip7623:        true,
 		eip7702:        true,
-		currentMaxGas:  100_000,
 		currentBaseFee: big.NewInt(1),
-		minTip:         big.NewInt(1),
-		isLocal:        true,
+		currentMaxGas:  100_000,
 		signer:         types.NewPragueSigner(big.NewInt(1)),
 	}
 }
 
-func TestValidateTx_RejectsTxBasedOnTypeAndActiveRevision(t *testing.T) {
-	tests := map[string]struct {
-		tx        *types.Transaction
-		configure func(validationOptions) validationOptions
-	}{
-		"accessList tx before eip2718": {
-			tx: types.NewTx(&types.AccessListTx{}),
-			configure: func(opts validationOptions) validationOptions {
-				opts.eip2718 = false
-				return opts
-			},
-		},
-		"dynamic fee tx before eip1559": {
-			tx: types.NewTx(&types.DynamicFeeTx{}),
-			configure: func(opts validationOptions) validationOptions {
-				opts.eip2718 = true
-				opts.eip1559 = false
-				return opts
-			},
-		},
-		"blob tx before eip4844": {
-			tx: types.NewTx(makeBlobTx(nil, nil)),
-			configure: func(opts validationOptions) validationOptions {
-				opts.eip2718 = true
-				opts.eip4844 = false
-				return opts
-			},
-		},
-		"setCode tx before eip7702": {
-			tx: types.NewTx(&types.SetCodeTx{}),
-			configure: func(opts validationOptions) validationOptions {
-				opts.eip2718 = true
-				opts.eip7702 = false
-				return opts
-			},
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			err := validateTx(test.tx, test.configure(getTestTransactionsOption()))
-			require.Equal(t, ErrTxTypeNotSupported, err)
-		})
-	}
-}
+////////////////////////////////////////////////////////////////////////////////
+// Static Validation
 
-func TestValidateTx_Nonce_RejectsTxWith(t *testing.T) {
+func TestValidateTxStatic_Data_RejectsTxWith(t *testing.T) {
+	oversizedData := make([]byte, txMaxSize+1)
 	for name, tx := range getTxsOfAllTypes() {
-		t.Run(fmt.Sprintf("older nonce/%v", name), func(t *testing.T) {
-			// setup validation context
-			opt := getTestTransactionsOption()
+		t.Run(fmt.Sprintf("oversized data/%v", name), func(t *testing.T) {
 
-			// set up to reach nonce check
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
+			setData(t, types.TxData(tx), oversizedData)
 
-			// set nonce lower than the current account nonce
-			currentNonce := uint64(2)
-			setNonce(t, tx, currentNonce-1)
-
-			// sign txs with sender and set current balance for account
-			address, signedTx := signTxForTest(t, tx)
-			testDb := newTestTxPoolStateDb()
-			testDb.nonces[address] = currentNonce
-			opt.currentState = testDb
-
-			// validate transaction
-			err := validateTx(signedTx, opt)
-			require.ErrorIs(t, err, ErrNonceTooLow)
+			err := ValidateTxStatic(types.NewTx(tx))
+			require.ErrorIs(t, err, ErrOversizedData)
 		})
 	}
 }
 
-func TestValidateTx_Value_RejectsTxWith(t *testing.T) {
+func TestValidateTxStatic_Value_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("negative value/%v", name), func(t *testing.T) {
 			if isBlobOrSetCode(tx) {
 				t.Skip("blob and setCode transactions cannot have negative value because they use uint256 Value")
 			}
 			setValueToNegative(t, tx)
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			err := ValidateTxStatic(types.NewTx(tx))
 			require.ErrorIs(t, err, ErrNegativeValue)
 		})
 	}
 }
 
-func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
+func TestValidateTxStatic_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 	extremelyLargeN := new(big.Int).Lsh(big.NewInt(1), 256)
 
 	// GasPrice/GasFeeCap tests
@@ -141,26 +79,8 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 				t.Skip("blob and setCode transactions cannot have gas price larger than uint256")
 			}
 			setGasPriceOrFeeCap(t, tx, extremelyLargeN)
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			err := ValidateTxStatic(types.NewTx(tx))
 			require.ErrorIs(t, err, ErrFeeCapVeryHigh)
-		})
-	}
-
-	for name, tx := range getTxsOfAllTypes() {
-		t.Run(fmt.Sprintf("gas price lower than base fee/%v", name), func(t *testing.T) {
-			// setup validation context
-			opt := getTestTransactionsOption()
-			opt.currentBaseFee = big.NewInt(2)
-
-			// gas fee cap should be higher than current gas price
-			setGasPriceOrFeeCap(t, tx, big.NewInt(1))
-
-			// sign txs with sender
-			_, signedTx := signTxForTest(t, tx)
-
-			// validate transaction
-			err := validateTx(signedTx, opt)
-			require.ErrorIs(t, err, ErrUnderpriced)
 		})
 	}
 
@@ -176,7 +96,7 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 			// set gas tip cap too large
 			setEffectiveTip(t, tx, extremelyLargeN)
 
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			err := ValidateTxStatic(types.NewTx(tx))
 
 			if _, ok := tx.(*types.DynamicFeeTx); ok {
 				require.ErrorIs(t, err, ErrTipVeryHigh)
@@ -191,32 +111,6 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 		})
 	}
 
-	for name, tx := range getTxsOfAllTypes() {
-		t.Run(fmt.Sprintf("gas tip lower than pool min tip/%v", name), func(t *testing.T) {
-
-			// setup validation context
-			opt := getTestTransactionsOption()
-			opt.isLocal = false
-			opt.minTip = big.NewInt(2)
-
-			// setup low tip cap
-			lowTipCap := new(big.Int).Sub(opt.minTip, big.NewInt(1))
-			// fee cap needs to be greater than or equal to tip cap
-			setEffectiveTip(t, tx, lowTipCap)
-
-			// --- needed for execution up to relevant check ---
-			setGasPriceOrFeeCap(t, tx, lowTipCap)
-			// sign txs with sender
-			_, signedTx := signTxForTest(t, tx)
-			opt.locals = newAccountSet(opt.signer)
-			// --- needed for execution up to relevant check ---
-
-			// validate transaction
-			err := validateTx(signedTx, opt)
-			require.ErrorIs(t, err, ErrUnderpriced)
-		})
-	}
-
 	// GasFeeCap and GasTipCap test
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("gas fee lower than gas tip/%v", name), func(t *testing.T) {
@@ -224,16 +118,7 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 			setGasPriceOrFeeCap(t, tx, big.NewInt(1))
 			setEffectiveTip(t, tx, big.NewInt(2))
 
-			setGas(t, tx, 53000)
-			address, signedTx := signTxForTest(t, tx)
-			opt := getTestTransactionsOption()
-			opt.locals = newAccountSet(opt.signer)
-
-			testDb := newTestTxPoolStateDb()
-			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
-			opt.currentState = testDb
-
-			err := validateTx(signedTx, opt)
+			err := ValidateTxStatic(types.NewTx(tx))
 			if isLegacyOrAccessList(tx) {
 				// legacy and access list transactions use the same field for
 				// gas fee and gas tip, so no error will be produced.
@@ -245,39 +130,123 @@ func TestValidateTx_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 	}
 }
 
-func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
+func TestValidateTxStatic_ReturnsNilToAcceptableTx(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
-		t.Run(fmt.Sprintf("current max gas lower than tx gas/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+		t.Run(name, func(t *testing.T) {
+			// set acceptable values
+			setGasPriceOrFeeCap(t, tx, big.NewInt(2))
+			setEffectiveTip(t, tx, big.NewInt(1))
+			setValue(t, tx, big.NewInt(1))
+			setData(t, tx, []byte("some data"))
+
+			err := ValidateTxStatic(types.NewTx(tx))
+			require.NoError(t, err)
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Network Rules Validation
+
+func TestValidateTxForNetworkRules_BeforeEip2718_RejectsNonLegacyTransactions(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		if _, ok := tx.(*types.LegacyTx); ok {
+			continue // Skip legacy transactions
+		}
+		t.Run(name, func(t *testing.T) {
+			err := ValidateTxForNetworkRules(types.NewTx(tx),
+				NetworkRulesForValidateTx{eip2718: false})
+			require.ErrorIs(t, ErrTxTypeNotSupported, err)
+		})
+	}
+}
+
+func TestValidateTxForNetworkRules_RejectsTxBasedOnTypeAndActiveRevision(t *testing.T) {
+	tests := map[string]struct {
+		tx        *types.Transaction
+		configure func(NetworkRulesForValidateTx) NetworkRulesForValidateTx
+	}{
+		"accessList tx before eip2718": {
+			tx: types.NewTx(&types.AccessListTx{}),
+			configure: func(opts NetworkRulesForValidateTx) NetworkRulesForValidateTx {
+				opts.eip2718 = false
+				return opts
+			},
+		},
+		"dynamic fee tx before eip1559": {
+			tx: types.NewTx(&types.DynamicFeeTx{}),
+			configure: func(opts NetworkRulesForValidateTx) NetworkRulesForValidateTx {
+				opts.eip2718 = true
+				opts.eip1559 = false
+				return opts
+			},
+		},
+		"blob tx before eip4844": {
+			tx: types.NewTx(makeBlobTx(nil, nil)),
+			configure: func(opts NetworkRulesForValidateTx) NetworkRulesForValidateTx {
+				opts.eip2718 = true
+				opts.eip4844 = false
+				return opts
+			},
+		},
+		"setCode tx before eip7702": {
+			tx: types.NewTx(&types.SetCodeTx{}),
+			configure: func(opts NetworkRulesForValidateTx) NetworkRulesForValidateTx {
+				opts.eip2718 = true
+				opts.eip7702 = false
+				return opts
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateTxForNetworkRules(test.tx, test.configure(getTestNetworkRules()))
+			require.Equal(t, ErrTxTypeNotSupported, err)
+		})
+	}
+}
+
+func TestValidateTxForNetworkRules_Gas_RejectsTxWith(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("gas over max gas allowed per tx/%v", name), func(t *testing.T) {
+			opt := getTestNetworkRules()
 			opt.currentMaxGas = 1
 
 			setGas(t, tx, 2)
 
-			err := validateTx(types.NewTx(tx), opt)
+			err := ValidateTxForNetworkRules(types.NewTx(tx), opt)
 			require.ErrorIs(t, err, ErrGasLimit)
 		})
 	}
 
 	for name, tx := range getTxsOfAllTypes() {
-		t.Run(fmt.Sprintf("tx gas lower than intrinsic gas/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+		t.Run(fmt.Sprintf("gas price lower than base fee/%v", name), func(t *testing.T) {
+			opt := getTestNetworkRules()
+			opt.currentBaseFee = big.NewInt(2)
+
+			// gas fee cap should be higher than current gas price
+			setGasPriceOrFeeCap(t, tx, big.NewInt(1))
+			// sign txs with sender
+			_, signedTx := signTxForTest(t, tx)
+
+			err := ValidateTxForNetworkRules(signedTx, opt)
+			require.ErrorIs(t, err, ErrUnderpriced)
+		})
+	}
+
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("gas lower than intrinsic gas/%v", name), func(t *testing.T) {
+			opt := getTestNetworkRules()
 
 			// setup tx to fail intrinsic gas calculation
-			setGas(t, tx, getIntrinsicGasForTest(t, tx, &opt)-1)
+			setGas(t, tx, getIntrinsicGasForTest(t, tx, opt)-1)
 
 			// --- needed for execution up to relevant check ---
-			// set tx for execution
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
-			// sign txs with sender
-			address, signedTx := signTxForTest(t, tx)
-			// setup enough balance
-			testDb := newTestTxPoolStateDb()
-			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
-			opt.currentState = testDb
+			setGasPriceOrFeeCap(t, tx, big.NewInt(opt.currentBaseFee.Int64()))
+			_, signedTx := signTxForTest(t, tx)
 			// ---
 
-			// validate transaction
-			err := validateTx(signedTx, opt)
+			err := ValidateTxForNetworkRules(signedTx, opt)
 			require.ErrorIs(t, err, ErrIntrinsicGas)
 		})
 	}
@@ -285,7 +254,7 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 	// EIP-7623
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("gas lower than floor data gas/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+			opt := getTestNetworkRules()
 
 			// setup tx to fail intrinsic gas calculation
 			someData := make([]byte, txSlotSize)
@@ -296,28 +265,20 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 			opt.currentMaxGas = floorDataGas
 
 			// --- needed for execution up to relevant check ---
-			// set tx for execution
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
-			// sign txs with sender
-			address, signedTx := signTxForTest(t, tx)
-			// setup enough balance
-			testDb := newTestTxPoolStateDb()
-			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
-			opt.currentState = testDb
+			setGasPriceOrFeeCap(t, tx, opt.currentBaseFee)
+			_, signedTx := signTxForTest(t, tx)
 			// ---
 
-			// validate transaction
-			err = validateTx(signedTx, opt)
+			err = ValidateTxForNetworkRules(signedTx, opt)
 			require.ErrorIs(t, err, ErrFloorDataGas)
 		})
 	}
 
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("floor data gas not checked before eip7623/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+			opt := getTestNetworkRules()
 			opt.eip7623 = false
 
-			// setup tx to fail intrinsic gas calculation
 			someData := make([]byte, txSlotSize)
 			setData(t, tx, someData)
 			floorDataGas, err := core.FloorDataGas(someData)
@@ -326,36 +287,18 @@ func TestValidateTx_Gas_RejectsTxWith(t *testing.T) {
 			opt.currentMaxGas = floorDataGas
 
 			// --- needed for execution up to relevant check ---
-			// set tx for execution
-			setGasPriceOrFeeCap(t, tx, opt.minTip)
-			// sign txs with sender
-			address, signedTx := signTxForTest(t, tx)
-			// setup enough balance
-			testDb := newTestTxPoolStateDb()
-			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
-			opt.currentState = testDb
+			setGasPriceOrFeeCap(t, tx, big.NewInt(opt.currentBaseFee.Int64()))
+			_, signedTx := signTxForTest(t, tx)
 			// ---
 
-			// validate transaction
-			err = validateTx(signedTx, opt)
+			err = ValidateTxForNetworkRules(signedTx, opt)
 			require.NoError(t, err)
 
 		})
 	}
 }
 
-func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
-	oversizedData := make([]byte, txMaxSize+1)
-	for name, tx := range getTxsOfAllTypes() {
-		t.Run(fmt.Sprintf("oversized data/%v", name), func(t *testing.T) {
-
-			setData(t, types.TxData(tx), oversizedData)
-
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
-			require.Equal(t, ErrOversizedData, err)
-		})
-	}
-
+func TestValidateTxForNetworkRules_Data_RejectsTxWith(t *testing.T) {
 	// EIP-3860
 	maxInitCode := make([]byte, params.MaxInitCodeSize+1)
 	for name, tx := range getTxsOfAllTypes() {
@@ -367,7 +310,7 @@ func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
 			setData(t, types.TxData(tx), maxInitCode)
 			setReceiverToNil(t, tx)
 
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			err := ValidateTxForNetworkRules(types.NewTx(tx), getTestNetworkRules())
 			require.ErrorIs(t, err, ErrMaxInitCodeSizeExceeded)
 		})
 	}
@@ -377,7 +320,7 @@ func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
 			if isBlobOrSetCode(tx) {
 				t.Skip("blob and setCode transactions cannot be used to initialize a contract")
 			}
-			opt := getTestTransactionsOption()
+			opt := getTestNetworkRules()
 			opt.shanghai = false
 			opt.eip4844 = false
 			opt.eip7623 = false
@@ -387,27 +330,25 @@ func TestValidateTx_Data_RejectsTxWith(t *testing.T) {
 			setData(t, types.TxData(tx), maxInitCode)
 			setReceiverToNil(t, tx)
 
+			// --- needed for execution up to relevant check ---
 			setGasPriceOrFeeCap(t, tx, opt.currentBaseFee)
 			setGas(t, tx, opt.currentMaxGas) // enough gas
-			address, signedTx := signTxForTest(t, tx)
-			testDb := newTestTxPoolStateDb()
-			testDb.balances[address] = uint256.NewInt(opt.currentMaxGas*opt.currentBaseFee.Uint64() + 1)
-			opt.currentState = testDb
+			_, signedTx := signTxForTest(t, tx)
+			// ---
 
-			err := validateTx(signedTx, opt)
+			err := ValidateTxForNetworkRules(signedTx, opt)
 			require.NoError(t, err)
 		})
 	}
-
 }
 
-func TestValidateTx_Signer_RejectsTxWith(t *testing.T) {
+func TestValidateTxForNetworkRules_Signer_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("invalid signature/%v", name), func(t *testing.T) {
-			opt := getTestTransactionsOption()
+			opt := getTestNetworkRules()
 			opt.signer = types.HomesteadSigner{}
 			setSignatureValues(t, tx, big.NewInt(1), big.NewInt(2), big.NewInt(3))
-			err := validateTx(types.NewTx(tx), getTestTransactionsOption())
+			err := ValidateTxForNetworkRules(types.NewTx(tx), getTestNetworkRules())
 			require.ErrorIs(t, err, ErrInvalidSender)
 		})
 	}
@@ -421,26 +362,87 @@ func TestValidateTx_Signer_RejectsTxWith(t *testing.T) {
 				types.NewPragueSigner(big.NewInt(2)), key)
 			require.NoError(t, err)
 
-			// validate transaction
-			err = validateTx(signedTx, getTestTransactionsOption())
+			err = ValidateTxForNetworkRules(signedTx, getTestNetworkRules())
 			require.ErrorIs(t, err, ErrInvalidSender)
 		})
 	}
 }
 
-func TestValidateTx_Balance_RejectsTxWhen(t *testing.T) {
+func TestValidateTxForNetworkRules_Blobs_RejectsTxWith(t *testing.T) {
+	// blob txs are not supported in sonic, so they must have empty hash list and sidecar
+
+	t.Run("blob tx with non-empty blob hashes", func(t *testing.T) {
+		tx := types.NewTx(makeBlobTx([]common.Hash{{0x01}}, nil))
+		err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
+		require.ErrorIs(t, err, ErrTxTypeNotSupported)
+	})
+
+	t.Run("blob tx with non-empty sidecar", func(t *testing.T) {
+		tx := types.NewTx(makeBlobTx(nil,
+			&types.BlobTxSidecar{Commitments: []kzg4844.Commitment{{0x01}}}))
+		err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
+		require.ErrorIs(t, err, ErrTxTypeNotSupported)
+	})
+}
+
+func TestValidateTxForNetworkRules_AuthorizationList_RejectsTxWith(t *testing.T) {
+	t.Run("setCode tx with empty authorization list", func(t *testing.T) {
+		tx := types.NewTx(&types.SetCodeTx{})
+		err := ValidateTxForNetworkRules(tx, getTestNetworkRules())
+		require.ErrorIs(t, err, ErrEmptyAuthorizations)
+	})
+}
+
+func TestValidateTxForNetworkRules_AcceptsTxWith(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(name, func(t *testing.T) {
+			opt := getTestNetworkRules()
+			overBaseFee := new(big.Int).Add(opt.currentBaseFee, big.NewInt(1))
+			underMaxGas := opt.currentMaxGas - 1
+
+			setGasPriceOrFeeCap(t, tx, overBaseFee)
+			setGas(t, tx, underMaxGas)
+
+			_, signedTx := signTxForTest(t, tx)
+			err := ValidateTxForNetworkRules(signedTx, opt)
+			require.NoError(t, err)
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// State Validation
+
+func TestValidateTxForState_Nonce_RejectsTxWith(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("older nonce/%v", name), func(t *testing.T) {
+
+			// set nonce lower than the current account nonce
+			currentNonce := uint64(2)
+			setNonce(t, tx, currentNonce-1)
+
+			// sign txs with sender and set current balance for account
+			address, signedTx := signTxForTest(t, tx)
+			testDb := newTestTxPoolStateDb()
+			testDb.nonces[address] = currentNonce
+
+			err := ValidateTxForState(signedTx, testDb, address)
+			require.ErrorIs(t, err, ErrNonceTooLow)
+		})
+	}
+}
+
+func TestValidateTxForState_Balance_RejectsTxWhen(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("insufficient balance/%v", name), func(t *testing.T) {
-			// setup validation context
-			opt := getTestTransactionsOption()
+
+			opt := getTestNetworkRules()
 			setValue(t, tx, big.NewInt(42))
 
 			// --- needed for execution up to relevant check ---
 			// setup transaction enough gas and fee cap to reach balance check
 			setGasPriceOrFeeCap(t, tx, opt.currentBaseFee)
 			setGas(t, tx, opt.currentMaxGas)
-
-			// sign txs with sender
 			address, signedTx := signTxForTest(t, tx)
 			// ---
 
@@ -454,82 +456,174 @@ func TestValidateTx_Balance_RejectsTxWhen(t *testing.T) {
 			)
 			txCost = zero.Add(txCost, uint256.MustFromBig(signedTx.Value()))
 			testDb.balances[address] = zero.Sub(txCost, uint256.NewInt(1))
-			opt.currentState = testDb
 
-			// validate transaction
-			err := validateTx(signedTx, opt)
+			err := ValidateTxForState(signedTx, testDb, address)
 			require.ErrorIs(t, err, ErrInsufficientFunds)
 		})
 	}
 }
 
-func TestValidateTx_Blobs_RejectsTxWith(t *testing.T) {
-	// blob txs are not supported in sonic, so they must have empty hash list and sidecar
+func TestValidateTxForState_Balance_AcceptsTxWith(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(name, func(t *testing.T) {
 
-	t.Run("blob tx with non-empty blob hashes", func(t *testing.T) {
-		tx := types.NewTx(makeBlobTx([]common.Hash{{0x01}}, nil))
-		err := validateTx(tx, getTestTransactionsOption())
-		require.ErrorIs(t, err, ErrTxTypeNotSupported)
-	})
+			setNonce(t, tx, 42)
 
-	t.Run("blob tx with non-empty sidecar", func(t *testing.T) {
-		tx := types.NewTx(makeBlobTx(nil,
-			&types.BlobTxSidecar{Commitments: []kzg4844.Commitment{{0x01}}}))
-		err := validateTx(tx, getTestTransactionsOption())
-		require.ErrorIs(t, err, ErrTxTypeNotSupported)
-	})
+			address, signedTx := signTxForTest(t, tx)
+			testDb := newTestTxPoolStateDb()
+			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
+			testDb.nonces[address] = 42
+
+			err := ValidateTxForState(signedTx, testDb, address)
+			require.NoError(t, err)
+		})
+	}
 }
 
-func TestValidateTx_AuthorizationList_RejectsTxWith(t *testing.T) {
-	t.Run("setCode tx with empty authorization list", func(t *testing.T) {
-		tx := types.NewTx(&types.SetCodeTx{})
-		err := validateTx(tx, getTestTransactionsOption())
-		require.ErrorIs(t, err, ErrEmptyAuthorizations)
-	})
+////////////////////////////////////////////////////////////////////////////////
+// TxPool Policies Validation
+
+func TestValidateTxForPool_RejectsNonLocalTxWith(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("gas tip lower than pool min tip/%v", name), func(t *testing.T) {
+
+			opt := getTestValidationOptions()
+			opt.isLocal = false
+			opt.minTip = big.NewInt(2)
+
+			// setup low tip cap
+			lowTipCap := new(big.Int).Sub(opt.minTip, big.NewInt(1))
+			// fee cap needs to be greater than or equal to tip cap
+			setEffectiveTip(t, tx, lowTipCap)
+
+			from, signedTx := signTxForTest(t, tx)
+			netRules := getTestNetworkRules()
+			opt.locals = newAccountSet(netRules.signer)
+
+			err := validateTxForPool(signedTx, opt, from)
+			require.ErrorIs(t, err, ErrUnderpriced)
+		})
+	}
+}
+
+func TestValidateTxForPool_GasPriceAndTip_AcceptsNonLocalTxWithBigTip(t *testing.T) {
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(name, func(t *testing.T) {
+
+			opt := getTestValidationOptions()
+			opt.isLocal = false
+			opt.minTip = big.NewInt(2)
+
+			// setup low tip cap
+			bigTip := new(big.Int).Add(opt.minTip, big.NewInt(1))
+			// fee cap needs to be greater than or equal to tip cap
+			setEffectiveTip(t, tx, bigTip)
+
+			// sign txs with sender
+			from, signedTx := signTxForTest(t, tx)
+			netRules := getTestNetworkRules()
+			opt.locals = newAccountSet(netRules.signer)
+
+			err := validateTxForPool(signedTx, opt, from)
+			require.NoError(t, err)
+		})
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ValidateTx
+
+func TestValidateTx_RejectsTxWhen(t *testing.T) {
+	oversizedData := make([]byte, txMaxSize+1)
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("fails static validation/%v", name), func(t *testing.T) {
+			setData(t, tx, oversizedData)
+
+			// validate transaction
+			err := validateTx(types.NewTx(tx),
+				getTestValidationOptions(), getTestNetworkRules())
+			require.ErrorIs(t, err, ErrOversizedData)
+		})
+	}
+
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("fails network rules/%v", name), func(t *testing.T) {
+			netRules := getTestNetworkRules()
+			netRules.currentMaxGas = 1
+
+			setGas(t, tx, 2)
+			setGasPriceOrFeeCap(t, tx, big.NewInt(1))
+
+			err := validateTx(types.NewTx(tx),
+				getTestValidationOptions(), netRules)
+			require.ErrorIs(t, err, ErrGasLimit)
+		})
+	}
+
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("fails pool policies/%v", name), func(t *testing.T) {
+			opt := getTestValidationOptions()
+			opt.isLocal = false
+			opt.minTip = big.NewInt(2)
+
+			// setup low tip cap
+			lowTipCap := new(big.Int).Sub(opt.minTip, big.NewInt(1))
+			// fee cap needs to be greater than or equal to tip cap
+			setEffectiveTip(t, tx, lowTipCap)
+
+			// --- needed for execution up to relevant check ---
+			netRules := getTestNetworkRules()
+			setGasPriceOrFeeCap(t, tx, netRules.currentBaseFee)
+			intrinsicGas := getIntrinsicGasForTest(t, tx, netRules)
+			setGas(t, tx, intrinsicGas+1) // enough gas
+			// ---
+
+			_, signedTx := signTxForTest(t, tx)
+			opt.locals = newAccountSet(netRules.signer)
+
+			err := validateTx(signedTx, opt, netRules)
+			require.ErrorIs(t, err, ErrUnderpriced)
+		})
+	}
+
+	for name, tx := range getTxsOfAllTypes() {
+		t.Run(fmt.Sprintf("fails state validation/%v", name), func(t *testing.T) {
+			// set nonce lower than the current account nonce
+			currentNonce := uint64(2)
+			setNonce(t, tx, currentNonce-1)
+
+			// --- needed for execution up to relevant check ---
+			netRules := getTestNetworkRules()
+			setGasPriceOrFeeCap(t, tx, netRules.currentBaseFee)
+			intrinsicGas := getIntrinsicGasForTest(t, tx, netRules)
+			setGas(t, tx, intrinsicGas+1) // enough gas
+			// ---
+
+			// sign txs with sender and set current balance for account
+			address, signedTx := signTxForTest(t, tx)
+			testDb := newTestTxPoolStateDb()
+			testDb.nonces[address] = currentNonce
+			opt := getTestValidationOptions()
+			opt.currentState = testDb
+
+			err := validateTx(signedTx, opt, netRules)
+			require.ErrorIs(t, err, ErrNonceTooLow)
+		})
+	}
 }
 
 func TestValidateTx_Success(t *testing.T) {
-	tests := map[string]types.TxData{
-		"Legacy": &types.LegacyTx{
-			Nonce:    0,
-			GasPrice: big.NewInt(1),
-			Gas:      21000,
-			To:       &common.Address{},
-			Value:    big.NewInt(1),
-		},
-		"AccessList": &types.AccessListTx{
-			Nonce:      0,
-			GasPrice:   big.NewInt(1),
-			Gas:        21000,
-			To:         &common.Address{},
-			Value:      big.NewInt(1),
-			AccessList: types.AccessList{},
-		},
-		"DynamicFee": &types.DynamicFeeTx{
-			Nonce:     0,
-			GasTipCap: big.NewInt(1),
-			GasFeeCap: big.NewInt(2),
-			Gas:       21000,
-			To:        &common.Address{},
-			Value:     big.NewInt(1),
-		},
-		"Blob": &types.BlobTx{
-			Nonce:     0,
-			GasTipCap: uint256.NewInt(1),
-			GasFeeCap: uint256.NewInt(2),
-			Gas:       21000,
-		},
-		"SetCode": &types.SetCodeTx{
-			Nonce:     0,
-			GasTipCap: uint256.NewInt(1),
-			GasFeeCap: uint256.NewInt(2),
-			Gas:       46000, // needs more gas than other tx types because of the auth list
-			AuthList:  []types.SetCodeAuthorization{{}},
-		},
-	}
-
-	for name, tx := range tests {
+	for name, tx := range getTxsOfAllTypes() {
 		t.Run(name, func(t *testing.T) {
+
+			netRules := getTestNetworkRules()
+			setNonce(t, tx, 0)
+			setGasPriceOrFeeCap(t, tx, big.NewInt(2))
+			setEffectiveTip(t, tx, big.NewInt(1))
+			setData(t, tx, []byte("some data"))
+			setGas(t, tx, getIntrinsicGasForTest(t, tx, netRules)+1)
+			setValue(t, tx, big.NewInt(1))
+
 			// Sign the transaction
 			address, signedTx := signTxForTest(t, tx)
 
@@ -538,11 +632,10 @@ func TestValidateTx_Success(t *testing.T) {
 			testDb.balances[address] = uint256.NewInt(math.MaxUint64)
 			testDb.nonces[address] = 0
 
-			opts := getTestTransactionsOption()
+			opts := getTestValidationOptions()
 			opts.currentState = testDb
 
-			// Validate the transaction
-			err := validateTx(signedTx, opts)
+			err := validateTx(signedTx, opts, netRules)
 			require.NoError(t, err)
 		})
 	}
@@ -750,7 +843,7 @@ func setSignatureValues(t *testing.T, tx types.TxData, v, r, s *big.Int) {
 	}
 }
 
-func getIntrinsicGasForTest(t *testing.T, tx types.TxData, opt *validationOptions) uint64 {
+func getIntrinsicGasForTest(t *testing.T, tx types.TxData, opt NetworkRulesForValidateTx) uint64 {
 	transaction := types.NewTx(tx)
 	intrGas, err := core.IntrinsicGas(
 		transaction.Data(),

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -138,14 +138,14 @@ func TestValidateTxStatic_Blobs_RejectsTxWith(t *testing.T) {
 	t.Run("blob tx with non-empty blob hashes", func(t *testing.T) {
 		tx := types.NewTx(makeBlobTx([]common.Hash{{0x01}}, nil))
 		err := ValidateTxStatic(tx)
-		require.ErrorIs(t, err, ErrTxTypeNotSupported)
+		require.ErrorIs(t, err, ErrNonEmptyBlobTx)
 	})
 
 	t.Run("blob tx with non-empty sidecar", func(t *testing.T) {
 		tx := types.NewTx(makeBlobTx(nil,
 			&types.BlobTxSidecar{Commitments: []kzg4844.Commitment{{0x01}}}))
 		err := ValidateTxStatic(tx)
-		require.ErrorIs(t, err, ErrTxTypeNotSupported)
+		require.ErrorIs(t, err, ErrNonEmptyBlobTx)
 	})
 }
 

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -157,7 +157,7 @@ func TestValidateTxStatic_AuthorizationList_RejectsTxWith(t *testing.T) {
 	})
 }
 
-func TestValidateTxStatic_ReturnsNilToAcceptableTx(t *testing.T) {
+func TestValidateTxStatic_AcceptsValidTransactions(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(name, func(t *testing.T) {
 			// set acceptable values

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -419,14 +419,10 @@ func TestValidateTxForState_Nonce_RejectsTxWith(t *testing.T) {
 	for name, tx := range getTxsOfAllTypes() {
 		t.Run(fmt.Sprintf("older nonce/%v", name), func(t *testing.T) {
 
-			// set nonce lower than the current account nonce
-			currentNonce := uint64(2)
-			setNonce(t, tx, currentNonce-1)
-
 			// sign txs with sender and set current balance for account
 			address, signedTx := signTxForTest(t, tx)
 			testDb := newTestTxPoolStateDb()
-			testDb.nonces[address] = currentNonce
+			testDb.nonces[address] = signedTx.Nonce() + 1
 
 			err := ValidateTxForState(signedTx, testDb, address)
 			require.ErrorIs(t, err, ErrNonceTooLow)

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -863,23 +863,6 @@ func setReceiverToNil(t *testing.T, tx types.TxData) {
 	}
 }
 
-func setReceiverToNotNil(t *testing.T, tx types.TxData) {
-	switch tx := tx.(type) {
-	case *types.LegacyTx:
-		tx.To = &common.Address{}
-	case *types.AccessListTx:
-		tx.To = &common.Address{}
-	case *types.DynamicFeeTx:
-		tx.To = &common.Address{}
-	case *types.BlobTx:
-		tx.To = common.Address{}
-	case *types.SetCodeTx:
-		tx.To = common.Address{}
-	default:
-		t.Fatalf("unexpected transaction type: %T", tx)
-	}
-}
-
 func setValue(t *testing.T, tx types.TxData, value *big.Int) {
 	switch tx := tx.(type) {
 	case *types.LegacyTx:

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -27,7 +27,7 @@ func getTestPoolOptions() poolOptions {
 	}
 }
 
-// getTestBlockState returns a test block state database that can be used for
+// getTestBlockState returns a test set of base feee and max gas that can be used for
 // validating transactions in the context of a block. It initializes the state
 // with a base fee of 1 and a max gas of 100_000
 func getTestBlockState() blockState {

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -49,8 +49,6 @@ func testBlobTx_WithBlobsIsRejected(t *testing.T, ctxt *testContext) {
 
 	// attempt to run tx
 	_, err = ctxt.net.Run(tx)
-	// because blobs are arrays of 128KB, transactions with blobs are
-	// considered oversized and rejected
 	require.ErrorContains(err, "non-empty blob transaction are not supported")
 
 	// repeat same tx (regression against reported repeated tx issue)

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -51,11 +51,11 @@ func testBlobTx_WithBlobsIsRejected(t *testing.T, ctxt *testContext) {
 	_, err = ctxt.net.Run(tx)
 	// because blobs are arrays of 128KB, transactions with blobs are
 	// considered oversized and rejected
-	require.ErrorContains(err, "oversized data")
+	require.ErrorContains(err, "non-empty blob transaction are not supported")
 
 	// repeat same tx (regression against reported repeated tx issue)
 	_, err = ctxt.net.Run(tx)
-	require.ErrorContains(err, "oversized data")
+	require.ErrorContains(err, "non-empty blob transaction are not supported")
 }
 
 func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, ctxt *testContext) {

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -49,11 +49,13 @@ func testBlobTx_WithBlobsIsRejected(t *testing.T, ctxt *testContext) {
 
 	// attempt to run tx
 	_, err = ctxt.net.Run(tx)
-	require.ErrorContains(err, "transaction type not supported")
+	// because blobs are arrays of 128KB, transactions with blobs are
+	// considered oversized and rejected
+	require.ErrorContains(err, "oversized data")
 
 	// repeat same tx (regression against reported repeated tx issue)
 	_, err = ctxt.net.Run(tx)
-	require.ErrorContains(err, "transaction type not supported")
+	require.ErrorContains(err, "oversized data")
 }
 
 func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, ctxt *testContext) {

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -993,8 +993,7 @@ func TestSetCodeTransaction_IsRejectBeforeAllegro(t *testing.T) {
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err, "failed to get chain ID")
 
-	setCodeTx := &types.SetCodeTx{AuthList: []types.SetCodeAuthorization{{}}}
-	tx := signTransaction(t, chainId, setCodeTx, net.GetSessionSponsor())
+	tx := signTransaction(t, chainId, &types.SetCodeTx{}, net.GetSessionSponsor())
 
 	err = client.SendTransaction(context.Background(), tx)
 	require.ErrorContains(t, err, "transaction type not supported")

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -993,8 +993,9 @@ func TestSetCodeTransaction_IsRejectBeforeAllegro(t *testing.T) {
 	chainId, err := client.ChainID(context.Background())
 	require.NoError(t, err, "failed to get chain ID")
 
-	tx := signTransaction(t, chainId, &types.SetCodeTx{}, net.GetSessionSponsor())
+	setCodeTx := &types.SetCodeTx{AuthList: []types.SetCodeAuthorization{{}}}
+	tx := signTransaction(t, chainId, setCodeTx, net.GetSessionSponsor())
 
 	err = client.SendTransaction(context.Background(), tx)
-	require.ErrorContains(t, err, "empty authorization")
+	require.ErrorContains(t, err, "transaction type not supported")
 }

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -996,5 +996,5 @@ func TestSetCodeTransaction_IsRejectBeforeAllegro(t *testing.T) {
 	tx := signTransaction(t, chainId, &types.SetCodeTx{}, net.GetSessionSponsor())
 
 	err = client.SendTransaction(context.Background(), tx)
-	require.ErrorContains(t, err, "transaction type not supported")
+	require.ErrorContains(t, err, "empty authorization")
 }


### PR DESCRIPTION
This PR refactors the `validateTx` function by breaking it into smaller functions, each grouped according to the type of validation and its dependencies. The goal is to make the validation logic more modular and reusable across packages—even in scenarios where some context (e.g., state, network rules) might be unavailable or irrelevant.

Network validations are performed first, because it is important to report unsupported transaction type as soon as possible. 
After network, validations are ordered to prioritize performance: cheaper checks are performed first, while more costly operations (like state access or complex computations) are deferred until later, and only executed if necessary.

New Validation Functions
These are the four introduced functions, listed in the order they are called:
- `ValidateTxForNetworkRules`: Validates the transaction against the current network rules, including fork-specific behaviors, gas limits, and fee caps.
- `ValidateTxStatic`: Performs checks that rely solely on data within the transaction itself (e.g., size, basic field validity).
- `ValidateTxForBlock`: Verifies that the transaction has `Gas` and `GasFee` compliant to the current block's `MaxGas` and `BaseFee` respectively.
- `validateTxForPool`:  Applies transaction pool-specific policies, such as minimum tip requirements for non-local senders.
- `ValidateTxForState`: Verifies that the sender has a sufficient balance to cover the cost and that the transaction nonce is acceptable based on the current state.

Notes for Reviewers: Changes to `tx_pool_test.go` and `blob_tx_test.go` were required because the transaction size check is now performed earlier—before the transaction type is validated.