### PR TITLE
Reduce turn timeout to 3 frames

### DIFF
--- a/eventcheck/proposalcheck/proposal_check_test.go
+++ b/eventcheck/proposalcheck/proposal_check_test.go
@@ -155,13 +155,13 @@ func TestProposalCheck_Validate_ValidEventWithProposalPasses(t *testing.T) {
 
 	event.EXPECT().Creator().Return(validator)
 	event.EXPECT().Epoch().Return(idx.Epoch(4))
-	event.EXPECT().Frame().Return(idx.Frame(20))
+	event.EXPECT().Frame().Return(idx.Frame(16))
 	event.EXPECT().MedianTime().Return(inter.Timestamp(123))
 	event.EXPECT().Parents().Return([]hash.Event{parent1, parent2})
 	event.EXPECT().Payload().Return(&inter.Payload{
 		ProposalSyncState: inter.ProposalSyncState{
 			LastSeenProposalTurn:  joinedState.LastSeenProposalTurn + 1,
-			LastSeenProposalFrame: 20,
+			LastSeenProposalFrame: 16,
 		},
 		Proposal: &inter.Proposal{
 			Time: inter.Timestamp(123),

--- a/inter/proposal_sync_state_test.go
+++ b/inter/proposal_sync_state_test.go
@@ -96,7 +96,7 @@ func TestIsAllowedToPropose_AcceptsValidProposerTurn(t *testing.T) {
 	}
 	next := ProposalSummary{
 		Turn:  Turn(6),
-		Frame: idx.Frame(17),
+		Frame: idx.Frame(14),
 	}
 	require.True(IsValidTurnProgression(last, next))
 
@@ -168,7 +168,7 @@ func TestIsAllowedToPropose_RejectsInvalidProposerTurn(t *testing.T) {
 			}
 
 			input := input{
-				currentFrame: 67,
+				currentFrame: 64,
 				validator:    validProposer,
 			}
 

--- a/inter/turns.go
+++ b/inter/turns.go
@@ -13,13 +13,12 @@ type Turn uint32
 // failed. Hence, if for the given number of frames no proposal is made, the
 // current turn times out and the next turn is started.
 //
-// The value is set to 8 frames after empirical testing of the network has shown
-// an average latency of 3 frames. The timeout is set to 8 frames to account for
-// network latency, processing time, and other factors that may cause delays.
+// The value is set to 3 frames after empirical testing of the network has shown
+// an average latency of 3 frames.
 //
 // ATTENTION: All nodes on the network must agree on the same value for this
 // constant. Thus, changing this value requires a hard fork.
-const TurnTimeoutInFrames = 8
+const TurnTimeoutInFrames = 3
 
 // IsValidTurnProgression determines whether `next` is a valid successor of
 // `last`. This is used during event validation to identify valid proposals and


### PR DESCRIPTION
This PR reduces the timeout for determining failed proposal attempts to 3 frames.

Statistics from the Sonic network and practical evaluation using integration tests have demonstrated that the number of duplicated proposals is acceptable low at this level of sensitivity. Below 3 frames, competing proposals become frequent occurrences.

Up-coming full-scale tests of the system may provide additional insights in the effects of this parameters. If competing proposals are too frequent in those setups, it might have to be slightly raised again.