### PR TITLE
Move gas-limit control from processor to scheduler

### DIFF
--- a/gossip/emitter/scheduler/processor.go
+++ b/gossip/emitter/scheduler/processor.go
@@ -22,9 +22,8 @@ type processorFactory interface {
 // individual transactions to be scheduled in a block.
 type processor interface {
 	// run runs the given transaction in the context of the current block
-	// and returns the result of the execution. The gas limit is the maximum
-	// amount of gas that can be used by the transaction.
-	run(tx *types.Transaction, gasLimit uint64) (success bool, gasUsed uint64)
+	// and returns the result of the execution.
+	run(tx *types.Transaction) (success bool, gasUsed uint64)
 
 	// release releases the resources used by the processor. In particular, it
 	// allows implementations to release temporary database state.
@@ -86,7 +85,7 @@ type evmProcessor struct {
 	stateDb   state.StateDB
 }
 
-func (p *evmProcessor) run(tx *types.Transaction, gasLimit uint64) (
+func (p *evmProcessor) run(tx *types.Transaction) (
 	result bool, gasUsed uint64,
 ) {
 	// Note: the index can be set to 0 since code running inside the EVM can not
@@ -96,7 +95,7 @@ func (p *evmProcessor) run(tx *types.Transaction, gasLimit uint64) (
 	if skipped || err != nil || receipt == nil {
 		return false, 0
 	}
-	return receipt.GasUsed < gasLimit, receipt.GasUsed
+	return true, receipt.GasUsed
 }
 
 func (p *evmProcessor) release() {

--- a/gossip/emitter/scheduler/processor_mock.go
+++ b/gossip/emitter/scheduler/processor_mock.go
@@ -95,18 +95,18 @@ func (mr *MockprocessorMockRecorder) release() *gomock.Call {
 }
 
 // run mocks base method.
-func (m *Mockprocessor) run(tx *types.Transaction, gasLimit uint64) (bool, uint64) {
+func (m *Mockprocessor) run(tx *types.Transaction) (bool, uint64) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "run", tx, gasLimit)
+	ret := m.ctrl.Call(m, "run", tx)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(uint64)
 	return ret0, ret1
 }
 
 // run indicates an expected call of run.
-func (mr *MockprocessorMockRecorder) run(tx, gasLimit any) *gomock.Call {
+func (mr *MockprocessorMockRecorder) run(tx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "run", reflect.TypeOf((*Mockprocessor)(nil).run), tx, gasLimit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "run", reflect.TypeOf((*Mockprocessor)(nil).run), tx)
 }
 
 // MockChain is a mock of Chain interface.

--- a/gossip/emitter/scheduler/processor_test.go
+++ b/gossip/emitter/scheduler/processor_test.go
@@ -35,23 +35,9 @@ func TestEvmProcessor_Run_IfExecutionSucceeds_ReportsSuccessAndGasUsage(t *testi
 	}, false, nil)
 
 	processor := &evmProcessor{processor: runner}
-	success, gasUsed := processor.run(nil, 50)
+	success, gasUsed := processor.run(nil)
 	require.True(t, success)
 	require.Equal(t, uint64(10), gasUsed)
-}
-
-func TestEvmProcessor_Run_IfGasLimitIsExceeded_ReportsAFailedExecution(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	runner := NewMockevmProcessorRunner(ctrl)
-
-	runner.EXPECT().Run(0, nil).Return(&types.Receipt{
-		GasUsed: 100,
-	}, false, nil)
-
-	processor := &evmProcessor{processor: runner}
-	success, used := processor.run(nil, 50)
-	require.False(t, success)
-	require.Equal(t, uint64(100), used)
 }
 
 func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecution(t *testing.T) {
@@ -61,7 +47,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecution(t *testing.T
 		runner := NewMockevmProcessorRunner(ctrl)
 		runner.EXPECT().Run(0, nil).Return(nil, true, nil)
 		processor := &evmProcessor{processor: runner}
-		success, _ := processor.run(nil, 50)
+		success, _ := processor.run(nil)
 		require.False(t, success)
 	})
 
@@ -70,7 +56,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecution(t *testing.T
 		runner := NewMockevmProcessorRunner(ctrl)
 		runner.EXPECT().Run(0, nil).Return(nil, false, fmt.Errorf("failed"))
 		processor := &evmProcessor{processor: runner}
-		success, _ := processor.run(nil, 50)
+		success, _ := processor.run(nil)
 		require.False(t, success)
 	})
 
@@ -79,7 +65,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecution(t *testing.T
 		runner := NewMockevmProcessorRunner(ctrl)
 		runner.EXPECT().Run(0, nil).Return(nil, false, nil)
 		processor := &evmProcessor{processor: runner}
-		success, _ := processor.run(nil, 50)
+		success, _ := processor.run(nil)
 		require.False(t, success)
 	})
 }

--- a/gossip/emitter/scheduler/scheduler.go
+++ b/gossip/emitter/scheduler/scheduler.go
@@ -71,13 +71,18 @@ func (s *Scheduler) Schedule(
 			break
 		}
 
+		if candidate.Gas() > remainingGas {
+			candidates.Skip()
+			continue
+		}
+
 		size := candidate.Size()
 		if size > remainingSize {
 			candidates.Skip()
 			continue
 		}
 
-		success, gasUsed := processor.run(candidate, remainingGas)
+		success, gasUsed := processor.run(candidate)
 		if !success || gasUsed > remainingGas {
 			candidates.Skip()
 			continue


### PR DESCRIPTION
While introducing the gas limit check in the block processor (see #326) it was realized that gas-limiting is enforced in the processor by comparing the remaining gas with the maximum gas used by a transaction, hence its static gas limit.

This property shall also be used in the scheduler analog to the block processor.

In this PR, the current check for the dynamic gas-costs when filling blocks in the scheduler is replaced by a static alternative. This has the advantage that it prevents too costly transactions from being trail-run. It also simplifies to code by aligning the gas-size check with the byte-size check.