### PR TITLE
Rename getSession to getIntegrationTestNetSession

### DIFF
--- a/tests/basefee_test.go
+++ b/tests/basefee_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestBaseFee_CanReadBaseFeeFromHeadAndBlockAndHistory(t *testing.T) {
-	session := getSession(t, opera.GetSonicUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the base fee contract.

--- a/tests/counter_test.go
+++ b/tests/counter_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
 
-	session := getSession(t, opera.GetSonicUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the counter contract.
@@ -51,7 +51,7 @@ func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
 
 func TestCounter_CanReadHistoricCounterValues(t *testing.T) {
 
-	session := getSession(t, opera.GetSonicUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 	// Deploy the counter contract.
 	contract, receipt, err := DeployContract(session, counter.DeployCounter)

--- a/tests/session_dispenser.go
+++ b/tests/session_dispenser.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	activeTestNetInstances = nil
 }
 
-// getSession creates a new session for network running on the
+// getIntegrationTestNetSession creates a new session for network running on the
 // given Upgrade. If there is no network running with this Upgrade, a new one
 // will be initialized.
 // If a tests can run in parallel, the call to t.Parallel() should be done
@@ -59,11 +59,14 @@ func TestMain(m *testing.M) {
 // A typical use case would look as follows:
 //
 //	t.Run("test_case", func(t *testing.T) {
-//		session := getSession(t, opera.GetSonicUpgrades())
+//		session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 //		t.Parallel()
 //		< use session instead of net of the rest of the test >
 //	})
-func getSession(t *testing.T, upgrades opera.Upgrades) IntegrationTestNetSession {
+//
+// This function uses a global state that is cleaned up after the execution of
+// the tests in `tests` package.
+func getIntegrationTestNetSession(t *testing.T, upgrades opera.Upgrades) IntegrationTestNetSession {
 	if activeTestNetInstances == nil {
 		activeTestNetInstances = make(map[common.Hash]*IntegrationTestNet)
 	}
@@ -73,7 +76,6 @@ func getSession(t *testing.T, upgrades opera.Upgrades) IntegrationTestNetSession
 		return net.SpawnSession(t)
 	}
 
-	t.Logf("Starting reusable test integration network for upgrade: %v", upgrades)
 	myNet := StartIntegrationTestNet(t, IntegrationTestNetOptions{
 		Upgrades: AsPointer(upgrades),
 		// Networks started by here will survive the test calling it, so they


### PR DESCRIPTION
The previous recommended way to start a test net used to be calling `StartIntegrationTestNet` which is not only a verbose clear name, but it also catches the attention of someone looking at a test, making its importance very clear. 
With the introduction of `getSession` in [#397](https://github.com/0xsoniclabs/sonic/pull/397) this very important initialization step seems hidden by a smaller function name.
To recover this visual effect this PR renames `getSession` to `getIntegrationTestNetSession`.
This PR also removes a debug log that remained from development. 