### PR TITLE
Consider node as synced once event emission starts

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -1089,6 +1089,9 @@ func (h *handler) emittedBroadcastLoop() {
 	for {
 		select {
 		case emitted := <-h.emittedEventsCh:
+			// If this node starts emitting events, it is considered synced and
+			// can start accepting transactions.
+			h.syncStatus.MarkMaybeSynced()
 			h.BroadcastEvent(emitted, 0)
 		// Err() channel will be closed when unsubscribing.
 		case <-h.emittedEventsSub.Err():


### PR DESCRIPTION
This change switches a node in validator node to consider it self synced as soon as it starts emitting events.

In the node's P2P setup, incoming transactions are ignored while the node is syncing up to the network ([here](https://github.com/0xsoniclabs/sonic/blob/e96b2eb27ded9a8632970371af54ac94e8e80630/gossip/handler.go#L756), [here](https://github.com/0xsoniclabs/sonic/blob/e96b2eb27ded9a8632970371af54ac94e8e80630/gossip/handler.go#L776), and [here](https://github.com/0xsoniclabs/sonic/blob/e96b2eb27ded9a8632970371af54ac94e8e80630/gossip/handler.go#L1151)). This is to avoid accumulating and propagating out-dated transactions. Once a node is reasonably synced, the node's status is updated to enable the handling of transactions ([here](https://github.com/0xsoniclabs/sonic/blob/e96b2eb27ded9a8632970371af54ac94e8e80630/gossip/handler.go#L697-L699)). The condition for this right now is to receive an event from another node that is not older than 10 minutes.

The current mechanism, however, faces a problem if there is only a single validator: it will never receive an event from any other node in the network, since it is the only source of events and any peer tracks events received from it. So no events will ever be echoed back. Thus, in a test network with a single validator, this single validator will never transition into a state accepting transactions from peers.

This change adds a second state-trigger: once a validator starts emitting events, it is also considered synced in. This trigger should be more conservative, since a node syncing up would have to have passed 10 minute old events while syncing in before being able to emit events. However, it will also trigger in single-validator test environments.