### PR TITLE
Add two fuzzing tests for the deserialization of Events

### DIFF
--- a/inter/event_serializer_test.go
+++ b/inter/event_serializer_test.go
@@ -688,3 +688,29 @@ func FakeEvent(version uint8, txsNum, mpsNum, bvsNum int, ersNum bool) *EventPay
 
 	return random.Build()
 }
+
+func FuzzEventDeserialization(f *testing.F) {
+	examples := []EventPayload{
+		emptyEvent(0),
+		emptyEvent(1),
+		emptyEvent(2),
+		emptyEvent(3),
+		*FakeEvent(1, 12, 1, 1, true),
+		*FakeEvent(2, 12, 0, 0, false),
+		*FakeEvent(3, 12, 0, 0, false),
+	}
+
+	for _, example := range examples {
+		data, err := rlp.EncodeToBytes(&example)
+		if err != nil {
+			f.Fatal(err)
+		}
+		f.Add(data)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Parsing errors are expected and OK. What we want to test for is
+		// whether the decoder can handle the data without panicking.
+		var event EventPayload
+		_ = rlp.DecodeBytes(data, &event)
+	})
+}


### PR DESCRIPTION
This PR adds two fuzzer tests for the deserialization of Event-related messages that are received from external sources:
- `FuzzEventDeserialization` targeting the deserialization of a full `Event` 
- `FuzzPayloadDeserialization` targeting the `Payload` added for the single-proposer protocol

Both tests have been run for more than 100h without detecting any issues.

For `FuzzEventDeserialization`
```
fuzz: elapsed: 103h59m30s, execs: 6540656167 (0/sec), new interesting: 458 (total: 509)
PASS
```
and for `FuzzPayloadDeserialization`
```
fuzz: elapsed: 103h58m36s, execs: 6907694374 (30007/sec), new interesting: 16 (total: 464)
PASS
```