### PR TITLE
Fix ineffective assign issue.

### DIFF
--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -39,7 +39,6 @@ func (p *StateProcessor) process_iteratively(
 		if skip {
 			skipped = append(skipped, uint32(i))
 			receipts[i] = nil
-			err = nil
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
This PR fixes 2 findings of ineffective assigns found a by `ineffassign` linter to be added by https://github.com/0xsoniclabs/sonic/pull/250.

ineffective assign analysis: the flagged assignment is `err = nil` before `continue`. When `continue` is called 2 things can happen:
- the loop starts again, in line 96 where `msg, err := TxAsMessage` writes over the value of `err`
- the loop ends and the value of `err` is returned. Given that there is no other assignment of `err` between the ineffectual `nil` assignment and the `return`, it is safe to just return `nil` and remove the assignment.