### PR TITLE
Include epoch as seed in proposer selection

### DIFF
--- a/eventcheck/proposalcheck/proposal_check.go
+++ b/eventcheck/proposalcheck/proposal_check.go
@@ -114,6 +114,7 @@ func (v *Checker) Validate(e inter.EventPayloadI) error {
 		e.Creator(),
 		v.reader.GetEpochValidators(),
 		incoming,
+		e.Epoch(),
 		e.Frame(),
 	)
 	if err != nil {

--- a/eventcheck/proposalcheck/proposal_check_test.go
+++ b/eventcheck/proposalcheck/proposal_check_test.go
@@ -54,6 +54,7 @@ func TestProposalCheck_Validate_ValidGenesisEventWithProposalPasses(t *testing.T
 	reader.EXPECT().GetEpochValidators().Return(validators)
 
 	event.EXPECT().Creator().Return(validator)
+	event.EXPECT().Epoch().Return(idx.Epoch(4))
 	event.EXPECT().Frame().Return(idx.Frame(1))
 	event.EXPECT().MedianTime().Return(inter.Timestamp(123))
 	event.EXPECT().Parents().Return([]hash.Event{})
@@ -135,6 +136,7 @@ func TestProposalCheck_Validate_ValidEventWithProposalPasses(t *testing.T) {
 	})
 
 	event.EXPECT().Creator().Return(validator)
+	event.EXPECT().Epoch().Return(idx.Epoch(4))
 	event.EXPECT().Frame().Return(idx.Frame(20))
 	event.EXPECT().MedianTime().Return(inter.Timestamp(123))
 	event.EXPECT().Parents().Return([]hash.Event{parent1, parent2})
@@ -249,6 +251,7 @@ func TestChecker_Validate_DetectsInvalidEvent(t *testing.T) {
 			event.EXPECT().AnyMisbehaviourProofs().AnyTimes()
 
 			event.EXPECT().Creator().Return(creator).AnyTimes()
+			event.EXPECT().Epoch().Return(idx.Epoch(0)).AnyTimes()
 			event.EXPECT().Frame().Return(idx.Frame(1)).AnyTimes()
 			event.EXPECT().Parents().Return([]hash.Event{}).AnyTimes()
 			event.EXPECT().Payload().Return(&inter.Payload{
@@ -275,6 +278,7 @@ func TestProposalCheck_Validate_ReportsInvalidValidatorSet(t *testing.T) {
 	reader.EXPECT().GetEpochValidators().Return(validators)
 
 	event.EXPECT().Creator().Return(validator)
+	event.EXPECT().Epoch().Return(idx.Epoch(4))
 	event.EXPECT().Frame().Return(idx.Frame(1))
 	event.EXPECT().Parents().Return([]hash.Event{})
 	event.EXPECT().Payload().Return(&inter.Payload{

--- a/gossip/emitter/proposals.go
+++ b/gossip/emitter/proposals.go
@@ -106,10 +106,12 @@ func createPayload(
 	}
 
 	// Determine whether this validator is allowed to propose a new block.
+	currentEpoch := event.Epoch()
 	isMyTurn, err := inter.IsAllowedToPropose(
 		validator,
 		validators,
 		incomingState,
+		currentEpoch,
 		currentFrame,
 	)
 	if err != nil {

--- a/gossip/emitter/proposals_test.go
+++ b/gossip/emitter/proposals_test.go
@@ -196,6 +196,7 @@ func TestCreatePayload_UnableToCreateProposalDueToLackOfTimeProgress_CreatesPayl
 	world.EXPECT().GetRules().Return(opera.Rules{})
 
 	event.EXPECT().Parents().Return(hash.Events{p1, p2})
+	event.EXPECT().Epoch().Return(idx.Epoch(0x12))
 	event.EXPECT().Frame().Return(idx.Frame(0x14))
 	event.EXPECT().MedianTime().Return(lastBlockTime)
 
@@ -283,6 +284,7 @@ func TestCreatePayload_ValidTurn_ProducesExpectedPayload(t *testing.T) {
 	world.EXPECT().GetRules().Return(opera.Rules{})
 
 	event.EXPECT().Parents().Return(hash.Events{p1, p2})
+	event.EXPECT().Epoch().Return(idx.Epoch(3)).AnyTimes()
 	event.EXPECT().Frame().Return(idx.Frame(4)).AnyTimes()
 	event.EXPECT().MedianTime().Return(inter.Timestamp(1234))
 
@@ -713,6 +715,7 @@ func TestCreatePayload_ReturnsErrorOnRandaoGenerationFailure(t *testing.T) {
 
 	event := inter.NewMockEventI(ctrl)
 	event.EXPECT().Parents().Return(hash.Events{})
+	event.EXPECT().Epoch().Return(idx.Epoch(1))
 	event.EXPECT().Frame().Return(idx.Frame(2)) // tracker should expect frame 2
 	event.EXPECT().MedianTime().Return(inter.Timestamp(1234))
 

--- a/inter/proposal_sync_state.go
+++ b/inter/proposal_sync_state.go
@@ -59,11 +59,12 @@ func IsAllowedToPropose(
 	validator idx.ValidatorID,
 	validators *pos.Validators,
 	proposalState ProposalSyncState,
+	currentEpoch idx.Epoch,
 	currentFrame idx.Frame,
 ) (bool, error) {
 	// Check whether it is this emitter's turn to propose a new block.
 	nextTurn := getCurrentTurn(proposalState, currentFrame) + 1
-	proposer, err := GetProposer(validators, nextTurn)
+	proposer, err := GetProposer(validators, currentEpoch, nextTurn)
 	if err != nil || proposer != validator {
 		return false, err
 	}

--- a/inter/proposal_sync_state_test.go
+++ b/inter/proposal_sync_state_test.go
@@ -107,6 +107,7 @@ func TestIsAllowedToPropose_AcceptsValidProposerTurn(t *testing.T) {
 			LastSeenProposalTurn:  last.Turn,
 			LastSeenProposalFrame: last.Frame,
 		},
+		idx.Epoch(42),
 		next.Frame,
 	)
 	require.NoError(err)
@@ -121,8 +122,9 @@ func TestIsAllowedToPropose_RejectsInvalidProposerTurn(t *testing.T) {
 	builder.Set(validatorB, 20)
 	validators := builder.Build()
 
+	validEpoch := idx.Epoch(4)
 	validTurn := Turn(5)
-	validProposer, err := GetProposer(validators, validTurn)
+	validProposer, err := GetProposer(validators, validEpoch, validTurn)
 	require.NoError(t, err)
 	invalidProposer := validatorA
 	if invalidProposer == validProposer {
@@ -162,6 +164,7 @@ func TestIsAllowedToPropose_RejectsInvalidProposerTurn(t *testing.T) {
 				input.validator,
 				validators,
 				ProposalState,
+				validEpoch,
 				input.currentFrame,
 			)
 			require.NoError(err)
@@ -172,6 +175,7 @@ func TestIsAllowedToPropose_RejectsInvalidProposerTurn(t *testing.T) {
 				input.validator,
 				validators,
 				ProposalState,
+				validEpoch,
 				input.currentFrame,
 			)
 			require.NoError(err)
@@ -183,13 +187,14 @@ func TestIsAllowedToPropose_RejectsInvalidProposerTurn(t *testing.T) {
 func TestIsAllowedToPropose_ForwardsTurnSelectionError(t *testing.T) {
 	validators := pos.ValidatorsBuilder{}.Build()
 
-	_, want := GetProposer(validators, Turn(0))
+	_, want := GetProposer(validators, idx.Epoch(0), Turn(0))
 	require.Error(t, want)
 
 	_, got := IsAllowedToPropose(
 		idx.ValidatorID(0),
 		validators,
 		ProposalSyncState{},
+		idx.Epoch(0),
 		idx.Frame(0),
 	)
 	require.Error(t, got)

--- a/inter/proposer_selection.go
+++ b/inter/proposer_selection.go
@@ -15,11 +15,12 @@ import (
 // proportional to the validator's stake.
 func GetProposer(
 	validators *pos.Validators,
+	epoch idx.Epoch,
 	turn Turn,
 ) (idx.ValidatorID, error) {
 
 	// The selection of the proposer for a given round is conducted as follows:
-	//  1. f := sha256(turn) / 2^256
+	//  1. f := sha256(epoch + turn) / 2^256
 	//  2. limit := f * total_weight
 	//  3. from the list of validators sorted by their stake, find the first
 	//     validator whose cumulative weight is greater than or equal to limit.
@@ -31,8 +32,9 @@ func GetProposer(
 	}
 
 	// Note that we use big.Rat to preserve precision in the division.
-	// limit := (sha256(turn) * total_weight) / 2^256
-	data := make([]byte, 0, 4)
+	// limit := (sha256(epoch + turn) * total_weight) / 2^256
+	data := make([]byte, 0, 4+4)
+	data = binary.BigEndian.AppendUint32(data, uint32(epoch))
 	data = binary.BigEndian.AppendUint32(data, uint32(turn))
 	hash := sha256.Sum256(data)
 	limit := new(big.Rat).Quo(

--- a/inter/proposer_selection.go
+++ b/inter/proposer_selection.go
@@ -32,7 +32,7 @@ func GetProposer(
 	}
 
 	// Note that we use big.Rat to preserve precision in the division.
-	// limit := (sha256(epoch + turn) * total_weight) / 2^256
+	// limit := (sha256(epoch || turn) * total_weight) / 2^256
 	data := make([]byte, 0, 4+4)
 	data = binary.BigEndian.AppendUint32(data, uint32(epoch))
 	data = binary.BigEndian.AppendUint32(data, uint32(turn))

--- a/inter/proposer_selection.go
+++ b/inter/proposer_selection.go
@@ -20,7 +20,7 @@ func GetProposer(
 ) (idx.ValidatorID, error) {
 
 	// The selection of the proposer for a given round is conducted as follows:
-	//  1. f := sha256(epoch + turn) / 2^256
+	//  1. f := sha256(epoch || turn) / 2^256, (where || is the concatenation operator)
 	//  2. limit := f * total_weight
 	//  3. from the list of validators sorted by their stake, find the first
 	//     validator whose cumulative weight is greater than or equal to limit.


### PR DESCRIPTION
This PR adds the epoch number to the seed for the verifiable random selection of proposers.

Before this change, the order of proposers in each block is equivalent as long as the stake distribution does not change. With this change, the epoch number adds additional randomness to the selection of proposers for individual turns.