### PR TITLE
Add gas limit to single-proposer mode

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -70,7 +70,8 @@ func NewStateProcessor(config *params.ChainConfig, bc DummyChain) *StateProcesso
 // Future hard-forks may be used to clean up the rules and make them more
 // consistent.
 func (p *StateProcessor) Process(
-	block *EvmBlock, statedb state.StateDB, cfg vm.Config, usedGas *uint64, onNewLog func(*types.Log),
+	block *EvmBlock, statedb state.StateDB, cfg vm.Config, gasLimit uint64,
+	usedGas *uint64, onNewLog func(*types.Log),
 ) (
 	types.Receipts, []*types.Log, []uint32,
 ) {
@@ -78,7 +79,7 @@ func (p *StateProcessor) Process(
 	allLogs := make([]*types.Log, 0, len(block.Transactions)*10) // 10 logs per tx is a reasonable estimate
 	skipped := make([]uint32, 0, len(block.Transactions))
 	var (
-		gp           = new(core.GasPool).AddGas(block.GasLimit)
+		gp           = new(core.GasPool).AddGas(gasLimit)
 		receipt      *types.Receipt
 		header       = block.Header()
 		time         = uint64(block.Time.Unix())
@@ -123,10 +124,11 @@ func (p *StateProcessor) Process(
 // This is required by the transaction scheduler in the emitter, which needs to
 // probe individual transactions to determine their applicability and gas usage.
 func (p *StateProcessor) BeginBlock(
-	block *EvmBlock, stateDb state.StateDB, cfg vm.Config, onNewLog func(*types.Log),
+	block *EvmBlock, stateDb state.StateDB, cfg vm.Config, gasLimit uint64,
+	onNewLog func(*types.Log),
 ) *TransactionProcessor {
 	var (
-		gp            = new(core.GasPool).AddGas(block.GasLimit)
+		gp            = new(core.GasPool).AddGas(gasLimit)
 		header        = block.Header()
 		time          = uint64(block.Time.Unix())
 		blockContext  = NewEVMBlockContext(header, p.bc, nil)

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -122,7 +122,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 	return evmcore.NewEvmBlock(h, txs)
 }
 
-func (p *OperaEVMProcessor) Execute(txs types.Transactions) types.Receipts {
+func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) types.Receipts {
 	evmProcessor := evmcore.NewStateProcessor(p.evmCfg, p.reader)
 	txsOffset := uint(len(p.incomingTxs))
 
@@ -130,7 +130,7 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions) types.Receipts {
 
 	// Process txs
 	evmBlock := p.evmBlockWith(txs)
-	receipts, _, skipped := evmProcessor.Process(evmBlock, p.statedb, vmConfig, &p.gasUsed, func(l *types.Log) {
+	receipts, _, skipped := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, func(l *types.Log) {
 		// Note: l.Index is properly set before
 		l.TxIndex += txsOffset
 		p.onNewLog(l)

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -1,6 +1,7 @@
 package evmmodule
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 	nonce := uint64(15)
 	inner := types.NewTransaction(nonce, targetAddress, common.Big0, 1e10, common.Big0, nil)
 
-	receipts := processor.Execute([]*types.Transaction{inner})
+	receipts := processor.Execute([]*types.Transaction{inner}, math.MaxUint64)
 
 	if len(receipts) != 1 {
 		t.Fatalf("Expected 1 receipt, got %d", len(receipts))

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -49,7 +49,7 @@ type ConfirmedEventsModule interface {
 }
 
 type EVMProcessor interface {
-	Execute(txs types.Transactions) types.Receipts
+	Execute(txs types.Transactions, gasLimit uint64) types.Receipts
 	Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs []uint32, receipts types.Receipts)
 }
 

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -172,6 +172,19 @@ func consensusCallbackBeginBlockFn(
 					idx.Block(number),
 				)
 
+				// The maximum amount of gas to be used for non-internal
+				// transactions in the resulting block. Note that this gas limit
+				// is different than the official BlockGasLimit, which is
+				// announced as part of the block, constant over the duration of
+				// a block, and must be large enough to include inner
+				// transactions. In Sonic, the Block's GasLimit is a network
+				// rule parameter.
+				// The limit defined here is the dynamically adjusted gas limit
+				// used to regulate the traffic on the network. Block proposals
+				// made in the single-proposer mode are expected to honor this
+				// gas limit. With this parameter, this limit is enforced.
+				userTransactionGasLimit := maxBlockGas
+
 				// Get a proposal for the block to be created.
 				proposal := inter.Proposal{
 					Number:     idx.Block(number),
@@ -193,6 +206,12 @@ func consensusCallbackBeginBlockFn(
 							lastBlockHeader.PrevRandao, randao,
 							log.Root(),
 						)
+
+						userTransactionGasLimit = inter.GetEffectiveGasLimit(
+							proposal.Time.Time().Sub(lastBlockHeader.Time.Time()),
+							es.Rules.Economy.ShortGasPower.AllocPerSec,
+						)
+
 					} else {
 						// If no proposal is found but a block needs to be
 						// created (as this function has been called), we
@@ -276,7 +295,7 @@ func consensusCallbackBeginBlockFn(
 
 				// Execute pre-internal transactions
 				preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
-				preInternalReceipts := evmProcessor.Execute(preInternalTxs)
+				preInternalReceipts := evmProcessor.Execute(preInternalTxs, maxBlockGas)
 				bs = txListener.Finalize()
 				for _, r := range preInternalReceipts {
 					if r.Status == 0 {
@@ -323,7 +342,7 @@ func consensusCallbackBeginBlockFn(
 
 					// Execute post-internal transactions
 					internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
-					internalReceipts := evmProcessor.Execute(internalTxs)
+					internalReceipts := evmProcessor.Execute(internalTxs, maxBlockGas)
 					for _, r := range internalReceipts {
 						if r.Status == 0 {
 							log.Warn("Internal transaction reverted", "txid", r.TxHash.String())
@@ -338,7 +357,7 @@ func consensusCallbackBeginBlockFn(
 					}
 
 					orderedTxs := proposal.Transactions
-					for i, receipt := range evmProcessor.Execute(orderedTxs) {
+					for i, receipt := range evmProcessor.Execute(orderedTxs, userTransactionGasLimit) {
 						if receipt != nil { // < nil if skipped
 							blockBuilder.AddTransaction(orderedTxs[i], receipt)
 						}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -176,7 +176,7 @@ func consensusCallbackBeginBlockFn(
 				// transactions in the resulting block. Note that this gas limit
 				// is different than the official BlockGasLimit, which is
 				// announced as part of the block, constant over the duration of
-				// a block, and must be large enough to include inner
+				// a block, and must be large enough to include internal
 				// transactions. In Sonic, the Block's GasLimit is a network
 				// rule parameter.
 				// The limit defined here is the dynamically adjusted gas limit

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -208,7 +208,7 @@ func consensusCallbackBeginBlockFn(
 						)
 
 						userTransactionGasLimit = inter.GetEffectiveGasLimit(
-							proposal.Time.Time().Sub(lastBlockHeader.Time.Time()),
+							blockTime.Time().Sub(lastBlockHeader.Time.Time()),
 							es.Rules.Economy.ShortGasPower.AllocPerSec,
 						)
 

--- a/gossip/emitter/proposals.go
+++ b/gossip/emitter/proposals.go
@@ -3,7 +3,6 @@ package emitter
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
@@ -226,9 +225,9 @@ func makeProposal(
 		// no time has passed, so no new proposal can be made
 		return nil, nil
 	}
-	effectiveGasLimit := getEffectiveGasLimit(
+	effectiveGasLimit := inter.GetEffectiveGasLimit(
 		newBlockTime.Time().Sub(lastBlockTime.Time()),
-		rules.Economy.ShortGasPower.AllocPerSec, // TODO: consider using a new rule set parameter
+		rules.Economy.ShortGasPower.AllocPerSec,
 	)
 
 	randaoReveal, randaoMix, err := randaoMixer.MixRandao(latestBlock.PrevRandao)
@@ -308,36 +307,6 @@ type timerMetric interface {
 // counterMetric is an abstraction for monitoring metrics to facilitate testing.
 type counterMetric interface {
 	Inc(int64)
-}
-
-// We put a strict cap of 2 second on the maximum time gas can be accumulated
-// for a single block. Thus, if the delay between two blocks is less than 2
-// seconds, gas is accumulated linearly. If the delay is longer than 2 seconds,
-// we cap the gas to the maximum accumulation time. This is to limit the maximum
-// block size to at most 2 seconds worth of gas.
-const maxAccumulationTime = 2 * time.Second
-
-// getEffectiveGasLimit computes the effective gas limit for the next block.
-// This is the time since the last block times the targeted network throughput.
-// The result is capped to the gas that corresponds to a maximum accumulation
-// time of maxAccumulationTime.
-func getEffectiveGasLimit(
-	delta time.Duration,
-	targetedThroughput uint64,
-) uint64 {
-	if delta <= 0 {
-		return 0
-	}
-	if delta > maxAccumulationTime {
-		delta = maxAccumulationTime
-	}
-	return new(big.Int).Div(
-		new(big.Int).Mul(
-			big.NewInt(int64(targetedThroughput)),
-			big.NewInt(int64(delta.Nanoseconds())),
-		),
-		big.NewInt(int64(time.Second.Nanoseconds())),
-	).Uint64()
 }
 
 // transactionPriorityAdapter is an adapter between the transactionsByPriceAndNonce

--- a/gossip/emitter/scheduler/processor.go
+++ b/gossip/emitter/scheduler/processor.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"math"
+
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -67,9 +69,13 @@ func (p *evmProcessorFactory) beginBlock(
 	vmConfig := opera.GetVmConfig(p.chain.GetCurrentNetworkRules())
 	state := p.chain.StateDB()
 
+	// The gas limit for transactions is enforced on a per-transaction level
+	// in the scheduler. See the scheduler.Schedule method for details. The
+	// total gas used for attempting to schedule transactions is not limited.
+	gasLimit := uint64(math.MaxUint64)
 	stateProcessor := evmcore.NewStateProcessor(chainCfg, p.chain)
 	return &evmProcessor{
-		processor: stateProcessor.BeginBlock(block, state, vmConfig, nil),
+		processor: stateProcessor.BeginBlock(block, state, vmConfig, gasLimit, nil),
 		stateDb:   state,
 	}
 }

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -250,12 +250,12 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	)
 
 	// Execute genesis transactions
-	evmProcessor.Execute(genesisTxs)
+	evmProcessor.Execute(genesisTxs, es.Rules.Blocks.MaxBlockGas)
 	bs = txListener.Finalize()
 
 	// Execute pre-internal transactions
 	preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
-	evmProcessor.Execute(preInternalTxs)
+	evmProcessor.Execute(preInternalTxs, es.Rules.Blocks.MaxBlockGas)
 	bs = txListener.Finalize()
 
 	// Seal epoch
@@ -265,7 +265,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 
 	// Execute post-internal transactions
 	internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
-	evmProcessor.Execute(internalTxs)
+	evmProcessor.Execute(internalTxs, es.Rules.Blocks.MaxBlockGas)
 
 	evmBlock, skippedTxs, receipts := evmProcessor.Finalize()
 	for i, r := range receipts {

--- a/inter/gas_rate_control.go
+++ b/inter/gas_rate_control.go
@@ -1,0 +1,36 @@
+package inter
+
+import (
+	"math/big"
+	"time"
+)
+
+// We put a strict cap of 2 second on the maximum time gas can be accumulated
+// for a single block. Thus, if the delay between two blocks is less than 2
+// seconds, gas is accumulated linearly. If the delay is longer than 2 seconds,
+// we cap the gas to the maximum accumulation time. This is to limit the maximum
+// block size to at most 2 seconds worth of gas.
+const maxAccumulationTime = 2 * time.Second
+
+// GetEffectiveGasLimit computes the effective gas limit for the next block.
+// This is the time since the last block times the targeted network throughput.
+// The result is capped to the gas that corresponds to a maximum accumulation
+// time of maxAccumulationTime.
+func GetEffectiveGasLimit(
+	delta time.Duration,
+	targetedThroughput uint64,
+) uint64 {
+	if delta <= 0 {
+		return 0
+	}
+	if delta > maxAccumulationTime {
+		delta = maxAccumulationTime
+	}
+	return new(big.Int).Div(
+		new(big.Int).Mul(
+			big.NewInt(int64(targetedThroughput)),
+			big.NewInt(int64(delta.Nanoseconds())),
+		),
+		big.NewInt(int64(time.Second.Nanoseconds())),
+	).Uint64()
+}

--- a/inter/gas_rate_control_test.go
+++ b/inter/gas_rate_control_test.go
@@ -1,0 +1,45 @@
+package inter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEffectiveGasLimit_IsProportionalToDelay(t *testing.T) {
+	rates := []uint64{0, 1, 20, 1234, 10_000_000_000} // < gas/sec
+	delay := []time.Duration{
+		0, 1 * time.Nanosecond, 50 * time.Microsecond,
+		100 * time.Millisecond, 1500 * time.Millisecond,
+	}
+
+	for _, rate := range rates {
+		for _, d := range delay {
+			got := GetEffectiveGasLimit(d, rate)
+			want := rate * uint64(d) / uint64(time.Second)
+			require.Equal(t, want, got, "rate %d, delay %v", rate, d)
+		}
+	}
+}
+
+func TestGetEffectiveGasLimit_IsZeroForNegativeDelay(t *testing.T) {
+	require.Equal(t, uint64(0), GetEffectiveGasLimit(-1*time.Nanosecond, 100))
+	require.Equal(t, uint64(0), GetEffectiveGasLimit(-1*time.Second, 100))
+	require.Equal(t, uint64(0), GetEffectiveGasLimit(-1*time.Hour, 100))
+}
+
+func TestGetEffectiveGasLimit_IsCappedAtMaximumAccumulationTime(t *testing.T) {
+	rate := uint64(100)
+	maxAccumulationTime := maxAccumulationTime
+	for _, d := range []time.Duration{
+		maxAccumulationTime,
+		maxAccumulationTime + 1*time.Nanosecond,
+		maxAccumulationTime + 1*time.Second,
+		maxAccumulationTime + 1*time.Hour,
+	} {
+		got := GetEffectiveGasLimit(d, rate)
+		want := GetEffectiveGasLimit(maxAccumulationTime, rate)
+		require.Equal(t, want, got, "delay %v", d)
+	}
+}


### PR DESCRIPTION
This RP introduces a check for the admissible gas limit for block proposals in the single-proposer mode.

**For Reviewers**
This PR applies three modifications:
- it moves the formerly private [`GetEffectiveGasLimit`](https://github.com/0xsoniclabs/sonic/blob/561abb92b658a7bc5cfe67a10af776528ca42ab4/gossip/emitter/proposals.go#L325) function from the `emitter` package into the `inter` package to make it available to the `gossip` package
- it extends the EVM State-Processor's [Process](https://github.com/0xsoniclabs/sonic/blob/561abb92b658a7bc5cfe67a10af776528ca42ab4/evmcore/state_processor.go#L72) function by an explicit gas-limit parameter for running the given transactions, independent of the overall block limit. While the block limit must be consistent for all transactions in a block, and can be accessed within the EVM, this gas limit is specific for the execution of the concrete set of transactions passed to the EVM
- it updates the calls to the `Process` function in the scheduler, the block formation code, and in tests to provide this additional parameter

In particular, the [c_block_callbacks.go](https://github.com/0xsoniclabs/sonic/blob/04f24e1406bb3abd3eb8bb8c1ce2e68988e500d1/gossip/c_block_callbacks.go#L208-L211) file is extended with the computation of the effective gas limit for the current block.