### PR TITLE
Rename Opera mentions to Sonic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ glide.lock
 *.tgz
 *.zip
 
-# opera project specific
+# sonic project specific
 scripts/certs
 scripts/nodes
 scripts/peers.json

--- a/cmd/cmdtest/test_cmd.go
+++ b/cmd/cmdtest/test_cmd.go
@@ -54,7 +54,7 @@ type TestCmd struct {
 }
 
 // Run exec's the current binary using name as argv[0] which will trigger the
-// reexec init function for that name (e.g. "opera-test" in cmd/run_test.go)
+// reexec init function for that name (e.g. "sonic-test" in cmd/run_test.go)
 func (tt *TestCmd) Run(name string, args ...string) {
 	tt.stderr = &testlogger{t: tt.T}
 	tt.cmd = &exec.Cmd{

--- a/cmd/sonicd/app/fake_test.go
+++ b/cmd/sonicd/app/fake_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 func TestFakeNetFlag_NonValidator(t *testing.T) {
-	// Start an opera console, make sure it's cleaned up and terminate the console
+	// Start an sonic console, make sure it's cleaned up and terminate the console
 	dataDir := tmpdir(t)
 	initFakenetDatadir(dataDir, 3)
 	cli := exec(t,
@@ -63,7 +63,7 @@ func TestFakeNetFlag_NonValidator(t *testing.T) {
 }
 
 func TestFakeNetFlag_Validator(t *testing.T) {
-	// Start an opera console, make sure it's cleaned up and terminate the console
+	// Start a sonic console, make sure it's cleaned up and terminate the console
 	dataDir := tmpdir(t)
 	initFakenetDatadir(dataDir, 3)
 	cli := exec(t,

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -236,7 +236,7 @@ func initApp() *cli.App {
 	return app
 }
 
-// opera is the main entry point into the system if no special subcommand is ran.
+// sonicd is the main entry point into the system if no special subcommand is ran.
 // It creates a default node based on the command line arguments and runs it in
 // blocking mode, waiting for it to be shut down.
 func lachesisMain(ctx *cli.Context) error {
@@ -360,7 +360,7 @@ func startNode(ctx *cli.Context, stack *node.Node) error {
 	events := make(chan accounts.WalletEvent, 16)
 	stack.AccountManager().Subscribe(events)
 
-	// Create a client to interact with local opera node.
+	// Create a client to interact with local sonic node.
 	rpcClient := stack.Attach()
 	ethClient := ethclient.NewClient(rpcClient)
 	go func() {

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -80,8 +80,8 @@ func (tt *testcli) readConfig() {
 }
 
 func init() {
-	// Run the app if we've been exec'd as "opera-test" in exec().
-	reexec.Register("opera-test", func() {
+	// Run the app if we've been exec'd as "sonic-test" in exec().
+	reexec.Register("sonic-test", func() {
 		app := initApp()
 		initAppHelp()
 		if err := app.Run(os.Args); err != nil {
@@ -132,9 +132,9 @@ func exec(t *testing.T, args ...string) *testcli {
 		}()
 	}
 
-	// Boot "opera". This actually runs the test binary but the TestMain
+	// Boot "sonic". This actually runs the test binary but the TestMain
 	// function will prevent any tests from running.
-	tt.Run("opera-test", args...)
+	tt.Run("sonic-test", args...)
 
 	// Read the generated key
 	tt.readConfig()

--- a/cmd/sonicd/diskusage/monitor.go
+++ b/cmd/sonicd/diskusage/monitor.go
@@ -17,11 +17,12 @@
 package diskusage
 
 import (
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 func MonitorFreeDiskSpace(stopNodeSig chan os.Signal, path string, freeDiskSpaceCritical uint64) {
@@ -34,11 +35,11 @@ func MonitorFreeDiskSpace(stopNodeSig chan os.Signal, path string, freeDiskSpace
 			break
 		}
 		if freeSpace < freeDiskSpaceCritical {
-			log.Error("Low disk space. Gracefully shutting down Opera to prevent database corruption.", "available", common.StorageSize(freeSpace))
+			log.Error("Low disk space. Gracefully shutting down Sonic to prevent database corruption.", "available", common.StorageSize(freeSpace))
 			stopNodeSig <- syscall.SIGTERM
 			break
 		} else if freeSpace < 2*freeDiskSpaceCritical {
-			log.Warn("Disk space is running low. Opera will shutdown if disk space runs below critical level.", "available", common.StorageSize(freeSpace), "critical_level", common.StorageSize(freeDiskSpaceCritical))
+			log.Warn("Disk space is running low. Sonic will shutdown if disk space runs below critical level.", "available", common.StorageSize(freeSpace), "critical_level", common.StorageSize(freeDiskSpaceCritical))
 		}
 		<-ticker.C
 	}

--- a/cmd/sonictool/app/cli.go
+++ b/cmd/sonictool/app/cli.go
@@ -43,10 +43,10 @@ var (
 	}
 )
 
-// remoteConsole will connect to a remote opera instance, attaching a JavaScript
+// remoteConsole will connect to a remote sonic instance, attaching a JavaScript
 // console to it.
 func remoteConsole(ctx *cli.Context) (err error) {
-	// Attach to a remotely running opera instance and start the JavaScript console
+	// Attach to a remotely running sonic instance and start the JavaScript console
 	endpoint := ctx.Args().First()
 	if endpoint == "" {
 		if !ctx.GlobalIsSet(flags.DataDirFlag.Name) {

--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -379,7 +379,7 @@ Note that exporting your key in unencrypted format is NOT supported.
 
 Keys are stored under <DATADIR>/keystore/validator.
 It is safe to transfer the entire directory or the individual keys therein
-between Opera nodes by simply copying.
+between Sonic nodes by simply copying.
 
 Make sure you backup your keys regularly.
 `,

--- a/config/config.go
+++ b/config/config.go
@@ -322,7 +322,7 @@ func cacheScaler(ctx *cli.Context) cachescale.Func {
 	if !ctx.GlobalIsSet(flags.CacheFlag.Name) {
 		recommendedCache := totalMemory / 2
 		if recommendedCache > baseSize {
-			log.Warn(fmt.Sprintf("Please add '--%s %d' flag to allocate more cache for Opera. Total memory is %d MB.", flags.CacheFlag.Name, recommendedCache, totalMemory))
+			log.Warn(fmt.Sprintf("Please add '--%s %d' flag to allocate more cache for Sonic. Total memory is %d MB.", flags.CacheFlag.Name, recommendedCache, totalMemory))
 		}
 		return cachescale.Identity
 	}

--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -53,7 +53,7 @@ func NewEVMBlockContext(header *EvmHeader, chain DummyChain, author *common.Addr
 		baseFee = new(big.Int).Set(header.BaseFee)
 	}
 
-	// For legacy Opera network, the difficulty is always 1 and random nil
+	// For legacy Sonic network, the difficulty is always 1 and random nil
 	difficulty := big.NewInt(1)
 	if header.PrevRandao.Cmp(common.Hash{}) != 0 {
 		// Difficulty must be set to 0 when PREVRANDAO is enabled.

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1279,7 +1279,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	if reset != nil {
 		pool.demoteUnexecutables()
 		if baseFee := pool.chain.GetCurrentBaseFee(); baseFee != nil {
-			// Opera-specific base fee
+			// Sonic-specific base fee
 			pool.priced.SetBaseFee(baseFee)
 		} else {
 			// for tests only
@@ -1321,7 +1321,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 // reset retrieves the current state of the blockchain and ensures the content
 // of the transaction pool is valid with regard to the chain state.
 func (pool *TxPool) reset(oldHead, newHead *EvmHeader) {
-	// update chain config (Opera-specific)
+	// update chain config (Sonic-specific)
 	if newConfig := pool.chain.Config(); newConfig != nil {
 		pool.chainconfig = newConfig
 	}

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -219,7 +219,7 @@ func ValidateTxStatic(tx *types.Transaction) error {
 // or if the transaction's gas fee cap is below the minimum required base fee.
 func ValidateTxForBlock(tx *types.Transaction, blockState blockState) error {
 
-	// Ensure Opera-specific hard bounds
+	// Ensure Sonic-specific hard bounds
 	if baseFee := blockState.baseFee; baseFee != nil {
 		limit := gaspricelimits.GetMinimumFeeCapForTransactionPool(baseFee)
 		if tx.GasFeeCapIntCmp(limit) < 0 {

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -109,7 +109,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 	}
 
 	prevRandao := common.Hash{}
-	// This condition must be kept, otherwise Opera will not be able to synchronize
+	// This condition must be kept, otherwise Sonic will not be able to synchronize
 	if p.net.Upgrades.Sonic {
 		prevRandao = p.prevRandao
 	}

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -75,7 +75,7 @@ type RulesRLP struct {
 	Upgrades Upgrades `rlp:"-"`
 }
 
-// Rules describes opera net.
+// Rules describes sonic net.
 // Note keep track of all the non-copiable variables in Copy()
 type Rules RulesRLP
 


### PR DESCRIPTION
This PR the old client name "Opera" from comments and error messages, and replaces it by "Sonic".

Note: most mentions of Opera in the code are due to the package of the same name. Renaming that package is a task for the future. This PR aims only for comments and error messages.

Note to reviewers:  the command 
` grep -i " opera" -r . | grep -v html | grep -v ".git/" | grep -v -i operation | grep -v opera. | grep -v OperaE*`
can be used to look for mentions of opera that **do not** include `html` files, files in `.git` folder, and ignore mentiones of "operation", `opera.` to ignore mentions of the package `opera`  and structs named `OperaEvm` or `OperaEpoch`. 