### PR TITLE
Add After hook for sonictool

### DIFF
--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -410,6 +410,10 @@ Converts an account private key to a validator private key and saves in the vali
 	app.Before = func(ctx *cli.Context) error {
 		return debug.Setup(ctx)
 	}
+	app.After = func(ctx *cli.Context) error {
+		debug.Exit()
+		return nil
+	}
 
 	sort.Sort(cli.CommandsByName(app.Commands))
 


### PR DESCRIPTION
This PR adds the `After` hook to the CLI, as without it [pprof](https://github.com/google/pprof), when used as an argument with `sonictool`, does not flush the `.prof` files required for profiling to disk and they would instead be empty files.

---

Example usage of this would be something like:

- seeding sonictool:

```
make sonictool
[place sonic.g, event100 files into ../dbs (or any appropriate genesis file, events file and DBs directory of your choice)]
./build/sonictool --datadir=../dbs genesis ../dbs/sonic.g
```

- running `sonictool` with `pprof` to generate profile database:

```
rm -rf ../dbs/carmen/archive
./build/sonictool --pprof.cpuprofile ../dbs/cpuprofile.prof --datadir=../dbs events import --mode=validator ../dbs/event100
```

- convert to `profile.pb.gz`:

```
cp ../dbs/cpuprofile.prof ../dbs/profile.pb.gz
```

- running profiler with available/generated profile database:

```
go install github.com/google/pprof@latest (install pprof)
go tool pprof -http=127.0.0.1:3001 ../dbs/profile.pb.gz
```