### PR TITLE
Force coverage report to fail on failed tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ test:
 .PHONY: coverage
 coverage:
 	@mkdir -p build ;\
-	go test -coverpkg=./... --timeout=30m -coverprofile=build/coverage.cov ./...;\
-	go tool cover -html build/coverage.cov -o build/coverage.html ;\
+	go test -coverpkg=./... --timeout=30m -coverprofile=build/coverage.cov ./... && \
+	go tool cover -html build/coverage.cov -o build/coverage.html &&\
 	echo "Coverage report generated in build/coverage.html"
 
 .PHONY: fuzz


### PR DESCRIPTION
This PR changes the connector in `make coverage` target, so that if running the tests or creating the coverage report fail, then the whole command reports a failure. 
In `bash` the connector `&&` is used as a lazy eval, that will return on the first failure, while `;` will execute all commands, regardless of intermediate exit status, and report the last exit status. 