### PR TITLE
feat: add CLI hooks for pprof

### DIFF
--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -32,6 +32,11 @@ var (
 		Name:  "experimental",
 		Usage: "Allow experimental features",
 	}
+	FakeUpgrades = cli.StringFlag{
+		Name:  "upgrades",
+		Usage: "Feature set enabled in the fake network, sonic|allegro.",
+		Value: "sonic",
+	}
 )
 
 func gfileGenesisImport(ctx *cli.Context) (err error) {


### PR DESCRIPTION
This PR is for parity with the current client to be able to profile with `sonictool`. The PR adds the `After` hook to the CLI, as without it [pprof](https://github.com/google/pprof), when used as an argument with `sonictool`, does not flush the `.prof` files required for profiling to disk and they would instead be empty files.

---

Example usage of this would be something like:

- seeding sonictool:

```
make sonictool
[place sonic.g, event100 files into ../dbs (or any appropriate genesis file, events file and DBs directory of your choice)]
./build/sonictool --datadir=../dbs genesis ../dbs/sonic.g
```

- running `sonictool` with `pprof` to generate profile database:

```
rm -rf ../dbs/carmen/archive
./build/sonictool --pprof.cpuprofile ../dbs/cpuprofile.prof --datadir=../dbs events import --mode=validator ../dbs/event100
```

- convert to `profile.pb.gz`:

```
cp ../dbs/cpuprofile.prof ../dbs/profile.pb.gz
```

- running profiler with available/generated profile database:

```
go install github.com/google/pprof@latest (install pprof)
go tool pprof -http=127.0.0.1:3001 ../dbs/profile.pb.gz
```