### PR TITLE
Factor out permutation utility for testing

### DIFF
--- a/utils/permute.go
+++ b/utils/permute.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"iter"
+	"slices"
+)
+
+// Permute is a utility function that creates an iterator producing all
+// permutations of the input slice. Du to the nature of permutations, the number
+// of results grows factorially with the size of the input slice, which means
+// that practical use is limited to small slices, in particular for test case
+// generation.
+//
+// The resulting iterator produces one result at a time. However, the
+// implementation is not optimized for performance nor memory usage. If you
+// consider using this function in production code, consider improving its
+// implementation.
+func Permute[T any](list []T) iter.Seq[[]T] {
+	list = slices.Clone(list) // clone to avoid modifying the original slice
+	return func(yield func([]T) bool) {
+		if len(list) == 0 {
+			yield(list)
+			return
+		}
+		for i := range list {
+			list[0], list[i] = list[i], list[0] // swap
+			for cur := range Permute(list[1:]) {
+				if !yield(append([]T{list[0]}, cur...)) {
+					return
+				}
+			}
+			list[0], list[i] = list[i], list[0] // swap back
+		}
+	}
+}

--- a/utils/permute.go
+++ b/utils/permute.go
@@ -6,10 +6,10 @@ import (
 )
 
 // Permute is a utility function that creates an iterator producing all
-// permutations of the input slice. Du to the nature of permutations, the number
-// of results grows factorially with the size of the input slice, which means
-// that practical use is limited to small slices, in particular for test case
-// generation.
+// permutations of the input slice. Due to the nature of permutations, the
+// number of results grows factorially with the size of the input slice, which
+// means that practical use is limited to small slices, in particular for test
+// case generation.
 //
 // The resulting iterator produces one result at a time. However, the
 // implementation is not optimized for performance nor memory usage. If you

--- a/utils/permute_test.go
+++ b/utils/permute_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermute_EmptyList_ProducesOneResult(t *testing.T) {
+	res := slices.Collect(Permute([]int{}))
+	require.Equal(t, [][]int{{}}, res)
+}
+
+func TestPermute_SingletonList_ProducesOneResult(t *testing.T) {
+	res := slices.Collect(Permute([]int{1}))
+	require.Equal(t, [][]int{{1}}, res)
+}
+
+func TestPermute_ListOfTwoElements_ProducesTwoResults(t *testing.T) {
+	res := slices.Collect(Permute([]int{1, 2}))
+	require.ElementsMatch(t, [][]int{{1, 2}, {2, 1}}, res)
+}
+
+func TestPermute_ListOfThreeElements_ProducesSixResults(t *testing.T) {
+	res := slices.Collect(Permute([]int{1, 2, 3}))
+	require.ElementsMatch(t, [][]int{
+		{1, 2, 3},
+		{1, 3, 2},
+		{2, 1, 3},
+		{2, 3, 1},
+		{3, 1, 2},
+		{3, 2, 1},
+	}, res)
+}
+
+func TestPermute_CanBeAborted(t *testing.T) {
+	res := [][]int{}
+	for cur := range Permute([]int{1, 2, 3}) {
+		res = append(res, cur)
+		if len(res) >= 3 { // stop after 3 results
+			break
+		}
+	}
+	require.Len(t, res, 3)
+	require.ElementsMatch(t, [][]int{
+		{1, 2, 3},
+		{1, 3, 2},
+		{2, 1, 3},
+	}, res)
+}


### PR DESCRIPTION
This PR is factoring out a utility to generate permutations of a given list from the `c_block_callbacks_test.go` unit test file into a general utility to facilitate proper re-use.