### PR TITLE
Register Tx-Pool for cleanup during node creation in case of a failure

### DIFF
--- a/config/make_node.go
+++ b/config/make_node.go
@@ -116,7 +116,9 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 		if cfg.TxPool.Journal != "" {
 			cfg.TxPool.Journal = path.Join(cfg.Node.DataDir, cfg.TxPool.Journal)
 		}
-		return evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader)
+		pool := evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader)
+		cleanup = append(cleanup, pool.Stop)
+		return pool
 	}
 	haltCheck := func(oldEpoch, newEpoch idx.Epoch, age time.Time) bool {
 		stop := ctx.GlobalIsSet(flags.ExitWhenAgeFlag.Name) && ctx.GlobalDuration(flags.ExitWhenAgeFlag.Name) >= time.Since(age)


### PR DESCRIPTION
While running data-race tests on the integration tests it was discovered that the transaction pool is not properly stopped before shutting down the database in case of a failure.

The race condition indicated that the transaction pool kept running in the background while the DB containing the current chain state was shut down. This lead to a data race. With this fix, the transaction pool is shut down before the DB is closed in case the startup of a node fails.