### PR TITLE
Fix deprecated dependencies

### DIFF
--- a/cmd/sonicd/app/misccmd.go
+++ b/cmd/sonicd/app/misccmd.go
@@ -40,6 +40,6 @@ func versionAction(ctx *cli.Context) error {
 	fmt.Println("Go Version:", runtime.Version())
 	fmt.Println("Operating System:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))
-	fmt.Printf("GOROOT=%s\n", runtime.GOROOT())
+	fmt.Printf("GOROOT=%s\n", os.Getenv("GOROOT"))
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/0xsoniclabs/sonic
 go 1.24.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20250318153505-712d1a76e929
+	github.com/0xsoniclabs/carmen/go v0.0.0-20250530111616-fabde4233b62
 	github.com/0xsoniclabs/tosca v0.0.0-20250414093812-91b42e73396f
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20250318153505-712d1a76e929 h1:byQDSYyUE0AIxd+WZEFna2paBftg4hQSyQDHru5vQ3Q=
-github.com/0xsoniclabs/carmen/go v0.0.0-20250318153505-712d1a76e929/go.mod h1:/u6oDZBv6eyPs9K7Ug5D4aL9l1Q7N43BnWEUPsvKmYw=
+github.com/0xsoniclabs/carmen/go v0.0.0-20250530111616-fabde4233b62 h1:NF+A6zk8FYDuDk9aTVtzn7/e8kj+LERtyt+cfcHz+vM=
+github.com/0xsoniclabs/carmen/go v0.0.0-20250530111616-fabde4233b62/go.mod h1:s161Ju9dIK9gZ982wBx2WaCNN5Hv4OjC6YyoftKKF48=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250403075908-a6b1c7063681 h1:0cGG6PL3gPMHUzlog9ivCQJ6L3Lrmm0H+Jn3h2ke7zo=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250403075908-a6b1c7063681/go.mod h1:neQD30i5v+/u41EUK4C9lFAnjefSWD6xhbdGI/rg6YQ=
 github.com/0xsoniclabs/tosca v0.0.0-20250414093812-91b42e73396f h1:Cqn4e6+R7zbQxZuzOkjvO1PTHCXz/wbR9ZCKTf69uvk=


### PR DESCRIPTION
This PR fixes findings by `staticcheck` rule `SA1019`.
This rule reports all the uses of dependencies that whose documentations says they are deprecated. For this two actions are taken:
- Update Carmen
- Get GOROOT from environment variable instead of using `runtime.GOROOT()` as suggested in the documentation (https://pkg.go.dev/runtime#GOROOT)

This rule will be activated with https://github.com/0xsoniclabs/sonic/pull/250
