### PR TITLE
fix: typo corrections and log message improvements across multiple modules

### DIFF
--- a/cmd/sonictool/check/common.go
+++ b/cmd/sonictool/check/common.go
@@ -19,7 +19,7 @@ func createGdb(dataDir string, cacheRatio cachescale.Func, archive carmen.Archiv
 	carmenDir := filepath.Join(dataDir, "carmen")
 
 	if stat, err := os.Stat(chaindataDir); err != nil || !stat.IsDir() {
-		return nil, nil, fmt.Errorf("unable to validate: datadir does not contain chandata")
+		return nil, nil, fmt.Errorf("unable to validate: datadir does not contain chaindata")
 	}
 	if stat, err := os.Stat(carmenDir); err != nil || !stat.IsDir() {
 		return nil, nil, fmt.Errorf("unable to validate: datadir does not contain carmen")

--- a/cmd/sonictool/check/live.go
+++ b/cmd/sonictool/check/live.go
@@ -29,7 +29,7 @@ func CheckLiveStateDb(ctx context.Context, dataDir string, cacheRatio cachescale
 	if err := mpt.VerifyFileLiveTrie(ctx, liveDir, info.Config, verificationObserver{}); err != nil {
 		return fmt.Errorf("live state verification failed: %w", err)
 	}
-	log.Info("Verification of the live state succeed")
+	log.Info("Verification of the live state succeeded")
 	return nil
 }
 

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -276,7 +276,7 @@ var (
 	}
 	DumpConfigFileFlag = cli.StringFlag{
 		Name:  "dump-config",
-		Usage: "wite configuration in TOML file and exit",
+		Usage: "write configuration in TOML file and exit",
 	}
 	CacheFlag = cli.IntFlag{
 		Name:  "cache",

--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -33,7 +33,7 @@ var (
 // error should be returned which is defined here.
 //
 // - If the pre-checking happens in the miner, then the transaction won't be packed.
-// - If the pre-checking happens in the block processing procedure, then a "BAD BLOCk"
+// - If the pre-checking happens in the block processing procedure, then a "BAD BLOCK"
 // error should be emitted.
 var (
 	// ErrNonceTooLow is returned if the nonce of a transaction is lower than the

--- a/gossip/peer.go
+++ b/gossip/peer.go
@@ -195,7 +195,7 @@ func (p *peer) MarkTransaction(hash common.Hash) {
 	p.knownTxs.Add(hash)
 }
 
-// SendTransactionHashes sends transaction hashess to the peer and includes the hashes
+// SendTransactionHashes sends transaction hashes to the peer and includes the hashes
 // in its transaction hash set for future reference.
 func (p *peer) SendTransactionHashes(txids []common.Hash) error {
 	// Mark all the transactions as known, but ensure we don't overflow our limits

--- a/gossip/store_epoch.go
+++ b/gossip/store_epoch.go
@@ -111,7 +111,7 @@ func (s *Store) createEpochStore(epoch idx.Epoch) {
 	name := fmt.Sprintf("gossip-%d", epoch)
 	db, err := s.dbs.OpenDB(name)
 	if err != nil {
-		s.Log.Crit("Filed to open DB", "name", name, "err", err)
+		s.Log.Crit("Failed to open DB", "name", name, "err", err)
 	}
 	s.epochStore.Store(newEpochStore(epoch, db))
 }


### PR DESCRIPTION
**This PR includes minor fixes across several files:**

- common.go: fixed typo **chandata** → **chaindata**
- live.go: corrected log message **succeed** → **succeeded**
- flags.go: fixed typo **wite** → **write**
- error.go: fixed casing in **BAD BLOCk** → **BAD BLOCK**
- peer.go: corrected typo **hashess** → **hashes**

