### PR TITLE
Reduce logging of failed transactions from Info to Debug

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -107,7 +107,7 @@ func (p *StateProcessor) Process(
 		statedb.SetTxContext(tx.Hash(), i)
 		receipt, _, err = applyTransaction(msg, gp, statedb, blockNumber, tx, usedGas, vmenv, onNewLog)
 		if err != nil {
-			log.Info("Failed to apply transaction", "tx", tx.Hash().Hex(), "err", err)
+			log.Debug("Failed to apply transaction", "tx", tx.Hash().Hex(), "err", err)
 			skipped = append(skipped, uint32(i))
 			receipts = append(receipts, nil)
 			continue // skip this transaction, but continue processing the rest of the block


### PR DESCRIPTION
This PR reduces the severeness level of a logging message reporting a skipped transaction from `Info` to `Debug`.

When syncing the client, information about failed transactions are frequently showing up like this:
```
INFO [07-24|12:42:27.179] New block                                index=37957086 id=a5aeed..cb29f4   gas_used=1,040,432   gas_rate=1479287.095          base_fee=50000000000 txs=1/0    age=13d12h3m        t=6.026ms     epoch=32988
INFO [07-24|12:42:27.279] New block                                index=37957087 id=de6ee8..e9d435   gas_used=1,106,773   gas_rate=1047779.849          base_fee=50000000000 txs=3/0    age=13d12h3m        t=5.530ms     epoch=32988
INFO [07-24|12:42:27.325] Failed to apply transaction              tx=0xe78231498e3653878010b9279847bd91e76dc48f4f9ea9bc1b573f1b473713ae err="nonce too low: address 0x0f0067cd819cB8F20BDa62046dAFF7a2b5c88280, tx: 99263 state: 99264"
INFO [07-24|12:42:27.325] Failed to apply transaction              tx=0xfbbf1861fd74842eec75e6e3fc013bc8422320ecddab81f91696d4edaf6cd073 err="nonce too low: address 0x51dCBaf6ce02705c2d0797d1809C69db56ab9cb1, tx: 40719 state: 40723"
INFO [07-24|12:42:27.325] Failed to apply transaction              tx=0x7ffb4f2bff169f4fa3508d7ff6e7668265f18181ce2ce035663f076f29e68d16 err="nonce too low: address 0x9C174F0E2d11559447E5fe2815D930475bE19016, tx: 10619 state: 10620"
INFO [07-24|12:42:27.325] Failed to apply transaction              tx=0x70125fdbb1f6fb71029740538973bd222bed53c7c2315f7a927f71b7198d0dad err="nonce too low: address 0x2BEE03E24d1e0e2C1c2E6abeE2Db534f8726E896, tx: 388 state: 389"  
INFO [07-24|12:42:27.326] New block                                index=37957088 id=dda8e3..34346e   gas_used=327,605     gas_rate=930869.085           base_fee=50000000000 txs=1/4    age=13d12h3m        t=5.692ms     epoch=32988
INFO [07-24|12:42:27.366] New block                                index=37957089 id=abec0a..9991db   gas_used=1,898,295   gas_rate=5392647.947          base_fee=50000000000 txs=4/0    age=13d12h3m        t=14.309ms    epoch=32988
INFO [07-24|12:42:27.399] New block  
```

Since the log output is used by operators to track the progress, reporting the inability of applying a transaction on this level seems to be misplaced. These outputs seem to pollute the logs.

Thus, this PR is proposing to reduce the severeness level to `Debug` to keep the user-facing log clean.