### PR TITLE
Protect concurrent emitter state access

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -86,6 +86,8 @@ type Emitter struct {
 
 	intervals                EmitIntervals
 	globalConfirmingInterval time.Duration
+	intervalsMinLock         sync.Mutex // lock for intervals.Min
+	globalConfirmingLock     sync.Mutex // lock for globalConfirmingInterval
 
 	done chan struct{}
 	wg   sync.WaitGroup
@@ -218,7 +220,12 @@ func (em *Emitter) tick() {
 	}
 
 	em.recheckChallenges()
-	if em.timeSinceLastEmit() >= em.intervals.Min {
+
+	em.intervalsMinLock.Lock()
+	min := em.intervals.Min
+	em.intervalsMinLock.Unlock()
+
+	if em.timeSinceLastEmit() >= min {
 		_, err := em.EmitEvent()
 		if err != nil {
 			em.Log.Error("Event emitting error", "err", err)

--- a/gossip/emitter/hooks.go
+++ b/gossip/emitter/hooks.go
@@ -71,9 +71,10 @@ func (em *Emitter) OnNewEpoch(newValidators *pos.Validators, newEpoch idx.Epoch)
 	em.intervalsMinLock.Lock()
 	em.intervals.Min = maxDuration(minDuration(em.config.EmitIntervals.Min*20, extMinInterval), em.config.EmitIntervals.Min/4)
 	em.intervalsMinLock.Unlock()
-	em.globalConfirmingLock.Lock()
-	em.globalConfirmingInterval = maxDuration(minDuration(em.config.EmitIntervals.Confirming*20, extConfirmingInterval), em.config.EmitIntervals.Confirming/4)
-	em.globalConfirmingLock.Unlock()
+	em.globalConfirmingInterval.Store(
+		uint64(maxDuration(
+			minDuration(em.config.EmitIntervals.Confirming*20, extConfirmingInterval),
+			em.config.EmitIntervals.Confirming/4)))
 	em.recountConfirmingIntervals(newValidators)
 
 	if switchToFCIndexer {

--- a/gossip/emitter/hooks.go
+++ b/gossip/emitter/hooks.go
@@ -68,8 +68,12 @@ func (em *Emitter) OnNewEpoch(newValidators *pos.Validators, newEpoch idx.Epoch)
 	}
 
 	// sanity check to ensure that durations aren't too small/large
+	em.intervalsMinLock.Lock()
 	em.intervals.Min = maxDuration(minDuration(em.config.EmitIntervals.Min*20, extMinInterval), em.config.EmitIntervals.Min/4)
+	em.intervalsMinLock.Unlock()
+	em.globalConfirmingLock.Lock()
 	em.globalConfirmingInterval = maxDuration(minDuration(em.config.EmitIntervals.Confirming*20, extConfirmingInterval), em.config.EmitIntervals.Confirming/4)
+	em.globalConfirmingLock.Unlock()
 	em.recountConfirmingIntervals(newValidators)
 
 	if switchToFCIndexer {

--- a/gossip/emitter/validators.go
+++ b/gossip/emitter/validators.go
@@ -16,6 +16,9 @@ func (em *Emitter) recountConfirmingIntervals(validators *pos.Validators) {
 	// validators with lower stake should emit fewer events to reduce network load
 	// confirmingEmitInterval = piecefunc(totalStakeBeforeMe / totalStake) * MinEmitInterval
 	totalStakeBefore := pos.Weight(0)
+	em.globalConfirmingLock.Lock()
+	globalConfirmingInterval := uint64(em.globalConfirmingInterval)
+	em.globalConfirmingLock.Unlock()
 	for i, stake := range validators.SortedWeights() {
 		vid := validators.GetID(idx.Validator(i))
 		// pos.Weight is uint32, so cast to uint64 to avoid an overflow
@@ -25,7 +28,7 @@ func (em *Emitter) recountConfirmingIntervals(validators *pos.Validators) {
 		}
 		confirmingEmitIntervalRatio := confirmingEmitIntervalF(stakeRatio)
 		em.stakeRatio[vid] = stakeRatio
-		em.expectedEmitIntervals[vid] = time.Duration(piecefunc.Mul(uint64(em.globalConfirmingInterval), confirmingEmitIntervalRatio))
+		em.expectedEmitIntervals[vid] = time.Duration(piecefunc.Mul(globalConfirmingInterval, confirmingEmitIntervalRatio))
 	}
 	em.intervals.Confirming = em.expectedEmitIntervals[em.config.Validator.ID]
 }


### PR DESCRIPTION
The variables `Emitter.intervals.Min` and `Emitter.globalConfirmingInterval` are read during regular ticks, and assigned during new epoch creation. These read/write run in different threads (emitter tick and service routine) so these accesses need to be protected. 

This PR adds two mutexes for these two variables. 