### PR TITLE
Use external logger for tx pool

### DIFF
--- a/config/make_node.go
+++ b/config/make_node.go
@@ -132,7 +132,7 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 		if cfg.TxPool.Journal != "" {
 			cfg.TxPool.Journal = path.Join(cfg.Node.DataDir, cfg.TxPool.Journal)
 		}
-		pool := evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader)
+		pool := evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader, log.Root())
 		cleanup = append(cleanup, pool.Stop)
 		return pool
 	}


### PR DESCRIPTION
## Decoupling Logging for Enhanced Testing and Maintainability

This PR refactors `txPool` and `txLookup` to **decouple their logging mechanisms from global state**. Specifically, a dedicated `logger` parameter and field member are introduced for both components.

* **Improves Testability:** By passing a logger as a parameter, we gain granular control over logging behavior during testing. This allows for easier "probing" to verify what is being logged (or not logged) in specific test scenarios, enhancing the corroboration and reliability of our tests.
* **Reduced Global State Dependency:** This change moves away from relying on a single, universal logger. Reducing global state dependencies makes our codebase more predictable, easier to understand, and less prone to unexpected side effects.
* **Consistency with Adopted Patterns:** This change aligns `txPool` and `txLookup` with a broader architectural pattern we are adopting across various functions and packages for the reasons outlined above.

**Current Impact:**

* At this moment, this change has **no direct behavioral impact** on the runtime operation of the transaction pool or lookup. Its primary benefit is enabling future testing improvements and promoting a more maintainable architecture.
