### PR TITLE
Eliminate global data directory for error lock

### DIFF
--- a/config/make_node.go
+++ b/config/make_node.go
@@ -42,8 +42,8 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 	}()
 
 	// check errlock file
-	errlock.SetDefaultDatadir(cfg.Node.DataDir)
-	if err := errlock.Check(); err != nil {
+	errorLock := errlock.New(cfg.Node.DataDir)
+	if err := errorLock.Check(); err != nil {
 		return nil, nil, nil, err
 	}
 
@@ -154,6 +154,7 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 			cfg.Emitter,
 			svc.EmitterWorld(signer),
 			gdb.AsBaseFeeSource(),
+			errorLock,
 		))
 	}
 

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -213,7 +213,7 @@ func newTestEnvWithUpgrades(
 		_ = valKeystore.Unlock(pubkey, validatorpk.FakePassword)
 		world := env.EmitterWorld(env.signer)
 		world.External = testEmitterWorldExternal{world.External, env}
-		em := emitter.NewEmitter(cfg, world, store.AsBaseFeeSource())
+		em := emitter.NewEmitter(cfg, world, store.AsBaseFeeSource(), nil)
 		env.RegisterEmitter(em)
 		env.pubkeys = append(env.pubkeys, pubkey)
 		em.Start()

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -107,6 +107,7 @@ type Emitter struct {
 	logger.Periodic
 
 	baseFeeSource BaseFeeSource
+	errorLock     *errlock.ErrorLock
 
 	lastTimeAnEventWasConfirmed atomic.Pointer[time.Time]
 }
@@ -120,6 +121,7 @@ func NewEmitter(
 	config Config,
 	world World,
 	baseFeeSource BaseFeeSource,
+	errorLock *errlock.ErrorLock,
 ) *Emitter {
 	// Randomize event time to decrease chance of 2 parallel instances emitting event at the same time
 	// It increases the chance of detecting parallel instances
@@ -134,6 +136,7 @@ func NewEmitter(
 		globalConfirmingInterval: config.EmitIntervals.Confirming,
 		Periodic:                 logger.Periodic{Instance: logger.New()},
 		baseFeeSource:            baseFeeSource,
+		errorLock:                errorLock,
 	}
 }
 
@@ -354,7 +357,7 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 	prevEmitted := em.readLastEmittedEventID()
 	if prevEmitted != nil && prevEmitted.Epoch() >= em.epoch {
 		if selfParent == nil || *selfParent != *prevEmitted {
-			errlock.Permanent(errors.New("Local database does not contain last emitted event - sync the node before enabling validation to avoid doublesign"))
+			em.errorLock.Permanent(errors.New("Local database does not contain last emitted event - sync the node before enabling validation to avoid doublesign"))
 		}
 	}
 

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -61,7 +61,7 @@ func TestEmitter(t *testing.T) {
 		TxPool:   txPool,
 		Signer:   signer,
 		TxSigner: txSigner,
-	}, fixedPriceBaseFeeSource{})
+	}, fixedPriceBaseFeeSource{}, nil)
 
 	t.Run("init", func(t *testing.T) {
 		external.EXPECT().GetRules().

--- a/gossip/emitter/parents_test.go
+++ b/gossip/emitter/parents_test.go
@@ -19,6 +19,7 @@ func TestChooseParents_NoParentsForGenesisEvent(t *testing.T) {
 		DefaultConfig(),
 		World{External: external},
 		fixedPriceBaseFeeSource{},
+		nil,
 	)
 
 	epoch := idx.Epoch(1)
@@ -45,6 +46,7 @@ func TestChooseParents_NonGenesisEventMustHaveOneSelfParent(t *testing.T) {
 		DefaultConfig(),
 		World{External: external},
 		fixedPriceBaseFeeSource{},
+		nil,
 	)
 	em.maxParents = 3
 	em.payloadIndexer = ancestor.NewPayloadIndexer(3)

--- a/gossip/emitter/sync.go
+++ b/gossip/emitter/sync.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/hash"
 
 	"github.com/0xsoniclabs/sonic/inter"
-	"github.com/0xsoniclabs/sonic/utils/errlock"
 )
 
 type syncStatus struct {
@@ -33,7 +32,7 @@ func (em *Emitter) onNewExternalEvent(e inter.EventPayloadI) {
 			"The node was stopped by one of the doublesign protection heuristics.\n" +
 			"There's no guaranteed automatic protection against a doublesign, " +
 			"please always ensure that no more than one instance of the same validator is running."
-		errlock.Permanent(fmt.Errorf(reason, e.ID().String(), em.config.Validator.ID, e.CreationTime().Time().Local().String(), passedSinceEvent.String()))
+		em.errorLock.Permanent(fmt.Errorf(reason, e.ID().String(), em.config.Validator.ID, e.CreationTime().Time().Local().String(), passedSinceEvent.String()))
 		panic("unreachable")
 	}
 }

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -9,9 +9,20 @@ import (
 	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
+type ErrorLock struct {
+	dataDir string
+}
+
+// New creates a new ErrLock instance with the specified data directory.
+func New(dataDir string) *ErrorLock {
+	return &ErrorLock{
+		dataDir: dataDir,
+	}
+}
+
 // Check if errlock is written
-func Check() error {
-	locked, reason, eLockPath, err := read(datadir)
+func (l *ErrorLock) Check() error {
+	locked, reason, eLockPath, err := read(l.dataDir)
 	if err != nil {
 		return fmt.Errorf("Node isn't allowed to start due to an error reading"+
 			" the lock file %s.\n Please fix the issue. Error message:\n%w",
@@ -26,18 +37,9 @@ func Check() error {
 	return nil
 }
 
-var (
-	datadir string
-)
-
-// SetDefaultDatadir for errlock files
-func SetDefaultDatadir(dir string) {
-	datadir = dir
-}
-
 // Permanent error
-func Permanent(err error) {
-	eLockPath, _ := write(datadir, err.Error())
+func (l *ErrorLock) Permanent(err error) {
+	eLockPath, _ := write(l.dataDir, err.Error())
 	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix"+
 		" the issue and then delete file \"%s\". Error message:\n%s",
 		eLockPath, err.Error()))


### PR DESCRIPTION
This PR eliminates a global variable used in the 'errlock' package on which a data race is detected when running integration tests.