### PR TITLE
Remove unused parameter from proposal check

### DIFF
--- a/eventcheck/proposalcheck/proposal_check.go
+++ b/eventcheck/proposalcheck/proposal_check.go
@@ -132,7 +132,7 @@ func (v *Checker) Validate(e inter.EventPayloadI) error {
 	}
 
 	// --- check the content of the proposal ---
-	return checkProposal(e, *proposal)
+	return checkProposal(*proposal)
 }
 
 // checkVersion3EventProperties checks key properties of the event payload for
@@ -157,12 +157,10 @@ func checkVersion3EventProperties(e inter.EventPayloadI) error {
 	return nil
 }
 
-// checkProposal checks the proposal in the event payload for validity.
-func checkProposal(
-	event inter.EventPayloadI,
-	proposal inter.Proposal,
-) error {
-	// --- check the present transactions ---
+// checkProposal checks the proposal for validity. A proposal is valid if there
+// are no nil transactions and the total size of the transactions does not
+// exceed a maximum limit of MaxSizeOfProposedTransactions.
+func checkProposal(proposal inter.Proposal) error {
 
 	// Check that there are no nil-transactions in the proposal.
 	for _, tx := range proposal.Transactions {

--- a/eventcheck/proposalcheck/proposal_check_test.go
+++ b/eventcheck/proposalcheck/proposal_check_test.go
@@ -380,10 +380,7 @@ func TestCheckProposal_AcceptsValidProposal(t *testing.T) {
 
 	for name, transactions := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			event := inter.NewMockEventPayloadI(ctrl)
-
-			require.NoError(t, checkProposal(event, inter.Proposal{
+			require.NoError(t, checkProposal(inter.Proposal{
 				Transactions: transactions,
 			}))
 		})
@@ -421,13 +418,9 @@ func TestCheckProposal_DetectsInvalidProposals(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			event := inter.NewMockEventPayloadI(ctrl)
-
 			proposal := &inter.Proposal{}
 			test.corrupt(proposal)
-
-			require.ErrorIs(t, checkProposal(event, *proposal), test.expected)
+			require.ErrorIs(t, checkProposal(*proposal), test.expected)
 		})
 	}
 }


### PR DESCRIPTION
Removes an unused parameter from the `checkProposal` function. The parameter became obsolete as part of #330, eliminating the need to check for a correct timestamp in the proposal.