### PR TITLE
Remove strict project coverage target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,9 +24,6 @@ coverage:
       default:
         target: 80% # coverage of the changes
         threshold: 1% # allow the coverage to drop by <threshold>%
-    project:
-      default:
-        target: 80% # coverage of the project
 ignore:
   - "tests/"
   - "**/*_mock.go"


### PR DESCRIPTION
This PR removes strict project coverage target. Project coverage meansures coverage level of the entire repository. Previously, project coverage has not been activated. With the recent codecov plan change, project coverage takes effects. This condition may unnecessary prevent PR from merging.