### PR TITLE
Ignore large transaction test when checking for race conditions

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -1086,4 +1087,17 @@ func validateAndSanitizeOptions(options ...IntegrationTestNetOptions) (Integrati
 	}
 
 	return options[0], nil
+}
+
+func isRaceTest() bool {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return false
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "-race" && setting.Value == "true" {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -1089,7 +1089,7 @@ func validateAndSanitizeOptions(options ...IntegrationTestNetOptions) (Integrati
 	return options[0], nil
 }
 
-func isRaceTest() bool {
+func isDataRaceDetectionEnabled() bool {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return false

--- a/tests/large_transactions_test.go
+++ b/tests/large_transactions_test.go
@@ -97,9 +97,9 @@ func TestLargeTransactions_CanHandleLargeTransactions(t *testing.T) {
 
 func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
 
-	if isRaceTest() {
+	if isDataRaceDetectionEnabled() {
 		t.Skip(`Due to the concurrency requirements of this test, 
-		it becomes unstable when running with the race condition detector.`)
+		it becomes unstable when running with enabled data race detection.`)
 	}
 
 	hardForks := map[string]opera.Upgrades{
@@ -115,7 +115,6 @@ func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
 	for name, upgrades := range hardForks {
 		for mode, singleProposer := range modes {
 			t.Run(fmt.Sprintf("%s/%s", name, mode), func(t *testing.T) {
-				t.Parallel()
 				effectiveUpgrades := upgrades
 				effectiveUpgrades.SingleProposerBlockFormation = singleProposer
 				testLargeTransactionLoadTest(t, &effectiveUpgrades)

--- a/tests/large_transactions_test.go
+++ b/tests/large_transactions_test.go
@@ -96,6 +96,12 @@ func TestLargeTransactions_CanHandleLargeTransactions(t *testing.T) {
 }
 
 func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
+
+	if isRaceTest() {
+		t.Skip(`Due to the concurrency requirements of this test, 
+		it becomes unstable when running with the race condition detector.`)
+	}
+
 	hardForks := map[string]opera.Upgrades{
 		"Sonic":   opera.GetSonicUpgrades(),
 		"Allegro": opera.GetAllegroUpgrades(),
@@ -109,6 +115,7 @@ func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
 	for name, upgrades := range hardForks {
 		for mode, singleProposer := range modes {
 			t.Run(fmt.Sprintf("%s/%s", name, mode), func(t *testing.T) {
+				t.Parallel()
 				effectiveUpgrades := upgrades
 				effectiveUpgrades.SingleProposerBlockFormation = singleProposer
 				testLargeTransactionLoadTest(t, &effectiveUpgrades)


### PR DESCRIPTION
This PR fixes https://github.com/0xsoniclabs/sonic-admin/issues/287, which describes a flaky test, due to the amount of parallelism in the test `testLargeTransactionLoadTest`, running it with `-race` took longer than anticipated and as a side effect the receipt for the transactions first submitted (last ones to be processed) got a long delay (between 1 and 6 minutes).

Now the tests is ignored when running with `-race`. 