### PR TITLE
Detect `log.Error` calls during integration tests

### DIFF
--- a/cmd/sonicd/app/app.go
+++ b/cmd/sonicd/app/app.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/0xsoniclabs/sonic/config/flags"
 	"gopkg.in/urfave/cli.v1"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // Run starts sonicd with the regular command line arguments.
@@ -40,6 +42,9 @@ type AppControl struct {
 	// The process is stopped by sending a message through this channel, or by
 	// closing it.
 	Shutdown <-chan struct{}
+	// Logger is the logger to be used by the application. If nil, the default logger
+	// is used which keeps into consideration the verbosity environment variable.
+	Logger log.Logger
 }
 
 // RunWithArgs starts sonicd with the given command line arguments.
@@ -52,7 +57,7 @@ func RunWithArgs(
 	args []string,
 	control *AppControl,
 ) error {
-	app := initApp()
+	app := initApp(control)
 	initAppHelp()
 
 	// If present, take ownership and inject the control struct into the action.

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -191,7 +191,7 @@ var initFilterAndFlags = sync.OnceFunc(func() {
 })
 
 // init the CLI app.
-func initApp() *cli.App {
+func initApp(control *AppControl) *cli.App {
 	initFilterAndFlags()
 
 	app := cli.NewApp()
@@ -211,8 +211,13 @@ func initApp() *cli.App {
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Flags = append(app.Flags, metricsFlags...)
 
+	var logger log.Logger
+	if control != nil {
+		logger = control.Logger
+	}
+
 	app.Before = func(ctx *cli.Context) error {
-		if err := debug.Setup(ctx); err != nil {
+		if err := debug.Setup(ctx, logger); err != nil {
 			return err
 		}
 

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -82,7 +82,7 @@ func (tt *testcli) readConfig() {
 func init() {
 	// Run the app if we've been exec'd as "sonic-test" in exec().
 	reexec.Register("sonic-test", func() {
-		app := initApp()
+		app := initApp(nil)
 		initAppHelp()
 		if err := app.Run(os.Args); err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/cmd/sonictool/app/main.go
+++ b/cmd/sonictool/app/main.go
@@ -424,7 +424,7 @@ Converts an account private key to a validator private key and saves in the vali
 	}
 
 	app.Before = func(ctx *cli.Context) error {
-		return debug.Setup(ctx)
+		return debug.Setup(ctx, nil)
 	}
 	app.After = func(ctx *cli.Context) error {
 		debug.Exit()

--- a/tests/fake_logger.go
+++ b/tests/fake_logger.go
@@ -1,0 +1,115 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type fakeLogger struct {
+	l log.Logger
+	t *testing.T
+
+	expectedErrorsLock sync.Mutex          // lock to protect the expected errors slice
+	expectedErrors     map[string]struct{} // expected errors in the logs of the network
+}
+
+func (f *fakeLogger) With(ctx ...interface{}) log.Logger {
+	return f.l.With(ctx...)
+}
+
+func (f *fakeLogger) New(ctx ...interface{}) log.Logger {
+	return f.l.With(ctx...)
+}
+
+func (f *fakeLogger) Log(level slog.Level, msg string, ctx ...interface{}) {
+	if (level == log.LevelCrit || level == log.LevelError) && !f.isExpectedError(msg) {
+		f.t.Errorf("Log at level '%s': '%s' with context '%v'\n stack: %v", log.LevelString(level), msg, ctx, debug.Stack())
+	}
+	f.l.Log(level, msg, ctx...)
+}
+
+func (f *fakeLogger) Trace(msg string, ctx ...interface{}) {
+	f.l.Trace(msg, ctx...)
+}
+
+func (f *fakeLogger) Debug(msg string, ctx ...interface{}) {
+	f.l.Debug(msg, ctx...)
+}
+
+func (f *fakeLogger) Info(msg string, ctx ...interface{}) {
+	f.l.Info(msg, ctx...)
+}
+
+func (f *fakeLogger) Warn(msg string, ctx ...interface{}) {
+	f.l.Warn(msg, ctx...)
+}
+
+func (f *fakeLogger) Error(msg string, ctx ...interface{}) {
+	if !f.isExpectedError(msg) {
+		f.t.Errorf("Error '%s' - with context '%v'\n stack: %v", msg, ctx, debug.Stack())
+	}
+}
+
+func (f *fakeLogger) Crit(msg string, ctx ...interface{}) {
+	if !f.isExpectedError(msg) {
+		f.t.Errorf("Critical error '%s' - with context '%v'\n stack: %v", msg, ctx, debug.Stack())
+	}
+}
+
+func (f *fakeLogger) Write(level slog.Level, msg string, ctx ...interface{}) {
+	if (level == log.LevelCrit || level == log.LevelError) && !f.isExpectedError(msg) {
+		f.t.Errorf("Write at level '%v' %v with context '%v' \n stack: %v", log.LevelString(level), msg, ctx, debug.Stack())
+	}
+	f.l.Log(level, msg, ctx...)
+}
+
+func (f *fakeLogger) Enabled(ctx context.Context, level slog.Level) bool {
+	return f.l.Enabled(ctx, level)
+}
+
+func (f *fakeLogger) Handler() slog.Handler {
+	return f.l.Handler()
+}
+
+// addExpectedError adds an error message to the list of expected errors,
+// which will not trigger a test failure when logged.
+func (f *fakeLogger) addExpectedError(err string) {
+	f.expectedErrorsLock.Lock()
+	defer f.expectedErrorsLock.Unlock()
+	if f.expectedErrors == nil {
+		f.expectedErrors = make(map[string]struct{})
+	}
+	f.expectedErrors[err] = struct{}{}
+}
+
+// isExpectedError checks if the given error message is among the known expected messages.
+func (f *fakeLogger) isExpectedError(err string) bool {
+	f.expectedErrorsLock.Lock()
+	defer f.expectedErrorsLock.Unlock()
+	if f.expectedErrors == nil {
+		return false
+	}
+	_, ok := f.expectedErrors[err]
+	return ok
+}

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -191,7 +191,8 @@ type IntegrationTestNet struct {
 	sessionsMutex sync.Mutex
 	Session
 
-	// fake logger to report calls to log.Error or log.Critical
+	// fakeLogger is a custom logger that will hold a reference to the testing.T
+	// and fail the test if at any point there is a call to log.Error or log.Crit
 	fakeLogger *fakeLogger
 }
 
@@ -412,7 +413,6 @@ func startIntegrationTestNet(
 			l: log.Root(),
 			t: t,
 		}
-		log.SetDefault(net.fakeLogger)
 	}
 
 	err := net.start()
@@ -517,6 +517,10 @@ func (n *IntegrationTestNet) start() error {
 				NodeIdAnnouncement:   nodeIds[i],
 				HttpPortAnnouncement: httpPorts[i],
 				Shutdown:             stop,
+			}
+
+			if n.fakeLogger != nil {
+				control.Logger = n.fakeLogger
 			}
 
 			if err := sonicd.RunWithArgs(args, control); err != nil {


### PR DESCRIPTION
During work on improving integration test runtime, it was noticed that some tests logged errors. While these errors were not breaking errors, they should also not be ignored. Hence this PR introduces the integration test net `fakeLogger`, an implementation of the [go-ethereum logger](https://github.com/ethereum/go-ethereum/blob/master/log/logger.go#L106), which will fail any test during which a call to `log.Error`, `log.Critical` or `log.Write` with log level of `Error` or `Critical`, are registered. 

