### PR TITLE
Check that proposals are only included in version 3 events

### DIFF
--- a/eventcheck/proposalcheck/proposal_check_test.go
+++ b/eventcheck/proposalcheck/proposal_check_test.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestProposalCheck_Validate_NonVersion3_Passes(t *testing.T) {
+func TestProposalCheck_Validate_NonVersion3WithoutProposal_Passes(t *testing.T) {
 	for version := range uint8(10) {
 		if version == 3 {
 			continue
@@ -20,9 +20,27 @@ func TestProposalCheck_Validate_NonVersion3_Passes(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		event := inter.NewMockEventPayloadI(ctrl)
 		event.EXPECT().Version().Return(version)
+		event.EXPECT().Payload().Return(&inter.Payload{})
 
 		checker := New(nil)
 		require.NoError(t, checker.Validate(event))
+	}
+}
+
+func TestProposalCheck_Validate_NonVersion3WithProposal_Fails(t *testing.T) {
+	for version := range uint8(10) {
+		if version == 3 {
+			continue
+		}
+		ctrl := gomock.NewController(t)
+		event := inter.NewMockEventPayloadI(ctrl)
+		event.EXPECT().Version().Return(version)
+		event.EXPECT().Payload().Return(&inter.Payload{
+			Proposal: &inter.Proposal{},
+		})
+
+		checker := New(nil)
+		require.ErrorIs(t, checker.Validate(event), ErrProposalInInvalidEventVersion)
 	}
 }
 


### PR DESCRIPTION
This PR adds an event validation step making sure that proposals may be attached only to version 3 events.

While serialization and deserialization of events right now are preventing proposals to be included in version 3 events, this check makes it a requirement in the event-validation as well -- which may be applied on an event instance that was derived from a different source than the deserialization of some data stream.

Preventing non-version 3 events from carrying proposals is also in line of the main objective of the event validation: to prevent spam in the event DAG.