### PR TITLE
archive cache size 

### DIFF
--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -141,11 +141,12 @@ func NewGenesisBuilder() *GenesisBuilder {
 		panic(fmt.Errorf("failed to create temporary dir for GenesisBuilder: %v", err))
 	}
 	carmenState, err := carmen.NewState(carmen.Parameters{
-		Variant:   "go-file",
-		Schema:    carmen.Schema(5),
-		Archive:   carmen.S5Archive,
-		Directory: carmenDir,
-		LiveCache: 1, // use minimum cache (not default)
+		Variant:      "go-file",
+		Schema:       carmen.Schema(5),
+		Archive:      carmen.S5Archive,
+		Directory:    carmenDir,
+		LiveCache:    1, // use minimum cache (not default)
+		ArchiveCache: 1, // use minimum cache (not default)
 	})
 	if err != nil {
 		panic(fmt.Errorf("failed to create carmen state; %s", err))


### PR DESCRIPTION
Thanks to the profiler tool introduced by #350 it was made obvious that the archive cache had a larger size than needed for the integration tests. In order to reduce the resources needed by the integration tests we limit the archive cache with the same value that the live cache is limited to. 