### PR TITLE
Use `t.Context` in integration tests

### DIFF
--- a/tests/basefee_test.go
+++ b/tests/basefee_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/tests/contracts/basefee"
@@ -40,7 +39,7 @@ func TestBaseFee_CanReadBaseFeeFromHeadAndBlockAndHistory(t *testing.T) {
 	}
 	defer client.Close()
 
-	block, err := client.BlockByNumber(context.Background(), receipt.BlockNumber)
+	block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
 	if err != nil {
 		t.Fatalf("failed to get block header; %v", err)
 	}

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -91,10 +90,10 @@ func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, ctxt *testContext) {
 func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) (*types.Transaction, error) {
 	require := require.New(t)
 
-	chainId, err := ctxt.client.ChainID(context.Background())
+	chainId, err := ctxt.client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetSessionSponsor().Address(), nil)
+	nonce, err := ctxt.client.NonceAt(t.Context(), ctxt.net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	var sidecar *types.BlobTxSidecar
@@ -144,10 +143,10 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*types.Transaction, error) {
 	require := require.New(t)
 
-	chainId, err := ctxt.client.ChainID(context.Background())
+	chainId, err := ctxt.client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(context.Background(), ctxt.net.GetSessionSponsor().Address(), nil)
+	nonce, err := ctxt.client.NonceAt(t.Context(), ctxt.net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	// Create and return transaction with the blob data and cryptographic proofs
@@ -172,11 +171,11 @@ func checkBlocksSanity(t *testing.T, client *ethclient.Client) {
 	// number where the last block was not correctly serialized
 	require := require.New(t)
 
-	lastBlock, err := client.BlockByNumber(context.Background(), nil)
+	lastBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(err)
 
 	for i := uint64(0); i < lastBlock.Number().Uint64(); i++ {
-		_, err := client.BlockByNumber(context.Background(), big.NewInt(int64(i)))
+		_, err := client.BlockByNumber(t.Context(), big.NewInt(int64(i)))
 		require.NoError(err)
 	}
 }

--- a/tests/blobbasefee_test.go
+++ b/tests/blobbasefee_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"bytes"
-	"context"
 	"math/big"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T) 
 	require.NoError(err, "failed to get client; ", err)
 	defer client.Close()
 
-	block, err := client.BlockByNumber(context.Background(), receipt.BlockNumber)
+	block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
 	require.NoError(err, "failed to get block header; ", err)
 	fromBlock := getBlobBaseFeeFrom(block.Header())
 
@@ -79,7 +78,7 @@ func TestBlobBaseFee_CanReadBlobGasUsed(t *testing.T) {
 	defer client.Close()
 
 	// Get blob gas used from the block header of the latest block.
-	block, err := client.BlockByNumber(context.Background(), nil)
+	block, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(err, "failed to get block header; ", err)
 	require.Empty(*block.BlobGasUsed(), "unexpected value in blob gas used")
 	require.Empty(*block.Header().ExcessBlobGas, "unexpected excess blob gas value")

--- a/tests/block_hash_test.go
+++ b/tests/block_hash_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -73,7 +72,7 @@ func testVisibleBlockHashOnHead(
 
 			want := common.Hash{}
 			if observed < current {
-				hash, err := client.BlockByNumber(context.Background(), entry.ObservedBlock)
+				hash, err := client.BlockByNumber(t.Context(), entry.ObservedBlock)
 				require.NoError(err, "failed to get block hash; %v", err)
 				want = hash.Hash()
 			}
@@ -93,15 +92,13 @@ func testVisibleBlockHashesInArchive(
 	require.NoError(err, "failed to get client; %v", err)
 	defer client.Close()
 
-	ctxt := context.Background()
-
 	// Get list of all block hashes.
-	numBlocks, err := client.BlockNumber(ctxt)
+	numBlocks, err := client.BlockNumber(t.Context())
 	require.NoError(err, "failed to get block number; %v", err)
 
 	hashes := []common.Hash{}
 	for i := uint64(0); i <= numBlocks; i++ {
-		hash, err := client.BlockByNumber(ctxt, big.NewInt(int64(i)))
+		hash, err := client.BlockByNumber(t.Context(), big.NewInt(int64(i)))
 		require.NoError(err, "failed to get block hash; %v", err)
 		hashes = append(hashes, hash.Hash())
 	}

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -534,7 +534,6 @@ func getStateRoot(client *ethclient.Client, blockNumber int) (common.Hash, error
 
 func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.Header, client *ethclient.Client) {
 	require := require.New(t)
-	ctxt := t.Context()
 	for i := range headers {
 		block := big.NewInt(int64(i))
 		for _, addr := range []common.Address{
@@ -544,7 +543,7 @@ func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.
 			sfc.ContractAddress,
 			evmwriter.ContractAddress,
 		} {
-			nonce, err := client.NonceAt(ctxt, addr, block)
+			nonce, err := client.NonceAt(t.Context(), addr, block)
 			require.NoError(err, "failed to get nonce for %s at block %d", addr, i)
 
 			want := uint64(1)

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"cmp"
-	"context"
 	"fmt"
 	"math/big"
 	"slices"
@@ -293,7 +292,7 @@ func testHeaders_TransactionRootMatchesBlockTxsHash(t *testing.T, headers []*typ
 	require := require.New(t)
 
 	for i, header := range headers {
-		block, err := client.BlockByNumber(context.Background(), header.Number)
+		block, err := client.BlockByNumber(t.Context(), header.Number)
 		require.NoError(err, "failed to get block %d", i)
 
 		txsHash := types.DeriveSha(block.Transactions(), trie.NewStackTrie(nil))
@@ -307,11 +306,11 @@ func testHeaders_TransactionReceiptReferencesCorrectContext(
 	require := require.New(t)
 
 	for i, header := range headers {
-		block, err := client.BlockByNumber(context.Background(), header.Number)
+		block, err := client.BlockByNumber(t.Context(), header.Number)
 		require.NoError(err, "failed to get block %d", i)
 
 		for j, tx := range block.Transactions() {
-			receipt, err := client.TransactionReceipt(context.Background(), tx.Hash())
+			receipt, err := client.TransactionReceipt(t.Context(), tx.Hash())
 			require.NoError(err, "failed to get transaction receipt")
 
 			require.Equal(tx.Hash(), receipt.TxHash, "transaction hash mismatch")
@@ -326,7 +325,7 @@ func testHeaders_ReceiptBlockHashMatchesBlockHash(t *testing.T, headers []*types
 	require := require.New(t)
 
 	for _, header := range headers {
-		receipts, err := client.BlockReceipts(context.Background(),
+		receipts, err := client.BlockReceipts(t.Context(),
 			rpc.BlockNumberOrHashWithHash(header.Hash(), false))
 		require.NoError(err, "failed to get block receipts")
 
@@ -340,7 +339,7 @@ func testHeaders_ReceiptRootMatchesBlockReceipts(t *testing.T, headers []*types.
 	require := require.New(t)
 
 	for _, header := range headers {
-		receipts, err := client.BlockReceipts(context.Background(),
+		receipts, err := client.BlockReceipts(t.Context(),
 			rpc.BlockNumberOrHashWithHash(header.Hash(), false))
 		require.NoError(err, "failed to get block receipts")
 
@@ -353,7 +352,7 @@ func testHeaders_LogsBloomMatchesLogsInReceipts(t *testing.T, headers []*types.H
 	require := require.New(t)
 
 	for _, header := range headers {
-		receipts, err := client.BlockReceipts(context.Background(),
+		receipts, err := client.BlockReceipts(t.Context(),
 			rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(header.Number.Uint64())))
 		require.NoError(err, "failed to get block receipts")
 
@@ -441,7 +440,7 @@ func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, header
 	maxEpoch := 0
 	for i := 0; i < len(headers)-1; i++ {
 
-		block, err := client.BlockByNumber(context.Background(), big.NewInt(int64(i)))
+		block, err := client.BlockByNumber(t.Context(), big.NewInt(int64(i)))
 		require.NoError(err, "failed to get block body")
 
 		currentBlockEpoch, err := getEpochOfBlock(client, i)
@@ -535,7 +534,7 @@ func getStateRoot(client *ethclient.Client, blockNumber int) (common.Hash, error
 
 func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.Header, client *ethclient.Client) {
 	require := require.New(t)
-	ctxt := context.Background()
+	ctxt := t.Context()
 	for i := range headers {
 		block := big.NewInt(int64(i))
 		for _, addr := range []common.Address{
@@ -565,7 +564,7 @@ func testHeaders_LogsReferenceTheirContext(t *testing.T, headers []*types.Header
 		blockHash := header.Hash()
 		blockNumber := header.Number.Uint64()
 
-		receipts, err := client.BlockReceipts(context.Background(),
+		receipts, err := client.BlockReceipts(t.Context(),
 			rpc.BlockNumberOrHashWithHash(blockHash, false))
 		require.NoError(err, "failed to get block receipts")
 
@@ -593,7 +592,7 @@ func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, cli
 	allLogs := []types.Log{}
 	for _, header := range headers {
 		blockHash := header.Hash()
-		receipts, err := client.BlockReceipts(context.Background(),
+		receipts, err := client.BlockReceipts(t.Context(),
 			rpc.BlockNumberOrHashWithHash(blockHash, false))
 		require.NoError(err, "failed to get block receipts")
 
@@ -609,7 +608,7 @@ func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, cli
 					topicFilter = append(topicFilter, []common.Hash{topic})
 				}
 				logs, err := client.FilterLogs(
-					context.Background(),
+					t.Context(),
 					ethereum.FilterQuery{
 						BlockHash: &blockHash,
 						Addresses: []common.Address{log.Address},
@@ -627,7 +626,7 @@ func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, cli
 	// Fetch all logs from the chain in a single query and see that no extra
 	// log entries are returned.
 	logs, err := client.FilterLogs(
-		context.Background(),
+		t.Context(),
 		ethereum.FilterQuery{
 			FromBlock: big.NewInt(0),
 			ToBlock:   big.NewInt(int64(len(headers) - 1)),
@@ -653,7 +652,7 @@ func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, cli
 		topicZeroOptions = append(topicZeroOptions, log.Topics[0])
 	}
 	logs, err = client.FilterLogs(
-		context.Background(),
+		t.Context(),
 		ethereum.FilterQuery{
 			ToBlock: big.NewInt(int64(len(headers) - 1)),
 			Topics:  [][]common.Hash{topicZeroOptions},
@@ -681,7 +680,7 @@ func testHeaders_CounterStateIsVerifiable(
 	for i, header := range headers {
 
 		// Get counter value according to the reported logs.
-		receipts, err := client.BlockReceipts(context.Background(), rpc.BlockNumberOrHashWithHash(header.Hash(), false))
+		receipts, err := client.BlockReceipts(t.Context(), rpc.BlockNumberOrHashWithHash(header.Hash(), false))
 		require.NoError(err, "failed to get block receipts")
 		for _, receipt := range receipts {
 			require.Equal(header.Hash(), receipt.BlockHash, "block hash mismatch")
@@ -704,7 +703,7 @@ func testHeaders_CounterStateIsVerifiable(
 		}
 
 		// Get the counter value from the state directly.
-		fromStateAsHash, err := client.StorageAt(context.Background(), counterAddress, common.Hash{}, big.NewInt(int64(i)))
+		fromStateAsHash, err := client.StorageAt(t.Context(), counterAddress, common.Hash{}, big.NewInt(int64(i)))
 		require.NoError(err)
 		fromState := int(new(big.Int).SetBytes(fromStateAsHash).Uint64())
 
@@ -799,7 +798,7 @@ func testScc_HasCommitteeCertificates(
 	require.NoError(err)
 	require.NotEmpty(results, "no committee certificates found")
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(err)
 	for _, result := range results {
 		require.Equal(chainId.Uint64(), result.ChainId)
@@ -832,7 +831,7 @@ func testScc_HasBlockCertificatesForBlocks(
 	}
 
 	// Check the certificate content.
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(err)
 	for _, cert := range results {
 		if cert.Number >= uint64(len(headers)) {

--- a/tests/block_in_archive_test.go
+++ b/tests/block_in_archive_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestBlockInArchive(t *testing.T) {
 		defer close(done)
 		rpcClient := client.Client()
 		headChannel := make(chan *types.Header)
-		subscription, err := client.SubscribeNewHead(context.Background(), headChannel)
+		subscription, err := client.SubscribeNewHead(t.Context(), headChannel)
 		require.NoError(err, "failed to subscribe to new head %v", err)
 		lastBlockNumber := uint64(0)
 

--- a/tests/chainid_test.go
+++ b/tests/chainid_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"slices"
@@ -22,7 +21,7 @@ func TestChainId_RejectsAllTxSignedWithWrongChainId(t *testing.T) {
 	client, err := net.GetClient()
 	require.NoError(t, err, "failed to get client")
 	defer client.Close()
-	actualChainID, err := client.ChainID(context.Background())
+	actualChainID, err := client.ChainID(t.Context())
 	require.NoError(t, err, "failed to get chain ID")
 	differentChainId := new(big.Int).Add(actualChainID, big.NewInt(1))
 
@@ -109,7 +108,7 @@ func TestChainId_AcceptsLegacyTxSignedWithHomestead(t *testing.T) {
 	account := makeAccountWithBalance(t, net, big.NewInt(1e18))
 
 	// get current nonce and sign the tx.
-	nonce, err := client.NonceAt(context.Background(), account.Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), account.Address(), nil)
 	require.NoError(t, err, "failed to get nonce")
 
 	to := &common.Address{42}
@@ -131,7 +130,7 @@ func TestChainId_AcceptsLegacyTxSignedWithHomestead(t *testing.T) {
 
 	// get the transaction by hash and verify that it has the correct chain ID
 	var json *ethapi.RPCTransaction
-	err = client.Client().CallContext(context.Background(), &json,
+	err = client.Client().CallContext(t.Context(), &json,
 		"eth_getTransactionByHash", signed.Hash(),
 	)
 	require.NoError(t, err)

--- a/tests/eip2935_test.go
+++ b/tests/eip2935_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -45,11 +44,11 @@ func TestEIP2935_IsAutomaticallyDeployedWithFakeNet(t *testing.T) {
 			require.NoError(t, err)
 			defer client.Close()
 
-			code, err := client.CodeAt(context.Background(), historyStorageAddress, nil)
+			code, err := client.CodeAt(t.Context(), historyStorageAddress, nil)
 			require.NoError(t, err)
 			require.Equal(t, params.HistoryStorageCode, code)
 
-			nonce, err := client.NonceAt(context.Background(), historyStorageAddress, nil)
+			nonce, err := client.NonceAt(t.Context(), historyStorageAddress, nil)
 			require.NoError(t, err)
 			require.Equal(t, uint64(1), nonce)
 		})
@@ -75,11 +74,11 @@ func TestEIP2935_HistoryContractIsNotDeployedBeforePrague(t *testing.T) {
 			require.NoError(t, err)
 			defer client.Close()
 
-			code, err := client.CodeAt(context.Background(), historyStorageAddress, nil)
+			code, err := client.CodeAt(t.Context(), historyStorageAddress, nil)
 			require.NoError(t, err)
 			require.Empty(t, code)
 
-			nonce, err := client.NonceAt(context.Background(), historyStorageAddress, nil)
+			nonce, err := client.NonceAt(t.Context(), historyStorageAddress, nil)
 			require.NoError(t, err)
 			require.Equal(t, uint64(0), nonce)
 		})
@@ -156,11 +155,11 @@ func TestEIP2935_DeployContract(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-	code, err := client.CodeAt(context.Background(), historyStorageAddress, nil)
+	code, err := client.CodeAt(t.Context(), historyStorageAddress, nil)
 	require.NoError(t, err)
 	require.Equal(t, params.HistoryStorageCode, code)
 
-	nonce, err := client.NonceAt(context.Background(), historyStorageAddress, nil)
+	nonce, err := client.NonceAt(t.Context(), historyStorageAddress, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), nonce)
 

--- a/tests/gas_cost_test.go
+++ b/tests/gas_cost_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"iter"
 	"math/big"
 	"strings"
@@ -56,7 +55,7 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
 	// From https://eips.ethereum.org/EIPS/eip-7623
@@ -79,7 +78,7 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 				tx := signTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
-				err := client.SendTransaction(context.Background(), tx)
+				err := client.SendTransaction(t.Context(), tx)
 				require.Error(t, err)
 				require.Condition(t, func() bool {
 					return strings.Contains(err.Error(), "intrinsic gas too low")
@@ -158,7 +157,7 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
 	// From https://eips.ethereum.org/EIPS/eip-7623
@@ -197,7 +196,7 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 				tx := signTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
-				err := client.SendTransaction(context.Background(), tx)
+				err := client.SendTransaction(t.Context(), tx)
 				require.Error(t, err)
 				require.Condition(t, func() bool {
 					return strings.Contains(err.Error(), "intrinsic gas too low") ||
@@ -299,7 +298,7 @@ func makeGasCostTestInputs(
 	require.NoError(t, err)
 	defer client.Close()
 
-	gasPrice, err := client.SuggestGasPrice(context.Background())
+	gasPrice, err := client.SuggestGasPrice(t.Context())
 	require.NoError(t, err)
 
 	existingAccountAddress := session.GetSessionSponsor().Address()

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"math/big"
 	"testing"
@@ -19,7 +18,7 @@ func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 
 	fees := []uint64{}
 	suggestions := []uint64{}
-	ctxt := context.Background()
+	ctxt := t.Context()
 	for i := 0; i < 10; i++ {
 		suggestedPrice, err := client.SuggestGasPrice(ctxt)
 		require.NoError(err)
@@ -49,13 +48,13 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 
 	net, client := makeNetAndClient(t)
 	send := func(tx *types.Transaction) error {
-		return client.SendTransaction(context.Background(), tx)
+		return client.SendTransaction(t.Context(), tx)
 	}
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.GetSessionSponsor().Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	factory := &txFactory{
@@ -63,7 +62,7 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 		chainId:   chainId,
 	}
 
-	lastBlock, err := client.BlockByNumber(context.Background(), nil)
+	lastBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(err)
 
 	// Everything below ~5% above the base fee should be rejected.

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -18,16 +18,15 @@ func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 
 	fees := []uint64{}
 	suggestions := []uint64{}
-	ctxt := t.Context()
 	for i := 0; i < 10; i++ {
-		suggestedPrice, err := client.SuggestGasPrice(ctxt)
+		suggestedPrice, err := client.SuggestGasPrice(t.Context())
 		require.NoError(err)
 
 		// new block
 		receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(100))
 		require.NoError(err)
 
-		lastBlock, err := client.BlockByNumber(ctxt, receipt.BlockNumber)
+		lastBlock, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
 		require.NoError(err)
 
 		// store suggested and actual prices.

--- a/tests/genesis_import_test.go
+++ b/tests/genesis_import_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestGenesis_NetworkCanCreateNewBlocksAfterExportImport(t *testing.T) {
 	defer client.Close()
 
 	// check address 42 has balance
-	balance42, err := client.BalanceAt(context.Background(), common.Address{42}, nil)
+	balance42, err := client.BalanceAt(t.Context(), common.Address{42}, nil)
 	require.NoError(err)
 	require.Equal(int64(100*numBlocks), balance42.Int64(), "unexpected balance")
 

--- a/tests/initcoder_test.go
+++ b/tests/initcoder_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -161,13 +160,13 @@ func runTransactionWithCodeSizeAndGas(t *testing.T, net *IntegrationTestNet, cod
 	require.NoError(err, "failed to connect to the network:")
 	defer client.Close()
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.GetSessionSponsor().Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
-	price, err := client.SuggestGasPrice(context.Background())
+	price, err := client.SuggestGasPrice(t.Context())
 	require.NoError(err, "failed to get gas price:")
 	// ---------
 

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -56,7 +55,7 @@ func TestIntegrationTestNet_CanFetchInformationFromTheNetwork(t *testing.T) {
 	}
 	defer client.Close()
 
-	block, err := client.BlockNumber(context.Background())
+	block, err := client.BlockNumber(t.Context())
 	if err != nil {
 		t.Fatalf("Failed to get block number: %v", err)
 	}
@@ -75,7 +74,7 @@ func TestIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T) {
 	}
 
 	address := common.Address{0x01}
-	balance, err := client.BalanceAt(context.Background(), address, nil)
+	balance, err := client.BalanceAt(t.Context(), address, nil)
 	if err != nil {
 		t.Fatalf("Failed to get balance for account: %v", err)
 	}
@@ -92,7 +91,7 @@ func TestIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T) {
 		}
 
 		want := balance.Add(balance, big.NewInt(int64(increment)))
-		balance, err = client.BalanceAt(context.Background(), address, nil)
+		balance, err = client.BalanceAt(t.Context(), address, nil)
 		if err != nil {
 			t.Fatalf("Failed to get balance for account: %v", err)
 		}
@@ -209,10 +208,10 @@ func TestIntegrationTestNet_CanStartWithCustomConfig(t *testing.T) {
 
 	sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
-	gp, err := client.SuggestGasPrice(context.Background())
+	gp, err := client.SuggestGasPrice(t.Context())
 	require.NoError(t, err)
 
 	gas, err := core.IntrinsicGas(nil, nil, nil, true, true, true, true)
@@ -225,7 +224,7 @@ func TestIntegrationTestNet_CanStartWithCustomConfig(t *testing.T) {
 		GasFeeCap: gp,
 		GasTipCap: big.NewInt(9),
 	}, sender)
-	err = client.SendTransaction(context.Background(), tx)
+	err = client.SendTransaction(t.Context(), tx)
 	require.ErrorContains(t, err, "transaction underpriced")
 
 	tx = signTransaction(t, chainId, &types.DynamicFeeTx{
@@ -235,7 +234,7 @@ func TestIntegrationTestNet_CanStartWithCustomConfig(t *testing.T) {
 		GasFeeCap: gp,
 		GasTipCap: big.NewInt(10),
 	}, sender)
-	err = client.SendTransaction(context.Background(), tx)
+	err = client.SendTransaction(t.Context(), tx)
 	require.NoError(t, err)
 }
 
@@ -268,10 +267,10 @@ func TestIntegrationTestNet_AccountsToBeDeployedWithGenesisCanBeCalled(t *testin
 
 	sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
 
-	gasPrice, err := client.SuggestGasPrice(context.Background())
+	gasPrice, err := client.SuggestGasPrice(t.Context())
 	require.NoError(t, err)
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
 	txData := &types.LegacyTx{

--- a/tests/integration_test_tools_test.go
+++ b/tests/integration_test_tools_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -59,13 +58,13 @@ func setTransactionDefaults[T types.TxData](
 	tmpTx := types.NewTx(txPayload)
 	nonce := tmpTx.Nonce()
 	if tmpTx.Nonce() == 0 {
-		nonce, err = client.PendingNonceAt(context.Background(), sender.Address())
+		nonce, err = client.PendingNonceAt(t.Context(), sender.Address())
 		require.NoError(t, err)
 	}
 
 	gasPrice := tmpTx.GasPrice()
 	if gasPrice == nil || gasPrice.Sign() == 0 {
-		gasPrice, err = client.SuggestGasPrice(context.Background())
+		gasPrice, err = client.SuggestGasPrice(t.Context())
 		require.NoError(t, err)
 	}
 
@@ -157,7 +156,7 @@ func TestIntegrationTestNet_setTransactionDefaults(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
 	type modificationFunction func(t *testing.T, tx *types.TxData)

--- a/tests/invalid_start_test.go
+++ b/tests/invalid_start_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/tests/contracts/invalidstart"
@@ -68,13 +67,13 @@ func getTransactionWithCodeAndNoReceiver(t testing.TB, code []byte, net *Integra
 	require.NoError(err, "failed to connect to the network:")
 
 	defer client.Close()
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(context.Background(), net.GetSessionSponsor().Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), net.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
-	price, err := client.SuggestGasPrice(context.Background())
+	price, err := client.SuggestGasPrice(t.Context())
 	require.NoError(err, "failed to get gas price:")
 	// ---------
 

--- a/tests/log_subscription_test.go
+++ b/tests/log_subscription_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -25,7 +24,7 @@ func TestLogSubscription_CanGetCallBacksForLogEvents(t *testing.T) {
 
 	allLogs := make(chan types.Log, NumEvents)
 	subscription, err := client.SubscribeFilterLogs(
-		context.Background(),
+		t.Context(),
 		ethereum.FilterQuery{},
 		allLogs,
 	)

--- a/tests/node_restart_test.go
+++ b/tests/node_restart_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -38,12 +37,12 @@ func TestNodeRestart_CanRestartAndRestoreItsState(t *testing.T) {
 	require.NoError(err)
 	defer client.Close()
 
-	lastBlock, err := client.BlockByNumber(context.Background(), nil)
+	lastBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(err)
 	require.GreaterOrEqual(lastBlock.NumberU64(), uint64(numBlocks*numRestarts))
 
 	for i := range lastBlock.NumberU64() {
-		block, err := client.BlockByNumber(context.Background(), big.NewInt(int64(i)))
+		block, err := client.BlockByNumber(t.Context(), big.NewInt(int64(i)))
 		require.NoError(err)
 
 		for _, receipt := range receipts[int(i)] {

--- a/tests/prevrandao_test.go
+++ b/tests/prevrandao_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -36,7 +35,7 @@ func TestPrevRandao(t *testing.T) {
 		t.Fatalf("failed to get client; %v", err)
 	}
 	defer client.Close()
-	block, err := client.BlockByNumber(context.Background(), receipt.BlockNumber)
+	block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
 	if err != nil {
 		t.Fatalf("failed to get block header; %v", err)
 	}

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"strings"
 	"testing"
@@ -27,7 +26,7 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 	require.NoError(t, err, "failed to get client")
 	defer client.Close()
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err, "failed to get chain ID::")
 
 	testTransactions := map[string]func(testing.TB, *Account) types.TxData{

--- a/tests/revision_forward_test.go
+++ b/tests/revision_forward_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -46,10 +45,10 @@ func TestTransaction_DelegationDesignationAddressAccessIsConsideredInAllegro(t *
 
 			sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
 
-			gasPrice, err := client.SuggestGasPrice(context.Background())
+			gasPrice, err := client.SuggestGasPrice(t.Context())
 			require.NoError(t, err)
 
-			chainId, err := client.ChainID(context.Background())
+			chainId, err := client.ChainID(t.Context())
 			require.NoError(t, err)
 
 			recipient := common.HexToAddress("0x44")

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"testing"
 
@@ -276,7 +275,7 @@ func makeAccountWithBalance(t *testing.T, net IntegrationTestNetSession, balance
 
 func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *ethclient.Client) int64 {
 	t.Helper()
-	block, err := client.BlockByNumber(context.Background(), blockNumber)
+	block, err := client.BlockByNumber(t.Context(), blockNumber)
 	require.NoError(t, err)
 	basefee := block.BaseFee()
 	return basefee.Int64()
@@ -284,7 +283,7 @@ func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *ethclient.Client) 
 
 func getBalance(t *testing.T, client *ethclient.Client, account common.Address) int64 {
 	t.Helper()
-	balance, err := client.BalanceAt(context.Background(), account, nil)
+	balance, err := client.BalanceAt(t.Context(), account, nil)
 	require.NoError(t, err)
 	return balance.Int64()
 }
@@ -300,7 +299,7 @@ func makeLegacyTx(t *testing.T,
 ) *types.Transaction {
 	t.Helper()
 
-	nonce, err := client.NonceAt(context.Background(), sender.Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), sender.Address(), nil)
 	require.NoError(t, err, "failed to get nonce for account", sender.Address())
 
 	tx := types.NewTx(&types.LegacyTx{
@@ -312,7 +311,7 @@ func makeLegacyTx(t *testing.T,
 		Data:     data,
 	})
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err, "failed to get chain ID")
 
 	signer := types.NewEIP155Signer(chainId)
@@ -333,7 +332,7 @@ func makeEip1559Transaction(t *testing.T,
 ) *types.Transaction {
 	t.Helper()
 
-	nonce, err := client.NonceAt(context.Background(), sender.Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), sender.Address(), nil)
 	require.NoError(t, err, "failed to get nonce for account", sender.Address())
 
 	tx := types.NewTx(&types.DynamicFeeTx{
@@ -346,7 +345,7 @@ func makeEip1559Transaction(t *testing.T,
 		Data:      data,
 	})
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err, "failed to get chain ID")
 
 	signer := types.NewLondonSigner(chainId)

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"math/rand/v2"
 	"testing"
@@ -37,7 +36,7 @@ func TestTransactionOrder(t *testing.T) {
 
 	// Repeat the test for X number of blocks
 	for range numBlocks {
-		blockNrBefore, err := client.BlockNumber(context.Background())
+		blockNrBefore, err := client.BlockNumber(t.Context())
 		require.NoError(t, err)
 
 		options := make([]bind.TransactOpts, 0, numTxs)
@@ -82,7 +81,7 @@ func TestTransactionOrder(t *testing.T) {
 				t.Fatalf("transactions are not ordered, got idx: %d, want idx: %d", accCount, nonce)
 			}
 		}
-		blockNrAfter, err := client.BlockNumber(context.Background())
+		blockNrAfter, err := client.BlockNumber(t.Context())
 		require.NoError(t, err)
 		// At least one block between iterations must be generated
 		// Multiple blocks between iterations can be generated
@@ -101,14 +100,13 @@ func TestTransactionOrder(t *testing.T) {
 	// Check that transactions are ordered correctly in the blockchain and that
 	// for each transaction a correct receipt is available.
 	globalCounter := uint64(0)
-	context := context.Background()
-	lastBlock, err := client.BlockNumber(context)
+	lastBlock, err := client.BlockNumber(t.Context())
 	require.NoError(t, err)
 	for i := range lastBlock + 1 {
-		block, err := client.BlockByNumber(context, big.NewInt(int64(i)))
+		block, err := client.BlockByNumber(t.Context(), big.NewInt(int64(i)))
 		require.NoError(t, err)
 		for i, tx := range block.Transactions() {
-			receipt, err := client.TransactionReceipt(context, tx.Hash())
+			receipt, err := client.TransactionReceipt(t.Context(), tx.Hash())
 			require.NoError(t, err)
 
 			// Check that the receipt matches to the transaction.

--- a/tests/transaction_store_test.go
+++ b/tests/transaction_store_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"math/big"
 	"slices"
 	"testing"
@@ -29,7 +28,7 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 	require.NoError(t, err)
 	defer client.Close()
 
-	chainId, err := client.ChainID(context.Background())
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
 	sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
@@ -102,7 +101,7 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 		sender))
 
 	for _, tx := range txs {
-		err := client.SendTransaction(context.Background(), tx)
+		err := client.SendTransaction(t.Context(), tx)
 		require.NoError(t, err)
 	}
 
@@ -123,7 +122,7 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 	require.NoError(t, err)
 
 	for tx, blockNumber := range executedIn {
-		block, err := client.BlockByNumber(context.Background(), blockNumber)
+		block, err := client.BlockByNumber(t.Context(), blockNumber)
 		require.NoError(t, err, "failed to get block %v", blockNumber)
 
 		require.True(t,

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"bytes"
-	"context"
 	"math/big"
 	"testing"
 
@@ -31,12 +30,12 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	t.Run("verify default values of block's Withdrawals list and hash", func(t *testing.T) {
 		require := require.New(t)
 
-		latest, err := client.BlockNumber(context.Background())
+		latest, err := client.BlockNumber(t.Context())
 		require.NoError(err, "Failed to get the latest block number: ", err)
 
 		// we check from block 1 onward because block 0 does not consider Sonic Upgrade.
 		for i := int64(1); i <= int64(latest); i++ {
-			block, err := client.BlockByNumber(context.Background(), big.NewInt(i))
+			block, err := client.BlockByNumber(t.Context(), big.NewInt(i))
 			require.NoError(err, "Failed to get the block: ", err)
 
 			// check that the block has an empty list of withdrawals
@@ -49,7 +48,7 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 		require := require.New(t)
 
 		// get block
-		block, err := client.BlockByNumber(context.Background(), nil)
+		block, err := client.BlockByNumber(t.Context(), nil)
 		requireBase.NoError(err, "Failed to get the block: ", err)
 
 		// encode block


### PR DESCRIPTION
The `testings` package offers a `context()`, this should be used in all tests. 
This PR replaces the uses of `context.Background()` for the testing alternative. 

This PR depends on https://github.com/0xsoniclabs/sonic/pull/336