### PR TITLE
Fix documentation of exported functions

### DIFF
--- a/debug/trace.go
+++ b/debug/trace.go
@@ -51,7 +51,7 @@ func (h *HandlerT) StartGoTrace(file string) error {
 	return nil
 }
 
-// StopTrace stops an ongoing trace.
+// StopGoTrace stops an ongoing trace.
 func (h *HandlerT) StopGoTrace() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -969,12 +969,12 @@ func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
 	return pool.addTxs(txs, false, false)
 }
 
-// This is like AddRemotes, but waits for pool reorganization. Tests use this method.
+// AddRemotesSync is like AddRemotes, but waits for pool reorganization. Tests use this method.
 func (pool *TxPool) AddRemotesSync(txs []*types.Transaction) []error {
 	return pool.addTxs(txs, false, true)
 }
 
-// This is like AddRemotes with a single transaction, but waits for pool reorganization. Tests use this method.
+// addRemoteSync is like AddRemotes with a single transaction, but waits for pool reorganization. Tests use this method.
 func (pool *TxPool) addRemoteSync(tx *types.Transaction) error {
 	errs := pool.AddRemotesSync([]*types.Transaction{tx})
 	return errs[0]

--- a/gossip/store_decided_state.go
+++ b/gossip/store_decided_state.go
@@ -19,6 +19,7 @@ type BlockEpochState struct {
 	EpochState *iblockproc.EpochState
 }
 
+// SetHistoryBlockEpochState stores the block and epoch state in the history table.
 // TODO propose to pass bs, es arguments by pointer
 func (s *Store) SetHistoryBlockEpochState(epoch idx.Epoch, bs iblockproc.BlockState, es iblockproc.EpochState) {
 	bs, es = bs.Copy(), es.Copy()

--- a/inter/block.go
+++ b/inter/block.go
@@ -80,7 +80,7 @@ func (b *Block) EncodeRLP(out io.Writer) error {
 	return rlp.Encode(out, b.blockData)
 }
 
-// EncodeRLP decodes a RLP encoded block.
+// DecodeRLP decodes a RLP encoded block.
 func (b *Block) DecodeRLP(in *rlp.Stream) error {
 	b.hash.Store(nil)
 	return in.Decode(&b.blockData)

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -323,7 +323,7 @@ func (r Rules) EvmChainConfig(hh []UpgradeHeight) *ethparams.ChainConfig {
 	return &cfg
 }
 
-// SonicUpgrades contains the feature flags for the Sonic upgrade.
+// GetSonicUpgrades contains the feature flags for the Sonic upgrade.
 func GetSonicUpgrades() Upgrades {
 	return Upgrades{
 		Berlin:  true,
@@ -334,7 +334,7 @@ func GetSonicUpgrades() Upgrades {
 	}
 }
 
-// AllegroUpgrades contains the feature flags for the Allegro upgrade.
+// GetAllegroUpgrades contains the feature flags for the Allegro upgrade.
 func GetAllegroUpgrades() Upgrades {
 	return Upgrades{
 		Berlin:  true,

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -190,7 +190,7 @@ func StartIntegrationTestNetWithFakeGenesis(
 	return net
 }
 
-// StartIntegrationTestNetWithFakeGenesis starts a single-node test network for
+// StartIntegrationTestNetWithJsonGenesis starts a single-node test network for
 // integration tests using the JSON-Genesis procedure. The JSON genesis procedure
 // is the genesis procedure used in long-running production networks like the
 // Sonic mainnet and the testnet.
@@ -469,7 +469,7 @@ func (n *IntegrationTestNet) Stop() {
 	}
 }
 
-// Stops and restarts the single node on the test network.
+// Restart stops and restarts the single node on the test network.
 func (n *IntegrationTestNet) Restart() error {
 	n.Stop()
 	return n.start()
@@ -486,7 +486,7 @@ func (n *IntegrationTestNet) GetClient() (*ethclient.Client, error) {
 	return n.GetClientConnectedToNode(0)
 }
 
-// GetClient provides raw access to a fresh connection to a selected node on
+// GetClientConnectedToNode provides raw access to a fresh connection to a selected node on
 // the network. The resulting client must be closed after use.
 func (n *IntegrationTestNet) GetClientConnectedToNode(i int) (*ethclient.Client, error) {
 	if i < 0 || i >= len(n.nodes) {
@@ -578,7 +578,7 @@ func (n *IntegrationTestNet) GetHeaders() ([]*types.Header, error) {
 	return headers, nil
 }
 
-// SpawnSession(t) creates a new test session on the network.
+// SpawnSession creates a new test session on the network.
 // The session is backed by an account which will be used to sign and pay for
 // transactions. By using this function, multiple test sessions can be run in
 // parallel on the same network, without conflicting nonce issues, since the
@@ -819,7 +819,7 @@ func (s *Session) GetClient() (*ethclient.Client, error) {
 	return s.GetClientConnectedToNode(0)
 }
 
-// GetClient provides raw access to a fresh connection to a selected node on
+// GetClientConnectedToNode provides raw access to a fresh connection to a selected node on
 // the network. The resulting client must be closed after use.
 func (s *Session) GetClientConnectedToNode(i int) (*ethclient.Client, error) {
 	return s.net.GetClientConnectedToNode(i)

--- a/txtrace/trace_logger.go
+++ b/txtrace/trace_logger.go
@@ -392,7 +392,7 @@ func CreateActionTrace(bHash common.Hash, bNumber big.Int, tHash common.Hash, tP
 	}
 }
 
-// GetErrorTrace constructs filled error trace
+// GetErrorTraceFromMsg constructs filled error trace
 func GetErrorTraceFromMsg(msg *core.Message, blockHash common.Hash, blockNumber big.Int, txHash common.Hash, index uint64, err error) *ActionTrace {
 	if msg == nil {
 		return createErrorTrace(blockHash, blockNumber, nil, &common.Address{}, txHash, 0, []byte{}, hexutil.Big{}, index, err)

--- a/utils/bits/bits.go
+++ b/utils/bits/bits.go
@@ -123,7 +123,7 @@ func (a *Reader) NonReadBytes() int {
 	return len(a.Bytes) - a.byteOffset
 }
 
-// NonReadBytes returns a number of non-consumed bits
+// NonReadBits returns a number of non-consumed bits
 func (a *Reader) NonReadBits() int {
 	//return a.nonReadBits
 	return a.NonReadBytes()*8 - a.bitOffset

--- a/utils/dbutil/threads/pool.go
+++ b/utils/dbutil/threads/pool.go
@@ -25,7 +25,7 @@ func (p *ThreadPool) init() {
 	}
 }
 
-// Capacity of pool
+// Cap returns the capacity of the pool
 func (p *ThreadPool) Cap() int {
 	if p.cap == 0 {
 		p.mu.Lock()

--- a/utils/fast/buffer.go
+++ b/utils/fast/buffer.go
@@ -24,7 +24,7 @@ func NewWriter(bb []byte) *Writer {
 	}
 }
 
-// WriteByte to the buffer.
+// MustWriteByte to the buffer.
 func (b *Writer) MustWriteByte(v byte) {
 	b.buf = append(b.buf, v)
 }
@@ -41,7 +41,7 @@ func (b *Reader) Read(n int) []byte {
 	return res
 }
 
-// ReadByte reads 1 byte.
+// MustReadByte reads 1 byte.
 func (b *Reader) MustReadByte() byte {
 	res := b.buf[b.offset]
 	b.offset++


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule ST1020.
This rule enforces that the documentation, if any, of an exported method must begin with the name of the method.
This rule will be activated with https://github.com/0xsoniclabs/sonic/pull/250