### PR TITLE
Fix documentation of exported variables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ const (
 	ClientIdentifier = "Sonic"
 )
 
-// These settings ensure that TOML keys use the same names as Go struct fields.
+// TomlSettings ensure that TOML keys use the same names as Go struct fields.
 var TomlSettings = toml.Config{
 	NormFieldName: func(rt reflect.Type, key string) string {
 		return key


### PR DESCRIPTION
This PR fixes finding by `staticcheck` rule `ST1022`.
This rule enforces that the documentation, if any, of an exported variable or constant must begin with the name of the variable or constant.
This rule will be activated with https://github.com/0xsoniclabs/sonic/pull/250