### PR TITLE
Remove TODO for pending validation

### DIFF
--- a/eventcheck/proposalcheck/proposal_check.go
+++ b/eventcheck/proposalcheck/proposal_check.go
@@ -161,8 +161,6 @@ func checkProposal(
 		return ErrInvalidProposalTime
 	}
 
-	// TODO: apply static checks on the randao reveal.
-
 	// --- check the present transactions ---
 
 	// Check that there are no nil-transactions in the proposal.


### PR DESCRIPTION
Randao reveal requires of knowing the previous randao mix value used in the previous block (prevRandao in the block data structure). This information may not be known at the time of validating an event. 

Additional checks have been considered: size of reveal is guaranteed by type system. 
In case a reveal is proposed which cannot be verified, the block processor will introduce more entropy in the system by using the dag-based randao mix calculation. 
