### PR TITLE
Remove embedded fields

### DIFF
--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -107,7 +107,7 @@ func IsGenesisTrusted(genesisStore *genesisstore.Store, genesisHashes genesis.Ha
 	if err != nil {
 		return fmt.Errorf("failed to calculate hash of genesis: %w", err)
 	}
-	signature, err := g.SignatureSection.GetSignature()
+	signature, err := g.GetSignature()
 	if err != nil {
 		return fmt.Errorf("genesis file doesn't refer to any trusted preset, signature not found: %w", err)
 	}

--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -2174,9 +2174,9 @@ func (api *PublicDebugAPI) traceTx(ctx context.Context, tx *types.Transaction, m
 			config.Config = &logger.Config{Limit: api.structLogLimit}
 		} else {
 			if api.structLogLimit > 0 &&
-				(config.Config.Limit == 0 || config.Config.Limit > api.structLogLimit) {
+				(config.Limit == 0 || config.Limit > api.structLogLimit) {
 
-				config.Config.Limit = api.structLogLimit
+				config.Limit = api.structLogLimit
 			}
 		}
 		logger := logger.NewStructLogger(config.Config)

--- a/eventcheck/heavycheck/adapters.go
+++ b/eventcheck/heavycheck/adapters.go
@@ -11,5 +11,5 @@ type EventsOnly struct {
 }
 
 func (c *EventsOnly) Enqueue(e dag.Event, onValidated func(error)) error {
-	return c.Checker.EnqueueEvent(e.(inter.EventPayloadI), onValidated)
+	return c.EnqueueEvent(e.(inter.EventPayloadI), onValidated)
 }

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -71,9 +71,9 @@ func NewEvmBlock(h *EvmHeader, txs types.Transactions) *EvmBlock {
 	}
 
 	if len(txs) == 0 {
-		b.EvmHeader.TxHash = types.EmptyRootHash
+		b.TxHash = types.EmptyRootHash
 	} else {
-		b.EvmHeader.TxHash = types.DeriveSha(txs, trie.NewStackTrie(nil))
+		b.TxHash = types.DeriveSha(txs, trie.NewStackTrie(nil))
 	}
 
 	return b
@@ -255,7 +255,7 @@ func (b *EvmBlock) EthBlock() *types.Block {
 		return nil
 	}
 	body := types.Body{Transactions: b.Transactions}
-	return types.NewBlock(b.EvmHeader.EthHeader(), &body, nil, trie.NewStackTrie(nil))
+	return types.NewBlock(b.EthHeader(), &body, nil, trie.NewStackTrie(nil))
 }
 
 func (b *EvmBlock) EstimateSize() int {

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -230,7 +230,7 @@ func ApplyTransactionWithEVM(msg *core.Message, config *params.ChainConfig, gp *
 
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+		receipt.ContractAddress = crypto.CreateAddress(evm.Origin, tx.Nonce())
 	}
 
 	// Tracing doesn't need logs and bloom.
@@ -341,7 +341,7 @@ func applyTransaction(
 
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+		receipt.ContractAddress = crypto.CreateAddress(evm.Origin, tx.Nonce())
 	}
 
 	// Set the receipt logs.

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -269,8 +269,8 @@ func TestExtractProposalForNextBlock_MultipleValidProposals_UsesTurnAndHashAsTie
 	}
 
 	slices.SortFunc(payloads, func(a, b *inter.Payload) int {
-		turnA := a.ProposalSyncState.LastSeenProposalTurn
-		turnB := b.ProposalSyncState.LastSeenProposalTurn
+		turnA := a.LastSeenProposalTurn
+		turnB := b.LastSeenProposalTurn
 		if res := cmp.Compare(turnA, turnB); res != 0 {
 			return res
 		}

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -372,7 +372,7 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 		parentHeaders[i] = parent
 		if parentHeaders[i].Creator() == em.config.Validator.ID && i != 0 {
 			// there are 2 heads from me, i.e. due to a fork, chooseParents could have found multiple self-parents
-			em.Periodic.Error(5*time.Second, "I've created a fork, events emitting isn't allowed", "creator", em.config.Validator.ID)
+			em.Error(5*time.Second, "I've created a fork, events emitting isn't allowed", "creator", em.config.Validator.ID)
 			return nil, nil
 		}
 		maxLamport = idx.MaxLamport(maxLamport, parent.Lamport())
@@ -418,7 +418,7 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 	err := em.world.Build(mutEvent, nil)
 	if err != nil {
 		if err == ErrNotEnoughGasPower {
-			em.Periodic.Warn(time.Second, "Not enough gas power to emit event. Too small stake?",
+			em.Warn(time.Second, "Not enough gas power to emit event. Too small stake?",
 				"stake%", 100*float64(em.validators.Get(em.config.Validator.ID))/float64(em.validators.TotalWeight()))
 		} else {
 			em.Log.Warn("Dropped event while emitting", "err", err)
@@ -444,7 +444,7 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 	// sign
 	bSig, err := em.world.EventsSigner.Sign(common.Hash(mutEvent.HashToSign()))
 	if err != nil {
-		em.Periodic.Error(time.Second, "Failed to sign event", "err", err)
+		em.Error(time.Second, "Failed to sign event", "err", err)
 		return nil, err
 	}
 	var sig inter.Signature
@@ -456,7 +456,7 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 
 	// check
 	if err := em.world.Check(event, parentHeaders); err != nil {
-		em.Periodic.Error(time.Second, "Emitted incorrect event", "err", err)
+		em.Error(time.Second, "Emitted incorrect event", "err", err)
 		return nil, err
 	}
 

--- a/gossip/emitter/parents.go
+++ b/gossip/emitter/parents.go
@@ -43,7 +43,7 @@ func (em *Emitter) chooseParents(epoch idx.Epoch, myValidatorID idx.ValidatorID)
 		return nil, nil, true
 	}
 	if len(em.world.DagIndex().NoCheaters(selfParent, hash.Events{*selfParent})) == 0 {
-		em.Periodic.Error(time.Second, "Events emitting isn't allowed due to the doublesign", "validator", myValidatorID)
+		em.Error(time.Second, "Events emitting isn't allowed due to the doublesign", "validator", myValidatorID)
 		return nil, nil, false
 	}
 	parents := hash.Events{*selfParent}

--- a/gossip/emitter/sync.go
+++ b/gossip/emitter/sync.go
@@ -73,9 +73,9 @@ func (em *Emitter) logSyncStatus(wait time.Duration, syncErr error) bool {
 	}
 
 	if wait == 0 {
-		em.Periodic.Info(7*time.Second, "Emitting is paused", "reason", syncErr)
+		em.Info(7*time.Second, "Emitting is paused", "reason", syncErr)
 	} else {
-		em.Periodic.Info(7*time.Second, "Emitting is paused", "reason", syncErr, "wait", wait)
+		em.Info(7*time.Second, "Emitting is paused", "reason", syncErr, "wait", wait)
 	}
 	return false
 }

--- a/gossip/emitter_world.go
+++ b/gossip/emitter_world.go
@@ -88,7 +88,7 @@ func (ew *emitterWorldProc) PeersNum() int {
 }
 
 func (ew *emitterWorldRead) GetHeads(epoch idx.Epoch) hash.Events {
-	return ew.Store.GetHeadsSlice(epoch)
+	return ew.GetHeadsSlice(epoch)
 }
 
 func (ew *emitterWorldRead) GetLastEvent(epoch idx.Epoch, from idx.ValidatorID) *hash.Event {
@@ -96,5 +96,5 @@ func (ew *emitterWorldRead) GetLastEvent(epoch idx.Epoch, from idx.ValidatorID) 
 }
 
 func (ew *emitterWorldRead) GetBlockEpoch(block idx.Block) idx.Epoch {
-	return ew.Store.FindBlockEpoch(block)
+	return ew.FindBlockEpoch(block)
 }

--- a/gossip/evmstore/statedb_logger.go
+++ b/gossip/evmstore/statedb_logger.go
@@ -27,7 +27,7 @@ type LoggingStateDB struct {
 func (l *LoggingStateDB) AddBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
 	prev := l.StateDB.AddBalance(addr, amount, reason)
 	if l.logger.OnBalanceChange != nil && !amount.IsZero() {
-		l.logger.OnBalanceChange(addr, prev.ToBig(), l.StateDB.GetBalance(addr).ToBig(), reason)
+		l.logger.OnBalanceChange(addr, prev.ToBig(), l.GetBalance(addr).ToBig(), reason)
 	}
 	return prev
 }
@@ -35,23 +35,23 @@ func (l *LoggingStateDB) AddBalance(addr common.Address, amount *uint256.Int, re
 func (l *LoggingStateDB) SubBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
 	prev := l.StateDB.SubBalance(addr, amount, reason)
 	if l.logger.OnBalanceChange != nil && !amount.IsZero() {
-		l.logger.OnBalanceChange(addr, prev.ToBig(), l.StateDB.GetBalance(addr).ToBig(), reason)
+		l.logger.OnBalanceChange(addr, prev.ToBig(), l.GetBalance(addr).ToBig(), reason)
 	}
 	return prev
 }
 
 func (l *LoggingStateDB) SetCode(addr common.Address, code []byte) []byte {
-	prevCodeHash := l.StateDB.GetCodeHash(addr)
+	prevCodeHash := l.GetCodeHash(addr)
 	prevCode := l.StateDB.SetCode(addr, code)
 	if l.logger.OnCodeChange != nil {
-		l.logger.OnCodeChange(addr, prevCodeHash, prevCode, l.StateDB.GetCodeHash(addr), code)
+		l.logger.OnCodeChange(addr, prevCodeHash, prevCode, l.GetCodeHash(addr), code)
 	}
 	return prevCode
 }
 
 func (l *LoggingStateDB) SetNonce(addr common.Address, nonce uint64, reason tracing.NonceChangeReason) {
 	if l.logger.OnNonceChange != nil {
-		prev := l.StateDB.GetNonce(addr)
+		prev := l.GetNonce(addr)
 		l.logger.OnNonceChange(addr, prev, nonce)
 	}
 	l.StateDB.SetNonce(addr, nonce, reason)
@@ -74,7 +74,7 @@ func (l *LoggingStateDB) AddLog(log *types.Log) {
 
 func (l *LoggingStateDB) SelfDestruct(addr common.Address) uint256.Int {
 	if l.logger.OnBalanceChange != nil {
-		prev := l.StateDB.GetBalance(addr)
+		prev := l.GetBalance(addr)
 		if prev.Sign() > 0 {
 			l.logger.OnBalanceChange(addr, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestruct)
 		}
@@ -88,7 +88,7 @@ func (l *LoggingStateDB) EndTransaction() {
 	if l.logger.OnBalanceChange != nil {
 		for addr := range l.selfDestructed {
 			if l.HasSelfDestructed(addr) {
-				prev := l.StateDB.GetBalance(addr)
+				prev := l.GetBalance(addr)
 				l.logger.OnBalanceChange(addr, prev.ToBig(), new(big.Int), tracing.BalanceDecreaseSelfdestructBurn)
 			}
 		}

--- a/gossip/evmstore/store_block_cache.go
+++ b/gossip/evmstore/store_block_cache.go
@@ -18,7 +18,7 @@ func (s *Store) GetCachedEvmBlock(n idx.Block) *evmcore.EvmBlock {
 
 func (s *Store) SetCachedEvmBlock(n idx.Block, b *evmcore.EvmBlock) {
 	var empty = common.Hash{}
-	if b.EvmHeader.TxHash == empty {
+	if b.TxHash == empty {
 		panic("You have to cache only completed blocks (with txs)")
 	}
 	s.cache.EvmBlocks.Add(n, b, uint(b.EstimateSize()))

--- a/gossip/filters/filter_system.go
+++ b/gossip/filters/filter_system.go
@@ -323,9 +323,9 @@ func (es *EventSystem) broadcast(filters filterIndex, ev interface{}) {
 			f.hashes <- hashes
 		}
 	case evmcore.ChainHeadNotify:
-		blkNumber := rpc.BlockNumber(e.Block.EvmHeader.Number.Int64())
+		blkNumber := rpc.BlockNumber(e.Block.Number.Int64())
 		receipts, _ := es.backend.GetReceiptsByNumber(context.Background(), blkNumber)
-		h := e.Block.EvmHeader.ToJson(receipts)
+		h := e.Block.ToJson(receipts)
 		for _, f := range filters[BlocksSubscription] {
 			f.headers <- h
 		}

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -363,7 +363,7 @@ func (h *handler) onlyInterestedEventsI(ids []interface{}) []interface{} {
 func (h *handler) removePeer(id string) {
 	peer := h.peers.Peer(id)
 	if peer != nil {
-		peer.Peer.Disconnect(p2p.DiscUselessPeer)
+		peer.Disconnect(p2p.DiscUselessPeer)
 	}
 }
 

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -550,7 +550,7 @@ func (p *peer) SendPeerInfoRequest() error {
 	// If the peer doesn't support the peer info protocol, don't bother
 	// sending the request. This request would lead to a disconnect
 	// if the peer doesn't understand it.
-	if !p.Peer.RunningCap(ProtocolName, []uint{_Sonic_64, _Sonic_65}) {
+	if !p.RunningCap(ProtocolName, []uint{_Sonic_64, _Sonic_65}) {
 		return nil
 	}
 	return p2p.Send(p.rw, GetPeerInfosMsg, struct{}{})
@@ -562,7 +562,7 @@ func (p *peer) SendEndPointUpdateRequest() error {
 	// If the peer doesn't support version 65 of this protocol, don't bother
 	// sending the request. This request would lead to a disconnect
 	// if the peer doesn't understand it.
-	if !p.Peer.RunningCap(ProtocolName, []uint{_Sonic_65}) {
+	if !p.RunningCap(ProtocolName, []uint{_Sonic_65}) {
 		return nil
 	}
 	return p2p.Send(p.rw, GetEndPointMsg, struct{}{})

--- a/gossip/sfc_test.go
+++ b/gossip/sfc_test.go
@@ -157,7 +157,7 @@ func TestSFC(t *testing.T) {
 
 			sfc10, err = sfc100.NewContract(sfc.ContractAddress, env)
 			require.NoError(err)
-			sfcEpoch, err := sfc10.ContractCaller.CurrentEpoch(env.ReadOnly())
+			sfcEpoch, err := sfc10.CurrentEpoch(env.ReadOnly())
 			require.NoError(err)
 			require.Equal(0, sfcEpoch.Cmp(big.NewInt(3)), "current SFC epoch %s", sfcEpoch.String())
 		})

--- a/inter/event_serializer_test.go
+++ b/inter/event_serializer_test.go
@@ -80,8 +80,8 @@ func TestEventPayloadSerialization(t *testing.T) {
 				require.EqualValues(t, toEncode.sigData, decoded.sigData)
 				require.Equal(t, len(toEncode.txs), len(decoded.txs))
 				require.Equal(t, toEncode.payload.Hash(), decoded.payload.Hash())
-				for i := range toEncode.payloadData.txs {
-					require.EqualValues(t, toEncode.payloadData.txs[i].Hash(), decoded.payloadData.txs[i].Hash())
+				for i := range toEncode.txs {
+					require.EqualValues(t, toEncode.txs[i].Hash(), decoded.txs[i].Hash())
 				}
 				require.EqualValues(t, toEncode.baseEvent, decoded.baseEvent)
 				require.EqualValues(t, toEncode.ID(), decoded.ID())

--- a/scc/cert/statement.go
+++ b/scc/cert/statement.go
@@ -73,7 +73,7 @@ func NewBlockStatement(chainID uint64, number idx.Block, hash, stateRoot common.
 //   - 32 bytes block hash
 //   - 32 bytes state root
 func (s BlockStatement) GetDataToSign() []byte {
-	res := s.statement.getDataToSign("bs")
+	res := s.getDataToSign("bs")
 	res = binary.BigEndian.AppendUint64(res, uint64(s.Number))
 	res = append(res, s.Hash.Bytes()...)
 	res = append(res, s.StateRoot.Bytes()...)
@@ -104,7 +104,7 @@ func NewCommitteeStatement(chainID uint64, period scc.Period, committee scc.Comm
 //   - 8 bytes period
 //   - variable length committee serialization
 func (s CommitteeStatement) GetDataToSign() []byte {
-	res := s.statement.getDataToSign("cs")
+	res := s.getDataToSign("cs")
 	res = binary.BigEndian.AppendUint64(res, uint64(s.Period))
 	res = append(res, s.Committee.Serialize()...)
 	return res

--- a/tests/db_factory.go
+++ b/tests/db_factory.go
@@ -69,8 +69,8 @@ func (c *carmenStateDB) IntermediateRoot(deleteEmptyObjects bool) common.Hash {
 
 // Commit ends transaction, ends block, and returns the state hash.
 func (c *carmenStateDB) Commit(block uint64, deleteEmptyObjects bool, noStorageWiping bool) (common.Hash, error) {
-	c.logs = c.CarmenStateDB.Logs() // backup logs, they are deleted on committing a tx/block
-	c.CarmenStateDB.EndTransaction()
-	c.CarmenStateDB.EndBlock(block)
-	return c.CarmenStateDB.GetStateHash(), nil
+	c.logs = c.Logs() // backup logs, they are deleted on committing a tx/block
+	c.EndTransaction()
+	c.EndBlock(block)
+	return c.GetStateHash(), nil
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -269,7 +269,8 @@ func startIntegrationTestNet(
 		},
 		nodes: make([]integrationTestNode, options.NumNodes),
 	}
-	net.Session.net = net
+	// the network's session needs to know about the network itself
+	net.net = net
 
 	if verbosityVariable := os.Getenv("SONIC_VERBOSITY"); verbosityVariable == "" {
 		if err := os.Setenv("SONIC_VERBOSITY", "0"); err != nil {

--- a/utils/adapters/kvdb2ethdb/adapter.go
+++ b/utils/adapters/kvdb2ethdb/adapter.go
@@ -54,7 +54,7 @@ func (db *Adapter) DeleteRange(start, end []byte) error {
 		if bytes.Compare(key, end) >= 0 {
 			break
 		}
-		if err := db.Store.Delete(key); err != nil {
+		if err := db.Delete(key); err != nil {
 			return err
 		}
 	}

--- a/utils/adapters/vecmt2dagidx/vecmt2lachesis.go
+++ b/utils/adapters/vecmt2dagidx/vecmt2lachesis.go
@@ -41,6 +41,7 @@ func (b AdapterSeq) Size() int {
 
 // Get i's position in the byte-encoded vector clock
 func (b AdapterSeq) Get(i idx.Validator) dagidx.Seq {
+	//nolint:staticcheck // QF1008: do not omit embedded field for clarity
 	seq := b.HighestBefore.VSeq.Get(i)
 	return &BranchSeq{seq}
 }

--- a/utils/dbutil/autocompact/store.go
+++ b/utils/dbutil/autocompact/store.go
@@ -89,7 +89,7 @@ func (s *Store) mayCompact(force bool) {
 	if force || s.cont.Size() > s.limit {
 		for _, r := range s.cont.Ranges() {
 			log.Debug("Autocompact", "name", s.name, "from", hexutils.BytesToHex(r.minKey), "to", hexutils.BytesToHex(r.maxKey))
-			_ = s.Store.Compact(r.minKey, r.maxKey)
+			_ = s.Compact(r.minKey, r.maxKey)
 		}
 		s.cont.Reset()
 	}

--- a/vecmt/median_time.go
+++ b/vecmt/median_time.go
@@ -19,7 +19,7 @@ type medianTimeIndex struct {
 
 // MedianTime calculates weighted median of claimed time within highest observed events.
 func (vi *Index) MedianTime(id hash.Event, defaultTime inter.Timestamp) inter.Timestamp {
-	vi.Engine.InitBranchesInfo()
+	vi.InitBranchesInfo()
 	// Get event by hash
 	_before := vi.Engine.GetMergedHighestBefore(id)
 	if _before == nil {

--- a/vecmt/no_cheaters.go
+++ b/vecmt/no_cheaters.go
@@ -14,7 +14,7 @@ func (vi *Index) NoCheaters(selfParent *hash.Event, options hash.Events) hash.Ev
 	}
 	vi.InitBranchesInfo()
 
-	if !vi.Engine.AtLeastOneFork() {
+	if !vi.AtLeastOneFork() {
 		return options
 	}
 


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `QF1008`.
In `Go` when a struct has an `embedded` struct, it allows the outer struct to call on methods and fields of the inner one, without actually naming the embedded struct.
This rule reports those cases where calling the embedded struct can be omitted to simply call its methods. 

This rule will be activated with https://github.com/0xsoniclabs/sonic/pull/250