### PR TITLE
Fix flaky setcodetx integration test

### DIFF
--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -378,6 +378,10 @@ func testDelegateCanBeSetAndUnset(t *testing.T, session IntegrationTestNetSessio
 	expectedCode := append([]byte{0xef, 0x01, 0x00}, delegateAddress[:]...)
 	require.Equal(t, expectedCode, codeSet, "code in account is expected to be delegation designation")
 
+	// wait until previous transaction has been
+	err = waitUntilTransactionIsRetiredFromPool(t, client, setCodeTx)
+	require.NoError(t, err, "transaction should be retired from the pool")
+
 	// unset by delegating to an empty address
 	unsetCodeTx := makeEip7702Transaction(t, client, account, account, common.Address{}, []byte{})
 	receipt, err = session.Run(unsetCodeTx)


### PR DESCRIPTION
Add a method to wait for transaction eviction from the pool. Use this method to solve the scenario where a new transaction conflicts with a recently executed one but not yet retired from the pool.