### PR TITLE
Fix termination of parent-hash update transaction

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -91,6 +91,7 @@ func (p *StateProcessor) Process(
 	// execute EIP-2935 HistoryStorage contract.
 	if p.config.IsPrague(blockNumber, time) {
 		ProcessParentBlockHash(block.ParentHash, vmenv)
+		statedb.EndTransaction()
 	}
 
 	// Iterate over and process the individual transactions
@@ -137,6 +138,7 @@ func (p *StateProcessor) BeginBlock(
 	// execute EIP-2935 HistoryStorage contract.
 	if p.config.IsPrague(blockNumber, time) {
 		ProcessParentBlockHash(block.ParentHash, vmEnvironment)
+		stateDb.EndTransaction()
 	}
 
 	return &TransactionProcessor{


### PR DESCRIPTION
This PR adds a missing transaction termination call to complete the internal transaction keeping track of block hashes.

This feature has been introduced as part of the Prague feature package and is not yet actively used on the network. Without the call to `EndTransaction`, effects of the hash-tracking transaction are visible to the subsequent transaction in the same block. For instance, accessed accounts or value slots would be considered warm. Also, if there is no subsequent transactions, clean-up steps would get skipped. In particular, empty accounts touched by the internal transaction would not get cleaned up as expected.