### PR TITLE
Test net node reuse client

### DIFF
--- a/scc/light_client/fake_net_provider_test.go
+++ b/scc/light_client/fake_net_provider_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
@@ -137,7 +136,7 @@ func TestServer_CanRequestMaxNumberOfResults(t *testing.T) {
 // helper functions
 ////////////////////////////////////////
 
-func startNetAndGetClient(t *testing.T) (*tests.IntegrationTestNet, *ethclient.Client) {
+func startNetAndGetClient(t *testing.T) (*tests.IntegrationTestNet, *tests.SharedClient) {
 	t.Helper()
 	require := require.New(t)
 	// start network

--- a/scc/light_client/fake_net_provider_test.go
+++ b/scc/light_client/fake_net_provider_test.go
@@ -42,7 +42,7 @@ func TestServer_GetCommitteeCertificates_CanRetrieveCertificates(t *testing.T) {
 	net, client := startNetAndGetClient(t)
 
 	// make providers
-	providerFromClient, err := newServerFromClient(client.Client())
+	providerFromClient, err := newServerFromClient(client)
 	require.NoError(err)
 	t.Cleanup(providerFromClient.close)
 	url := fmt.Sprintf("http://localhost:%d", net.GetJsonRpcPort())
@@ -50,7 +50,7 @@ func TestServer_GetCommitteeCertificates_CanRetrieveCertificates(t *testing.T) {
 	require.NoError(err)
 	t.Cleanup(providerFromURL.close)
 
-	chainId := getChainIdFromClient(t, client.Client())
+	chainId := getChainIdFromClient(t, client)
 
 	for _, provider := range []*server{providerFromClient, providerFromURL} {
 
@@ -72,7 +72,7 @@ func TestServer_GetBlockCertificates_CanRetrieveCertificates(t *testing.T) {
 	net, client := startNetAndGetClient(t)
 
 	// make providers
-	providerFromClient, err := newServerFromClient(client.Client())
+	providerFromClient, err := newServerFromClient(client)
 	require.NoError(err)
 	t.Cleanup(providerFromClient.close)
 	url := fmt.Sprintf("http://localhost:%d", net.GetJsonRpcPort())
@@ -80,7 +80,7 @@ func TestServer_GetBlockCertificates_CanRetrieveCertificates(t *testing.T) {
 	require.NoError(err)
 	t.Cleanup(providerFromURL.close)
 
-	chainId := getChainIdFromClient(t, client.Client())
+	chainId := getChainIdFromClient(t, client)
 
 	for _, provider := range []*server{providerFromClient, providerFromURL} {
 
@@ -113,7 +113,7 @@ func TestServer_CanRequestMaxNumberOfResults(t *testing.T) {
 	net, client := startNetAndGetClient(t)
 
 	// make providers
-	providerFromClient, err := newServerFromClient(client.Client())
+	providerFromClient, err := newServerFromClient(client)
 	require.NoError(err)
 	t.Cleanup(providerFromClient.close)
 	url := fmt.Sprintf("http://localhost:%d", net.GetJsonRpcPort())
@@ -136,7 +136,7 @@ func TestServer_CanRequestMaxNumberOfResults(t *testing.T) {
 // helper functions
 ////////////////////////////////////////
 
-func startNetAndGetClient(t *testing.T) (*tests.IntegrationTestNet, *tests.SharedClient) {
+func startNetAndGetClient(t *testing.T) (*tests.IntegrationTestNet, *rpc.Client) {
 	t.Helper()
 	require := require.New(t)
 	// start network
@@ -144,7 +144,7 @@ func startNetAndGetClient(t *testing.T) (*tests.IntegrationTestNet, *tests.Share
 
 	client, err := net.GetClient()
 	require.NoError(err)
-	return net, client
+	return net, client.Client()
 }
 
 func getChainIdFromClient(t *testing.T, client *rpc.Client) *big.Int {

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
@@ -264,7 +263,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetSessionSponsor().PrivateKey)
 }
 
-func checkBlocksSanity(t *testing.T, client *ethclient.Client) {
+func checkBlocksSanity(t *testing.T, client *SharedClient) {
 	// This check is a regression from an issue found while fetching a block by
 	// number where the last block was not correctly serialized
 	require := require.New(t)
@@ -280,7 +279,7 @@ func checkBlocksSanity(t *testing.T, client *ethclient.Client) {
 
 type testContext struct {
 	net    *IntegrationTestNet
-	client *ethclient.Client
+	client *SharedClient
 }
 
 func MakeTestContext(t *testing.T) *testContext {

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -263,7 +263,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetSessionSponsor().PrivateKey)
 }
 
-func checkBlocksSanity(t *testing.T, client *SharedClient) {
+func checkBlocksSanity(t *testing.T, client *PooledEhtClient) {
 	// This check is a regression from an issue found while fetching a block by
 	// number where the last block was not correctly serialized
 	require := require.New(t)
@@ -279,7 +279,7 @@ func checkBlocksSanity(t *testing.T, client *SharedClient) {
 
 type testContext struct {
 	net    *IntegrationTestNet
-	client *SharedClient
+	client *PooledEhtClient
 }
 
 func MakeTestContext(t *testing.T) *testContext {

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -310,7 +310,7 @@ func testHeaders_BaseFeeEvolutionFollowsPricingRules(t *testing.T, headers []*ty
 	}
 }
 
-func testHeaders_TransactionRootMatchesBlockTxsHash(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_TransactionRootMatchesBlockTxsHash(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 
 	for i, header := range headers {
@@ -323,7 +323,7 @@ func testHeaders_TransactionRootMatchesBlockTxsHash(t *testing.T, headers []*typ
 }
 
 func testHeaders_TransactionReceiptReferencesCorrectContext(
-	t *testing.T, headers []*types.Header, client *SharedClient,
+	t *testing.T, headers []*types.Header, client *PooledEhtClient,
 ) {
 	require := require.New(t)
 
@@ -343,7 +343,7 @@ func testHeaders_TransactionReceiptReferencesCorrectContext(
 	}
 }
 
-func testHeaders_ReceiptBlockHashMatchesBlockHash(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_ReceiptBlockHashMatchesBlockHash(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 
 	for _, header := range headers {
@@ -357,7 +357,7 @@ func testHeaders_ReceiptBlockHashMatchesBlockHash(t *testing.T, headers []*types
 	}
 }
 
-func testHeaders_ReceiptRootMatchesBlockReceipts(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_ReceiptRootMatchesBlockReceipts(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 
 	for _, header := range headers {
@@ -370,7 +370,7 @@ func testHeaders_ReceiptRootMatchesBlockReceipts(t *testing.T, headers []*types.
 	}
 }
 
-func testHeaders_LogsBloomMatchesLogsInReceipts(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_LogsBloomMatchesLogsInReceipts(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 
 	for _, header := range headers {
@@ -447,7 +447,7 @@ func testHeaders_MixDigestDiffersForAllBlocks(t *testing.T, headers []*types.Hea
 	require.NotZero(len(seen), "no non-empty blocks in the chain")
 }
 
-func testHeaders_InitialBlocksHaveCorrectEpochNumbers(t *testing.T, client *SharedClient) {
+func testHeaders_InitialBlocksHaveCorrectEpochNumbers(t *testing.T, client *PooledEhtClient) {
 	require := require.New(t)
 	for block, want := range []int{1, 1, 2} {
 		got, err := getEpochOfBlock(client, block)
@@ -456,7 +456,7 @@ func testHeaders_InitialBlocksHaveCorrectEpochNumbers(t *testing.T, client *Shar
 	}
 }
 
-func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 
 	maxEpoch := 0
@@ -495,7 +495,7 @@ func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, header
 	}
 }
 
-func getEpochOfBlock(client *SharedClient, blockNumber int) (int, error) {
+func getEpochOfBlock(client *PooledEhtClient, blockNumber int) (int, error) {
 	var result struct {
 		Epoch hexutil.Uint64
 	}
@@ -511,7 +511,7 @@ func getEpochOfBlock(client *SharedClient, blockNumber int) (int, error) {
 	return int(result.Epoch), nil
 }
 
-func testHeaders_StateRootsMatchActualStateRoots(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_StateRootsMatchActualStateRoots(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 	for i, header := range headers {
 		// The direct way to get the state root of a block would be to request the
@@ -527,7 +527,7 @@ func testHeaders_StateRootsMatchActualStateRoots(t *testing.T, headers []*types.
 	}
 }
 
-func getStateRoot(client *SharedClient, blockNumber int) (common.Hash, error) {
+func getStateRoot(client *PooledEhtClient, blockNumber int) (common.Hash, error) {
 	var result struct {
 		AccountProof []string
 	}
@@ -554,7 +554,7 @@ func getStateRoot(client *SharedClient, blockNumber int) (common.Hash, error) {
 	return common.BytesToHash(crypto.Keccak256(data)), nil
 }
 
-func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 	for i := range headers {
 		block := big.NewInt(int64(i))
@@ -577,7 +577,7 @@ func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.
 	}
 }
 
-func testHeaders_LogsReferenceTheirContext(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_LogsReferenceTheirContext(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 
 	numLogs := 0
@@ -609,7 +609,7 @@ func testHeaders_LogsReferenceTheirContext(t *testing.T, headers []*types.Header
 	require.NotZero(numLogs, "no logs found in the chain")
 }
 
-func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, client *SharedClient) {
+func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, client *PooledEhtClient) {
 	require := require.New(t)
 
 	allLogs := []types.Log{}
@@ -691,7 +691,7 @@ func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, cli
 func testHeaders_CounterStateIsVerifiable(
 	t *testing.T,
 	headers []*types.Header,
-	client *SharedClient,
+	client *PooledEhtClient,
 	counterAddress common.Address,
 ) {
 	require := require.New(t)
@@ -741,7 +741,7 @@ func testHeaders_CounterStateIsVerifiable(
 
 func getVerifiedCounterState(
 	t *testing.T,
-	client *SharedClient,
+	client *PooledEhtClient,
 	stateRoot common.Hash,
 	counterAddress common.Address,
 	blockNumber int,
@@ -811,7 +811,7 @@ func getVerifiedCounterState(
 
 func testScc_HasCommitteeCertificates(
 	t *testing.T,
-	client *SharedClient,
+	client *PooledEhtClient,
 ) {
 	require := require.New(t)
 	results := []struct {
@@ -831,7 +831,7 @@ func testScc_HasCommitteeCertificates(
 func testScc_HasBlockCertificatesForBlocks(
 	t *testing.T,
 	headers []*types.Header,
-	client *SharedClient,
+	client *PooledEhtClient,
 ) {
 	require := require.New(t)
 

--- a/tests/block_header_test.go
+++ b/tests/block_header_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/stretchr/testify/require"
@@ -311,7 +310,7 @@ func testHeaders_BaseFeeEvolutionFollowsPricingRules(t *testing.T, headers []*ty
 	}
 }
 
-func testHeaders_TransactionRootMatchesBlockTxsHash(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_TransactionRootMatchesBlockTxsHash(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 
 	for i, header := range headers {
@@ -324,7 +323,7 @@ func testHeaders_TransactionRootMatchesBlockTxsHash(t *testing.T, headers []*typ
 }
 
 func testHeaders_TransactionReceiptReferencesCorrectContext(
-	t *testing.T, headers []*types.Header, client *ethclient.Client,
+	t *testing.T, headers []*types.Header, client *SharedClient,
 ) {
 	require := require.New(t)
 
@@ -344,7 +343,7 @@ func testHeaders_TransactionReceiptReferencesCorrectContext(
 	}
 }
 
-func testHeaders_ReceiptBlockHashMatchesBlockHash(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_ReceiptBlockHashMatchesBlockHash(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 
 	for _, header := range headers {
@@ -358,7 +357,7 @@ func testHeaders_ReceiptBlockHashMatchesBlockHash(t *testing.T, headers []*types
 	}
 }
 
-func testHeaders_ReceiptRootMatchesBlockReceipts(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_ReceiptRootMatchesBlockReceipts(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 
 	for _, header := range headers {
@@ -371,7 +370,7 @@ func testHeaders_ReceiptRootMatchesBlockReceipts(t *testing.T, headers []*types.
 	}
 }
 
-func testHeaders_LogsBloomMatchesLogsInReceipts(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_LogsBloomMatchesLogsInReceipts(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 
 	for _, header := range headers {
@@ -448,7 +447,7 @@ func testHeaders_MixDigestDiffersForAllBlocks(t *testing.T, headers []*types.Hea
 	require.NotZero(len(seen), "no non-empty blocks in the chain")
 }
 
-func testHeaders_InitialBlocksHaveCorrectEpochNumbers(t *testing.T, client *ethclient.Client) {
+func testHeaders_InitialBlocksHaveCorrectEpochNumbers(t *testing.T, client *SharedClient) {
 	require := require.New(t)
 	for block, want := range []int{1, 1, 2} {
 		got, err := getEpochOfBlock(client, block)
@@ -457,7 +456,7 @@ func testHeaders_InitialBlocksHaveCorrectEpochNumbers(t *testing.T, client *ethc
 	}
 }
 
-func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 
 	maxEpoch := 0
@@ -496,7 +495,7 @@ func testHeaders_LastBlockOfEpochContainsSealingTransaction(t *testing.T, header
 	}
 }
 
-func getEpochOfBlock(client *ethclient.Client, blockNumber int) (int, error) {
+func getEpochOfBlock(client *SharedClient, blockNumber int) (int, error) {
 	var result struct {
 		Epoch hexutil.Uint64
 	}
@@ -512,7 +511,7 @@ func getEpochOfBlock(client *ethclient.Client, blockNumber int) (int, error) {
 	return int(result.Epoch), nil
 }
 
-func testHeaders_StateRootsMatchActualStateRoots(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_StateRootsMatchActualStateRoots(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 	for i, header := range headers {
 		// The direct way to get the state root of a block would be to request the
@@ -528,7 +527,7 @@ func testHeaders_StateRootsMatchActualStateRoots(t *testing.T, headers []*types.
 	}
 }
 
-func getStateRoot(client *ethclient.Client, blockNumber int) (common.Hash, error) {
+func getStateRoot(client *SharedClient, blockNumber int) (common.Hash, error) {
 	var result struct {
 		AccountProof []string
 	}
@@ -555,7 +554,7 @@ func getStateRoot(client *ethclient.Client, blockNumber int) (common.Hash, error
 	return common.BytesToHash(crypto.Keccak256(data)), nil
 }
 
-func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 	for i := range headers {
 		block := big.NewInt(int64(i))
@@ -578,7 +577,7 @@ func testHeaders_SystemContractsHaveNonZeroNonce(t *testing.T, headers []*types.
 	}
 }
 
-func testHeaders_LogsReferenceTheirContext(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_LogsReferenceTheirContext(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 
 	numLogs := 0
@@ -610,7 +609,7 @@ func testHeaders_LogsReferenceTheirContext(t *testing.T, headers []*types.Header
 	require.NotZero(numLogs, "no logs found in the chain")
 }
 
-func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, client *ethclient.Client) {
+func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, client *SharedClient) {
 	require := require.New(t)
 
 	allLogs := []types.Log{}
@@ -692,7 +691,7 @@ func testHeaders_CanRetrieveLogEvents(t *testing.T, headers []*types.Header, cli
 func testHeaders_CounterStateIsVerifiable(
 	t *testing.T,
 	headers []*types.Header,
-	client *ethclient.Client,
+	client *SharedClient,
 	counterAddress common.Address,
 ) {
 	require := require.New(t)
@@ -742,7 +741,7 @@ func testHeaders_CounterStateIsVerifiable(
 
 func getVerifiedCounterState(
 	t *testing.T,
-	client *ethclient.Client,
+	client *SharedClient,
 	stateRoot common.Hash,
 	counterAddress common.Address,
 	blockNumber int,
@@ -812,7 +811,7 @@ func getVerifiedCounterState(
 
 func testScc_HasCommitteeCertificates(
 	t *testing.T,
-	client *ethclient.Client,
+	client *SharedClient,
 ) {
 	require := require.New(t)
 	results := []struct {
@@ -832,7 +831,7 @@ func testScc_HasCommitteeCertificates(
 func testScc_HasBlockCertificatesForBlocks(
 	t *testing.T,
 	headers []*types.Header,
-	client *ethclient.Client,
+	client *SharedClient,
 ) {
 	require := require.New(t)
 

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -49,7 +48,7 @@ func TestGasPrice(t *testing.T) {
 func testGasPrice_SuggestedGasPricesApproximateActualBaseFees(
 	t *testing.T,
 	net IntegrationTestNetSession,
-	client *ethclient.Client,
+	client *SharedClient,
 ) {
 	require := require.New(t)
 
@@ -83,7 +82,7 @@ func testGasPrice_SuggestedGasPricesApproximateActualBaseFees(
 func testGasPrice_UnderpricedTransactionsAreRejected(
 	t *testing.T,
 	net IntegrationTestNetSession,
-	client *ethclient.Client,
+	client *SharedClient,
 ) {
 	require := require.New(t)
 
@@ -147,7 +146,7 @@ func testGasPrice_UnderpricedTransactionsAreRejected(
 	require.NoError(send(setCodeFactory.makeSetCodeTransactionWithPrice(t, chainId, 0, feeCap, 0)))
 }
 
-func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *ethclient.Client) {
+func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *SharedClient) {
 	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
 		Upgrades: AsPointer(opera.GetAllegroUpgrades()),
 	})

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -48,7 +48,7 @@ func TestGasPrice(t *testing.T) {
 func testGasPrice_SuggestedGasPricesApproximateActualBaseFees(
 	t *testing.T,
 	net IntegrationTestNetSession,
-	client *SharedClient,
+	client *PooledEhtClient,
 ) {
 	require := require.New(t)
 
@@ -82,7 +82,7 @@ func testGasPrice_SuggestedGasPricesApproximateActualBaseFees(
 func testGasPrice_UnderpricedTransactionsAreRejected(
 	t *testing.T,
 	net IntegrationTestNetSession,
-	client *SharedClient,
+	client *PooledEhtClient,
 ) {
 	require := require.New(t)
 
@@ -146,7 +146,7 @@ func testGasPrice_UnderpricedTransactionsAreRejected(
 	require.NoError(send(setCodeFactory.makeSetCodeTransactionWithPrice(t, chainId, 0, feeCap, 0)))
 }
 
-func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *SharedClient) {
+func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *PooledEhtClient) {
 	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
 		Upgrades: AsPointer(opera.GetAllegroUpgrades()),
 	})

--- a/tests/integration_test_tools_test.go
+++ b/tests/integration_test_tools_test.go
@@ -169,7 +169,7 @@ func computeMinimumGas(t *testing.T, session IntegrationTestNetSession, tx types
 // Because the transaction pool eviction is asynchronous, executed transactions may remain in the pool
 // for some time after they have been executed.
 // function will eventually time out if the transaction is not retired and an error will be returned.
-func waitUntilTransactionIsRetiredFromPool(t *testing.T, client *SharedClient, tx *types.Transaction) error {
+func waitUntilTransactionIsRetiredFromPool(t *testing.T, client *PooledEhtClient, tx *types.Transaction) error {
 	t.Helper()
 
 	txHash := tx.Hash()

--- a/tests/integration_test_tools_test.go
+++ b/tests/integration_test_tools_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -170,7 +169,7 @@ func computeMinimumGas(t *testing.T, session IntegrationTestNetSession, tx types
 // Because the transaction pool eviction is asynchronous, executed transactions may remain in the pool
 // for some time after they have been executed.
 // function will eventually time out if the transaction is not retired and an error will be returned.
-func waitUntilTransactionIsRetiredFromPool(t *testing.T, client *ethclient.Client, tx *types.Transaction) error {
+func waitUntilTransactionIsRetiredFromPool(t *testing.T, client *SharedClient, tx *types.Transaction) error {
 	t.Helper()
 
 	txHash := tx.Hash()

--- a/tests/network_rules_update_test.go
+++ b/tests/network_rules_update_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -275,7 +274,7 @@ func TestNetworkRules_PragueFeaturesBecomeAvailableWithAllegroUpgrade(t *testing
 	account := makeAccountWithBalance(t, net, big.NewInt(1e18))
 
 	t.Run("expectations before sonic-allegro hardfork", func(t *testing.T) {
-		forEachClientInNet(t, net, func(t *testing.T, client *ethclient.Client) {
+		forEachClientInNet(t, net, func(t *testing.T, client *SharedClient) {
 			tx := makeSetCodeTx(t, net, account)
 			err := client.SendTransaction(t.Context(), tx)
 			require.ErrorContains(t,
@@ -313,7 +312,7 @@ func TestNetworkRules_PragueFeaturesBecomeAvailableWithAllegroUpgrade(t *testing
 		delegationIndicator :=
 			hexutil.MustDecode("0xEF01002A00000000000000000000000000000000000000")
 
-		forEachClientInNet(t, net, func(t *testing.T, client *ethclient.Client) {
+		forEachClientInNet(t, net, func(t *testing.T, client *SharedClient) {
 
 			// make sure that this client has already processed the transaction
 			_, err := net.GetReceipt(tx.Hash())
@@ -329,7 +328,7 @@ func TestNetworkRules_PragueFeaturesBecomeAvailableWithAllegroUpgrade(t *testing
 func forEachClientInNet(
 	t *testing.T,
 	net *IntegrationTestNet,
-	fn func(t *testing.T, client *ethclient.Client),
+	fn func(t *testing.T, client *SharedClient),
 ) {
 	for i := 0; i < net.NumNodes(); i++ {
 		t.Run(fmt.Sprintf("client%d", i), func(t *testing.T) {

--- a/tests/network_rules_update_test.go
+++ b/tests/network_rules_update_test.go
@@ -274,7 +274,7 @@ func TestNetworkRules_PragueFeaturesBecomeAvailableWithAllegroUpgrade(t *testing
 	account := makeAccountWithBalance(t, net, big.NewInt(1e18))
 
 	t.Run("expectations before sonic-allegro hardfork", func(t *testing.T) {
-		forEachClientInNet(t, net, func(t *testing.T, client *SharedClient) {
+		forEachClientInNet(t, net, func(t *testing.T, client *PooledEhtClient) {
 			tx := makeSetCodeTx(t, net, account)
 			err := client.SendTransaction(t.Context(), tx)
 			require.ErrorContains(t,
@@ -312,7 +312,7 @@ func TestNetworkRules_PragueFeaturesBecomeAvailableWithAllegroUpgrade(t *testing
 		delegationIndicator :=
 			hexutil.MustDecode("0xEF01002A00000000000000000000000000000000000000")
 
-		forEachClientInNet(t, net, func(t *testing.T, client *SharedClient) {
+		forEachClientInNet(t, net, func(t *testing.T, client *PooledEhtClient) {
 
 			// make sure that this client has already processed the transaction
 			_, err := net.GetReceipt(tx.Hash())
@@ -328,7 +328,7 @@ func TestNetworkRules_PragueFeaturesBecomeAvailableWithAllegroUpgrade(t *testing
 func forEachClientInNet(
 	t *testing.T,
 	net *IntegrationTestNet,
-	fn func(t *testing.T, client *SharedClient),
+	fn func(t *testing.T, client *PooledEhtClient),
 ) {
 	for i := 0; i < net.NumNodes(); i++ {
 		t.Run(fmt.Sprintf("client%d", i), func(t *testing.T) {

--- a/tests/selfdestruct_test.go
+++ b/tests/selfdestruct_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
 
@@ -367,7 +366,7 @@ func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
 // avoid clashes between tests. This struct will be filled with the results of
 // the each test setup.
 type effectContext struct {
-	client             *ethclient.Client                 //< client to interact with the network
+	client             *SharedClient                     //< client to interact with the network
 	contract           *selfdestruct.SelfDestruct        //< contract to test (may have selfdestructed)
 	factory            *selfdestruct.SelfDestructFactory //< factory contract to deploy new contracts
 	executionReceipt   *types.Receipt                    //< receipt of the execution transaction for constructor tests

--- a/tests/selfdestruct_test.go
+++ b/tests/selfdestruct_test.go
@@ -366,7 +366,7 @@ func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
 // avoid clashes between tests. This struct will be filled with the results of
 // the each test setup.
 type effectContext struct {
-	client             *SharedClient                     //< client to interact with the network
+	client             *PooledEhtClient                  //< client to interact with the network
 	contract           *selfdestruct.SelfDestruct        //< contract to test (may have selfdestructed)
 	factory            *selfdestruct.SelfDestructFactory //< factory contract to deploy new contracts
 	executionReceipt   *types.Receipt                    //< receipt of the execution transaction for constructor tests

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -938,7 +938,7 @@ func testChainOfCalls(t *testing.T, session IntegrationTestNetSession) {
 // - delegate account is the contract address installed in the delegator code
 // - callData is used to pass the encoded use of the delegate's called method ABI
 func makeEip7702Transaction(t *testing.T,
-	client *SharedClient,
+	client *PooledEhtClient,
 	sponsor *Account,
 	sponsored *Account,
 	delegate common.Address,

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -939,7 +938,7 @@ func testChainOfCalls(t *testing.T, session IntegrationTestNetSession) {
 // - delegate account is the contract address installed in the delegator code
 // - callData is used to pass the encoded use of the delegate's called method ABI
 func makeEip7702Transaction(t *testing.T,
-	client *ethclient.Client,
+	client *SharedClient,
 	sponsor *Account,
 	sponsored *Account,
 	delegate common.Address,

--- a/tests/single_proposer_protocol_test.go
+++ b/tests/single_proposer_protocol_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
@@ -247,7 +246,7 @@ func testSingleProposerProtocol_CanBeEnabledAndDisabled(
 // getUsedEventVersion retrieves the current event version used by the network.
 func getUsedEventVersion(
 	t *testing.T,
-	client *ethclient.Client,
+	client *SharedClient,
 ) int {
 	t.Helper()
 	require := require.New(t)

--- a/tests/single_proposer_protocol_test.go
+++ b/tests/single_proposer_protocol_test.go
@@ -246,7 +246,7 @@ func testSingleProposerProtocol_CanBeEnabledAndDisabled(
 // getUsedEventVersion retrieves the current event version used by the network.
 func getUsedEventVersion(
 	t *testing.T,
-	client *SharedClient,
+	client *PooledEhtClient,
 ) int {
 	t.Helper()
 	require := require.New(t)

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
 
@@ -289,7 +288,7 @@ func makeAccountWithBalance(t *testing.T, net IntegrationTestNetSession, balance
 	return account
 }
 
-func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *ethclient.Client) int64 {
+func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *SharedClient) int64 {
 	t.Helper()
 	block, err := client.BlockByNumber(t.Context(), blockNumber)
 	require.NoError(t, err)
@@ -297,7 +296,7 @@ func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *ethclient.Client) 
 	return basefee.Int64()
 }
 
-func getBalance(t *testing.T, client *ethclient.Client, account common.Address) int64 {
+func getBalance(t *testing.T, client *SharedClient, account common.Address) int64 {
 	t.Helper()
 	balance, err := client.BalanceAt(t.Context(), account, nil)
 	require.NoError(t, err)
@@ -307,7 +306,7 @@ func getBalance(t *testing.T, client *ethclient.Client, account common.Address) 
 // makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
 // and gas limit.
 func makeLegacyTx(t *testing.T,
-	client *ethclient.Client,
+	client *SharedClient,
 	gasPrice int64,
 	sender *Account,
 	to *common.Address,
@@ -339,7 +338,7 @@ func makeLegacyTx(t *testing.T,
 // makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
 // and gas limit.
 func makeEip1559Transaction(t *testing.T,
-	client *ethclient.Client,
+	client *SharedClient,
 	maxFeeCap int64,
 	maxGasTip int64,
 	sender *Account,

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -288,7 +288,7 @@ func makeAccountWithBalance(t *testing.T, net IntegrationTestNetSession, balance
 	return account
 }
 
-func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *SharedClient) int64 {
+func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *PooledEhtClient) int64 {
 	t.Helper()
 	block, err := client.BlockByNumber(t.Context(), blockNumber)
 	require.NoError(t, err)
@@ -296,7 +296,7 @@ func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *SharedClient) int6
 	return basefee.Int64()
 }
 
-func getBalance(t *testing.T, client *SharedClient, account common.Address) int64 {
+func getBalance(t *testing.T, client *PooledEhtClient, account common.Address) int64 {
 	t.Helper()
 	balance, err := client.BalanceAt(t.Context(), account, nil)
 	require.NoError(t, err)
@@ -306,7 +306,7 @@ func getBalance(t *testing.T, client *SharedClient, account common.Address) int6
 // makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
 // and gas limit.
 func makeLegacyTx(t *testing.T,
-	client *SharedClient,
+	client *PooledEhtClient,
 	gasPrice int64,
 	sender *Account,
 	to *common.Address,
@@ -338,7 +338,7 @@ func makeLegacyTx(t *testing.T,
 // makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
 // and gas limit.
 func makeEip1559Transaction(t *testing.T,
-	client *SharedClient,
+	client *PooledEhtClient,
 	maxFeeCap int64,
 	maxGasTip int64,
 	sender *Account,

--- a/tests/transaction_receipt_idx_test.go
+++ b/tests/transaction_receipt_idx_test.go
@@ -123,7 +123,7 @@ func TestReceipt_InternalTransactionsDoNotChangeReceiptIndex(t *testing.T) {
 }
 
 func getSenderOfTransaction(
-	client *SharedClient,
+	client *PooledEhtClient,
 	txHash common.Hash,
 ) (common.Address, error) {
 	details := struct {

--- a/tests/transaction_receipt_idx_test.go
+++ b/tests/transaction_receipt_idx_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,7 +123,7 @@ func TestReceipt_InternalTransactionsDoNotChangeReceiptIndex(t *testing.T) {
 }
 
 func getSenderOfTransaction(
-	client *ethclient.Client,
+	client *SharedClient,
 	txHash common.Hash,
 ) (common.Address, error) {
 	details := struct {


### PR DESCRIPTION
In order to reduce the amount of `ethclient.Client` that need to be initialized and released per test net, this PR introduces the `SharedClient` type, which is a wrapper on `ethclient.Client`, which instead releasing the client on `Close()` will return to a pool of which is a part of each network node.