### PR TITLE
Fix support for metric flag

### DIFF
--- a/cmd/sonicd/metrics/flags.go
+++ b/cmd/sonicd/metrics/flags.go
@@ -2,13 +2,14 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/metrics/exp"
 	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"gopkg.in/urfave/cli.v1"
-	"strings"
-	"time"
 )
 
 var (
@@ -89,7 +90,8 @@ var (
 )
 
 func SetupMetrics(ctx *cli.Context) error {
-	if metrics.Enabled() {
+	if ctx.GlobalBool(MetricsEnabledFlag.Name) {
+		metrics.Enable()
 		log.Info("Enabling metrics collection")
 
 		var (


### PR DESCRIPTION
This PR re-enables support for enabling metrics.

In Geth 1.14 this feature was [implicitly](https://github.com/0xsoniclabs/go-ethereum/blob/2b3ee95747f96901ad7e0f58c1dae8bf8a0bc825/metrics/metrics.go#L36-L55) enabled using init code. With newer Geth versions (e.g. [1.15.11](https://github.com/0xsoniclabs/go-ethereum/blob/e563918a84b4104e44935ddc6850f11738dcc3f5/metrics/metrics.go#L31)), this feature needs to be enabled [explicitly](https://github.com/0xsoniclabs/go-ethereum/blob/e563918a84b4104e44935ddc6850f11738dcc3f5/metrics/metrics.go#L31).

The underlying feature is an Ethereum feature that is not thread-safe. However, it is a global feature flag only set during startup once and should not be part of our integration tests. If, however, this is introducing a data race, an additional patch on top of Sonic's go-ethereum fork will be required.