### PR TITLE
Add golang-ci output to stdout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,3 +42,5 @@ output:
     html:
       # for human consumption
       path: ./build/golangci-lint-report.html
+    tab:
+      path: stdout


### PR DESCRIPTION
This PR adds the output of `golang-ci` linters to `stdout` so that its findigs can easily be read in failing CI steps.