### PR TITLE
Fix incorrectly formatted error strings

### DIFF
--- a/cmd/cmdtest/test_cmd.go
+++ b/cmd/cmdtest/test_cmd.go
@@ -130,12 +130,12 @@ func (tt *TestCmd) matchExactOutput(want []byte) error {
 		// Find the mismatch position.
 		for i := 0; i < n; i++ {
 			if want[i] != buf[i] {
-				return fmt.Errorf("Output mismatch at ◊:\n---------------- (stdout text)\n%s◊%s\n---------------- (expected text)\n%s",
+				return fmt.Errorf("output mismatch at ◊:\n---------------- (stdout text)\n%s◊%s\n---------------- (expected text)\n%s",
 					buf[:i], buf[i:n], want)
 			}
 		}
 		if n < len(want) {
-			return fmt.Errorf("Not enough output, got until ◊:\n---------------- (stdout text)\n%s\n---------------- (expected text)\n%s◊%s",
+			return fmt.Errorf("not enough output, got until ◊:\n---------------- (stdout text)\n%s\n---------------- (expected text)\n%s◊%s",
 				buf, want[:n], want[n:])
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -91,9 +91,9 @@ func LoadAllConfigs(file string, cfg *Config) (err error) {
 		err = errors.New(file + ", " + err.Error())
 	}
 	if err != nil {
-		return fmt.Errorf("TOML config file error: %v.\n"+
+		return fmt.Errorf("failed to decode TOML config file: %v\n"+
 			"Use 'dumpconfig' command to get an example config file.\n"+
-			"If node was recently upgraded and a previous network config file is used, then check updates for the config file.", err)
+			"If node was recently upgraded and a previous network config file is used, then check updates for the config file", err)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -91,9 +91,11 @@ func LoadAllConfigs(file string, cfg *Config) (err error) {
 		err = errors.New(file + ", " + err.Error())
 	}
 	if err != nil {
-		return fmt.Errorf("failed to decode TOML config file: %v\n"+
+		// This is a user-facing error, so we want to provide a clear message.
+		//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+		return fmt.Errorf("TOML config file error: %v.\n"+
 			"Use 'dumpconfig' command to get an example config file.\n"+
-			"If node was recently upgraded and a previous network config file is used, then check updates for the config file", err)
+			"If node was recently upgraded and a previous network config file is used, then check updates for the config file.", err)
 	}
 	return nil
 }

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2080,7 +2080,9 @@ func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (stri
 //
 // This is a temporary method to debug the externalsigner integration,
 func (api *PublicDebugAPI) TestSignCliqueBlock(ctx context.Context, address common.Address, number uint64) (common.Address, error) {
-	return common.Address{}, errors.New("clique isn't supported")
+	// This is a user-facing error, so we want to provide a clear message.
+	//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+	return common.Address{}, errors.New("Clique isn't supported")
 }
 
 // PrintBlock retrieves a block and returns its pretty printed form.

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2080,7 +2080,7 @@ func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (stri
 //
 // This is a temporary method to debug the externalsigner integration,
 func (api *PublicDebugAPI) TestSignCliqueBlock(ctx context.Context, address common.Address, number uint64) (common.Address, error) {
-	return common.Address{}, errors.New("Clique isn't supported")
+	return common.Address{}, errors.New("clique isn't supported")
 }
 
 // PrintBlock retrieves a block and returns its pretty printed form.

--- a/evmcore/tx_journal.go
+++ b/evmcore/tx_journal.go
@@ -67,9 +67,9 @@ func (journal *txJournal) load(add func([]*types.Transaction) []error) (err erro
 	// Open the journal for loading any past transactions
 	input, err := os.Open(journal.path)
 	if err != nil {
-		return fmt.Errorf("Failed to open transaction journal: %w", err)
+		return fmt.Errorf("failed to open transaction journal: %w", err)
 	}
-	defer caution.CloseAndReportError(&err, input, "Failed to close transaction journal")
+	defer caution.CloseAndReportError(&err, input, "failed to close transaction journal")
 
 	// Temporarily discard any journal additions (don't double add on load)
 	journal.writer = new(devNull)

--- a/gossip/blockproc/verwatcher/version_watcher.go
+++ b/gossip/blockproc/verwatcher/version_watcher.go
@@ -33,11 +33,11 @@ func (w *VersionWatcher) Pause() error {
 	have := getVersionNumber()
 	needed := versionNumber(w.store.GetNetworkVersion())
 	if needed > have {
-		return fmt.Errorf("Network upgrade %v was activated. Current node version is %v. "+
-			"Please upgrade your node to continue syncing.", needed, have)
+		return fmt.Errorf("network upgrade %v was activated. Current node version is %v. "+
+			"Please upgrade your node to continue syncing", needed, have)
 	} else if w.store.GetMissedVersion() > 0 {
-		return fmt.Errorf("Node's state is dirty because node was upgraded after the network upgrade %v was activated. "+
-			"Please re-sync the chain data to continue.", versionNumber(w.store.GetMissedVersion()))
+		return fmt.Errorf("node's state is dirty because node was upgraded after the network upgrade %v was activated. "+
+			"Please re-sync the chain data to continue", versionNumber(w.store.GetMissedVersion()))
 	}
 	return nil
 }

--- a/gossip/blockproc/verwatcher/version_watcher.go
+++ b/gossip/blockproc/verwatcher/version_watcher.go
@@ -33,11 +33,15 @@ func (w *VersionWatcher) Pause() error {
 	have := getVersionNumber()
 	needed := versionNumber(w.store.GetNetworkVersion())
 	if needed > have {
-		return fmt.Errorf("network upgrade %v was activated. Current node version is %v. "+
-			"Please upgrade your node to continue syncing", needed, have)
+		// This is a user-facing error, so we want to provide a clear message.
+		//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+		return fmt.Errorf("Network upgrade %v was activated. Current node version is %v. "+
+			"Please upgrade your node to continue syncing.", needed, have)
 	} else if w.store.GetMissedVersion() > 0 {
-		return fmt.Errorf("node's state is dirty because node was upgraded after the network upgrade %v was activated. "+
-			"Please re-sync the chain data to continue", versionNumber(w.store.GetMissedVersion()))
+		// This is a user-facing error, so we want to provide a clear message.
+		//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+		return fmt.Errorf("Node's state is dirty because node was upgraded after the network upgrade %v was activated. "+
+			"Please re-sync the chain data to continue.", versionNumber(w.store.GetMissedVersion()))
 	}
 	return nil
 }

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -356,7 +356,7 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 	prevEmitted := em.readLastEmittedEventID()
 	if prevEmitted != nil && prevEmitted.Epoch() >= em.epoch {
 		if selfParent == nil || *selfParent != *prevEmitted {
-			errlock.Permanent(errors.New("Local database does not contain last emitted event - sync the node before enabling validation to avoid doublesign"))
+			errlock.Permanent(errors.New("local database does not contain last emitted event - sync the node before enabling validation to avoid double sign"))
 		}
 	}
 

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -356,7 +356,9 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 	prevEmitted := em.readLastEmittedEventID()
 	if prevEmitted != nil && prevEmitted.Epoch() >= em.epoch {
 		if selfParent == nil || *selfParent != *prevEmitted {
-			errlock.Permanent(errors.New("local database does not contain last emitted event - sync the node before enabling validation to avoid double sign"))
+			// This is a user-facing error, so we want to provide a clear message.
+			//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+			errlock.Permanent(errors.New("Local database does not contain last emitted event - sync the node before enabling validation to avoid double sign."))
 		}
 	}
 

--- a/gossip/emitter/sync.go
+++ b/gossip/emitter/sync.go
@@ -27,12 +27,14 @@ func (em *Emitter) onNewExternalEvent(e inter.EventPayloadI) {
 	status := em.currentSyncStatus()
 	if doublesign.DetectParallelInstance(status, em.config.EmitIntervals.ParallelInstanceProtection) {
 		passedSinceEvent := status.Since(status.ExternalSelfEventCreated)
-		reason := "received a recent event (event id=%s) from this validator (validator ID=%d) which wasn't created on this node.\n" +
+		reason := "Received a recent event (event id=%s) from this validator (validator ID=%d) which wasn't created on this node.\n" +
 			"This external event was created %s, %s ago at the time of this error.\n" +
 			"It might mean that a duplicating instance of the same validator is running simultaneously, which may eventually lead to a doublesign.\n" +
 			"The node was stopped by one of the doublesign protection heuristics.\n" +
 			"There's no guaranteed automatic protection against a doublesign, " +
-			"please always ensure that no more than one instance of the same validator is running"
+			"please always ensure that no more than one instance of the same validator is running."
+		// This is a user-facing error, so we want to provide a clear message.
+		//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
 		errlock.Permanent(fmt.Errorf(reason, e.ID().String(), em.config.Validator.ID, e.CreationTime().Time().Local().String(), passedSinceEvent.String()))
 		panic("unreachable")
 	}

--- a/gossip/emitter/sync.go
+++ b/gossip/emitter/sync.go
@@ -27,12 +27,12 @@ func (em *Emitter) onNewExternalEvent(e inter.EventPayloadI) {
 	status := em.currentSyncStatus()
 	if doublesign.DetectParallelInstance(status, em.config.EmitIntervals.ParallelInstanceProtection) {
 		passedSinceEvent := status.Since(status.ExternalSelfEventCreated)
-		reason := "Received a recent event (event id=%s) from this validator (validator ID=%d) which wasn't created on this node.\n" +
+		reason := "received a recent event (event id=%s) from this validator (validator ID=%d) which wasn't created on this node.\n" +
 			"This external event was created %s, %s ago at the time of this error.\n" +
 			"It might mean that a duplicating instance of the same validator is running simultaneously, which may eventually lead to a doublesign.\n" +
 			"The node was stopped by one of the doublesign protection heuristics.\n" +
 			"There's no guaranteed automatic protection against a doublesign, " +
-			"please always ensure that no more than one instance of the same validator is running."
+			"please always ensure that no more than one instance of the same validator is running"
 		errlock.Permanent(fmt.Errorf(reason, e.ID().String(), em.config.Validator.ID, e.CreationTime().Time().Local().String(), passedSinceEvent.String()))
 		panic("unreachable")
 	}

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -221,25 +221,31 @@ func validateUpgrades(upgrade Upgrades) error {
 	}
 
 	if !upgrade.London {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
 		issues = append(issues, errors.New("London upgrade is required"))
 	}
 
 	if !upgrade.Berlin {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
 		issues = append(issues, errors.New("Berlin upgrade is required"))
 	}
 
 	if upgrade.Sonic && !upgrade.London {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
 		issues = append(issues, errors.New("Sonic upgrade requires London"))
 	}
 	if upgrade.London && !upgrade.Berlin {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
 		issues = append(issues, errors.New("London upgrade requires Berlin"))
 	}
 
 	if !upgrade.Sonic {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
 		issues = append(issues, errors.New("Sonic upgrade is required"))
 	}
 
 	if !upgrade.Allegro {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
 		issues = append(issues, errors.New("Allegro upgrade is required"))
 	}
 

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -13,13 +13,17 @@ import (
 func Check() error {
 	locked, reason, eLockPath, err := read(datadir)
 	if err != nil {
-		return fmt.Errorf("node isn't allowed to start due to an error reading"+
+		// This is a user-facing error, so we want to provide a clear message.
+		//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+		return fmt.Errorf("Node isn't allowed to start due to an error reading"+
 			" the lock file %s.\n Please fix the issue. Error message:\n%w",
 			eLockPath, err)
 	}
 
 	if locked {
-		return fmt.Errorf("node isn't allowed to start due to a previous error."+
+		// This is a user-facing error, so we want to provide a clear message.
+		//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+		return fmt.Errorf("Node isn't allowed to start due to a previous error."+
 			" Please fix the issue and then delete file \"%s\". Error message:\n%s",
 			eLockPath, reason)
 	}
@@ -38,7 +42,9 @@ func SetDefaultDatadir(dir string) {
 // Permanent error
 func Permanent(err error) {
 	eLockPath, _ := write(datadir, err.Error())
-	panic(fmt.Errorf("node is permanently stopping due to an issue. Please fix"+
+	// This is a user-facing error, so we want to provide a clear message.
+	//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
+	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix"+
 		" the issue and then delete file \"%s\". Error message:\n%s",
 		eLockPath, err.Error()))
 }

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -13,13 +13,13 @@ import (
 func Check() error {
 	locked, reason, eLockPath, err := read(datadir)
 	if err != nil {
-		return fmt.Errorf("Node isn't allowed to start due to an error reading"+
+		return fmt.Errorf("node isn't allowed to start due to an error reading"+
 			" the lock file %s.\n Please fix the issue. Error message:\n%w",
 			eLockPath, err)
 	}
 
 	if locked {
-		return fmt.Errorf("Node isn't allowed to start due to a previous error."+
+		return fmt.Errorf("node isn't allowed to start due to a previous error."+
 			" Please fix the issue and then delete file \"%s\". Error message:\n%s",
 			eLockPath, reason)
 	}
@@ -38,7 +38,7 @@ func SetDefaultDatadir(dir string) {
 // Permanent error
 func Permanent(err error) {
 	eLockPath, _ := write(datadir, err.Error())
-	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix"+
+	panic(fmt.Errorf("node is permanently stopping due to an issue. Please fix"+
 		" the issue and then delete file \"%s\". Error message:\n%s",
 		eLockPath, err.Error()))
 }


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `ST1005`. 
This rule says that error strings must not begin with Capitalized letters, nor end with punctuation or new lines.
This rule will be activated with #250 