### PR TITLE
Improve handling of early returning transactions

### DIFF
--- a/cmd/sonicd/app/app.go
+++ b/cmd/sonicd/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"os"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -40,6 +41,12 @@ func RunWithArgs(
 
 	// If present, take ownership and inject the control struct into the action.
 	if control != nil {
+		// Disable txPool validation, only to be used in tests.
+		app.Flags = append(app.Flags, cli.BoolFlag{
+			Name:        "disable-txPool-validation",
+			Usage:       "Disable transaction pool validation",
+			Destination: &evmcore.DefaultTxPoolConfig.DisableTxPoolValidation,
+		})
 		if control.NodeIdAnnouncement != nil {
 			defer close(control.NodeIdAnnouncement)
 		}

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -296,9 +296,17 @@ func applyTransaction(
 		msg.BlobHashes = nil
 	}
 
+	isAllegro := evm.ChainConfig().IsPrague(blockNumber, evm.Context.Time)
+	var snapshot int
+	if isAllegro {
+		snapshot = statedb.Snapshot()
+	}
 	// Apply the transaction to the current state (included in the env).
 	result, err := core.ApplyMessage(evm, msg, gp)
 	if err != nil {
+		if isAllegro {
+			statedb.RevertToSnapshot(snapshot)
+		}
 		return nil, 0, result == nil, err
 	}
 	// Notify about logs with potential state changes.

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -293,6 +293,88 @@ func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {
 	}
 }
 
+func TestApplyTransaction_BlobHashesNotSupportedAndSkipped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := state.NewMockStateDB(ctrl)
+	evm := vm.NewEVM(vm.BlockContext{}, state, &params.ChainConfig{}, vm.Config{})
+	gp := new(core.GasPool).AddGas(1000000)
+
+	msg := &core.Message{
+		From:       common.Address{1},
+		To:         &common.Address{2},
+		GasLimit:   21000,
+		GasPrice:   big.NewInt(1),
+		BlobHashes: []common.Hash{{0x01}},
+	}
+	usedGas := uint64(0)
+	receipt, gasUsed, skipped, err := applyTransaction(msg, gp, state, big.NewInt(1), nil, &usedGas, evm, nil)
+	require.ErrorContains(t, err, "blob data is not supported")
+	require.Nil(t, receipt)
+	require.Equal(t, uint64(0), gasUsed)
+	require.True(t, skipped)
+}
+
+func TestApplyTransaction_ApplyMessageError_RevertsSnapshotIfPrague(t *testing.T) {
+	versions := map[string]bool{
+		"pre prague": false,
+		"prague":     true,
+	}
+
+	for name, isPrague := range versions {
+		t.Run(name, func(t *testing.T) {
+			pragueTime := uint64(1000)
+			if isPrague {
+				pragueTime = 0
+			}
+			any := gomock.Any()
+			ctrl := gomock.NewController(t)
+			state := state.NewMockStateDB(ctrl)
+			evm := vm.NewEVM(vm.BlockContext{}, state, &params.ChainConfig{
+				LondonBlock:        new(big.Int).SetUint64(0),
+				MergeNetsplitBlock: new(big.Int).SetUint64(0),
+				ShanghaiTime:       new(uint64),
+				CancunTime:         new(uint64),
+				PragueTime:         &pragueTime,
+			}, vm.Config{})
+			gp := new(core.GasPool).AddGas(1000000)
+
+			blockNumber := big.NewInt(100)
+			evm.Context.Random = &common.Hash{0x01} // triggers isMerge
+			evm.Context.BlockNumber = blockNumber   // triggers isMerge
+			evm.Context.Time = 100                  // triggers IsPrague
+
+			initCode := make([]byte, 50000) // large init code to trigger error
+			msg := &core.Message{
+				From:             common.Address{1},
+				To:               nil, // contract creation
+				GasLimit:         1000000,
+				GasPrice:         big.NewInt(1),
+				GasFeeCap:        big.NewInt(0),
+				GasTipCap:        big.NewInt(0),
+				Value:            big.NewInt(0),
+				Data:             initCode,
+				SkipNonceChecks:  true,
+				SkipFromEOACheck: true,
+			}
+
+			state.EXPECT().GetBalance(msg.From).Return(uint256.NewInt(1000000))
+			state.EXPECT().SubBalance(any, any, any)
+
+			if isPrague {
+				// Set up snapshot and revert expectations
+				state.EXPECT().Snapshot().Return(42)
+				state.EXPECT().RevertToSnapshot(42)
+			}
+
+			receipt, gasUsed, skipped, err := applyTransaction(msg, gp, state, blockNumber, nil, new(uint64), evm, nil)
+			require.ErrorContains(t, err, "max initcode size exceeded")
+			require.Nil(t, receipt)
+			require.Equal(t, uint64(0), gasUsed)
+			require.True(t, skipped)
+		})
+	}
+}
+
 // processFunction is a function type alias for the StateProcessor's Process
 // function to allow side-by-side testing of different implementations.
 type processFunction = func(

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -185,6 +185,8 @@ type TxPoolConfig struct {
 	GlobalQueue  uint64 // Maximum number of non-executable transaction slots for all accounts
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
+
+	DisableTxPoolValidation bool
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction
@@ -761,7 +763,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 	isLocal := local || pool.locals.containsTx(tx)
 
 	// If the transaction fails basic validation, discard it
-	if err := pool.validateTx(tx, isLocal); err != nil {
+	if err := pool.validateTx(tx, isLocal); !pool.config.DisableTxPoolValidation && err != nil {
 		log.Trace("Discarding invalid transaction", "hash", hash, "err", err)
 		invalidTxMeter.Mark(1)
 		return false, err

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *testing.T) {
+	versions := map[string]opera.Upgrades{
+		"sonic":   opera.GetSonicUpgrades(),
+		"allegro": opera.GetAllegroUpgrades(),
+	}
+
+	for name, version := range versions {
+		t.Run(name, func(t *testing.T) {
+			net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
+				Upgrades: &version,
+			})
+
+			client, err := net.GetClient()
+			require.NoError(t, err)
+			defer client.Close()
+
+			sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
+
+			gasPrice, err := client.SuggestGasPrice(t.Context())
+			require.NoError(t, err)
+
+			chainId, err := client.ChainID(t.Context())
+			require.NoError(t, err)
+
+			initCode := make([]byte, 50000)
+			txData := &types.LegacyTx{
+				Nonce:    0,
+				Gas:      10000000,
+				GasPrice: gasPrice,
+				To:       nil, // address 0x00 for contract creation
+				Value:    big.NewInt(0),
+				Data:     initCode,
+			}
+			tx := signTransaction(t, chainId, txData, sender)
+
+			preBalance, err := client.BalanceAt(t.Context(), sender.Address(), nil)
+			require.NoError(t, err)
+
+			receipt, err := net.Run(tx)
+			require.Error(t, err, "init code size too large")
+			require.Nil(t, receipt)
+
+			postBalance, err := client.BalanceAt(t.Context(), sender.Address(), nil)
+			require.NoError(t, err)
+
+			if version == opera.GetSonicUpgrades() {
+				require.Less(t, postBalance.Uint64(), preBalance.Uint64(), "balance should decrease after failed contract creation")
+			}
+			if version == opera.GetAllegroUpgrades() {
+				require.Equal(t, preBalance, postBalance, "balance should not change after failed contract creation")
+			}
+		})
+	}
+}
+
+func TestAccountCreation_CreateCallsProducingCodesTooLargeProduceAUnsuccessfulReceipt(t *testing.T) {
+	codeSize := uint256.NewInt(25000).Bytes32()
+	initCode := []byte{byte(vm.PUSH32)}
+	initCode = append(initCode, codeSize[:]...)
+	initCode = append(initCode, []byte{
+		byte(vm.PUSH1), byte(0),
+		byte(vm.RETURN),
+	}...)
+
+	upgrade := opera.GetSonicUpgrades()
+	net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
+		Upgrades: &upgrade,
+	})
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
+
+	gasPrice, err := client.SuggestGasPrice(t.Context())
+	require.NoError(t, err)
+
+	chainId, err := client.ChainID(t.Context())
+	require.NoError(t, err)
+
+	txData := &types.LegacyTx{
+		Nonce:    0,
+		Gas:      100000,
+		GasPrice: gasPrice,
+		To:       nil, // address 0x00 for contract creation
+		Value:    big.NewInt(0),
+		Data:     initCode,
+	}
+	tx := signTransaction(t, chainId, txData, sender)
+
+	receipt, err := net.Run(tx)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusFailed, receipt.Status)
+}

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -21,6 +21,9 @@ func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *te
 		t.Run(name, func(t *testing.T) {
 			net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
 				Upgrades: &version,
+				ClientExtraArguments: []string{
+					"--disable-txPool-validation",
+				},
 			})
 
 			client, err := net.GetClient()


### PR DESCRIPTION
This PR adds a snapshot and rollback to the transaction execution like it is done in the [t8n tool](https://github.com/ethereum/go-ethereum/blob/2a1784baef0e9d0c0641bc97d1a3478048de5c23/cmd/evm/internal/t8ntool/execution.go#L262) from ethereum.