### PR TITLE
Check validity of constraints for MaxEventGas

### DIFF
--- a/opera/validate.go
+++ b/opera/validate.go
@@ -151,7 +151,7 @@ func validateEconomyRules(rules EconomyRules) error {
 
 const (
 	// upperBoundForRuleChangeGasCosts is a safe over-approximation of the gas costs of a rule change.
-	upperBoundForRuleChangeGasCosts = 1_000_000 // < TODO: verify this number
+	upperBoundForRuleChangeGasCosts = 1_000_000
 
 	// minimumMaxBlockGas is the minimum allowed max block gas.
 	//It must be large enough to allow internal transactions to seal blocks
@@ -161,6 +161,11 @@ const (
 	// It should fit into 64-bit signed integers to avoid parsing errors in third-party libraries
 	maximumMaxBlockGas = math.MaxInt64
 )
+
+// UpperBoundForRuleChangeGasCosts returns the estimated upper bound for the gas costs of a rule change.
+func UpperBoundForRuleChangeGasCosts() uint64 {
+	return upperBoundForRuleChangeGasCosts
+}
 
 func validateGasRules(rules GasRules) error {
 	var issues []error

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -511,3 +511,7 @@ func TestUpgradesValidation_AcceptsValidRules(t *testing.T) {
 		require.NoError(t, validateUpgrades(test))
 	}
 }
+
+func Test_UpperBoundForRuleChangeGasCosts_CorrectValue(t *testing.T) {
+	require.Equal(t, upperBoundForRuleChangeGasCosts, int(UpperBoundForRuleChangeGasCosts()))
+}

--- a/tests/network_rules_update_test.go
+++ b/tests/network_rules_update_test.go
@@ -186,7 +186,7 @@ func TestNetworkRule_Update_Restart_Recovers_Original_Value(t *testing.T) {
 	require.GreaterOrEqual(blockAfter.BaseFee().Int64(), newMinBaseFee, "BaseFee should reflect new MinBaseFee")
 }
 
-func TestNetworkRule_MinGas_Allows_Changing_Rules(t *testing.T) {
+func TestNetworkRule_MinEventGas_AllowsChangingRules(t *testing.T) {
 	require := require.New(t)
 	net := StartIntegrationTestNetWithFakeGenesis(t, IntegrationTestNetOptions{FeatureSet: opera.SonicFeatures})
 

--- a/tests/network_rules_update_test.go
+++ b/tests/network_rules_update_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -183,6 +184,48 @@ func TestNetworkRule_Update_Restart_Recovers_Original_Value(t *testing.T) {
 	require.NoError(err)
 
 	require.GreaterOrEqual(blockAfter.BaseFee().Int64(), newMinBaseFee, "BaseFee should reflect new MinBaseFee")
+}
+
+func TestNetworkRule_MinGas_Allows_Changing_Rules(t *testing.T) {
+	require := require.New(t)
+	net := StartIntegrationTestNetWithFakeGenesis(t, IntegrationTestNetOptions{FeatureSet: opera.SonicFeatures})
+
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	var rules opera.Rules
+	data, err := json.Marshal(rules)
+	require.NoError(err)
+
+	abi, err := driverauth100.ContractMetaData.GetAbi()
+	require.NoError(err)
+
+	input, err := abi.Pack("updateNetworkRules", data)
+	require.NoError(err)
+
+	gasPrice, err := client.SuggestGasPrice(t.Context())
+	require.NoError(err)
+
+	msg := ethereum.CallMsg{
+		From:     net.account.Address(),
+		To:       &driverauth.ContractAddress,
+		GasPrice: gasPrice.Mul(gasPrice, big.NewInt(10)),
+		Data:     input,
+	}
+
+	gas, err := client.EstimateGas(t.Context(), msg)
+	require.NoError(err)
+
+	defaultGasRules := opera.DefaultGasRules()
+
+	require.Less(gas, defaultGasRules.MaxEventGas, "Gas should be less than MaxEventGas")
+	require.Less(gas, opera.UpperBoundForRuleChangeGasCosts(), "Gas should be less than upper bound for rule change gas costs")
+
+	require.Less(gas, opera.UpperBoundForRuleChangeGasCosts()/10, "There should ne 10times head room for gas costs")
+
+	// Check that these two properties do not contradict each other
+	require.Less(opera.UpperBoundForRuleChangeGasCosts(), defaultGasRules.MaxEventGas, "Upper bound for rule change gas costs should be less than MaxEventGas")
 }
 
 // updateNetworkRules sends a transaction to update the network rules.

--- a/tests/network_rules_update_test.go
+++ b/tests/network_rules_update_test.go
@@ -222,7 +222,7 @@ func TestNetworkRule_MinGas_Allows_Changing_Rules(t *testing.T) {
 	require.Less(gas, defaultGasRules.MaxEventGas, "Gas should be less than MaxEventGas")
 	require.Less(gas, opera.UpperBoundForRuleChangeGasCosts(), "Gas should be less than upper bound for rule change gas costs")
 
-	require.Less(gas, opera.UpperBoundForRuleChangeGasCosts()/10, "There should ne 10times head room for gas costs")
+	require.Less(gas, opera.UpperBoundForRuleChangeGasCosts()/10, "There should be a factor of 10 head room for gas costs")
 
 	// Check that these two properties do not contradict each other
 	require.Less(opera.UpperBoundForRuleChangeGasCosts(), defaultGasRules.MaxEventGas, "Upper bound for rule change gas costs should be less than MaxEventGas")


### PR DESCRIPTION
This PR tests that constraints set for MaxEventGas are realistic. It tats that

* Gas to update network rules does not exceeds 1M defined as the lowest limit, with headroom of 10times
* Gas to update network rules does not exceeds default limit, i.e. this value can be updated
* default and the lowest limit does not contradict 