### PR TITLE
 Improve c_block_callbacks testing coverage: add test for spillBlockEvents  

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -175,7 +175,15 @@ func consensusCallbackBeginBlockFn(
 				// sort events by Lamport time
 				sort.Sort(confirmedEvents)
 				maxBlockGas := es.Rules.Blocks.MaxBlockGas
-				blockEvents := spillBlockEvents(store, confirmedEvents, maxBlockGas)
+				blockEvents := spillBlockEvents(confirmedEvents, maxBlockGas,
+					func(id hash.Event) inter.EventPayloadI {
+						e := store.GetEventPayload(id)
+						if e == nil {
+							return nil
+						}
+						return e
+					},
+				)
 
 				// Start assembling the resulting block.
 				number := uint64(bs.LastBlock.Idx + 1)
@@ -208,11 +216,7 @@ func consensusCallbackBeginBlockFn(
 				}
 				var blockTime inter.Timestamp
 				if es.Rules.Upgrades.SingleProposerBlockFormation {
-					events := make([]inter.EventPayloadI, 0, blockEvents.Len())
-					for _, e := range blockEvents {
-						events = append(events, e)
-					}
-					if proposed, proposer, time := extractProposalForNextBlock(lastBlockHeader, events, log.Root()); proposed != nil {
+					if proposed, proposer, time := extractProposalForNextBlock(lastBlockHeader, blockEvents, log.Root()); proposed != nil {
 						proposal = *proposed
 						blockTime = time
 						validatorKeys := readEpochPubKeys(store, cBlock.Atropos.Epoch())
@@ -239,7 +243,7 @@ func consensusCallbackBeginBlockFn(
 					}
 				} else {
 					// Collect transactions from events and schedule them.
-					unorderedTxs := make(types.Transactions, 0, blockEvents.Len()*10)
+					unorderedTxs := make(types.Transactions, 0, len(blockEvents)*10)
 					for _, e := range blockEvents {
 						unorderedTxs = append(unorderedTxs, e.Transactions()...)
 					}
@@ -571,20 +575,20 @@ func resolveRandaoMix(
 }
 
 // spillBlockEvents excludes first events which exceed MaxBlockGas
-func spillBlockEvents(store *Store, events hash.OrderedEvents, maxBlockGas uint64) inter.EventPayloads {
-	fullEvents := make(inter.EventPayloads, len(events))
+func spillBlockEvents(
+	events hash.OrderedEvents,
+	maxBlockGas uint64,
+	getEventPayload func(id hash.Event) inter.EventPayloadI,
+) []inter.EventPayloadI {
+	fullEvents := make([]inter.EventPayloadI, len(events))
 	if len(events) == 0 {
 		return fullEvents
 	}
 	gasPowerUsedSum := uint64(0)
 	// iterate in reversed order
-	for i := len(events) - 1; ; i-- {
+	for i := len(events) - 1; i >= 0; i-- {
 		id := events[i]
-		e := store.GetEventPayload(id)
-		if e == nil {
-			log.Crit("Block event not found", "event", id.String())
-			break
-		}
+		e := getEventPayload(id)
 		fullEvents[i] = e
 		gasPowerUsedSum += e.GasPowerUsed()
 		// stop if limit is exceeded, erase [:i] events
@@ -592,9 +596,6 @@ func spillBlockEvents(store *Store, events hash.OrderedEvents, maxBlockGas uint6
 			// spill
 			spilledEventsMeter.Mark(int64(len(fullEvents) - (i + 1)))
 			fullEvents = fullEvents[i+1:]
-			break
-		}
-		if i == 0 {
 			break
 		}
 	}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -177,11 +177,15 @@ func consensusCallbackBeginBlockFn(
 				maxBlockGas := es.Rules.Blocks.MaxBlockGas
 				blockEvents := spillBlockEvents(confirmedEvents, maxBlockGas,
 					func(id hash.Event) inter.EventPayloadI {
-						e := store.GetEventPayload(id)
-						if e == nil {
-							return nil
-						}
-						return e
+						// Note: currently, GetEventPayload returns a pointer to struct,
+						// conversion to interface may yield a broken interface if
+						// the value is nil.
+						// Adding a nil check to return a nil interface would
+						// solve that, but at this point in the code, every event
+						// must have a known payload, and getting a nil would be a
+						// critical error. We will let it panic if that happens,
+						// as there is no recovery from it.
+						return store.GetEventPayload(id)
 					},
 				)
 

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -700,31 +700,31 @@ func TestSpillBlockEvents(t *testing.T) {
 			expectedSignatures: []inter.Signature{{0x42}, {0x43}, {0x44}},
 		},
 		"multiple events with last gas usage exceeding limit are spilled": {
+			maxBlockGas: 20,
 			events: map[hash.Event]payloadSetup{
 				{0x42}: makeMockEventPayload(1, inter.Signature{0x42}),
 				{0x43}: makeMockEventPayload(1, inter.Signature{0x43}),
 				{0x44}: makeMockEventPayload(21, inter.Signature{0x44}), // last event checked first
 			},
-			maxBlockGas:        20,
 			expectedSignatures: []inter.Signature{},
 		},
 		"multiple events are included until gas limit is reached, rest is spilled": {
+			maxBlockGas: 20,
 			events: map[hash.Event]payloadSetup{
 				{0x42}: makeMockEventPayload(1, inter.Signature{0x42}),
 				{0x43}: makeMockEventPayload(10, inter.Signature{0x43}),
 				{0x44}: makeMockEventPayload(10, inter.Signature{0x44}),
 				{0x45}: makeMockEventPayload(10, inter.Signature{0x45}), // last event checked first
 			},
-			maxBlockGas:        20,
 			expectedSignatures: []inter.Signature{{0x44}, {0x45}},
 		},
 		"multiple events are included until gas limit is exceeded, rest is spilled even if they would fit independently": {
+			maxBlockGas: 20,
 			events: map[hash.Event]payloadSetup{
 				{0x42}: makeMockEventPayload(1, inter.Signature{0x42}),
 				{0x43}: makeMockEventPayload(11, inter.Signature{0x43}),
 				{0x44}: makeMockEventPayload(10, inter.Signature{0x44}),
 			},
-			maxBlockGas:        20,
 			expectedSignatures: []inter.Signature{{0x44}},
 		},
 	}


### PR DESCRIPTION
This PR adds testing for  `spillBlockEvents`

The function is responsible for scheduling events with a total gas consumption equal or smaller than the block gas limit. 
The test enforces the properties of the current implementation, changes to this algorithm may hurt history replayability. 

This PR includes the following changes: 
- Testing of function properties
- Refactor of function:
    - write a canonical for loop instead of tailing break if
    - remove `log.crit`. The reasoning behind is as follows:
    An event considered for execution reaches the endBlock callback, this element is identified by hash and its payload needs to be recovered from the state. If no payload exists, this is a system corruption and there is no recovery possible.  `log.Crit` invocation ends program execution with a single line error reported, Not doing so will continue program execution and when the nil payload pointer is derefed the program will panic with a complete stacktrace. The later was preferred to keep the algorithm leaner. 
    
    