### PR TITLE
Consider block gas limit in effective gas limit computation

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -210,6 +210,7 @@ func consensusCallbackBeginBlockFn(
 						userTransactionGasLimit = inter.GetEffectiveGasLimit(
 							blockTime.Time().Sub(lastBlockHeader.Time.Time()),
 							es.Rules.Economy.ShortGasPower.AllocPerSec,
+							maxBlockGas,
 						)
 
 					} else {

--- a/gossip/emitter/proposals.go
+++ b/gossip/emitter/proposals.go
@@ -213,9 +213,11 @@ func makeProposal(
 		// no time has passed, so no new proposal can be made
 		return nil, nil
 	}
+	blockGasLimit := rules.Blocks.MaxBlockGas
 	effectiveGasLimit := inter.GetEffectiveGasLimit(
 		newBlockTime.Time().Sub(lastBlockTime.Time()),
 		rules.Economy.ShortGasPower.AllocPerSec,
+		blockGasLimit,
 	)
 
 	randaoReveal, randaoMix, err := randaoMixer.MixRandao(latestBlock.PrevRandao)
@@ -254,7 +256,7 @@ func makeProposal(
 		&scheduler.BlockInfo{
 			Number:      proposal.Number,
 			Time:        newBlockTime,
-			GasLimit:    rules.Blocks.MaxBlockGas,
+			GasLimit:    blockGasLimit,
 			MixHash:     randaoMix,
 			Coinbase:    evmcore.GetCoinbase(),
 			BaseFee:     *baseFee256,

--- a/gossip/emitter/proposals_test.go
+++ b/gossip/emitter/proposals_test.go
@@ -370,7 +370,11 @@ func TestMakeProposal_ValidArguments_CreatesValidProposal(t *testing.T) {
 		},
 		nil,
 		scheduler.Limits{
-			Gas:  inter.GetEffectiveGasLimit(delta, rules.Economy.ShortGasPower.AllocPerSec),
+			Gas: inter.GetEffectiveGasLimit(
+				delta,
+				rules.Economy.ShortGasPower.AllocPerSec,
+				rules.Blocks.MaxBlockGas,
+			),
 			Size: maxTotalTransactionsSizeInEventInBytes,
 		},
 	).Return(transactions)

--- a/inter/gas_rate_control.go
+++ b/inter/gas_rate_control.go
@@ -15,10 +15,11 @@ const maxAccumulationTime = 2 * time.Second
 // GetEffectiveGasLimit computes the effective gas limit for the next block.
 // This is the time since the last block times the targeted network throughput.
 // The result is capped to the gas that corresponds to a maximum accumulation
-// time of maxAccumulationTime.
+// time of maxAccumulationTime and the given block limit.
 func GetEffectiveGasLimit(
 	delta time.Duration,
 	targetedThroughput uint64,
+	blockLimit uint64,
 ) uint64 {
 	if delta <= 0 {
 		return 0
@@ -26,11 +27,11 @@ func GetEffectiveGasLimit(
 	if delta > maxAccumulationTime {
 		delta = maxAccumulationTime
 	}
-	return new(big.Int).Div(
+	return min(blockLimit, new(big.Int).Div(
 		new(big.Int).Mul(
 			big.NewInt(int64(targetedThroughput)),
 			big.NewInt(int64(delta.Nanoseconds())),
 		),
 		big.NewInt(int64(time.Second.Nanoseconds())),
-	).Uint64()
+	).Uint64())
 }


### PR DESCRIPTION
This PR extends the computation of the effective gas limit for a block in the single proposer protocol by including consideration of the set block gas limit.