### PR TITLE
Apply DeMorgan's law

### DIFF
--- a/gossip/blockproc/verwatcher/version_number_test.go
+++ b/gossip/blockproc/verwatcher/version_number_test.go
@@ -39,7 +39,7 @@ func TestVersionNumber_AreOrderedFollowingSemanticVersioningRules(t *testing.T) 
 	for i := range len(versions) - 1 {
 		a := toVersionNumber(versions[i])
 		b := toVersionNumber(versions[i+1])
-		if !(a < b) {
+		if a >= b {
 			t.Errorf("unexpected result, %s < %s (%d.%d.%d.%d < %d.%d.%d.%d) does not hold",
 				versions[i], versions[i+1],
 				(a>>48)&0xffff, (a>>32)&0xffff, (a>>16)&0xffff, (a>>0)&0xffff,


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `QF1001`.
This rule reports possible applications of [De Morgan's Law](https://en.wikipedia.org/wiki/De_Morgan%27s_laws). 
In particular, there is only one reported finding, in a test for of version number ordering, where a positive proposition is preferred. 


This rule will be activated with https://github.com/0xsoniclabs/sonic/pull/250