### PR TITLE
Check NoArchiveError when sending block notifications

### DIFF
--- a/gossip/evmstore/statedb.go
+++ b/gossip/evmstore/statedb.go
@@ -14,6 +14,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// NoArchiveError is an error returned by implementation of the State interface
+// for archive operations if no archive is maintained by this implementation.
+const NoArchiveError = carmen.NoArchiveError
+
 // GetLiveStateDb obtains StateDB for block processing - the live writable state
 func (s *Store) GetLiveStateDb(stateRoot hash.Hash) (state.StateDB, error) {
 	if s.liveStateDb == nil {

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -130,7 +130,7 @@ func (f *ServiceFeed) Start(store ArchiveBlockHeightSource) {
 			if err != nil {
 				// If there is no archive, set height to the last block
 				// and send all notifications
-				if err == evmstore.NoArchiveError {
+				if errors.Is(err, evmstore.NoArchiveError) {
 					height = pending[len(pending)-1].block.Number.Uint64()
 				} else {
 					log.Error("failed to get archive block height", "err", err)

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -41,6 +41,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/sealmodule"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/verwatcher"
 	"github.com/0xsoniclabs/sonic/gossip/emitter"
+	"github.com/0xsoniclabs/sonic/gossip/evmstore"
 	"github.com/0xsoniclabs/sonic/gossip/filters"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice"
 	"github.com/0xsoniclabs/sonic/gossip/proclogger"
@@ -127,12 +128,20 @@ func (f *ServiceFeed) Start(store ArchiveBlockHeightSource) {
 
 			height, empty, err := store.GetArchiveBlockHeight()
 			if err != nil {
-				log.Error("failed to get archive block height", "err", err)
-				continue
+				// If there is no archive, set height to the last block
+				// and send all notifications
+				if err == evmstore.NoArchiveError {
+					height = pending[len(pending)-1].block.Number.Uint64()
+				} else {
+					log.Error("failed to get archive block height", "err", err)
+					continue
+				}
+			} else {
+				if empty {
+					continue
+				}
 			}
-			if empty {
-				continue
-			}
+
 			for _, update := range pending {
 				if update.block.Number.Uint64() > height {
 					break

--- a/gossip/service_test.go
+++ b/gossip/service_test.go
@@ -168,7 +168,7 @@ func TestServiceFeed_ArchiveState(t *testing.T) {
 			// no notification should be received
 			case <-time.After(100 * time.Millisecond):
 				if test.expectedNotification != nil {
-					t.Fatal("expected notification to be sent")
+					t.Fatal("expected no notification to be sent")
 				}
 			}
 

--- a/gossip/service_test.go
+++ b/gossip/service_test.go
@@ -1,11 +1,13 @@
 package gossip
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/gossip/evmstore"
 	"go.uber.org/mock/gomock"
 )
 
@@ -93,4 +95,84 @@ func TestServiceFeed_BlocksInOrder(t *testing.T) {
 	}
 
 	feed.Stop()
+}
+
+type expectedBlockNotification struct {
+	blockNumber uint64
+}
+
+func TestServiceFeed_ArchiveState(t *testing.T) {
+
+	tests := map[string]struct {
+		blockHeight          uint64
+		emptyArchive         bool
+		err                  error
+		expectedNotification *expectedBlockNotification
+	}{
+		"empty archive": {
+			blockHeight:          0,
+			emptyArchive:         true,
+			err:                  nil,
+			expectedNotification: nil,
+		},
+		"non-empty archive": {
+			blockHeight:          12,
+			emptyArchive:         false,
+			err:                  nil,
+			expectedNotification: &expectedBlockNotification{blockNumber: 12},
+		},
+		"non-existing archive": {
+			blockHeight:          12,
+			emptyArchive:         true,
+			err:                  evmstore.NoArchiveError,
+			expectedNotification: &expectedBlockNotification{blockNumber: 12},
+		},
+		"different archive error": {
+			blockHeight:          12,
+			emptyArchive:         false,
+			err:                  fmt.Errorf("some other error"),
+			expectedNotification: nil,
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+
+			ctrl := gomock.NewController(t)
+			store := NewMockArchiveBlockHeightSource(ctrl)
+
+			store.EXPECT().GetArchiveBlockHeight().Return(test.blockHeight, test.emptyArchive, test.err).AnyTimes()
+
+			feed := ServiceFeed{}
+			feed.Start(store)
+
+			consumer := make(chan evmcore.ChainHeadNotify, 1)
+			feed.SubscribeNewBlock(consumer)
+
+			feed.notifyAboutNewBlock(&evmcore.EvmBlock{
+				EvmHeader: evmcore.EvmHeader{
+					Number: big.NewInt(int64(test.blockHeight)),
+				},
+			}, nil)
+
+			// The notification should be delivered.
+			select {
+			case notification := <-consumer:
+				if test.expectedNotification == nil {
+					t.Fatal("expected notification to be sent")
+				} else {
+					if notification.Block.Number.Cmp(big.NewInt(int64(test.expectedNotification.blockNumber))) != 0 {
+						t.Fatalf("expected block number %d, got %d", test.expectedNotification.blockNumber, notification.Block.Number)
+					}
+				}
+			// no notification should be received
+			case <-time.After(100 * time.Millisecond):
+				if test.expectedNotification != nil {
+					t.Fatal("expected notification to be sent")
+				}
+			}
+
+			feed.Stop()
+		})
+	}
 }


### PR DESCRIPTION
This PR fixes situation, when there is no archive database for checking current block height when sending subscribers block notification
Related to https://github.com/0xsoniclabs/sonic-admin/issues/175