### PR TITLE
Extends integration test with advance-epoch function

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -807,8 +807,8 @@ func (s *Session) GetClientConnectedToNode(i int) (*ethclient.Client, error) {
 	return s.net.GetClientConnectedToNode(i)
 }
 
-// AdvanceEpoch sends a transaction to advance to the next epoch.
-// It also waits until the new epoch is really reached.
+// AdvanceEpoch trigger the sealing of an epoch and the epoch number to progress by the given number.
+// The function blocks until the final epoch has been reached.
 func (s *Session) AdvanceEpoch(epochs int) error {
 	client, err := s.GetClient()
 	if err != nil {

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
+	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math"
 	"math/big"
 	"os"
@@ -61,6 +64,10 @@ type IntegrationTestNetSession interface {
 	// GetClient provides raw access to a fresh connection to the network.
 	// The resulting client must be closed after use.
 	GetClient() (*ethclient.Client, error)
+
+	// AdvanceEpoch sends a transaction to advance to the next epoch.
+	// It also waits until the new epoch is really reached.
+	AdvanceEpoch(epochs int) error
 }
 
 // IntegrationTestNetOptions are configuration options for the integration test network.
@@ -798,6 +805,51 @@ func (s *Session) GetClient() (*ethclient.Client, error) {
 // the network. The resulting client must be closed after use.
 func (s *Session) GetClientConnectedToNode(i int) (*ethclient.Client, error) {
 	return s.net.GetClientConnectedToNode(i)
+}
+
+// AdvanceEpoch sends a transaction to advance to the next epoch.
+// It also waits until the new epoch is really reached.
+func (s *Session) AdvanceEpoch(epochs int) error {
+	client, err := s.GetClient()
+	if err != nil {
+		return fmt.Errorf("failed to connect to the client: %w", err)
+	}
+	defer client.Close()
+
+	var currentEpoch hexutil.Uint64
+	if err := client.Client().Call(&currentEpoch, "eth_currentEpoch"); err != nil {
+		return fmt.Errorf("failed to get current epoch: %w", err)
+	}
+
+	contract, err := driverauth100.NewContract(driverauth.ContractAddress, client)
+	if err != nil {
+		return fmt.Errorf("failed to create contract: %w", err)
+	}
+
+	receipt, err := s.Apply(func(ops *bind.TransactOpts) (*types.Transaction, error) {
+		return contract.AdvanceEpochs(ops, big.NewInt(int64(epochs)))
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send transaction: %w", err)
+	}
+
+	if got, want := receipt.Status, types.ReceiptStatusSuccessful; got != want {
+		return fmt.Errorf("expected status %d, got %d", want, got)
+	}
+
+	// wait until the epoch is advanced
+	for {
+		var newEpoch hexutil.Uint64
+		if err := client.Client().Call(&newEpoch, "eth_currentEpoch"); err != nil {
+			return fmt.Errorf("failed to get current epoch: %w", err)
+		}
+
+		if newEpoch >= currentEpoch+hexutil.Uint64(epochs) {
+			break
+		}
+	}
+
+	return nil
 }
 
 // validateAndSanitizeOptions ensures that the options are valid and sets the default values.

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"testing"
 
@@ -288,4 +289,25 @@ func TestIntegrationTestNet_AccountsToBeDeployedWithGenesisCanBeCalled(t *testin
 
 	require.Equal(t, topic, receipt.Logs[0].Topics[0])
 
+}
+
+func TestIntegrationTestNet_AdvanceEpoch(t *testing.T) {
+	net := StartIntegrationTestNet(t)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	var epochBefore hexutil.Uint64
+	err = client.Client().Call(&epochBefore, "eth_currentEpoch")
+	require.NoError(t, err)
+
+	err = net.AdvanceEpoch(13)
+	require.NoError(t, err)
+
+	var epochAfter hexutil.Uint64
+	err = client.Client().Call(&epochAfter, "eth_currentEpoch")
+	require.NoError(t, err)
+
+	require.Equal(t, epochBefore+13, epochAfter)
 }

--- a/tests/network_rules_update_test.go
+++ b/tests/network_rules_update_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"math/big"
@@ -208,51 +207,17 @@ func updateNetworkRules(t *testing.T, net IntegrationTestNetSession, rulesChange
 	require.Equal(receipt.Status, types.ReceiptStatusSuccessful)
 }
 
-// advanceEpoch sends a transaction to advance to the next epoch.
-// It also waits until the new epoch is really reached.
-func advanceEpoch(t *testing.T, net IntegrationTestNetSession) {
-	t.Helper()
-	require := require.New(t)
-
-	client, err := net.GetClient()
-	require.NoError(err)
-	defer client.Close()
-
-	var currentEpoch hexutil.Uint64
-	err = client.Client().Call(&currentEpoch, "eth_currentEpoch")
-	require.NoError(err)
-
-	contract, err := driverauth100.NewContract(driverauth.ContractAddress, client)
-	require.NoError(err)
-
-	receipt, err := net.Apply(func(ops *bind.TransactOpts) (*types.Transaction, error) {
-		return contract.AdvanceEpochs(ops, big.NewInt(1))
-	})
-
-	require.NoError(err)
-	require.Equal(receipt.Status, types.ReceiptStatusSuccessful)
-
-	// wait until the epoch is advanced
-	for {
-		var newEpoch hexutil.Uint64
-		err = client.Client().Call(&newEpoch, "eth_currentEpoch")
-		require.NoError(err)
-		if newEpoch > currentEpoch {
-			break
-		}
-	}
-
-}
-
 // advanceEpochAndWaitForBlocks sends a transaction to advance to the next epoch.
 // It also waits until the new epoch is really reached and the next two blocks are produced.
 // It is useful to test a situation when the rule change is applied to the next block after the epoch change.
 func advanceEpochAndWaitForBlocks(t *testing.T, net IntegrationTestNetSession) {
 	t.Helper()
 
-	advanceEpoch(t, net)
-
 	require := require.New(t)
+
+	err := net.AdvanceEpoch(1)
+	require.NoError(err)
+
 	client, err := net.GetClient()
 	require.NoError(err)
 	defer client.Close()


### PR DESCRIPTION
This PR enriches integration tests with methods `AdvanceEpoch`. 

This method allows for progressing epoch by the configured number of steps. 