### PR TITLE
Apply cache size flag when importing genesis

### DIFF
--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -131,12 +131,13 @@ func jsonGenesisImport(ctx *cli.Context) (err error) {
 	}
 	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")
 	return genesis.ImportGenesisStore(genesis.ImportParams{
-		GenesisStore:  genesisStore,
-		DataDir:       dataDir,
-		ValidatorMode: validatorMode,
-		CacheRatio:    cacheRatio,
-		LiveDbCache:   ctx.GlobalInt64(flags.LiveDbCacheFlag.Name),
-		ArchiveCache:  ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
+		GenesisStore:     genesisStore,
+		DataDir:          dataDir,
+		ValidatorMode:    validatorMode,
+		CacheRatio:       cacheRatio,
+		LiveDbCache:      ctx.GlobalInt64(flags.LiveDbCacheFlag.Name),
+		ArchiveCache:     ctx.GlobalInt64(flags.ArchiveCacheFlag.Name),
+		StateDbCacheSize: ctx.GlobalInt64(flags.StateDbCacheCapacityFlag.Name),
 	})
 }
 

--- a/cmd/sonictool/db/dbutils.go
+++ b/cmd/sonictool/db/dbutils.go
@@ -85,6 +85,7 @@ type GossipDbParameters struct {
 	ValidatorMode             bool
 	CacheRatio                cachescale.Func
 	LiveDbCache, ArchiveCache int64 // in bytes
+	StateDbCacheSize          int64 // number of elements
 }
 
 func MakeGossipDb(params GossipDbParameters) (*gossip.Store, error) {
@@ -102,6 +103,7 @@ func MakeGossipDb(params GossipDbParameters) (*gossip.Store, error) {
 		gdbConfig.EVM.StateDb.ArchiveCache = params.ArchiveCache
 	}
 	gdbConfig.EVM.StateDb.Directory = filepath.Join(params.DataDir, "carmen")
+	gdbConfig.EVM.Cache.StateDbCapacity = int(params.StateDbCacheSize)
 
 	gdb, err := gossip.NewStore(params.Dbs, gdbConfig)
 	if err != nil {

--- a/cmd/sonictool/genesis/import.go
+++ b/cmd/sonictool/genesis/import.go
@@ -38,6 +38,7 @@ type ImportParams struct {
 	ValidatorMode             bool
 	CacheRatio                cachescale.Func
 	LiveDbCache, ArchiveCache int64 // in bytes
+	StateDbCacheSize          int64 // number of elements
 }
 
 func ImportGenesisStore(params ImportParams) (err error) {
@@ -57,12 +58,13 @@ func ImportGenesisStore(params ImportParams) (err error) {
 	setGenesisProcessing(chaindataDir)
 
 	gdb, err := db.MakeGossipDb(db.GossipDbParameters{
-		Dbs:           dbs,
-		DataDir:       params.DataDir,
-		ValidatorMode: params.ValidatorMode,
-		CacheRatio:    params.CacheRatio,
-		LiveDbCache:   params.LiveDbCache,
-		ArchiveCache:  params.ArchiveCache,
+		Dbs:              dbs,
+		DataDir:          params.DataDir,
+		ValidatorMode:    params.ValidatorMode,
+		CacheRatio:       params.CacheRatio,
+		LiveDbCache:      params.LiveDbCache,
+		ArchiveCache:     params.ArchiveCache,
+		StateDbCacheSize: params.StateDbCacheSize,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create gossip db: %w", err)


### PR DESCRIPTION
The command line flag `--statedb.cache` was not properly forwarded in the case of importing a json genesis file.
This PR fixes that issue by adding the cache size to `genesis.ImportParams` and `db.GossipDbParameters`