### PR TITLE
Add HasProposal flag to event header

### DIFF
--- a/inter/event.go
+++ b/inter/event.go
@@ -34,6 +34,7 @@ type EventI interface {
 	AnyBlockVotes() bool
 	AnyEpochVote() bool
 	AnyMisbehaviourProofs() bool
+	HasProposal() bool
 	PayloadHash() hash.Hash
 }
 
@@ -98,6 +99,7 @@ type extEventData struct {
 	anyBlockVotes         bool
 	anyEpochVote          bool
 	anyMisbehaviourProofs bool
+	hasProposal           bool
 	payloadHash           hash.Hash
 }
 
@@ -190,6 +192,8 @@ func (e *extEventData) AnyEpochVote() bool { return e.anyEpochVote }
 
 func (e *extEventData) AnyBlockVotes() bool { return e.anyBlockVotes }
 
+func (e *extEventData) HasProposal() bool { return e.hasProposal }
+
 func (e *extEventData) GasPowerLeft() GasPowerLeft { return e.gasPowerLeft }
 
 func (e *extEventData) GasPowerUsed() uint64 { return e.gasPowerUsed }
@@ -270,6 +274,7 @@ func (e *MutableEventPayload) SetEpochVote(v LlrEpochVote) {
 
 func (e *MutableEventPayload) SetPayload(payload Payload) {
 	e.payload = payload
+	e.hasProposal = payload.Proposal != nil
 	e.payloadHash = payload.Hash()
 }
 

--- a/inter/event_mock.go
+++ b/inter/event_mock.go
@@ -195,6 +195,20 @@ func (mr *MockEventIMockRecorder) GasPowerUsed() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GasPowerUsed", reflect.TypeOf((*MockEventI)(nil).GasPowerUsed))
 }
 
+// HasProposal mocks base method.
+func (m *MockEventI) HasProposal() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasProposal")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasProposal indicates an expected call of HasProposal.
+func (mr *MockEventIMockRecorder) HasProposal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProposal", reflect.TypeOf((*MockEventI)(nil).HasProposal))
+}
+
 // HashToSign mocks base method.
 func (m *MockEventI) HashToSign() hash.Hash {
 	m.ctrl.T.Helper()
@@ -608,6 +622,20 @@ func (m *MockEventPayloadI) GasPowerUsed() uint64 {
 func (mr *MockEventPayloadIMockRecorder) GasPowerUsed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GasPowerUsed", reflect.TypeOf((*MockEventPayloadI)(nil).GasPowerUsed))
+}
+
+// HasProposal mocks base method.
+func (m *MockEventPayloadI) HasProposal() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasProposal")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasProposal indicates an expected call of HasProposal.
+func (mr *MockEventPayloadIMockRecorder) HasProposal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProposal", reflect.TypeOf((*MockEventPayloadI)(nil).HasProposal))
 }
 
 // HashToSign mocks base method.

--- a/inter/event_serializer_test.go
+++ b/inter/event_serializer_test.go
@@ -199,6 +199,23 @@ func TestEventUnmarshalCSER_Version3DetectsUnsupportedPayload(t *testing.T) {
 			})
 			return builder.Build()
 		}(),
+		"with proposal but missing has-proposal flag": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(3)
+			builder.SetPayload(Payload{
+				Proposal: &Proposal{
+					Number: 1,
+				},
+			})
+			builder.hasProposal = false
+			return builder.Build()
+		}(),
+		"without proposal but with has-proposal flag": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(3)
+			builder.hasProposal = true
+			return builder.Build()
+		}(),
 	}
 
 	for name, event := range tests {


### PR DESCRIPTION
This PR adds a flag to the event header indicating whether an event is carrying a block proposal or not.

While this is adding one bit of extra payload requirements, this extension is in line with other bits indicating the presence of transactions or votes in the event format. The information of the presence of a proposal in the event header is also required by the block processor to identify events carrying proposals (see #232 for its integration).