### PR TITLE
Update carmen and specify db cache capacity

### DIFF
--- a/cmd/sonictool/app/heal.go
+++ b/cmd/sonictool/app/heal.go
@@ -135,7 +135,7 @@ func healLiveFromArchive(ctx context.Context, carmenLiveDir, carmenArchiveDir st
 		}
 	}()
 
-	err = mptio.ImportLiveDb(mptio.NewLog(), carmenLiveDir, bufReader)
+	err = mptio.ImportLiveDb(mptio.NewLog(), carmenLiveDir, bufReader, 0)
 
 	wg.Wait()
 	return errors.Join(err, exportErr)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ module github.com/0xsoniclabs/sonic
 go 1.24.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20250530111616-fabde4233b62
+	github.com/0xsoniclabs/carmen/go v0.0.0-20250703063030-c1151bbfb404
 	github.com/0xsoniclabs/tosca v0.0.0-20250624065842-ec138d34756c
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20250530111616-fabde4233b62 h1:NF+A6zk8FYDuDk9aTVtzn7/e8kj+LERtyt+cfcHz+vM=
-github.com/0xsoniclabs/carmen/go v0.0.0-20250530111616-fabde4233b62/go.mod h1:s161Ju9dIK9gZ982wBx2WaCNN5Hv4OjC6YyoftKKF48=
+github.com/0xsoniclabs/carmen/go v0.0.0-20250703063030-c1151bbfb404 h1:KeJdOkXc63uby9l/ZguSEfxyqPNvGaX1t4VEn5PhOP4=
+github.com/0xsoniclabs/carmen/go v0.0.0-20250703063030-c1151bbfb404/go.mod h1:NZOGPGDkjKaY3VlnCSU6WTPNApNpbbuPXzIlSS+T8Iw=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250623123926-e563918a84b4 h1:CXx1PvzOP9kXGKSdPE+S+va2ovhFWnfb3nE7mStpNA4=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20250623123926-e563918a84b4/go.mod h1:1VtASSKSjBQIF9mFv5/B5sllR7KFR05tVsiouSGI2dQ=
 github.com/0xsoniclabs/tosca v0.0.0-20250624065842-ec138d34756c h1:O2u0V3HlVl1wKfsxZZ94yyORL0AocoVnaarthM/x5s0=

--- a/gossip/evmstore/statedb_import.go
+++ b/gossip/evmstore/statedb_import.go
@@ -52,7 +52,7 @@ func (s *Store) ImportLiveWorldState(liveReader io.Reader) error {
 	if err := os.MkdirAll(liveDir, 0700); err != nil {
 		return fmt.Errorf("failed to create carmen dir during FWS import; %v", err)
 	}
-	if err := mptio.ImportLiveDb(mptio.NewLog(), liveDir, liveReader); err != nil {
+	if err := mptio.ImportLiveDb(mptio.NewLog(), liveDir, liveReader, 2_000); err != nil {
 		return fmt.Errorf("failed to import LiveDB; %v", err)
 	}
 	return nil
@@ -69,7 +69,7 @@ func (s *Store) ImportArchiveWorldState(archiveReader io.Reader) error {
 		if err := os.MkdirAll(archiveDir, 0700); err != nil {
 			return fmt.Errorf("failed to create carmen archive dir during FWS import; %v", err)
 		}
-		if err := mptio.ImportArchive(mptio.NewLog(), archiveDir, archiveReader); err != nil {
+		if err := mptio.ImportArchive(mptio.NewLog(), archiveDir, archiveReader, 2_000); err != nil {
 			return fmt.Errorf("failed to initialize Archive; %v", err)
 		}
 		return nil


### PR DESCRIPTION
The profiling introduced by #350 showed that live and archive caches were unnecessarily big in integration tests.
Since [this](https://github.com/0xsoniclabs/carmen/pull/36) change of carmen users of carmen can specify the capacity when calling the mpt import methods.
So this PR updates carmen dependency to include this change and specifies the minimum recommended for import, while keeping the default value (`0`) for the heal import.

As a custom [test run ](https://scala.fantom.network/job/Carmen/job/Validate-State-Toolchain-Archive/373/) showed that this configuration is stable for big databases.  