### PR TITLE
Fix error handling in debug_traceBlock - use error field

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -113,6 +113,16 @@ func ApplyTransactionWithEVM(msg *core.Message, config *params.ChainConfig, gp *
 	txContext := NewEVMTxContext(msg)
 	evm.Reset(txContext, statedb)
 
+	// For now, Sonic only supports Blob transactions without blob data.
+	if msg.BlobHashes != nil {
+		if len(msg.BlobHashes) > 0 {
+			statedb.Finalise()
+			return nil, fmt.Errorf("blob data is not supported")
+		}
+		// PreCheck requires non-nil blobHashes not to be empty
+		msg.BlobHashes = nil
+	}
+
 	// Apply the transaction to the current state (included in the env).
 	result, err := core.ApplyMessage(evm, msg, gp)
 	if err != nil {


### PR DESCRIPTION
This is backport of #308 into v2.0.

Fixes debug_traceBlock for situation where tracing of a single tx fails:

**Before fix:**
```
curl 'http://localhost/' -X POST -H 'Content-Type: application/json' --data '{     
    "jsonrpc": "2.0",
    "method": "debug_traceBlockByNumber",
    "params": [
        "0x200873b",
        {
            "tracer": "callTracer",
            "tracerConfig": {
                "withLog": true
            }
        }
    ],
    "id": 1
}' | jq
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "tracing failed: blob transaction missing blob hashes"
  }
}
```
