### PR TITLE
Restrict input of gas base fee computation to required fields

### DIFF
--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -39,7 +39,11 @@ func (p *EVMModule) Start(
 	} else {
 		header := reader.GetHeader(common.Hash{}, uint64(block.Idx-1))
 		prevBlockHash = header.Hash
-		baseFee = gasprice.GetBaseFeeForNextBlock(header, net.Economy)
+		baseFee = gasprice.GetBaseFeeForNextBlock(gasprice.ParentBlockInfo{
+			BaseFee:  header.BaseFee,
+			Duration: header.Duration,
+			GasUsed:  header.GasUsed,
+		}, net.Economy)
 	}
 
 	// Start block

--- a/gossip/gasprice/base_fee_test.go
+++ b/gossip/gasprice/base_fee_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/opera"
 )
 
@@ -93,7 +92,7 @@ func TestBaseFee_ExamplePriceAdjustments(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			header := &evmcore.EvmHeader{
+			header := ParentBlockInfo{
 				BaseFee:  big.NewInt(int64(test.parentBaseFee)),
 				GasUsed:  test.parentGasUsed,
 				Duration: test.parentDuration,
@@ -124,7 +123,7 @@ func TestBaseFee_ExamplePriceAdjustments(t *testing.T) {
 
 func TestBaseFee_PriceCanRecoverFromPriceZero(t *testing.T) {
 	target := uint64(1e6)
-	header := &evmcore.EvmHeader{
+	header := ParentBlockInfo{
 		BaseFee:  big.NewInt(0),
 		GasUsed:  target + 1,
 		Duration: time.Second,
@@ -163,7 +162,7 @@ func TestBaseFee_GrowsAtMostTwelveAndAHalfPercentPer15Seconds(t *testing.T) {
 		t.Run(fmt.Sprintf("blockTime=%s", blockTime.String()), func(t *testing.T) {
 			const initialPrice = 100_000_000
 			// Define a header using 2x the target rate of gas in the given block time.
-			header := &evmcore.EvmHeader{
+			header := ParentBlockInfo{
 				BaseFee:  big.NewInt(initialPrice),
 				GasUsed:  uint64((2 * targetRate * blockTime) / time.Second),
 				Duration: blockTime,
@@ -211,7 +210,7 @@ func TestBaseFee_ShrinksAtMostTwelveAndAHalfPercentPer15Seconds(t *testing.T) {
 		t.Run(fmt.Sprintf("blockTime=%s", blockTime.String()), func(t *testing.T) {
 			const initialPrice = 100_000_000
 			// Define a header using no gas at all.
-			header := &evmcore.EvmHeader{
+			header := ParentBlockInfo{
 				BaseFee:  big.NewInt(initialPrice),
 				GasUsed:  0,
 				Duration: blockTime,
@@ -255,7 +254,7 @@ func TestBaseFee_DecayTimeFromInitialToZeroIsApproximately40Minutes(t *testing.T
 	}
 	for _, blockTime := range blockTimes {
 		t.Run(fmt.Sprintf("blockTime=%s", blockTime.String()), func(t *testing.T) {
-			header := &evmcore.EvmHeader{
+			header := ParentBlockInfo{
 				BaseFee:  GetInitialBaseFee(opera.EconomyRules{}),
 				GasUsed:  0,
 				Duration: blockTime,
@@ -298,7 +297,7 @@ func TestBaseFee_DoesNotSinkBelowMinBaseFee(t *testing.T) {
 			}
 
 			t.Run("price does not sink below minimum", func(t *testing.T) {
-				header := &evmcore.EvmHeader{
+				header := ParentBlockInfo{
 					BaseFee:  minPrice,
 					GasUsed:  0, // < should reduce the price
 					Duration: time.Second,
@@ -310,7 +309,7 @@ func TestBaseFee_DoesNotSinkBelowMinBaseFee(t *testing.T) {
 			})
 
 			t.Run("at threshold price is capped at minimum", func(t *testing.T) {
-				header := &evmcore.EvmHeader{
+				header := ParentBlockInfo{
 					BaseFee:  new(big.Int).Add(minPrice, big.NewInt(1)),
 					GasUsed:  0, // < should reduce the price
 					Duration: time.Second,
@@ -419,7 +418,7 @@ func TestApproximateExponential_RandomInputs(t *testing.T) {
 }
 
 func BenchmarkBaseFeeComputation(b *testing.B) {
-	header := &evmcore.EvmHeader{
+	header := ParentBlockInfo{
 		BaseFee:  big.NewInt(1e9),
 		GasUsed:  1e6,
 		Duration: time.Second,

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/0xsoniclabs/carmen/go/carmen"
 	"github.com/0xsoniclabs/carmen/go/common/immutable"
 	"github.com/0xsoniclabs/carmen/go/database/mpt"
-	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -261,7 +260,7 @@ func testHeaders_BaseFeeEvolutionFollowsPricingRules(t *testing.T, headers []*ty
 	for i := 1; i < len(headers); i++ {
 		_, duration, err := inter.DecodeExtraData(headers[i-1].Extra)
 		require.NoError(err, "decoding extra data of block %d", i-1)
-		last := &evmcore.EvmHeader{
+		last := gasprice.ParentBlockInfo{
 			BaseFee:  headers[i-1].BaseFee,
 			GasUsed:  headers[i-1].GasUsed,
 			Duration: duration,


### PR DESCRIPTION
This PR restricts the parameters required for computing base fees to the essential properties of the preceding block required to do so. The aim is to clarify the required input and to eliminate the implicit requirement of provisioning a full block header.