### PR TITLE
Rename `GasLimit` to `MinTip`

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -85,7 +85,7 @@ func initFlags() {
 		flags.TxPoolNoLocalsFlag,
 		flags.TxPoolJournalFlag,
 		flags.TxPoolRejournalFlag,
-		flags.TxPoolPriceLimitFlag,
+		flags.TxPoolMinTipFlag,
 		flags.TxPoolPriceBumpFlag,
 		flags.TxPoolAccountSlotsFlag,
 		flags.TxPoolGlobalSlotsFlag,

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -85,6 +85,7 @@ func initFlags() {
 		flags.TxPoolNoLocalsFlag,
 		flags.TxPoolJournalFlag,
 		flags.TxPoolRejournalFlag,
+		flags.TxPoolPriceLimitFlag,
 		flags.TxPoolMinTipFlag,
 		flags.TxPoolPriceBumpFlag,
 		flags.TxPoolAccountSlotsFlag,

--- a/config/config.go
+++ b/config/config.go
@@ -186,8 +186,8 @@ func setTxPool(ctx *cli.Context, cfg *evmcore.TxPoolConfig) error {
 	if ctx.GlobalIsSet(flags.TxPoolRejournalFlag.Name) {
 		cfg.Rejournal = ctx.GlobalDuration(flags.TxPoolRejournalFlag.Name)
 	}
-	if ctx.GlobalIsSet(flags.TxPoolPriceLimitFlag.Name) {
-		cfg.PriceLimit = ctx.GlobalUint64(flags.TxPoolPriceLimitFlag.Name)
+	if ctx.GlobalIsSet(flags.TxPoolMinTipFlag.Name) {
+		cfg.MinimumTip = ctx.GlobalUint64(flags.TxPoolMinTipFlag.Name)
 	}
 	if ctx.GlobalIsSet(flags.TxPoolPriceBumpFlag.Name) {
 		cfg.PriceBump = ctx.GlobalUint64(flags.TxPoolPriceBumpFlag.Name)

--- a/config/config.go
+++ b/config/config.go
@@ -189,6 +189,7 @@ func setTxPool(ctx *cli.Context, cfg *evmcore.TxPoolConfig) error {
 	// TxPoolPriceLimitFlag will be deprecated in the future.
 	// hence TxPoolMinTipFlag is favored.
 	if ctx.GlobalIsSet(flags.TxPoolPriceLimitFlag.Name) {
+		log.Warn("The flag --txpool.price-limit is deprecated. Use --txpool.min-tip instead.")
 		cfg.MinimumTip = ctx.GlobalUint64(flags.TxPoolPriceLimitFlag.Name)
 	}
 	if ctx.GlobalIsSet(flags.TxPoolMinTipFlag.Name) {

--- a/config/config.go
+++ b/config/config.go
@@ -186,6 +186,11 @@ func setTxPool(ctx *cli.Context, cfg *evmcore.TxPoolConfig) error {
 	if ctx.GlobalIsSet(flags.TxPoolRejournalFlag.Name) {
 		cfg.Rejournal = ctx.GlobalDuration(flags.TxPoolRejournalFlag.Name)
 	}
+	// TxPoolPriceLimitFlag will be deprecated in the future.
+	// hence TxPoolMinTipFlag is favored.
+	if ctx.GlobalIsSet(flags.TxPoolPriceLimitFlag.Name) {
+		cfg.MinimumTip = ctx.GlobalUint64(flags.TxPoolPriceLimitFlag.Name)
+	}
 	if ctx.GlobalIsSet(flags.TxPoolMinTipFlag.Name) {
 		cfg.MinimumTip = ctx.GlobalUint64(flags.TxPoolMinTipFlag.Name)
 	}

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -89,12 +89,12 @@ var (
 	// txpool.pricelimit is deprecated, use txpool.mintip instead
 	TxPoolPriceLimitFlag = cli.Uint64Flag{
 		Name:  "txpool.pricelimit",
-		Usage: "This flag will be DEPRECATED, please use txpool.mintip instead. Minimum gas price limit to enforce for acceptance into the pool",
+		Usage: "This flag will be DEPRECATED, please use txpool.mintip instead. Minimum gas tip required to be accepted into the pool",
 		Value: evmcore.DefaultTxPoolConfig.MinimumTip,
 	}
 	TxPoolMinTipFlag = cli.Uint64Flag{
 		Name:  "txpool.mintip",
-		Usage: "Minimum gas price limit to enforce for acceptance into the pool",
+		Usage: "Minimum gas tip to required to be accepted into the pool",
 		Value: evmcore.DefaultTxPoolConfig.MinimumTip,
 	}
 	TxPoolPriceBumpFlag = cli.Uint64Flag{

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -86,10 +86,11 @@ var (
 		Usage: "Time interval to regenerate the local transaction journal",
 		Value: evmcore.DefaultTxPoolConfig.Rejournal,
 	}
-	TxPoolPriceLimitFlag = cli.Uint64Flag{
+	// TODO: update flag name and description to match actual meaning
+	TxPoolMinTipFlag = cli.Uint64Flag{
 		Name:  "txpool.pricelimit",
 		Usage: "Minimum gas price limit to enforce for acceptance into the pool",
-		Value: evmcore.DefaultTxPoolConfig.PriceLimit,
+		Value: evmcore.DefaultTxPoolConfig.MinimumTip,
 	}
 	TxPoolPriceBumpFlag = cli.Uint64Flag{
 		Name:  "txpool.pricebump",

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -86,9 +86,14 @@ var (
 		Usage: "Time interval to regenerate the local transaction journal",
 		Value: evmcore.DefaultTxPoolConfig.Rejournal,
 	}
-	// TODO: update flag name and description to match actual meaning
-	TxPoolMinTipFlag = cli.Uint64Flag{
+	// txpool.pricelimit is deprecated, use txpool.mintip instead
+	TxPoolPriceLimitFlag = cli.Uint64Flag{
 		Name:  "txpool.pricelimit",
+		Usage: "This flag will be DEPRECATED, please use txpool.mintip instead. Minimum gas price limit to enforce for acceptance into the pool",
+		Value: evmcore.DefaultTxPoolConfig.MinimumTip,
+	}
+	TxPoolMinTipFlag = cli.Uint64Flag{
+		Name:  "txpool.mintip",
 		Usage: "Minimum gas price limit to enforce for acceptance into the pool",
 		Value: evmcore.DefaultTxPoolConfig.MinimumTip,
 	}

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -62,11 +62,11 @@ func BenchmarkTxListAdd(t *testing.B) {
 	}
 	// Insert the transactions in a random order
 	list := newTxList(true)
-	priceLimit := big.NewInt(int64(DefaultTxPoolConfig.MinimumTip))
+	minimumTip := big.NewInt(int64(DefaultTxPoolConfig.MinimumTip))
 	t.ResetTimer()
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
-		list.Filter(priceLimit, DefaultTxPoolConfig.MinimumTip)
+		list.Filter(minimumTip, DefaultTxPoolConfig.MinimumTip)
 	}
 }
 

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -62,11 +62,11 @@ func BenchmarkTxListAdd(t *testing.B) {
 	}
 	// Insert the transactions in a random order
 	list := newTxList(true)
-	priceLimit := big.NewInt(int64(DefaultTxPoolConfig.PriceLimit))
+	priceLimit := big.NewInt(int64(DefaultTxPoolConfig.MinimumTip))
 	t.ResetTimer()
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
-		list.Filter(priceLimit, DefaultTxPoolConfig.PriceLimit)
+		list.Filter(priceLimit, DefaultTxPoolConfig.MinimumTip)
 	}
 }
 

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -176,7 +176,7 @@ type TxPoolConfig struct {
 	Journal   string           // Journal of local transactions to survive node restarts
 	Rejournal time.Duration    // Time interval to regenerate the local transaction journal
 
-	MinimumTip uint64 // Minimum tip to enforce for acceptance into the pool
+	MinimumTip uint64 // Minimum tip to required to be accepted into the pool
 	PriceBump  uint64 // Minimum price bump percentage to replace an already existing transaction (nonce)
 
 	AccountSlots uint64 // Number of executable transaction slots guaranteed per account
@@ -471,28 +471,6 @@ func (pool *TxPool) MinTip() *big.Int {
 	defer pool.mu.RUnlock()
 
 	return new(big.Int).Set(pool.minTip)
-}
-
-// setMinTip is a test function that updates the minimum tip required by the
-// transaction pool for a new transaction, and drops all transactions below
-// this threshold.
-func (pool *TxPool) setMinTip(price *big.Int) {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
-
-	old := pool.minTip
-	pool.minTip = price
-	// if the min miner fee increased, remove transactions below the new threshold
-	if price.Cmp(old) > 0 {
-		// pool.priced is sorted by GasFeeCap, so we have to iterate through pool.all instead
-		drop := pool.all.RemotesBelowTip(price)
-		for _, tx := range drop {
-			pool.removeTx(tx.Hash(), true)
-		}
-		pool.priced.Removed(len(drop))
-	}
-
-	log.Info("Transaction pool price threshold updated", "price", price)
 }
 
 // Nonce returns the next nonce of an account, with all transactions executable

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -176,7 +176,7 @@ type TxPoolConfig struct {
 	Journal   string           // Journal of local transactions to survive node restarts
 	Rejournal time.Duration    // Time interval to regenerate the local transaction journal
 
-	PriceLimit uint64 // Minimum gas price to enforce for acceptance into the pool
+	MinimumTip uint64 // Minimum tip to enforce for acceptance into the pool
 	PriceBump  uint64 // Minimum price bump percentage to replace an already existing transaction (nonce)
 
 	AccountSlots uint64 // Number of executable transaction slots guaranteed per account
@@ -193,7 +193,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1,
+	MinimumTip: 1,
 	PriceBump:  10,
 
 	AccountSlots: 16,
@@ -212,9 +212,9 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
 	}
-	if conf.PriceLimit < 1 {
-		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultTxPoolConfig.PriceLimit)
-		conf.PriceLimit = DefaultTxPoolConfig.PriceLimit
+	if conf.MinimumTip < 1 {
+		log.Warn("Sanitizing invalid txpool minimum tip", "provided", conf.MinimumTip, "updated", DefaultTxPoolConfig.MinimumTip)
+		conf.MinimumTip = DefaultTxPoolConfig.MinimumTip
 	}
 	if conf.PriceBump < 1 {
 		log.Warn("Sanitizing invalid txpool price bump", "provided", conf.PriceBump, "updated", DefaultTxPoolConfig.PriceBump)
@@ -268,7 +268,7 @@ type TxPool struct {
 	config      TxPoolConfig
 	chainconfig *params.ChainConfig
 	chain       StateReader
-	gasPrice    *big.Int
+	minTip      *big.Int
 	txFeed      notify.Feed
 	scope       notify.SubscriptionScope
 	signer      types.Signer
@@ -331,7 +331,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain State
 		queueTxEventCh:  make(chan *types.Transaction),
 		reorgDoneCh:     make(chan chan struct{}),
 		reorgShutdownCh: make(chan struct{}),
-		gasPrice:        new(big.Int).SetUint64(config.PriceLimit),
+		minTip:          new(big.Int).SetUint64(config.MinimumTip),
 	}
 	pool.locals = newAccountSet(pool.signer)
 	for _, addr := range config.Locals {
@@ -465,22 +465,23 @@ func (pool *TxPool) SubscribeNewTxsNotify(ch chan<- NewTxsNotify) notify.Subscri
 	return pool.scope.Track(pool.txFeed.Subscribe(ch))
 }
 
-// GasPrice returns the current gas price enforced by the transaction pool.
-func (pool *TxPool) GasPrice() *big.Int {
+// MinTip returns the current gas price enforced by the transaction pool.
+func (pool *TxPool) MinTip() *big.Int {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 
-	return new(big.Int).Set(pool.gasPrice)
+	return new(big.Int).Set(pool.minTip)
 }
 
-// SetGasPrice updates the minimum price required by the transaction pool for a
-// new transaction, and drops all transactions below this threshold.
-func (pool *TxPool) SetGasPrice(price *big.Int) {
+// setMinTip is a test function that updates the minimum tip required by the
+// transaction pool for a new transaction, and drops all transactions below
+// this threshold.
+func (pool *TxPool) setMinTip(price *big.Int) {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
-	old := pool.gasPrice
-	pool.gasPrice = price
+	old := pool.minTip
+	pool.minTip = price
 	// if the min miner fee increased, remove transactions below the new threshold
 	if price.Cmp(old) > 0 {
 		// pool.priced is sorted by GasFeeCap, so we have to iterate through pool.all instead
@@ -586,7 +587,7 @@ func (pool *TxPool) Pending(enforceTips bool) (map[common.Address]types.Transact
 		// If the miner requests tip enforcement, cap the lists now
 		if enforceTips && !pool.locals.contains(addr) {
 			for i, tx := range txs {
-				if tx.EffectiveGasTipIntCmp(pool.gasPrice, pool.priced.urgent.baseFee) < 0 {
+				if tx.EffectiveGasTipIntCmp(pool.minTip, pool.priced.urgent.baseFee) < 0 {
 					txs = txs[:i]
 					break
 				}
@@ -675,7 +676,7 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	opts := poolOptions{
 		currentState: pool.currentState,
-		minTip:       pool.gasPrice,
+		minTip:       pool.minTip,
 		locals:       pool.locals,
 		isLocal:      local,
 	}

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -890,7 +890,7 @@ func TestInvalidTransactions(t *testing.T) {
 	}
 
 	tx = transaction(1, 100000, key)
-	pool.gasPrice = big.NewInt(1000)
+	pool.minTip = big.NewInt(1000)
 	if err := pool.AddRemote(tx); err != ErrUnderpriced {
 		t.Error("expected", ErrUnderpriced, "got", err)
 	}
@@ -2042,7 +2042,7 @@ func TestTransactionPoolRepricing(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 	// Reprice the pool and check that underpriced transactions get dropped
-	pool.SetGasPrice(big.NewInt(2))
+	pool.setMinTip(big.NewInt(2))
 
 	pending, queued = pool.Stats()
 	if pending != 2 {
@@ -2167,7 +2167,7 @@ func TestTransactionPoolRepricingDynamicFee(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 	// Reprice the pool and check that underpriced transactions get dropped
-	pool.SetGasPrice(big.NewInt(2))
+	pool.setMinTip(big.NewInt(2))
 
 	pending, queued = pool.Stats()
 	if pending != 2 {
@@ -2296,13 +2296,13 @@ func TestTransactionPoolRepricingKeepsLocals(t *testing.T) {
 	validate()
 
 	// Reprice the pool and check that nothing is dropped
-	pool.SetGasPrice(big.NewInt(2))
+	pool.setMinTip(big.NewInt(2))
 	validate()
 
-	pool.SetGasPrice(big.NewInt(2))
-	pool.SetGasPrice(big.NewInt(4))
-	pool.SetGasPrice(big.NewInt(8))
-	pool.SetGasPrice(big.NewInt(100))
+	pool.setMinTip(big.NewInt(2))
+	pool.setMinTip(big.NewInt(4))
+	pool.setMinTip(big.NewInt(8))
+	pool.setMinTip(big.NewInt(100))
 	validate()
 }
 

--- a/gossip/dummy_tx_pool.go
+++ b/gossip/dummy_tx_pool.go
@@ -77,7 +77,7 @@ func (p *dummyTxPool) Pending(enforceTips bool) (map[common.Address]types.Transa
 	return batches, nil
 }
 
-func (p *dummyTxPool) GasPrice() *big.Int {
+func (p *dummyTxPool) MinTip() *big.Int {
 	return big.NewInt(0)
 }
 

--- a/gossip/gpo_backend.go
+++ b/gossip/gpo_backend.go
@@ -44,7 +44,7 @@ func (b *GPOBackend) PendingTxs() map[common.Address]types.Transactions {
 }
 
 func (b *GPOBackend) MinGasTip() *big.Int {
-	return b.txpool.GasPrice()
+	return b.txpool.MinTip()
 }
 
 // TotalGasPowerLeft returns a total amount of obtained gas power by the validators, according to the latest events from each validator

--- a/gossip/protocol.go
+++ b/gossip/protocol.go
@@ -130,7 +130,7 @@ type TxPool interface {
 	Stats() (int, int)
 	Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	ContentFrom(addr common.Address) (types.Transactions, types.Transactions)
-	GasPrice() *big.Int
+	MinTip() *big.Int
 
 	Stop()
 }

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/0xsoniclabs/tosca/go/tosca/vm"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -201,7 +201,7 @@ func TestIntegrationTestNet_CanStartWithCustomConfig(t *testing.T) {
 			// enable minimum tip check for local tx submission
 			config.TxPool.NoLocals = true
 			// increase minimum tip, default is 1
-			config.TxPool.PriceLimit = 10
+			config.TxPool.MinimumTip = 10
 		},
 	})
 	client, err := net.GetClient()


### PR DESCRIPTION
This PR addresses a naming inconsistency in the `TxPool` that could lead to confusion about the field’s actual purpose.

The `gasPrice` field was being used to represent the minimum gas tip required for a transaction to be accepted, but its name suggested it was a general gas price value. In practice, it’s compared directly against the tip in `validateTx` and `TxPool.Pending`.

To make this clearer (and align with the naming used in Geth), it's been renamed to `minTip`. The `GasPrice()` method in the `TxPool` interface has also been renamed to `MinTip()` to reflect what it's actually returning. These changes help make the code easier to understand at a glance and avoid misleading assumptions.

A new command line flag (`txpool.mintip`) is added as an alternative to the already existing `txpool.pricelimi`. The latter has been documented as deprecated.

The corresponding changes have been made in the `dummy_tx_pool` implementation as well.

This addresses [sonic-admin#149](https://github.com/0xsoniclabs/sonic-admin/issues/149).
This PR should be merged after https://github.com/0xsoniclabs/sonic/pull/200 