### PR TITLE
Add transaction size limit support to scheduler

### DIFF
--- a/gossip/emitter/proposals_mock.go
+++ b/gossip/emitter/proposals_mock.go
@@ -151,7 +151,7 @@ func (m *MocktxScheduler) EXPECT() *MocktxSchedulerMockRecorder {
 }
 
 // Schedule mocks base method.
-func (m *MocktxScheduler) Schedule(arg0 context.Context, arg1 *scheduler.BlockInfo, arg2 scheduler.PrioritizedTransactions, arg3 uint64) []*types.Transaction {
+func (m *MocktxScheduler) Schedule(arg0 context.Context, arg1 *scheduler.BlockInfo, arg2 scheduler.PrioritizedTransactions, arg3 scheduler.Limits) []*types.Transaction {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Schedule", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*types.Transaction)

--- a/gossip/emitter/proposals_test.go
+++ b/gossip/emitter/proposals_test.go
@@ -342,7 +342,10 @@ func TestMakeProposal_ValidArguments_CreatesValidProposal(t *testing.T) {
 			BlobBaseFee: uint256.Int{}, // TODO: implement
 		},
 		nil,
-		getEffectiveGasLimit(delta, rules.Economy.ShortGasPower.AllocPerSec),
+		scheduler.Limits{
+			Gas:  getEffectiveGasLimit(delta, rules.Economy.ShortGasPower.AllocPerSec),
+			Size: maxTotalTransactionsSizeInProposalsInBytes,
+		},
 	).Return(transactions)
 
 	// Scheduling time should be monitored.
@@ -396,7 +399,7 @@ func TestMakeProposal_IfSchedulerTimesOut_SignalTimeoutToMonitor(t *testing.T) {
 	mockScheduler.EXPECT().Schedule(any, any, any, any).Do(
 		func(
 			ctx context.Context, _ *scheduler.BlockInfo,
-			_ scheduler.PrioritizedTransactions, _ uint64,
+			_ scheduler.PrioritizedTransactions, _ scheduler.Limits,
 		) {
 			deadline, ok := ctx.Deadline()
 			require.True(t, ok, "scheduler call should have a deadline")

--- a/gossip/emitter/scheduler/integration_test.go
+++ b/gossip/emitter/scheduler/integration_test.go
@@ -32,7 +32,10 @@ func TestIntegration_NoTransactions_ProducesAnEmptySchedule(t *testing.T) {
 		t.Context(),
 		&BlockInfo{},
 		&fakeTxCollection{},
-		100_000_000,
+		Limits{
+			Gas:  100_000_000,
+			Size: 100_000,
+		},
 	))
 }
 
@@ -80,7 +83,10 @@ func TestIntegration_OneTransactions_ProducesScheduleWithOneTransaction(t *testi
 			GasLimit: 100_000_000,
 		},
 		&fakeTxCollection{transactions: txs},
-		100_000_000,
+		Limits{
+			Gas:  100_000_000,
+			Size: 100_000,
+		},
 	)
 
 	require.Equal(t, txs, schedule)

--- a/gossip/emitter/scheduler/processor_mock.go
+++ b/gossip/emitter/scheduler/processor_mock.go
@@ -196,9 +196,9 @@ func (m *MockevmProcessorRunner) EXPECT() *MockevmProcessorRunnerMockRecorder {
 }
 
 // Run mocks base method.
-func (m *MockevmProcessorRunner) Run(arg0 int, arg1 *types.Transaction) (*types.Receipt, bool, error) {
+func (m *MockevmProcessorRunner) Run(index int, tx *types.Transaction) (*types.Receipt, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run", arg0, arg1)
+	ret := m.ctrl.Call(m, "Run", index, tx)
 	ret0, _ := ret[0].(*types.Receipt)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -206,7 +206,7 @@ func (m *MockevmProcessorRunner) Run(arg0 int, arg1 *types.Transaction) (*types.
 }
 
 // Run indicates an expected call of Run.
-func (mr *MockevmProcessorRunnerMockRecorder) Run(arg0, arg1 any) *gomock.Call {
+func (mr *MockevmProcessorRunnerMockRecorder) Run(index, tx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockevmProcessorRunner)(nil).Run), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockevmProcessorRunner)(nil).Run), index, tx)
 }


### PR DESCRIPTION
This PR extends the constraints considered by the transaction scheduler to cover one additional limit: the total size of the scheduled transactions in bytes.

With this change, an upper limit for the size of proposals can be effectively enforced. Higher-priority transactions being to large to fit into a proposal are skipped in favor of lower-priority transactions.