### PR TITLE
Avoid mutating shared log instance in RPC handler

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -1693,7 +1693,7 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 
 // formatTxReceipt encodes transaction receipt into the expected API output.
 func (s *PublicTransactionPoolAPI) formatTxReceipt(header *evmcore.EvmHeader, tx *types.Transaction, txIndex uint64, receipt *types.Receipt) map[string]interface{} {
-	// Clone the logs before adding transaction meta data to avoid data racesAdd commentMore actions
+	// Clone the logs before adding transaction meta data to avoid data races
 	// due to concurrent accesses.
 	logs := slices.Clone(receipt.Logs)
 	for i := range logs {


### PR DESCRIPTION
`formatTxReceipt` takes a `*receipts` and modifies it through the pointer. But modifications should not be done to the pointed receipt but to a local copy of it, cutting out the risk of modifying while the backend reads it for another request.