### PR TITLE
Simplify makefile targets.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,19 +33,9 @@ pipeline {
             }
         }
 
-        stage('Run unit tests') {
+        stage('Run tests') {
             steps {
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    sh 'make unit-cover-all'
-                }
-            }
-        }
-
-        stage('Run integration tests') {
-            steps {
-                catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                    sh 'make integration-cover-all'
-                }
+                sh 'make coverage'
             }
         }
 
@@ -54,8 +44,7 @@ pipeline {
                 CODECOV_TOKEN = credentials('codecov-uploader-0xsoniclabs-global')
             }
             steps {
-                sh ('codecov upload-process -r 0xsoniclabs/sonic -f ./build/coverage/*/unit-cover.out -t ${CODECOV_TOKEN}')
-                sh ('codecov upload-process -r 0xsoniclabs/sonic -f ./build/coverage/*/integration-cover.out -t ${CODECOV_TOKEN}')
+                sh("codecov upload-process -r 0xsoniclabs/sonic -f ./build/coverage.cov -t $CODECOV_TOKEN")
             }
         }
 


### PR DESCRIPTION
This PR is required because the changes committed this morning would only test integration test runs. This was reporting misleading coverage for the PRs during the day.

To avoid future confusion. This script is simplified to the minimum set of features: 
- test target runs all tests without coverage
- coverage target runs all tests with coverage
These targets are meant for integration with the CI system. No need to keep historical data or other features. 
Developers have access to better tooling in the IDE. 