### PR TITLE
Accept zero-hashes as the state root of empty accounts

### DIFF
--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/carmen/go/common/immutable"
+	"github.com/0xsoniclabs/carmen/go/database/mpt"
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice"
 	"github.com/0xsoniclabs/sonic/inter"
@@ -749,6 +750,11 @@ func getVerifiedCounterState(
 	_, storageRoot, complete := proof.GetAccountElements(carmen.Hash(stateRoot), carmen.Address(counterAddress))
 	require.True(complete, "proof is not complete")
 	require.Equal(common.Hash(storageRoot), result.StorageHash, "storage root mismatch")
+
+	// Zero-storage root is interpreted as the empty storage trie.
+	if storageRoot == (carmen.Hash{}) {
+		storageRoot = carmen.Hash(mpt.EmptyNodeEthereumHash)
+	}
 
 	// Check that the storage proof starts with an element that corresponds to
 	// the storage root.


### PR DESCRIPTION
This PR updates the integration test checking witness proofs to be able to handle zero-hashes being reported in proofs for empty accounts. This is a feature recently added to Carmen ([#23](https://github.com/0xsoniclabs/carmen/pull/23)).