### PR TITLE
Move legacy intrinsic gas to basic check

### DIFF
--- a/eventcheck/basiccheck/basic_check.go
+++ b/eventcheck/basiccheck/basic_check.go
@@ -7,7 +7,6 @@ import (
 	base "github.com/Fantom-foundation/lachesis-base/eventcheck/basiccheck"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/inter"
 )
 
@@ -41,7 +40,7 @@ func validateTx(tx *types.Transaction) error {
 		return ErrNegativeValue
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
-	intrGas, err := evmcore.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil)
+	intrGas, err := intrinsicGasLegacy(tx.Data(), tx.AccessList(), tx.To() == nil)
 	if err != nil {
 		return err
 	}

--- a/eventcheck/basiccheck/basic_check_test.go
+++ b/eventcheck/basiccheck/basic_check_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -38,4 +39,33 @@ func TestChecker_checkTxs_DetectsIssuesInTransactions(t *testing.T) {
 
 	err := New().checkTxs(event)
 	require.Error(t, err)
+}
+
+func TestChecker_IntrinsicGas_LegacyCalculationDoesNotAccountForInitDataOrAuthList(t *testing.T) {
+
+	tests := map[string]*types.Transaction{
+		"legacyTx": types.NewTx(&types.LegacyTx{
+			To:  nil,
+			Gas: 21_000,
+			// some data that takes
+			Data: []byte("this is a string that is longer than 32 bytes, so it will cost more"),
+		}),
+		"setCodeTx": types.NewTx(&types.SetCodeTx{
+			To:       common.Address{},
+			Gas:      21_000,
+			AuthList: []types.SetCodeAuthorization{{}}}),
+	}
+
+	for name, tx := range tests {
+		t.Run(name, func(t *testing.T) {
+			costLegacy, err := intrinsicGasLegacy(tx.Data(), tx.AccessList(), tx.To() == nil)
+			require.NoError(t, err)
+
+			// in sonic, Homestead, Istanbul and Shanghai are always active
+			costNew, err := core.IntrinsicGas(tx.Data(), tx.AccessList(),
+				tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
+			require.NoError(t, err)
+			require.Greater(t, costNew, costLegacy)
+		})
+	}
 }

--- a/eventcheck/basiccheck/intrinsic_gas_legacy.go
+++ b/eventcheck/basiccheck/intrinsic_gas_legacy.go
@@ -19,7 +19,6 @@ package basiccheck
 import (
 	"math"
 
-	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
@@ -56,7 +55,7 @@ func intrinsicGasLegacy(data []byte, accessList types.AccessList, isContractCrea
 
 		z := uint64(len(data)) - nz
 		if (math.MaxUint64-gas)/params.TxDataZeroGas < z {
-			return 0, evmcore.ErrGasUintOverflow
+			return 0, vm.ErrGasUintOverflow
 		}
 		gas += z * params.TxDataZeroGas
 	}

--- a/eventcheck/basiccheck/intrinsic_gas_legacy.go
+++ b/eventcheck/basiccheck/intrinsic_gas_legacy.go
@@ -14,18 +14,24 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package evmcore
+package basiccheck
 
 import (
 	"math"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation bool) (uint64, error) {
+// intrinsicGasLegacy computes the 'intrinsic gas' for a message with the given data.
+// This is an outdated version of
+// https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L71
+// and is only kept for history reproduction.
+// It does not account for init data or authorization lists.
+// It also assumes, that the Homestead, Istanbul, and Shanghai forks are always active.
+func intrinsicGasLegacy(data []byte, accessList types.AccessList, isContractCreation bool) (uint64, error) {
 	// Set the starting gas for the raw transaction
 	var gas uint64
 	if isContractCreation {
@@ -50,7 +56,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 
 		z := uint64(len(data)) - nz
 		if (math.MaxUint64-gas)/params.TxDataZeroGas < z {
-			return 0, ErrGasUintOverflow
+			return 0, evmcore.ErrGasUintOverflow
 		}
 		gas += z * params.TxDataZeroGas
 	}

--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -56,9 +56,6 @@ var (
 	// is higher than the balance of the user's account.
 	ErrInsufficientFunds = errors.New("insufficient funds for gas * price + value")
 
-	// ErrGasUintOverflow is returned when calculating gas usage.
-	ErrGasUintOverflow = errors.New("gas uint64 overflow")
-
 	// ErrIntrinsicGas is returned if the transaction is specified to use less gas
 	// than required to start the invocation.
 	ErrIntrinsicGas = core.ErrIntrinsicGas


### PR DESCRIPTION
The function `evmcore.IntrinsicGas` is only used in `eventcheck/basiccheck` and it is an outdated version of [geth's](https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L71). 

This PR moves `IntrinsicGas` from `evmcore` to the `basiccheck`, where the function will be kept for history reproduction, but this function should not be used anywhere else. Whenever needed the [geth's](https://github.com/ethereum/go-ethereum/blob/master/core/state_transition.go#L71) function should be used. 