### PR TITLE
Introduce feature flag for single-proposer protocol

### DIFF
--- a/opera/legacy_serialization.go
+++ b/opera/legacy_serialization.go
@@ -99,6 +99,9 @@ func (u Upgrades) EncodeRLP(w io.Writer) error {
 	if u.Allegro {
 		bitmap.V |= allegroBit
 	}
+	if u.SingleProposerBlockFormation {
+		bitmap.V |= singleProposerBlockFormationBit
+	}
 	return rlp.Encode(w, &bitmap)
 }
 
@@ -116,6 +119,8 @@ func (u *Upgrades) DecodeRLP(s *rlp.Stream) error {
 	u.Llr = (bitmap.V & llrBit) != 0
 	u.Sonic = (bitmap.V & sonicBit) != 0
 	u.Allegro = (bitmap.V & allegroBit) != 0
+
+	u.SingleProposerBlockFormation = (bitmap.V & singleProposerBlockFormationBit) != 0
 	return nil
 }
 

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -100,6 +100,7 @@ func TestUpgradesRLP_CanBeEncodedAndDecoded(t *testing.T) {
 		func(u *Upgrades) { u.Llr = true },
 		func(u *Upgrades) { u.Sonic = true },
 		func(u *Upgrades) { u.Allegro = true },
+		func(u *Upgrades) { u.SingleProposerBlockFormation = true },
 	}
 
 	for mask := range 1 << len(setUpgrade) {

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -25,8 +25,13 @@ const (
 	berlinBit              = 1 << 0
 	londonBit              = 1 << 1
 	llrBit                 = 1 << 2
-	sonicBit               = 1 << 3
-	allegroBit             = 1 << 4
+
+	// hard-forks
+	sonicBit   = 1 << 3
+	allegroBit = 1 << 4
+
+	// optional features
+	singleProposerBlockFormationBit = 1 << 63
 
 	MinimumMaxBlockGas          = 5_000_000_000 // < must be large enough to allow internal transactions to seal blocks
 	MaximumMaxBlockGas          = math.MaxInt64 // < should fit into 64-bit signed integers to avoid parsing errors in third-party libraries
@@ -214,9 +219,26 @@ type Upgrades struct {
 	London bool
 	Llr    bool
 
-	// -- Sonic Chain --
-	Sonic   bool // < launch version of the Sonic chain
-	Allegro bool // < first hard fork of the Sonic chain
+	// -- Sonic Chain Hard Forks --
+	Sonic   bool // < launch version of the Sonic chain, introducing Cancun features
+	Allegro bool // < first hard fork of the Sonic chain, introducing Prague features
+
+	// -- Optional Features --
+
+	// SingleProposerBlockFormation enables the creation of full block proposals
+	// by a single proposer, rather than a distributed event-based protocol.
+	// This feature is introduced by V2.1 of the Sonic client. It thus
+	//
+	//    MUST ONLY BE ENABLED WHEN ALL NODES ARE RUNNING V2.1 OR LATER
+	//
+	// Any node not running V2.1 or later will ignore this flag, will not be
+	// able to process the new payload format used by this protocol, and
+	// eventually drop of the network due to the inability to stay synced.
+	//
+	// Given the conditions stated above, the feature is considered optional.
+	// It can be enabled or disabled at any time. Changes in the feature state
+	// become effective at the start of the next epoch.
+	SingleProposerBlockFormation bool
 }
 
 type UpgradeHeight struct {

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -164,6 +164,11 @@ func TestRules_Copy_CopiesAreDisjoint(t *testing.T) {
 				rule.Upgrades.Allegro = !rule.Upgrades.Allegro
 			},
 		},
+		"update Upgrades.SingleProposerBlockFormation": {
+			update: func(rule *Rules) {
+				rule.Upgrades.SingleProposerBlockFormation = !rule.Upgrades.SingleProposerBlockFormation
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -2,10 +2,11 @@ package opera
 
 import (
 	"errors"
-	"github.com/0xsoniclabs/sonic/inter"
 	"math"
 	"math/big"
 	"time"
+
+	"github.com/0xsoniclabs/sonic/inter"
 )
 
 // This file handles the validation of network rules.
@@ -241,6 +242,8 @@ func validateUpgrades(upgrade Upgrades) error {
 	if !upgrade.Allegro {
 		issues = append(issues, errors.New("Allegro upgrade is required"))
 	}
+
+	// The SingleProposerBlockFormation feature can be freely modified.
 
 	return errors.Join(issues...)
 }


### PR DESCRIPTION
This PR introduces a feature-flag for the Single-Proposer protocol.

This PR only establishes the flag. Its actual integration into the code to have the desired effect is left for a follow-up RP.