### PR TITLE
Refactor in testing helper functions

### DIFF
--- a/tests/invalid_start_test.go
+++ b/tests/invalid_start_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestInvalidStart_IdentifiesInvalidStartContract(t *testing.T) {
-	r := require.New(t)
+	require := require.New(t)
 	// byteccode source: https://eips.ethereum.org/EIPS/eip-3541#test-cases
 	invalidCode := []byte{0x60, 0xef, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
 	validCode := []byte{0x60, 0xfe, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
@@ -19,61 +19,63 @@ func TestInvalidStart_IdentifiesInvalidStartContract(t *testing.T) {
 
 	// Deploy the invalid start contract.
 	contract, _, err := DeployContract(net, invalidstart.DeployInvalidstart)
-	r.NoError(err)
+	require.NoError(err)
 
 	// -- invalid codes
 
 	// attempt to create a contract with code starting with 0xEF using CREATE
 	receipt, err := net.Apply(contract.CreateContractWithInvalidCode)
-	r.NoError(err)
-	r.Equal(types.ReceiptStatusFailed, receipt.Status, "unexpected succeeded on invalid code with CREATE")
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusFailed, receipt.Status, "unexpected succeeded on invalid code with CREATE")
 
 	// attempt to create a contract with code starting with 0xEF using CREATE2
 	receipt, err = net.Apply(contract.Create2ContractWithInvalidCode)
-	r.NoError(err)
-	r.Equal(types.ReceiptStatusFailed, receipt.Status, "unexpected succeeded on invalid code with CREATE2")
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusFailed, receipt.Status, "unexpected succeeded on invalid code with CREATE2")
 
 	// attempt to run a transaction without receiver, with an invalid code.
-	invalidTransaction, err := getTransactionWithCodeAndNoReceiver(r, invalidCode, net)
-	r.NoError(err)
+	invalidTransaction, err := getTransactionWithCodeAndNoReceiver(t, invalidCode, net)
+	require.NoError(err)
 	receipt, err = net.Run(invalidTransaction)
-	r.NoError(err)
-	r.Equal(types.ReceiptStatusFailed, receipt.Status, "unexpected succeeded on transfer to empty receiver with invalid code")
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusFailed, receipt.Status, "unexpected succeeded on transfer to empty receiver with invalid code")
 
 	// -- valid codes
 
 	// create a contract with valid code using CREATE
 	receipt, err = net.Apply(contract.CreateContractWithValidCode)
-	r.NoError(err)
-	r.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on valid code with CREATE")
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on valid code with CREATE")
 
 	// create a contract with valid code using CREATE2
 	receipt, err = net.Apply(contract.Create2ContractWithValidCode)
-	r.NoError(err)
-	r.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on valid code with CREATE2")
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on valid code with CREATE2")
 
 	// run a transaction without receiver, with a valid code.
-	validTransaction, err := getTransactionWithCodeAndNoReceiver(r, validCode, net)
-	r.NoError(err)
+	validTransaction, err := getTransactionWithCodeAndNoReceiver(t, validCode, net)
+	require.NoError(err)
 	receipt, err = net.Run(validTransaction)
-	r.NoError(err)
-	r.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on transfer to empty receiver with valid code")
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on transfer to empty receiver with valid code")
 }
 
-func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net *IntegrationTestNet) (*types.Transaction, error) {
+func getTransactionWithCodeAndNoReceiver(t testing.TB, code []byte, net *IntegrationTestNet) (*types.Transaction, error) {
 	// these values are needed for the transaction but are irrelevant for the test
+	t.Helper()
+	require := require.New(t)
 	client, err := net.GetClient()
-	r.NoError(err, "failed to connect to the network:")
+	require.NoError(err, "failed to connect to the network:")
 
 	defer client.Close()
 	chainId, err := client.ChainID(context.Background())
-	r.NoError(err, "failed to get chain ID::")
+	require.NoError(err, "failed to get chain ID::")
 
 	nonce, err := client.NonceAt(context.Background(), net.GetSessionSponsor().Address(), nil)
-	r.NoError(err, "failed to get nonce:")
+	require.NoError(err, "failed to get nonce:")
 
 	price, err := client.SuggestGasPrice(context.Background())
-	r.NoError(err, "failed to get gas price:")
+	require.NoError(err, "failed to get gas price:")
 	// ---------
 
 	transaction, err := types.SignTx(types.NewTx(&types.AccessListTx{
@@ -84,7 +86,7 @@ func getTransactionWithCodeAndNoReceiver(r *require.Assertions, code []byte, net
 		Nonce:    nonce,
 		Data:     code,
 	}), types.NewLondonSigner(chainId), net.GetSessionSponsor().PrivateKey)
-	r.NoError(err, "failed to sign transaction:")
+	require.NoError(err, "failed to sign transaction:")
 
 	return transaction, nil
 }


### PR DESCRIPTION
This PR implements a refactor in two integrations tests helper functions.
It shall pass `t` instead of `require.Assertion` in test functions.