### PR TITLE
Fix documentation of exported structs

### DIFF
--- a/ethapi/sonic_api.go
+++ b/ethapi/sonic_api.go
@@ -15,7 +15,7 @@ import (
 
 //go:generate mockgen -source=sonic_api.go -package=ethapi -destination=sonic_api_mock.go
 
-// PublicSccAPI provides an API to access certificates of the Sonic
+// PublicSccApi provides an API to access certificates of the Sonic
 // Certification Chain.
 type PublicSccApi struct {
 	backend    SccApiBackend

--- a/gossip/emitter/world.go
+++ b/gossip/emitter/world.go
@@ -45,7 +45,7 @@ type (
 		GetHeader(common.Hash, uint64) *evmcore.EvmHeader
 	}
 
-	// aliases for mock generator
+	// Signer and TxSigner are aliases for mock generator
 	Signer interface {
 		valkeystore.SignerI
 	}

--- a/scc/cert/types.go
+++ b/scc/cert/types.go
@@ -4,6 +4,6 @@ package cert
 // for cert.Certificate[cert.CommitteeStatement] to improve readability.
 type CommitteeCertificate = Certificate[CommitteeStatement]
 
-// CommitteeCertificate is a certificate for a block. This is an alias
+// BlockCertificate is a certificate for a block. This is an alias
 // for cert.Certificate[cert.BlockStatement] to improve readability.
 type BlockCertificate = Certificate[BlockStatement]

--- a/utils/dbutil/threads/pool.go
+++ b/utils/dbutil/threads/pool.go
@@ -7,7 +7,7 @@ import (
 
 const GoroutinesPerThread = 0.8
 
-// threadPool counts threads in use
+// ThreadPool counts threads in use
 type ThreadPool struct {
 	mu   sync.Mutex
 	cap  int


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule ST1021.
This rule enforces that the documentation, if any, of an exported struct must begin with the name of the struct.
This rule will be activated with https://github.com/0xsoniclabs/sonic/pull/250