### PR TITLE
feat(demo): add resume script for restarting existing blockchain nodes

### DIFF
--- a/demo/resume.sh
+++ b/demo/resume.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+cd $(dirname $0)
+. ./_params.sh
+
+set -e
+
+echo -e "\nResuming $N nodes:\n"
+
+for ((i=0;i<$N;i+=1))
+do
+    DATADIR="${PWD}/sonic$i.datadir"
+    PORT=$(($PORT_BASE+$i))
+    RPCP=$(($RPCP_BASE+$i))
+    WSP=$(($WSP_BASE+$i))
+    ACC=$(($i+1))
+
+    # Check if datadir exists
+    if [ ! -e ${DATADIR} ]
+    then
+        echo "Error: Data directory ${DATADIR} does not exist. Please run start.sh first."
+        exit 1
+    fi
+
+    (../build/demo_sonicd \
+--datadir=${DATADIR} \
+--mode=rpc \
+--fakenet=${ACC}/$N \
+--port=${PORT} \
+--nat extip:127.0.0.1 \
+--http --http.addr="127.0.0.1" --http.port=${RPCP} --http.corsdomain="*" --http.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag,sonic" \
+--ws --ws.addr="127.0.0.1" --ws.port=${WSP} --ws.origins="*" --ws.api="eth,debug,net,admin,web3,personal,txpool,ftm,dag,sonic" \
+--metrics --metrics.addr=127.0.0.1 --metrics.port=$(($RPCP+1100)) \
+--verbosity=3 >> sonicd$i.log 2>&1)&
+
+    echo -e "\tnode$i ok"
+done
+
+echo -e "\nConnect nodes to ring:\n"
+for ((i=0;i<$N;i+=1))
+do
+    for ((n=0;n<$M;n+=1))
+    do
+        j=$(((i+n+1) % N))
+
+        enode=$(attach_and_exec $j 'admin.nodeInfo.enode')
+        echo "    p2p address = ${enode}"
+
+        echo " connecting node-$i to node-$j:"
+        res=$(attach_and_exec $i "admin.addPeer(${enode})")
+        echo "    result = ${res}"
+    done
+done
+
+for ((i=0;i<$N;i+=1))
+do
+  echo "Node $i peers:"
+  attach_and_exec $i 'admin.peers'
+done


### PR DESCRIPTION
I've created a new script demo/resume.sh that can resume the blockchain nodes without regenerating genesis or rebuilding binaries. The script:

1. Uses existing datadirs and binaries
2. Validates that datadirs exist before starting (exits with error if not found)
3. Starts each node with the same configuration as start.sh
4. Reconnects the nodes in a ring topology
5. Verifies peer connections at the end

Usage flow:

1. First time setup: Use `./start.sh`
2. Stop nodes: Use `./stop.sh`
3. Resume nodes: Use `./resume.sh`
