### PR TITLE
Add golangci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,10 @@ linters:
         # Ignored rules
         - "-ST1000" # Incorrect or missing package comment.
         - "-ST1003" # Poorly chosen identifier.
+        # rules ST1023 and QF1011 have few findings, but in those cases adding
+        # the type to the declaration improves readability.
+        - "-ST1023" # Redundant type in variable declaration.
+        - "-QF1011" # Omit redundant type from variable declaration.
 
 
 formatters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,40 @@
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+
+  settings:
+    staticcheck:
+      checks:
+        - "all"
+        # Ignored rules
+        - "-ST1000" # Incorrect or missing package comment.
+        - "-ST1003" # Poorly chosen identifier.
+
+
+formatters:
+  # Enable specific formatter.
+  enable:
+    - gofmt
+
+issues:
+  # do not limit number of findings per linter
+  max-issues-per-linter: 0
+  # do not limit number of same finding
+  max-same-issues: 0
+  # do not limit number of issues per line
+  uniq-by-line: false
+
+output:
+  formats:
+    text:
+      # for CI or automated processing
+      path: ./build/golangci-lint-report.txt
+    html:
+      # for human consumption
+      path: ./build/golangci-lint-report.html

--- a/Makefile
+++ b/Makefile
@@ -72,26 +72,7 @@ clean:
 
 # Linting
 
-.PHONY: vet
-vet:
-	go vet ./...
-
-STATICCHECK_VERSION = 2025.1
-.PHONY: staticcheck
-staticcheck:
-	@go install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
-	staticcheck ./...
-
-ERRCHECK_VERSION = v1.9.0
-.PHONY: errcheck
-errorcheck:
-	@go install github.com/kisielk/errcheck@$(ERRCHECK_VERSION)
-	errcheck ./...
-
-.PHONY: deadcode
-deadcode:
-	@go install golang.org/x/tools/cmd/deadcode@latest
-	deadcode -test ./...
-
 .PHONY: lint
-lint: vet staticcheck deadcode errorcheck
+lint: 
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+	@golangci-lint run ./...

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -126,11 +126,11 @@ func (fixedPriceBaseFeeSource) GetCurrentBaseFee() *big.Int {
 func TestEmitter_CreateEvent_CreatesCorrectEventVersion(t *testing.T) {
 
 	tests := map[string]opera.Upgrades{
-		"sonic": opera.Upgrades{
+		"sonic": {
 			Sonic:   true,
 			Allegro: false,
 		},
-		"allegro": opera.Upgrades{
+		"allegro": {
 			Sonic:   true,
 			Allegro: true,
 		},

--- a/valkeystore/signer.go
+++ b/valkeystore/signer.go
@@ -25,7 +25,7 @@ type signerAuthorityImpl struct {
 	pubkey  validatorpk.PubKey
 }
 
-// Constructs a new SignerAuthority using the provided keystore and public key.
+// NewSignerAuthority constructs a new SignerAuthority using the provided keystore and public key.
 // The validator's private key is expected to be stored in the keystore
 func NewSignerAuthority(store KeystoreI, pubkey validatorpk.PubKey) SignerAuthority {
 	return &signerAuthorityImpl{


### PR DESCRIPTION
This PR introduces golangci-lint which is a go linters runner. Linters which are enabled includes:
     - errcheck
    - govet
    - ineffassign
    - misspell
    - staticcheck
    - unused

The linters currently used in Sonic are errcheck, govet, staticcheck and deadcode. All except deadcode are supported by golangci-lint. The runner supports unused tool which serves as unused code detection which has similar features as deadcode.

`make  lint` now uses golangci.

This PR also fixes two issues that have been introduced since the breaking rules were fixed. 