### PR TITLE
Refactor txpool reprice tests 

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -2023,18 +2023,6 @@ func (t *txLookup) RemoteToLocals(locals *accountSet) int {
 	return migrated
 }
 
-// RemotesBelowTip finds all remote transactions below the given gas price threshold.
-func (t *txLookup) RemotesBelowTip(threshold *big.Int) types.Transactions {
-	found := make(types.Transactions, 0, 128)
-	t.Range(func(hash common.Hash, tx *types.Transaction, local bool) bool {
-		if tx.GasTipCapIntCmp(threshold) < 0 {
-			found = append(found, tx)
-		}
-		return true
-	}, false, true) // Only iterate remotes
-	return found
-}
-
 // numSlots calculates the number of slots needed for a single transaction.
 func numSlots(tx *types.Transaction) int {
 	return int((tx.Size() + txSlotSize - 1) / txSlotSize)


### PR DESCRIPTION
As mentioned in https://github.com/0xsoniclabs/sonic/pull/271#discussion_r2126929274, the function `setMinTip` is only used in the repricing tests, and those repricing tests only tests the correct functionality of `setMinTip`. 

This PR removes unused functions `setMinTip` and `RemotesBelowTip` (which is only used in `setMinTip`), and refactors the repricing tests into two new tests.

New tests have been introduced instead:
- `TestTransactionPool_RejectsUnderTippedTransactions`
- `TestTransactionPool_AcceptsUnderTippedLocals`
Which as their names state, check that acceptance of transactions respects the min tip of the transaction pool for non local transactions. 
