### PR TITLE
Add license targets to `Makefile` and github CI

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Static lints
         run: make lint
 
+      - name: License Check
+        run: make license-check
+
       - name: Build
         run: make

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,11 @@ clean:
 lint: 
 	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 	@golangci-lint run ./...
+
+.PHONY: license-check
+license-check:
+	go run ./scripts/license/add_license_header.go --check -dir ./
+
+.PHONY: license-add
+license-add:
+	go run ./scripts/license/add_license_header.go -dir ./


### PR DESCRIPTION
This PR adds two targets to the Makefile, one that checks the files for the license header, and one that adds the license header.
This PR also adds a github workflows step that runs the check. 