### PR TITLE
fix(metrics): enable metrics collection when --metrics flag is set

### DIFF
--- a/cmd/sonicd/metrics/flags.go
+++ b/cmd/sonicd/metrics/flags.go
@@ -89,7 +89,8 @@ var (
 )
 
 func SetupMetrics(ctx *cli.Context) error {
-	if metrics.Enabled() {
+	if ctx.GlobalBool(MetricsEnabledFlag.Name) {
+		metrics.Enable()
 		log.Info("Enabling metrics collection")
 
 		var (


### PR DESCRIPTION
I've updated the `SetupMetrics` function in` cmd/sonicd/metrics/flags.go` to call `metrics.Enable()` when the `--metrics` flag is set. This change ensures that the internal state for metrics is enabled, allowing `metrics.Enabled()` to return true and thus enabling metrics collection and reporting. The issue with metrics not being enabled despite using the `--metrics` flag should now be resolved. Fixed #289 