### PR TITLE
Continue processing block after a failing transaction

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -97,7 +97,7 @@ func (p *StateProcessor) Process(
 	for i, tx := range block.Transactions {
 		msg, err := TxAsMessage(tx, signer, header.BaseFee)
 		if err != nil {
-			log.Error("Failed to convert transaction to message", "tx", tx.Hash().Hex(), "err", err)
+			log.Info("Failed to convert transaction to message", "tx", tx.Hash().Hex(), "err", err)
 			skipped = append(skipped, uint32(i))
 			receipts = append(receipts, nil)
 			continue // skip this transaction, but continue processing the rest of the block
@@ -106,7 +106,7 @@ func (p *StateProcessor) Process(
 		statedb.SetTxContext(tx.Hash(), i)
 		receipt, _, err = applyTransaction(msg, gp, statedb, blockNumber, tx, usedGas, vmenv, onNewLog)
 		if err != nil {
-			log.Error("Failed to apply transaction", "tx", tx.Hash().Hex(), "err", err)
+			log.Info("Failed to apply transaction", "tx", tx.Hash().Hex(), "err", err)
 			skipped = append(skipped, uint32(i))
 			receipts = append(receipts, nil)
 			continue // skip this transaction, but continue processing the rest of the block

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -99,6 +99,7 @@ func (p *StateProcessor) Process(
 		msg, err := TxAsMessage(tx, signer, header.BaseFee)
 		if err != nil {
 			log.Error("Failed to convert transaction to message", "tx", tx.Hash().Hex(), "err", err)
+			skipped = append(skipped, uint32(i))
 			receipts = append(receipts, nil)
 			continue // skip this transaction, but continue processing the rest of the block
 		}
@@ -112,6 +113,7 @@ func (p *StateProcessor) Process(
 		}
 		if err != nil {
 			log.Error("Failed to apply transaction", "tx", tx.Hash().Hex(), "err", err)
+			skipped = append(skipped, uint32(i))
 			receipts = append(receipts, nil)
 			continue // skip this transaction, but continue processing the rest of the block
 		}

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -43,6 +43,7 @@ func (p *StateProcessor) process_iteratively(
 		}
 		if err != nil {
 			// If an error occurs, we skip the transaction and continue with the next one.
+			skipped = append(skipped, uint32(i))
 			receipts[i] = nil
 			continue
 		}
@@ -191,8 +192,8 @@ func TestProcess_DetectsTransactionThatCanNotBeConvertedIntoAMessage(t *testing.
 			receipts, logs, skipped := process(block, state, vmConfig, usedGas, nil)
 
 			require.ElementsMatch(receipts, []*types.Receipt{nil})
+			require.ElementsMatch(skipped, []uint32{0})
 			require.Empty(logs)
-			require.Empty(skipped)
 		})
 	}
 }
@@ -313,9 +314,8 @@ func TestProcess_FailingTransactionAreSkippedButTheBlockIsNotTerminated(t *testi
 	require.Len(t, receipts, 2)
 	require.Nil(t, receipts[0])
 	require.NotNil(t, receipts[1])
-
+	require.Len(t, skipped, 1)
 	require.Empty(t, logs)
-	require.Empty(t, skipped)
 }
 
 func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -26,7 +26,7 @@ import (
 func (p *StateProcessor) process_iteratively(
 	block *EvmBlock, stateDb state.StateDB, cfg vm.Config, usedGas *uint64, onNewLog func(*types.Log),
 ) (
-	types.Receipts, []*types.Log, []uint32, error,
+	types.Receipts, []*types.Log, []uint32,
 ) {
 	// This implementation is a wrapper around the BeginBlock function, which
 	// handles the actual transaction processing.
@@ -42,14 +42,16 @@ func (p *StateProcessor) process_iteratively(
 			continue
 		}
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to process transaction %d [%v]: %w", i, tx.Hash().Hex(), err)
+			// If an error occurs, we skip the transaction and continue with the next one.
+			receipts[i] = nil
+			continue
 		}
 		receipts[i] = receipt
 		allLogs = append(allLogs, receipt.Logs...)
 		*usedGas = receipt.CumulativeGasUsed
 	}
 
-	return receipts, allLogs, skipped, nil
+	return receipts, allLogs, skipped
 }
 
 func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
@@ -100,8 +102,7 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 
 			vmConfig := vm.Config{}
 			usedGas := new(uint64)
-			receipts, logs, skipped, err := process(block, state, vmConfig, usedGas, onLog)
-			require.NoError(err)
+			receipts, logs, skipped := process(block, state, vmConfig, usedGas, onLog)
 
 			// Receipts should be set accordingly.
 			require.Len(receipts, len(transactions))
@@ -187,12 +188,11 @@ func TestProcess_DetectsTransactionThatCanNotBeConvertedIntoAMessage(t *testing.
 
 			vmConfig := vm.Config{}
 			usedGas := new(uint64)
-			receipts, logs, skipped, err := process(block, state, vmConfig, usedGas, nil)
-			require.ErrorContains(err, "invalid transaction v, r, s values")
+			receipts, logs, skipped := process(block, state, vmConfig, usedGas, nil)
 
-			require.Nil(receipts)
-			require.Nil(logs)
-			require.Nil(skipped)
+			require.ElementsMatch(receipts, []*types.Receipt{nil})
+			require.Empty(logs)
+			require.Empty(skipped)
 		})
 	}
 }
@@ -248,14 +248,74 @@ func TestProcess_TracksParentBlockHashIfPragueIsEnabled(t *testing.T) {
 
 				vmConfig := vm.Config{}
 				usedGas := new(uint64)
-				receipts, logs, skipped, err := process(block, state, vmConfig, usedGas, nil)
-				require.NoError(err)
+				receipts, logs, skipped := process(block, state, vmConfig, usedGas, nil)
 				require.Empty(receipts)
 				require.Empty(logs)
 				require.Empty(skipped)
 			})
 		}
 	}
+}
+
+func TestProcess_FailingTransactionAreSkippedButTheBlockIsNotTerminated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := state.NewMockStateDB(ctrl)
+
+	chainConfig := params.ChainConfig{}
+	chain := NewMockDummyChain(ctrl)
+	processor := NewStateProcessor(&chainConfig, chain)
+
+	block := &EvmBlock{
+		EvmHeader: EvmHeader{
+			Number:   big.NewInt(1),
+			GasLimit: 100_000,
+		},
+		Transactions: []*types.Transaction{
+			// This transaction will fail due to an invalid signature.
+			types.NewTx(&types.LegacyTx{
+				Nonce:    0,
+				To:       &common.Address{},
+				Gas:      21_000,
+				GasPrice: big.NewInt(1),
+				V:        big.NewInt(1), // invalid signature
+			}),
+			// Valid transaction that will succeed.
+			types.NewTx(&types.LegacyTx{
+				Nonce:    0,
+				To:       &common.Address{},
+				Gas:      21_000,
+				GasPrice: big.NewInt(1),
+			}),
+		},
+	}
+
+	// Mock the state database interactions for passing transaction.
+	any := gomock.Any()
+	state.EXPECT().SetTxContext(any, any).Times(1)
+	state.EXPECT().GetBalance(any).Return(uint256.NewInt(1000000)).Times(1)
+	state.EXPECT().SubBalance(any, any, any).Times(2)
+	state.EXPECT().Prepare(any, any, any, any, any, any).Times(1)
+	state.EXPECT().GetNonce(any).Return(uint64(0)).Times(1)
+	state.EXPECT().SetNonce(any, any, any).Times(1)
+	state.EXPECT().GetCode(any).Return(nil).Times(2)
+	state.EXPECT().Snapshot().Return(0).Times(1)
+	state.EXPECT().Exist(any).Return(true).Times(1)
+	state.EXPECT().AddBalance(any, any, any).Times(3)
+	state.EXPECT().GetRefund().Return(uint64(0)).Times(2)
+	state.EXPECT().GetLogs(any, any).Return([]*types.Log{})
+	state.EXPECT().EndTransaction().Times(1)
+	state.EXPECT().TxIndex().Return(0).Times(1)
+
+	// Process the block
+	usedGas := new(uint64)
+	receipts, logs, skipped := processor.Process(block, state, vm.Config{}, usedGas, nil)
+
+	require.Len(t, receipts, 2)
+	require.Nil(t, receipts[0])
+	require.NotNil(t, receipts[1])
+
+	require.Empty(t, logs)
+	require.Empty(t, skipped)
 }
 
 func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {
@@ -395,7 +455,6 @@ type processFunction = func(
 	receipts types.Receipts,
 	allLogs []*types.Log,
 	skipped []uint32,
-	err error,
 )
 
 func getStateDbMockForTransactions(

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -339,7 +339,7 @@ func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {
 			// The transaction will fail for various reasons, but for this test
 			// this is not relevant. We just want to check if the base fee
 			// configuration flag is updated to match the SkipAccountChecks flag.
-			_, _, _, err := applyTransaction(&core.Message{
+			_, _, err := applyTransaction(&core.Message{
 				SkipNonceChecks:  internal,
 				SkipFromEOACheck: internal,
 				GasPrice:         big.NewInt(0),
@@ -372,12 +372,11 @@ func TestApplyTransaction_BlobHashesNotSupportedAndSkipped(t *testing.T) {
 		BlobHashes: []common.Hash{{0x01}},
 	}
 	usedGas := uint64(0)
-	receipt, gasUsed, skipped, err :=
+	receipt, gasUsed, err :=
 		applyTransaction(msg, gp, state, big.NewInt(1), nil, &usedGas, evm, nil)
 	require.ErrorContains(t, err, "blob data is not supported")
 	require.Nil(t, receipt)
 	require.Equal(t, uint64(0), gasUsed)
-	require.True(t, skipped)
 }
 
 func TestApplyTransaction_ApplyMessageError_RevertsSnapshotIfPrague(t *testing.T) {
@@ -433,12 +432,11 @@ func TestApplyTransaction_ApplyMessageError_RevertsSnapshotIfPrague(t *testing.T
 				state.EXPECT().EndTransaction(),
 			)
 
-			receipt, gasUsed, skipped, err :=
+			receipt, gasUsed, err :=
 				applyTransaction(msg, gp, state, blockNumber, nil, new(uint64), evm, nil)
 			require.ErrorContains(t, err, "max initcode size exceeded")
 			require.Nil(t, receipt)
 			require.Equal(t, uint64(0), gasUsed)
-			require.True(t, skipped)
 		})
 	}
 }

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -248,7 +248,7 @@ func FuzzValidateTransaction(f *testing.F) {
 
 		gp := new(core.GasPool).AddGas(maxGas)
 		var usedGas uint64
-		_, _, _, processorError := applyTransaction(msg, gp, state, big.NewInt(blockNum),
+		_, _, processorError := applyTransaction(msg, gp, state, big.NewInt(blockNum),
 			signedTx, &usedGas, evm, nil)
 
 		// validateTx should not reject transactions that the processor would accept

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
@@ -131,14 +130,11 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions) types.Receipts {
 
 	// Process txs
 	evmBlock := p.evmBlockWith(txs)
-	receipts, _, skipped, err := evmProcessor.Process(evmBlock, p.statedb, vmConfig, &p.gasUsed, func(l *types.Log) {
+	receipts, _, skipped := evmProcessor.Process(evmBlock, p.statedb, vmConfig, &p.gasUsed, func(l *types.Log) {
 		// Note: l.Index is properly set before
 		l.TxIndex += txsOffset
 		p.onNewLog(l)
 	})
-	if err != nil {
-		log.Crit("EVM internal error", "err", err)
-	}
 
 	if txsOffset > 0 {
 		for i, n := range skipped {


### PR DESCRIPTION
The `log.Crit` call in the `Execute` function of the `OperaEVMProcessor` has been removed, by moving the error handling into the `Process` function of the `evmProcessor`. This allows to handle failing transactions separately and not on a block level. Failing transactions are ignored and the block processing continues with the next transaction.