### PR TITLE
Fix race-condition on test flag for transaction pool validation switch

### DIFF
--- a/cmd/sonicd/app/app.go
+++ b/cmd/sonicd/app/app.go
@@ -3,7 +3,7 @@ package app
 import (
 	"os"
 
-	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/config/flags"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -42,11 +42,7 @@ func RunWithArgs(
 	// If present, take ownership and inject the control struct into the action.
 	if control != nil {
 		// Disable txPool validation, only to be used in tests.
-		app.Flags = append(app.Flags, cli.BoolFlag{
-			Name:        "disable-txPool-validation",
-			Usage:       "Disable transaction pool validation",
-			Destination: &evmcore.DefaultTxPoolConfig.DisableTxPoolValidation,
-		})
+		app.Flags = append(app.Flags, &flags.TEST_ONLY_DisableTransactionPoolValidation)
 		if control.NodeIdAnnouncement != nil {
 			defer close(control.NodeIdAnnouncement)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -374,6 +374,9 @@ func MakeAllConfigsFromFile(ctx *cli.Context, configFile string) (*Config, error
 	if cfg.Emitter.Validator.ID != 0 && len(cfg.Emitter.PrevEmittedEventFile.Path) == 0 {
 		cfg.Emitter.PrevEmittedEventFile.Path = path.Join(cfg.Node.DataDir, "emitter", fmt.Sprintf("last-%d", cfg.Emitter.Validator.ID))
 	}
+	if ctx.IsSet(flags.TEST_ONLY_DisableTransactionPoolValidation.Name) {
+		cfg.TxPool.DisableTxPoolValidation = true
+	}
 	if err := setTxPool(ctx, &cfg.TxPool); err != nil {
 		return nil, err
 	}

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -383,4 +383,10 @@ var (
 			"Setting this to <1 will automatically set the value to a DB defined default.",
 		Value: 0,
 	}
+
+	// --- Testing Only ---
+	TEST_ONLY_DisableTransactionPoolValidation = cli.BoolFlag{
+		Name:  "disable-txPool-validation",
+		Usage: "Disable transaction pool validation",
+	}
 )


### PR DESCRIPTION
This change fixes a race condition in the propagation of the transaction-pool-validation disabling flag.

Before this PR, a global constant defining the default value of this flag was updated multiple times while running integration tests. With this change, this race condition is eliminated.

This is part of an effort to re-establish support for running race-detection tests on our integration tests.