### PR TITLE
Use shared sessions

### DIFF
--- a/tests/address_access_test.go
+++ b/tests/address_access_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	accessCost "github.com/0xsoniclabs/sonic/tests/contracts/access_cost"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,7 +31,7 @@ import (
 func TestAddressAccess(t *testing.T) {
 	someAccountAddress := common.Address{1}
 
-	net := StartIntegrationTestNet(t)
+	net := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	contract, receipt, err := DeployContract(net, accessCost.DeployAccessCost)
 	require.NoError(t, err)

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/blobbasefee"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -36,35 +37,34 @@ import (
 
 func TestBlobTransaction(t *testing.T) {
 
-	ctxt := MakeTestContext(t)
-	defer ctxt.Close()
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	t.Run("blob tx with non-empty blobs is rejected", func(t *testing.T) {
-		testBlobTx_WithBlobsIsRejected(t, ctxt)
+		testBlobTx_WithBlobsIsRejected(t, session)
 	})
 
 	t.Run("blob tx with empty blobs is executed", func(t *testing.T) {
-		testBlobTx_WithEmptyBlobsIsExecuted(t, ctxt)
-		checkBlocksSanity(t, ctxt.client)
+		testBlobTx_WithEmptyBlobsIsExecuted(t, session)
+		checkBlocksSanity(t, session)
 	})
 
 	t.Run("blob tx with nil sidecar is executed", func(t *testing.T) {
-		testBlobTx_WithNilSidecarIsExecuted(t, ctxt)
-		checkBlocksSanity(t, ctxt.client)
+		testBlobTx_WithNilSidecarIsExecuted(t, session)
+		checkBlocksSanity(t, session)
 	})
 
 	t.Run("blob base fee can be read from head, block and history", func(t *testing.T) {
-		testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t, ctxt)
-		checkBlocksSanity(t, ctxt.client)
+		testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t, session)
+		checkBlocksSanity(t, session)
 	})
 
 	t.Run("blob gas used can be read from block header", func(t *testing.T) {
-		testBlobBaseFee_CanReadBlobGasUsed(t, ctxt)
-		checkBlocksSanity(t, ctxt.client)
+		testBlobBaseFee_CanReadBlobGasUsed(t, session)
+		checkBlocksSanity(t, session)
 	})
 }
 
-func testBlobTx_WithBlobsIsRejected(t *testing.T, ctxt *testContext) {
+func testBlobTx_WithBlobsIsRejected(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 	nonZeroNumberOfBlobs := 2
 
@@ -75,26 +75,26 @@ func testBlobTx_WithBlobsIsRejected(t *testing.T, ctxt *testContext) {
 		copy(blobs[i], blob[:])
 	}
 
-	tx, err := createTestBlobTransaction(t, ctxt, blobs...)
+	tx, err := createTestBlobTransaction(t, session, blobs...)
 	require.NoError(err)
 
 	// attempt to run tx
-	_, err = ctxt.net.Run(tx)
+	_, err = session.Run(tx)
 	require.ErrorContains(err, "non-empty blob transaction are not supported")
 
 	// repeat same tx (regression against reported repeated tx issue)
-	_, err = ctxt.net.Run(tx)
+	_, err = session.Run(tx)
 	require.ErrorContains(err, "non-empty blob transaction are not supported")
 }
 
-func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, ctxt *testContext) {
+func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 
-	tx, err := createTestBlobTransaction(t, ctxt)
+	tx, err := createTestBlobTransaction(t, session)
 	require.NoError(err)
 
 	// run tx
-	receipt, err := ctxt.net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(err, "transaction must be accepted")
 	require.Equal(
 		types.ReceiptStatusSuccessful,
@@ -103,14 +103,14 @@ func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, ctxt *testContext) {
 	)
 }
 
-func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, ctxt *testContext) {
+func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 
-	tx, err := createTestBlobTransactionWithNilSidecar(t, ctxt)
+	tx, err := createTestBlobTransactionWithNilSidecar(t, session)
 	require.NoError(err)
 
 	// run tx
-	receipt, err := ctxt.net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(err, "transaction must be accepted")
 	require.Equal(
 		types.ReceiptStatusSuccessful,
@@ -119,15 +119,19 @@ func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, ctxt *testContext) {
 	)
 }
 
-func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, ctxt *testContext) {
+func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
+
+	client, err := session.GetClient()
+	require.NoError(err, "failed to get client; ", err)
+	defer client.Close()
 
 	// Deploy the blob base fee contract.
-	contract, _, err := DeployContract(ctxt.net, blobbasefee.DeployBlobbasefee)
+	contract, _, err := DeployContract(session, blobbasefee.DeployBlobbasefee)
 	require.NoError(err, "failed to deploy contract; ", err)
 
 	// Collect the current blob base fee from the head state.
-	receipt, err := ctxt.net.Apply(contract.LogCurrentBlobBaseFee)
+	receipt, err := session.Apply(contract.LogCurrentBlobBaseFee)
 	require.NoError(err, "failed to log current blob base fee; ", err)
 	require.Equal(len(receipt.Logs), 1, "unexpected number of logs; expected 1, got ", len(receipt.Logs))
 
@@ -136,7 +140,7 @@ func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, 
 	fromLog := entry.Fee.Uint64()
 
 	// Collect the blob base fee from the block header.
-	block, err := ctxt.client.BlockByNumber(t.Context(), receipt.BlockNumber)
+	block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
 	require.NoError(err, "failed to get block header; ", err)
 	fromBlock := getBlobBaseFeeFrom(block.Header())
 
@@ -146,7 +150,7 @@ func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, 
 
 	// call the blob base fee rpc method
 	fromRpc := new(hexutil.Uint64)
-	err = ctxt.client.Client().Call(&fromRpc, "eth_blobBaseFee")
+	err = client.Client().Call(&fromRpc, "eth_blobBaseFee")
 	require.NoError(err, "failed to get blob base fee from rpc; ", err)
 
 	// we check blob base fee is one because it is not implemented yet. TODO issue #147
@@ -156,11 +160,15 @@ func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, 
 	require.Equal(fromLog, uint64(*fromRpc), "blob base fee mismatch; from log %v, from rpc %v", fromLog, fromRpc)
 }
 
-func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, ctxt *testContext) {
+func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 
+	client, err := session.GetClient()
+	require.NoError(err, "failed to get client; ", err)
+	defer client.Close()
+
 	// Get blob gas used from the block header of the latest block.
-	block, err := ctxt.client.BlockByNumber(t.Context(), nil)
+	block, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(err, "failed to get block header; ", err)
 	require.Empty(*block.BlobGasUsed(), "unexpected value in blob gas used")
 	require.Empty(*block.Header().ExcessBlobGas, "unexpected excess blob gas value")
@@ -184,13 +192,17 @@ func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, ctxt *testContext) {
 // Helper Functions
 ////////////////////////////////////////////////////////////////////////////////
 
-func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) (*types.Transaction, error) {
+func createTestBlobTransaction(t *testing.T, session IntegrationTestNetSession, data ...[]byte) (*types.Transaction, error) {
 	require := require.New(t)
 
-	chainId, err := ctxt.client.ChainID(t.Context())
+	client, err := session.GetClient()
+	require.NoError(err, "failed to get client; ", err)
+	defer client.Close()
+
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(t.Context(), ctxt.net.GetSessionSponsor().Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), session.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	var sidecar *types.BlobTxSidecar
@@ -234,16 +246,23 @@ func createTestBlobTransaction(t *testing.T, ctxt *testContext, data ...[]byte) 
 		Sidecar:    sidecar,               // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetSessionSponsor().PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), session.GetSessionSponsor().PrivateKey)
 }
 
-func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*types.Transaction, error) {
+func createTestBlobTransactionWithNilSidecar(
+	t *testing.T,
+	session IntegrationTestNetSession,
+) (*types.Transaction, error) {
 	require := require.New(t)
 
-	chainId, err := ctxt.client.ChainID(t.Context())
+	client, err := session.GetClient()
+	require.NoError(err, "failed to get client; ", err)
+	defer client.Close()
+
+	chainId, err := client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := ctxt.client.NonceAt(t.Context(), ctxt.net.GetSessionSponsor().Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), session.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	// Create and return transaction with the blob data and cryptographic proofs
@@ -260,13 +279,17 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, ctxt *testContext) (*
 		Sidecar:    nil,                   // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), ctxt.net.GetSessionSponsor().PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), session.GetSessionSponsor().PrivateKey)
 }
 
-func checkBlocksSanity(t *testing.T, client *PooledEhtClient) {
+func checkBlocksSanity(t *testing.T, session IntegrationTestNetSession) {
 	// This check is a regression from an issue found while fetching a block by
 	// number where the last block was not correctly serialized
 	require := require.New(t)
+
+	client, err := session.GetClient()
+	require.NoError(err, "failed to get client; ", err)
+	defer client.Close()
 
 	lastBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(err)
@@ -275,25 +298,6 @@ func checkBlocksSanity(t *testing.T, client *PooledEhtClient) {
 		_, err := client.BlockByNumber(t.Context(), big.NewInt(int64(i)))
 		require.NoError(err)
 	}
-}
-
-type testContext struct {
-	net    *IntegrationTestNet
-	client *PooledEhtClient
-}
-
-func MakeTestContext(t *testing.T) *testContext {
-	net := StartIntegrationTestNet(t)
-
-	client, err := net.GetClient()
-	require.NoError(t, err)
-
-	return &testContext{net, client}
-}
-
-func (tc *testContext) Close() {
-	tc.client.Close()
-	tc.net.Stop()
 }
 
 // helper functions to calculate blob base fee based on https://eips.ethereum.org/EIPS/eip-4844#gas-accounting

--- a/tests/block_override_test.go
+++ b/tests/block_override_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	"github.com/0xsoniclabs/sonic/opera"
 	block_override "github.com/0xsoniclabs/sonic/tests/contracts/blockoverride"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -37,7 +38,8 @@ const (
 
 func TestBlockOverride(t *testing.T) {
 	require := req.New(t)
-	net := StartIntegrationTestNet(t)
+
+	net := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the block override observer contract.
 	_, receipt, err := DeployContract(net, block_override.DeployBlockOverride)

--- a/tests/bls_onchain_test.go
+++ b/tests/bls_onchain_test.go
@@ -30,10 +30,7 @@ import (
 )
 
 func TestBlsVerificationOnChain(t *testing.T) {
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
-		Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-	})
-	defer net.Stop()
+	net := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
 	// Deploy contract with transaction options
 	blsContract, _, err := DeployContract(net, blsContracts.DeployBLS)

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -114,10 +114,7 @@ func TestAccountCreation_CreateCallsProducingCodesTooLargeProduceAUnsuccessfulRe
 		byte(vm.RETURN),
 	}...)
 
-	upgrade := opera.GetSonicUpgrades()
-	net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
-		Upgrades: &upgrade,
-	})
+	net := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	client, err := net.GetClient()
 	require.NoError(t, err)

--- a/tests/eth_call_test.go
+++ b/tests/eth_call_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestEthCall_CodeLargerThanMaxInitCodeSizeIsAccepted(t *testing.T) {
 			math.MaxUint16 + 1,
 		},
 	}
-	net := StartIntegrationTestNet(t)
+	net := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	client, err := net.GetClient()
 	require.NoError(t, err, "Failed to connect to the integration test network")

--- a/tests/gas_cost_test.go
+++ b/tests/gas_cost_test.go
@@ -63,9 +63,8 @@ func TestGasCostTest_Sonic(t *testing.T) {
 func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	upgrades := opera.GetSonicUpgrades()
 	upgrades.SingleProposerBlockFormation = singleProposer
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+
+	net := getIntegrationTestNetSession(t, upgrades)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -84,7 +83,6 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	// > )
 
 	t.Run("reject transactions with insufficient gas", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -104,7 +102,6 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("transactions with exact gas succeed", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -125,7 +122,6 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("Sonic processor charges 10% of unused gas", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -165,9 +161,8 @@ func TestGasCostTest_Allegro(t *testing.T) {
 func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	upgrades := opera.GetAllegroUpgrades()
 	upgrades.SingleProposerBlockFormation = singleProposer
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+
+	net := getIntegrationTestNetSession(t, upgrades)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -201,7 +196,7 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	}
 
 	t.Run("reject transactions with insufficient gas", func(t *testing.T) {
-		t.Parallel()
+
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -223,7 +218,7 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("transactions with exact gas succeed", func(t *testing.T) {
-		t.Parallel()
+
 		session := net.SpawnSession(t)
 
 		var corrections int
@@ -252,7 +247,7 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("Sonic processor charges 10% of unused gas", func(t *testing.T) {
-		t.Parallel()
+
 		session := net.SpawnSession(t)
 
 		var floorGreaterThan20Percent int

--- a/tests/gas_estimate_test.go
+++ b/tests/gas_estimate_test.go
@@ -35,7 +35,6 @@ import (
 func TestEstimateGas(t *testing.T) {
 	t.Run("Sonic", func(t *testing.T) {
 		session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
-		t.Parallel()
 
 		dataContract, receipt, err := DeployContract(session, data_reader.DeployDataReader)
 		require.NoError(t, err, "failed to deploy contract; %v", err)
@@ -46,7 +45,6 @@ func TestEstimateGas(t *testing.T) {
 	})
 	t.Run("Allegro", func(t *testing.T) {
 		session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
-		t.Parallel()
 
 		dataContract, receipt, err := DeployContract(session, data_reader.DeployDataReader)
 		require.NoError(t, err, "failed to deploy contract; %v", err)

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -33,13 +33,11 @@ func TestGasPrice(t *testing.T) {
 	net, client := makeNetAndClient(t)
 
 	t.Run("SuggestedGasPriceApproximateActualBaseFees", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		testGasPrice_SuggestedGasPricesApproximateActualBaseFees(t, session, client)
 	})
 
 	t.Run("UnderpricedTransactionsAreRejected", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		testGasPrice_UnderpricedTransactionsAreRejected(t, session, client)
 	})
@@ -146,10 +144,8 @@ func testGasPrice_UnderpricedTransactionsAreRejected(
 	require.NoError(send(setCodeFactory.makeSetCodeTransactionWithPrice(t, chainId, 0, feeCap, 0)))
 }
 
-func makeNetAndClient(t *testing.T) (*IntegrationTestNet, *PooledEhtClient) {
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
-		Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-	})
+func makeNetAndClient(t *testing.T) (IntegrationTestNetSession, *PooledEhtClient) {
+	net := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
 	client, err := net.GetClient()
 	require.NoError(t, err)

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -28,7 +29,7 @@ import (
 )
 
 func TestGetAccount(t *testing.T) {
-	net := StartIntegrationTestNet(t)
+	net := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
 	// Deploy the transient storage contract
 	_, deployReceipt, err := DeployContract(net, counter.DeployCounter)

--- a/tests/initcode_test.go
+++ b/tests/initcode_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/contractcreator"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -35,14 +36,14 @@ const sufficientGas = uint64(150_000)
 func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	requireBase := require.New(t)
 
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
-	contract, receipt, err := DeployContract(net, contractcreator.DeployContractcreator)
+	contract, receipt, err := DeployContract(session, contractcreator.DeployContractcreator)
 	requireBase.NoError(err)
 	requireBase.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed to deploy contract")
 
 	// run measureGasAndAssign to get cost of deploying a contract without create.
-	receipt = createContractSuccessfully(t, net, contract.GetOverheadCost, 0, 0)
+	receipt = createContractSuccessfully(t, session, contract.GetOverheadCost, 0, 0)
 
 	// -- using CREATE instruction
 	const wordCostCreate uint64 = 2
@@ -51,7 +52,7 @@ func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	t.Run("create", func(t *testing.T) {
 		t.Parallel()
 		// This tests creates multiple sessions in parallel inside sub-tests.
-		testForVariant(t, net, contract, contract.CreatetWith, gasForCreate, wordCostCreate)
+		testForVariant(t, session, contract, contract.CreatetWith, gasForCreate, wordCostCreate)
 	})
 
 	// -- using CREATE2 instruction
@@ -61,24 +62,24 @@ func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	t.Run("create2", func(t *testing.T) {
 		t.Parallel()
 		// This tests creates multiple sessions in parallel inside sub-tests.
-		testForVariant(t, net, contract, contract.Create2With, gasForCreate, wordCostCreate2)
+		testForVariant(t, session, contract, contract.Create2With, gasForCreate, wordCostCreate2)
 	})
 
 	t.Run("create transaction", func(t *testing.T) {
 		t.Parallel()
 		// This tests creates multiple sessions in parallel inside sub-tests.
-		testForTransaction(t, net)
+		testForTransaction(t, session)
 	})
 }
 
-func testForVariant(t *testing.T, net *IntegrationTestNet,
+func testForVariant(t *testing.T, session IntegrationTestNetSession,
 	contract *contractcreator.Contractcreator, variant variant,
 	gasForContract, wordCost uint64) {
 
 	t.Run("charges depending on the init code size", func(t *testing.T) {
-		t.Parallel()
 		require := require.New(t)
-		session := net.SpawnSession(t)
+		session := session.SpawnSession(t)
+		t.Parallel()
 
 		createAndGetCost := func(codeLen uint64) uint64 {
 			receipt, err := createContractWithCodeLenAndGas(session, variant, codeLen, sufficientGas)
@@ -100,9 +101,10 @@ func testForVariant(t *testing.T, net *IntegrationTestNet,
 	})
 
 	t.Run("fails without enough gas", func(t *testing.T) {
-		t.Parallel()
 		require := require.New(t)
-		session := net.SpawnSession(t)
+		session := session.SpawnSession(t)
+		t.Parallel()
+
 		// 4 for a zero byte, 1 to make it fail.
 		receipt, err := createContractWithCodeLenAndGas(session, variant, 1, gasForContract-wordCost-1)
 		require.NoError(err)
@@ -111,9 +113,10 @@ func testForVariant(t *testing.T, net *IntegrationTestNet,
 	})
 
 	t.Run("with max init code size", func(t *testing.T) {
-		t.Parallel()
 		require := require.New(t)
-		session := net.SpawnSession(t)
+		session := session.SpawnSession(t)
+		t.Parallel()
+
 		receipt, err := createContractWithCodeLenAndGas(session, variant, MAX_INIT_CODE_SIZE, sufficientGas)
 		require.NoError(err)
 		require.Equal(types.ReceiptStatusSuccessful, receipt.Status,
@@ -121,9 +124,10 @@ func testForVariant(t *testing.T, net *IntegrationTestNet,
 	})
 
 	t.Run("aborts with init code size larger than MAX_INITCODE_SIZE", func(t *testing.T) {
-		t.Parallel()
 		require := require.New(t)
-		session := net.SpawnSession(t)
+		session := session.SpawnSession(t)
+		t.Parallel()
+
 		receipt, err := createContractWithCodeLenAndGas(session, variant, MAX_INIT_CODE_SIZE+1, sufficientGas)
 		require.NoError(err)
 		require.Equal(types.ReceiptStatusFailed, receipt.Status,
@@ -131,11 +135,12 @@ func testForVariant(t *testing.T, net *IntegrationTestNet,
 	})
 }
 
-func testForTransaction(t *testing.T, net *IntegrationTestNet) {
+func testForTransaction(t *testing.T, net IntegrationTestNetSession) {
 	t.Run("charges depending on the init code size", func(t *testing.T) {
-		t.Parallel()
 		require := require.New(t)
 		session := net.SpawnSession(t)
+		t.Parallel()
+
 		// transactions charge 4 gas for each zero byte in data.
 		const zeroByteCost uint64 = 4
 		// create a transaction with 1 byte of code.
@@ -156,9 +161,10 @@ func testForTransaction(t *testing.T, net *IntegrationTestNet) {
 	})
 
 	t.Run("aborts with init code size larger than MAX_INITCODE_SIZE", func(t *testing.T) {
-		t.Parallel()
 		require := require.New(t)
 		session := net.SpawnSession(t)
+		t.Parallel()
+
 		// as specified in https://eips.ethereum.org/EIPS/eip-3860#rules,
 		// this is similar to transactions considered invalid for not meeting the intrinsic gas cost requirement.
 		_, err := runTransactionWithCodeSizeAndGas(t, session, MAX_INIT_CODE_SIZE+1, sufficientGas)
@@ -170,8 +176,8 @@ func testForTransaction(t *testing.T, net *IntegrationTestNet) {
 	})
 }
 
-func createContractSuccessfully(t *testing.T, net *IntegrationTestNet, variant variant, codeLen, gasLimit uint64) *types.Receipt {
-	receipt, err := createContractWithCodeLenAndGas(net, variant, codeLen, gasLimit)
+func createContractSuccessfully(t *testing.T, session IntegrationTestNetSession, variant variant, codeLen, gasLimit uint64) *types.Receipt {
+	receipt, err := createContractWithCodeLenAndGas(session, variant, codeLen, gasLimit)
 	require := require.New(t)
 	require.NoError(err)
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed to create contract with code length ", codeLen)

--- a/tests/network_rules_update_test.go
+++ b/tests/network_rules_update_test.go
@@ -387,7 +387,9 @@ func getNetworkRules(t *testing.T, net IntegrationTestNetSession) opera.Rules {
 }
 
 // updateNetworkRules sends a transaction to update the network rules.
-func updateNetworkRules(t *testing.T, net IntegrationTestNetSession, rulesChange any) {
+// This method changes the behavior of the network, it should not be used for
+// shared sessions
+func updateNetworkRules(t *testing.T, net *IntegrationTestNet, rulesChange any) {
 	t.Helper()
 	require := require.New(t)
 
@@ -412,7 +414,7 @@ func updateNetworkRules(t *testing.T, net IntegrationTestNetSession, rulesChange
 // advanceEpochAndWaitForBlocks sends a transaction to advance to the next epoch.
 // It also waits until the new epoch is really reached and the next two blocks are produced.
 // It is useful to test a situation when the rule change is applied to the next block after the epoch change.
-func advanceEpochAndWaitForBlocks(t *testing.T, net IntegrationTestNetSession) {
+func advanceEpochAndWaitForBlocks(t *testing.T, net *IntegrationTestNet) {
 	t.Helper()
 
 	require := require.New(t)

--- a/tests/prevrandao_test.go
+++ b/tests/prevrandao_test.go
@@ -20,13 +20,14 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/prevrandao"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrevRandao(t *testing.T) {
-	net := StartIntegrationTestNet(t)
+	net := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the contract.
 	contract, _, err := DeployContract(net, prevrandao.DeployPrevrandao)

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -32,13 +32,10 @@ import (
 func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 
 	// start network
-	net := StartIntegrationTestNet(t,
-		IntegrationTestNetOptions{
-			Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-		})
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
 	// create a client
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err, "failed to get client")
 	defer client.Close()
 
@@ -71,7 +68,7 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 			auth, err := types.SignSetCode(account.PrivateKey,
 				types.SetCodeAuthorization{
 					ChainID: *uint256.MustFromBig(chainId),
-					Address: net.GetSessionSponsor().Address(),
+					Address: session.GetSessionSponsor().Address(),
 					Nonce:   0,
 				})
 			require.NoError(t, err)
@@ -89,16 +86,16 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 				account := NewAccount()
 
 				txData := txFactory(t, account)
-				txData = setTransactionDefaults(t, net, txData, account)
+				txData = setTransactionDefaults(t, session, txData, account)
 				tx := signTransaction(t, chainId, txData, account)
 				cost := tx.Cost()
 
 				//  endow account with less than the cost of the transaction
-				receipt, err := net.EndowAccount(account.Address(), new(big.Int).Sub(cost, big.NewInt(1)))
+				receipt, err := session.EndowAccount(account.Address(), new(big.Int).Sub(cost, big.NewInt(1)))
 				require.NoError(t, err)
 				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-				_, err = net.Run(tx)
+				_, err = session.Run(tx)
 				require.ErrorContains(t, err, "insufficient funds")
 			})
 
@@ -106,22 +103,22 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 				account := NewAccount()
 
 				txData := txFactory(t, account)
-				txData = setTransactionDefaults(t, net, txData, account)
+				txData = setTransactionDefaults(t, session, txData, account)
 				tx := signTransaction(t, chainId, txData, account)
 
 				// provide enough funds for successful execution
-				receipt, err := net.EndowAccount(account.Address(), big.NewInt(1e18))
+				receipt, err := session.EndowAccount(account.Address(), big.NewInt(1e18))
 				require.NoError(t, err)
 				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 				// submit transaction once
-				receipt, err = net.Run(tx)
+				receipt, err = session.Run(tx)
 				require.NoError(t, err)
 				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 				for {
 					// submit transaction again
-					_, err := net.Run(tx)
+					_, err := session.Run(tx)
 					require.Error(t, err)
 
 					// Pool may take longer to purge the transaction after its execution.

--- a/tests/selfdestruct_test.go
+++ b/tests/selfdestruct_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/selfdestruct"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,20 +31,20 @@ import (
 
 func TestSelfDestruct(t *testing.T) {
 
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	t.Run("constructor", func(t *testing.T) {
 		t.Parallel()
-		testSelfDestruct_Constructor(t, net)
+		testSelfDestruct_Constructor(t, session)
 	})
 
 	t.Run("nested call", func(t *testing.T) {
 		t.Parallel()
-		testSelfDestruct_NestedCall(t, net)
+		testSelfDestruct_NestedCall(t, session)
 	})
 }
 
-func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
+func testSelfDestruct_Constructor(t *testing.T, session IntegrationTestNetSession) {
 	contractInitialBalance := int64(1234)
 
 	tests := map[string]struct {
@@ -141,8 +142,8 @@ func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
+			session := session.SpawnSession(t)
 			t.Parallel()
-			session := net.SpawnSession(t)
 
 			// New beneficiary address for each test
 			beneficiaryAddress := common.Address{}
@@ -201,7 +202,7 @@ func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
 	}
 }
 
-func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
+func testSelfDestruct_NestedCall(t *testing.T, net IntegrationTestNetSession) {
 	contractInitialBalance := int64(1234)
 
 	tests := map[string]struct {
@@ -294,8 +295,8 @@ func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			t.Parallel()
 			session := net.SpawnSession(t)
+			t.Parallel()
 
 			// generate a new beneficiary address for each test
 			beneficiaryAddress := common.Address{}

--- a/tests/set_code_trace_test.go
+++ b/tests/set_code_trace_test.go
@@ -38,43 +38,41 @@ import (
 // assign fees for a dApp also in this delegate scenario and dApp
 // address will be visible in the trace
 func TestTrace7702Transaction(t *testing.T) {
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
-		Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-	})
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
-	sponsor := makeAccountWithBalance(t, net, big.NewInt(1e18))
-	sponsored := makeAccountWithBalance(t, net, big.NewInt(10))
+	sponsor := makeAccountWithBalance(t, session, big.NewInt(1e18))
+	sponsored := makeAccountWithBalance(t, session, big.NewInt(10))
 
 	// Deploy the contract to forward the call
-	sponsoringDelegate, receipt, err := DeployContract(net, sponsoring.DeploySponsoring)
+	sponsoringDelegate, receipt, err := DeployContract(session, sponsoring.DeploySponsoring)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 	delegateAddress := receipt.ContractAddress
 
 	// Deploy simple contract to increment the counter
-	counterContract, receipt, err := DeployContract(net, counter.DeployCounter)
+	counterContract, receipt, err := DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 	counterAddress := receipt.ContractAddress
 
 	// Prepare calldata for incrementing the counter
-	counterCallData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	counterCallData := getCallData(t, session, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return counterContract.IncrementCounter(opts)
 	})
 
 	// Prepare calldata for the sponsoring transaction
-	sponsoringCallData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	sponsoringCallData := getCallData(t, session, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		// Increment the counter in the context of the sponsored account
 		return sponsoringDelegate.Execute(opts, counterAddress, big.NewInt(0), counterCallData)
 	})
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	// Create a setCode transaction calling the counter contract
 	setCodeTx := makeEip7702Transaction(t, client, sponsor, sponsored, delegateAddress, sponsoringCallData)
-	receipt, err = net.Run(setCodeTx)
+	receipt, err = session.Run(setCodeTx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 

--- a/tests/storage_override_test.go
+++ b/tests/storage_override_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/storage"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -30,12 +31,10 @@ import (
 )
 
 func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testing.T) {
-	net := StartIntegrationTestNet(t)
-
-	defer net.Stop()
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the contract.
-	contract, receipt, err := DeployContract(net, storage.DeployStorage)
+	contract, receipt, err := DeployContract(session, storage.DeployStorage)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 
 	checkStorage := func(t *testing.T) {
@@ -61,7 +60,7 @@ func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testi
 	addressStr := address.String()
 
 	// get the client to call RPC methods
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err, "failed to get client")
 	defer client.Close()
 
@@ -106,10 +105,10 @@ func TestSetStorage_Contract_Not_On_Blockchain_Executed_With_Extra_Storage(t *te
 	require := require.New(t)
 
 	// start network
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// create a client
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
 	defer client.Close()
 

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -31,14 +32,14 @@ const enoughGasPrice = 150_000_000_000
 
 func TestTransactionGasPrice(t *testing.T) {
 
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	// use a fresh account to send transactions from
-	account := makeAccountWithBalance(t, net, big.NewInt(1e18))
+	account := makeAccountWithBalance(t, session, big.NewInt(1e18))
 
 	t.Run("Legacy transaction, effectivePrice is equal to requested price", func(t *testing.T) {
 
@@ -58,7 +59,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeLegacyTx(t, client, specifiedPrice, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := session.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,
@@ -111,7 +112,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeEip1559Transaction(t, client, maxGasPrice, 0, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := session.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,
@@ -174,7 +175,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := session.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,
@@ -234,7 +235,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := session.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter_event_emitter"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -34,12 +35,13 @@ func TestTransactionOrder(t *testing.T) {
 		numBlocks   = uint64(3)
 		numTxs      = numAccounts * numPerAcc
 	)
-	net := StartIntegrationTestNet(t)
 
-	contract, _, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+
+	contract, _, err := DeployContract(session, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(t, err)
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
@@ -47,7 +49,7 @@ func TestTransactionOrder(t *testing.T) {
 
 	// Only transactions from different accounts can change order.
 	for range numAccounts {
-		accounts = append(accounts, makeAccountWithBalance(t, net, big.NewInt(1e18)))
+		accounts = append(accounts, makeAccountWithBalance(t, session, big.NewInt(1e18)))
 	}
 
 	// Repeat the test for X number of blocks
@@ -58,7 +60,7 @@ func TestTransactionOrder(t *testing.T) {
 		options := make([]bind.TransactOpts, 0, numTxs)
 		// Each account creates M transactions
 		for _, acc := range accounts {
-			opts, err := net.GetTransactOptions(acc)
+			opts, err := session.GetTransactOptions(acc)
 			require.NoError(t, err)
 			for range numPerAcc {
 				options = append(options, *opts)
@@ -84,7 +86,7 @@ func TestTransactionOrder(t *testing.T) {
 
 		// Check that the value in receipt is incremented by one - signals the transactions are ordered
 		for _, tx := range transactions {
-			receipt, err := net.GetReceipt(tx.Hash()) // first query synchronizes the execution
+			receipt, err := session.GetReceipt(tx.Hash()) // first query synchronizes the execution
 			require.NoError(t, err)
 			count, err := contract.ParseCount(*receipt.Logs[0])
 			require.NoError(t, err)

--- a/tests/transientstorage_test.go
+++ b/tests/transientstorage_test.go
@@ -19,16 +19,17 @@ package tests
 import (
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the transient storage contract
-	contract, _, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	contract, _, err := DeployContract(session, transientstorage.DeployTransientstorage)
 	require.NoError(t, err, "failed to deploy contract")
 
 	// Get the value from the contract before changing it
@@ -36,7 +37,7 @@ func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
 	require.NoError(t, err, "failed to get value")
 
 	// Store the value in transient storage value
-	receipt, err := net.Apply(contract.StoreValue)
+	receipt, err := session.Apply(contract.StoreValue)
 	require.NoError(t, err, "failed to store value")
 
 	// Check that the value was stored during transaction and emitted to logs

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -30,16 +31,15 @@ import (
 func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	requireBase := require.New(t)
 
-	// start network.
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// run endowment to ensure at least one block exists
-	receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(1))
+	receipt, err := session.EndowAccount(common.Address{42}, big.NewInt(1))
 	requireBase.NoError(err)
 	requireBase.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
 
 	// get client
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	requireBase.NoError(err, "Failed to get the client: ", err)
 	defer client.Close()
 


### PR DESCRIPTION
This PR uses the shared test sessions' infrastructure to reuse integration test network instances among test cases. 

This PR leverages partition of the blockchain address space by designating a different "sponsor" account for each session. Any contract deployed will be disjoined from other session address space. 
It is the responsibility of the user not to share addresses between sessions. 
