### PR TITLE
Replace on-DAG block proposal tracking with local tracking

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -109,6 +109,8 @@ type Emitter struct {
 	baseFeeSource BaseFeeSource
 
 	lastTimeAnEventWasConfirmed atomic.Pointer[time.Time]
+
+	proposalTracker inter.ProposalTracker
 }
 
 type BaseFeeSource interface {

--- a/gossip/emitter/proposals_mock.go
+++ b/gossip/emitter/proposals_mock.go
@@ -25,6 +25,43 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// MockproposalTracker is a mock of proposalTracker interface.
+type MockproposalTracker struct {
+	ctrl     *gomock.Controller
+	recorder *MockproposalTrackerMockRecorder
+}
+
+// MockproposalTrackerMockRecorder is the mock recorder for MockproposalTracker.
+type MockproposalTrackerMockRecorder struct {
+	mock *MockproposalTracker
+}
+
+// NewMockproposalTracker creates a new mock instance.
+func NewMockproposalTracker(ctrl *gomock.Controller) *MockproposalTracker {
+	mock := &MockproposalTracker{ctrl: ctrl}
+	mock.recorder = &MockproposalTrackerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockproposalTracker) EXPECT() *MockproposalTrackerMockRecorder {
+	return m.recorder
+}
+
+// IsPending mocks base method.
+func (m *MockproposalTracker) IsPending(frame idx.Frame, block idx.Block) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPending", frame, block)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPending indicates an expected call of IsPending.
+func (mr *MockproposalTrackerMockRecorder) IsPending(frame, block any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPending", reflect.TypeOf((*MockproposalTracker)(nil).IsPending), frame, block)
+}
+
 // MockworldReader is a mock of worldReader interface.
 type MockworldReader struct {
 	ctrl     *gomock.Controller
@@ -46,20 +83,6 @@ func NewMockworldReader(ctrl *gomock.Controller) *MockworldReader {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockworldReader) EXPECT() *MockworldReaderMockRecorder {
 	return m.recorder
-}
-
-// GetEpochStartBlock mocks base method.
-func (m *MockworldReader) GetEpochStartBlock(arg0 idx.Epoch) idx.Block {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEpochStartBlock", arg0)
-	ret0, _ := ret[0].(idx.Block)
-	return ret0
-}
-
-// GetEpochStartBlock indicates an expected call of GetEpochStartBlock.
-func (mr *MockworldReaderMockRecorder) GetEpochStartBlock(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpochStartBlock", reflect.TypeOf((*MockworldReader)(nil).GetEpochStartBlock), arg0)
 }
 
 // GetEventPayload mocks base method.

--- a/inter/event_serializer_test.go
+++ b/inter/event_serializer_test.go
@@ -253,7 +253,7 @@ func TestEventPayloadUnmarshalCSER_DetectsInvalidPayloadEncoding(t *testing.T) {
 
 	payload := Payload{ProposalSyncState: ProposalSyncState{
 		LastSeenProposalTurn:  123,
-		LastSeenProposedBlock: 456,
+		LastSeenProposalFrame: 456,
 	}}
 	payloadData, err := payload.Serialize()
 	require.NoError(err)
@@ -650,7 +650,6 @@ func FakeEvent(version uint8, txsNum, mpsNum, bvsNum int, ersNum bool) *EventPay
 		random.SetPayload(Payload{
 			ProposalSyncState: ProposalSyncState{
 				LastSeenProposalTurn:  Turn(rand.IntN(100)),
-				LastSeenProposedBlock: idx.Block(rand.IntN(10_000_000)),
 				LastSeenProposalFrame: idx.Frame(rand.IntN(100)),
 			},
 			Proposal: &Proposal{

--- a/inter/payload.go
+++ b/inter/payload.go
@@ -35,7 +35,6 @@ type Payload struct {
 func (e *Payload) Hash() hash.Hash {
 	data := []byte{currentPayloadVersion}
 	data = binary.BigEndian.AppendUint32(data, uint32(e.LastSeenProposalTurn))
-	data = binary.BigEndian.AppendUint64(data, uint64(e.LastSeenProposedBlock))
 	data = binary.BigEndian.AppendUint32(data, uint32(e.LastSeenProposalFrame))
 	if e.Proposal != nil {
 		hash := e.Proposal.Hash()
@@ -56,7 +55,6 @@ func (e *Payload) Serialize() ([]byte, error) {
 	return proto.Marshal(&pb.Payload{
 		Version:               currentPayloadVersion,
 		LastSeenProposalTurn:  uint32(e.LastSeenProposalTurn),
-		LastSeenProposedBlock: uint64(e.LastSeenProposedBlock),
 		LastSeenProposalFrame: uint32(e.LastSeenProposalFrame),
 		Proposal:              proposal,
 	})
@@ -71,7 +69,6 @@ func (e *Payload) Deserialize(data []byte) error {
 		return fmt.Errorf("unsupported payload version: %d", pb.Version)
 	}
 	e.LastSeenProposalTurn = Turn(pb.LastSeenProposalTurn)
-	e.LastSeenProposedBlock = idx.Block(pb.LastSeenProposedBlock)
 	e.LastSeenProposalFrame = idx.Frame(pb.LastSeenProposalFrame)
 	if pb.Proposal != nil {
 		p := &Proposal{}

--- a/inter/payload_test.go
+++ b/inter/payload_test.go
@@ -27,17 +27,15 @@ func TestPayload_Hash_IsShaOfFieldConcatenation(t *testing.T) {
 		payload := &Payload{
 			ProposalSyncState: ProposalSyncState{
 				LastSeenProposalTurn:  Turn(1 + i),
-				LastSeenProposedBlock: idx.Block(2 + i),
-				LastSeenProposalFrame: idx.Frame(3 + i),
+				LastSeenProposalFrame: idx.Frame(2 + i),
 			},
 			Proposal: &Proposal{
-				Number: idx.Block(4 + i),
+				Number: idx.Block(3 + i),
 			},
 		}
 
 		data := []byte{currentPayloadVersion}
 		data = binary.BigEndian.AppendUint32(data, uint32(payload.LastSeenProposalTurn))
-		data = binary.BigEndian.AppendUint64(data, uint64(payload.LastSeenProposedBlock))
 		data = binary.BigEndian.AppendUint32(data, uint32(payload.LastSeenProposalFrame))
 		proposalHash := payload.Proposal.Hash()
 		data = append(data, proposalHash[:]...)
@@ -49,15 +47,13 @@ func TestPayload_Hash_MissingPayloadIsOmittedInHashInput(t *testing.T) {
 	payload := &Payload{
 		ProposalSyncState: ProposalSyncState{
 			LastSeenProposalTurn:  1,
-			LastSeenProposedBlock: 2,
-			LastSeenProposalFrame: 3,
+			LastSeenProposalFrame: 2,
 		},
 		Proposal: nil,
 	}
 
 	data := []byte{currentPayloadVersion}
 	data = binary.BigEndian.AppendUint32(data, uint32(payload.LastSeenProposalTurn))
-	data = binary.BigEndian.AppendUint64(data, uint64(payload.LastSeenProposedBlock))
 	data = binary.BigEndian.AppendUint32(data, uint32(payload.LastSeenProposalFrame))
 	require.Equal(t, hash.Hash(sha256.Sum256(data)), payload.Hash())
 }
@@ -66,9 +62,6 @@ func TestPayload_Hash_ModifyingContent_ChangesHash(t *testing.T) {
 	tests := map[string]func(*Payload){
 		"change last seen proposal turn": func(p *Payload) {
 			p.LastSeenProposalTurn = p.LastSeenProposalTurn + 1
-		},
-		"change last seen proposed block": func(p *Payload) {
-			p.LastSeenProposedBlock = p.LastSeenProposedBlock + 1
 		},
 		"change last seen proposal frame": func(p *Payload) {
 			p.LastSeenProposalFrame = p.LastSeenProposalFrame + 1
@@ -89,8 +82,7 @@ func TestPayload_Hash_ModifyingContent_ChangesHash(t *testing.T) {
 			payload := &Payload{
 				ProposalSyncState: ProposalSyncState{
 					LastSeenProposalTurn:  1,
-					LastSeenProposedBlock: 2,
-					LastSeenProposalFrame: 3,
+					LastSeenProposalFrame: 2,
 				},
 				Proposal: &Proposal{
 					Number: 4,
@@ -112,8 +104,7 @@ func TestPayload_CanBeSerializedAndRestored(t *testing.T) {
 		original := &Payload{
 			ProposalSyncState: ProposalSyncState{
 				LastSeenProposalTurn:  1,
-				LastSeenProposedBlock: 2,
-				LastSeenProposalFrame: 3,
+				LastSeenProposalFrame: 2,
 			},
 			Proposal: proposal,
 		}
@@ -129,7 +120,6 @@ func TestPayload_CanBeSerializedAndRestored(t *testing.T) {
 		// possible because transactions have insignificant meta-information that
 		// is not serialized and restored.
 		require.Equal(original.LastSeenProposalTurn, restored.LastSeenProposalTurn)
-		require.Equal(original.LastSeenProposedBlock, restored.LastSeenProposedBlock)
 		require.Equal(original.LastSeenProposalFrame, restored.LastSeenProposalFrame)
 
 		if original.Proposal == nil {

--- a/inter/pb/payload.proto
+++ b/inter/pb/payload.proto
@@ -26,22 +26,12 @@ message Payload {
     // next turn is starts.
     uint32 lastSeenProposalTurn = 2;
 
-    // The number of the last proposed block seen by the event containing this
-    // payload. A proposal is "seen" if it is contained in an event in the
-    // ancestry of this event. If there are multiple seen proposals, the one with
-    // the highest number is to be used. If this event contains a proposal,
-    // the number of the proposed block is to be used.
-    //
-    // If the event containing this payload is a genesis event, this number is
-    // to be set to the block height at the begin of the respective epoch.
-    uint64 lastSeenProposedBlock = 3;
-
     // The frame number of the last seen proposal. For genesis events, this
     // value is 0.
-    uint32 lastSeenProposalFrame = 4;
+    uint32 lastSeenProposalFrame = 3;
 
     // An optional proposal made by this event. If present, it is the latest
     // seen proposal for this event. Proposals made must be valid successors
     // of the last seen proposal in the strict ancestry of this event.
-    optional Proposal proposal = 5;
+    optional Proposal proposal = 4;
 }

--- a/inter/proposal_sync_state.go
+++ b/inter/proposal_sync_state.go
@@ -14,7 +14,6 @@ import (
 type ProposalSyncState struct {
 	LastSeenProposalTurn  Turn
 	LastSeenProposalFrame idx.Frame
-	LastSeenProposedBlock idx.Block
 }
 
 // JoinProposalSyncStates merges two proposal sync states by taking the maximum
@@ -23,7 +22,6 @@ type ProposalSyncState struct {
 func JoinProposalSyncStates(a, b ProposalSyncState) ProposalSyncState {
 	return ProposalSyncState{
 		LastSeenProposalTurn:  max(a.LastSeenProposalTurn, b.LastSeenProposalTurn),
-		LastSeenProposedBlock: max(a.LastSeenProposedBlock, b.LastSeenProposedBlock),
 		LastSeenProposalFrame: max(a.LastSeenProposalFrame, b.LastSeenProposalFrame),
 	}
 }
@@ -62,18 +60,7 @@ func IsAllowedToPropose(
 	validators *pos.Validators,
 	proposalState ProposalSyncState,
 	currentFrame idx.Frame,
-	blockToPropose idx.Block,
 ) (bool, error) {
-	// Check that the block about to be proposed is not a replacement of the
-	// last seen proposed block, which might not have been confirmed yet.
-	// If a proposal was not confirmed within the timeout period, a replacement
-	// can be proposed.
-	if currentFrame < proposalState.LastSeenProposalFrame+TurnTimeoutInFrames {
-		if blockToPropose == proposalState.LastSeenProposedBlock {
-			return false, nil
-		}
-	}
-
 	// Check whether it is this emitter's turn to propose a new block.
 	nextTurn := getCurrentTurn(proposalState, currentFrame) + 1
 	proposer, err := GetProposer(validators, nextTurn)

--- a/inter/proposal_tracker.go
+++ b/inter/proposal_tracker.go
@@ -1,0 +1,78 @@
+package inter
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+)
+
+// ProposalTracker is a thread-safe structure that tracks proposals seen in the
+// network. It retains a list of pending proposals which are automatically
+// purged after a certain timeout (defined by TurnTimeoutInFrames). At any time
+// users of this utility may query whether a certain block is pending at a
+// given frame height.
+//
+// Attention: the tracker does not keep track of the highest frame number. If
+// used with a non-monotonic frame number, results are unspecified.
+//
+// All methods of ProposalTracker are thread-safe.
+type ProposalTracker struct {
+	pendingProposals []proposalTrackerEntry
+	mu               sync.Mutex
+}
+
+type proposalTrackerEntry struct {
+	frame idx.Frame
+	block idx.Block
+}
+
+// Reset clears the list of pending proposals. After the pending proposals are
+// cleared, the frame counter can start from zero again.
+func (t *ProposalTracker) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pendingProposals = nil
+}
+
+// RegisterSeenProposal informs the tracker about a fresh observation of a block
+// proposal at a given frame height. This proposal is tracked until it times
+// out.
+func (t *ProposalTracker) RegisterSeenProposal(
+	frame idx.Frame,
+	block idx.Block,
+) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pendingProposals = append(t.pendingProposals, proposalTrackerEntry{
+		frame: frame,
+		block: block,
+	})
+}
+
+// IsPending checks whether a proposal for the given block is pending at the
+// given frame height. If the proposal is pending, it returns true, otherwise
+// it returns false.
+//
+// A side effect of this function is that it purges proposals that are out-dated
+// according to the given frame height. Thus, users of this function should
+// ensure that the frame number is always monotonically increasing.
+func (t *ProposalTracker) IsPending(
+	frame idx.Frame,
+	block idx.Block,
+) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pendingProposals = slices.DeleteFunc(
+		t.pendingProposals,
+		func(entry proposalTrackerEntry) bool {
+			return entry.frame+TurnTimeoutInFrames < frame
+		},
+	)
+	for _, entry := range t.pendingProposals {
+		if entry.block == block {
+			return true
+		}
+	}
+	return false
+}

--- a/inter/proposal_tracker_test.go
+++ b/inter/proposal_tracker_test.go
@@ -1,0 +1,103 @@
+package inter
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProposalTracker_Reset_ResetsPendingProposals(t *testing.T) {
+	require := require.New(t)
+	tracker := &ProposalTracker{}
+
+	tracker.RegisterSeenProposal(0, 0)
+	tracker.RegisterSeenProposal(1, 1)
+
+	require.True(tracker.IsPending(2, 0))
+	require.True(tracker.IsPending(2, 1))
+
+	tracker.Reset()
+
+	require.False(tracker.IsPending(2, 0))
+	require.False(tracker.IsPending(2, 1))
+}
+
+func TestProposalTracker_RegisterSeenProposal_RegistersProposals(t *testing.T) {
+	require := require.New(t)
+	tracker := &ProposalTracker{}
+
+	// Initially, no proposals are pending
+	require.False(tracker.IsPending(0, 0))
+	require.False(tracker.IsPending(0, 1))
+
+	// Register a proposal for block 0 at frame 0
+	tracker.RegisterSeenProposal(0, 0)
+	require.True(tracker.IsPending(0, 0))
+	require.False(tracker.IsPending(0, 1))
+
+	// Register a proposal for block 1 at frame 1
+	tracker.RegisterSeenProposal(1, 1)
+	require.True(tracker.IsPending(1, 1))
+	require.True(tracker.IsPending(0, 0))
+}
+
+func TestProposalTracker_RegisterSeenProposal_CanHandleMultipleProposalsInSameFrame(t *testing.T) {
+	require := require.New(t)
+	tracker := &ProposalTracker{}
+
+	now := idx.Frame(5)
+	require.False(tracker.IsPending(now, 0))
+	require.False(tracker.IsPending(now, 1))
+
+	tracker.RegisterSeenProposal(now, 0)
+	tracker.RegisterSeenProposal(now, 1)
+
+	require.True(tracker.IsPending(now, 0))
+	require.True(tracker.IsPending(now, 1))
+
+	now++
+	require.True(tracker.IsPending(now, 0))
+	require.True(tracker.IsPending(now, 1))
+
+	now += TurnTimeoutInFrames - 1
+	require.True(tracker.IsPending(now, 0))
+	require.True(tracker.IsPending(now, 1))
+
+	now++
+	require.False(tracker.IsPending(now, 0))
+	require.False(tracker.IsPending(now, 1))
+}
+
+func TestProposalTracker_IsPending_InitiallyNoProposalsArePending(t *testing.T) {
+	tracker := &ProposalTracker{}
+	for b := range idx.Block(10) {
+		for f := range idx.Frame(10) {
+			require.False(
+				t, tracker.IsPending(f, b),
+				"block %d should not be pending in frame %d", b, f,
+			)
+		}
+	}
+}
+
+func TestProposalTracker_IsPending_PurgesOutdatedProposals(t *testing.T) {
+	require := require.New(t)
+	tracker := &ProposalTracker{}
+
+	block := idx.Block(123)
+	initialFrame := idx.Frame(12)
+	currentFrame := initialFrame
+	require.False(tracker.IsPending(currentFrame, block))
+	tracker.RegisterSeenProposal(currentFrame, block)
+	require.True(tracker.IsPending(currentFrame, block))
+
+	for range TurnTimeoutInFrames {
+		currentFrame++
+		require.True(tracker.IsPending(currentFrame, block))
+	}
+	require.Equal(initialFrame+TurnTimeoutInFrames, currentFrame)
+
+	currentFrame++
+	require.False(tracker.IsPending(currentFrame, block))
+}


### PR DESCRIPTION
This PR replaces the tracking of the progression of block proposals retained as part of the event payloads with a process local tracking of pending proposals.

**Avoiding Proposals for the same Block**
Without tracking pending proposals the following sequence of operations would occur on the chain:
- initially, validator A and B have completed the processing of block 10
- validator A is allowed to make a proposal for a new block, and does so for block 11
- with the proposal of A for block 11, a new proposer turn starts, allowing validator B to make a proposal
- since the proposal 11 is not yet confirmed and processed, validator B's local state is at block 10; thus, validator B would decide to make another proposal for block 11, thus producing a competing proposal to the one made by validator A, adding extra load on the network

The aim of the proposal tracking is to avoid such competing proposals, essentially by blocking the proposal of block numbers that have been seen on the DAG, but not yet been confirmed.

**The Existing Mechanism**
Before this change, the events on the DAG kept track of the last proposed block number and validators are not allowed to re-propose the last seen block for a certain time-out window.

However, this mechanism has the following vulnerability:
- initially all validators have completed block 6 locally
- an honest validator A proposed a (valid) block 7
- a malicious validator B uses the next turn to propose a block 100, expected to be ignored
- an honest validator C sees the last proposed block 100, identifies it as invalid, checks its local state, and creates a proposal for block 7; this is competing with A's proposal, leading to inefficiencies

By this mechanism, a malicious validator can double its impact. The cause for this problem the lack of history when just tracking the last seen proposal.

**The New Mechanism**
The mechanism introduced in this PR removes the on-DAG tracking of seen proposals. Instead, every emitter locally tracks seen proposals, invalidating them as they time out. This information on pending proposals is used by emitters when deciding for which block a proposal is to be made.

**For reviewers**
The PR comprises three parts:
- the introduction of the `ProposalTracker` in the `inter` package
- the integration of the tracker into the `Emitter` in the `emitter` package
- the elimination of the ´LastSeenProposedBlock` field of the sync state (all the rest)

It is suggested to review these changes in the given order.