### PR TITLE
Replace individual test networks with shared test networks

### DIFF
--- a/tests/address_access_test.go
+++ b/tests/address_access_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	accessCost "github.com/0xsoniclabs/sonic/tests/contracts/access_cost"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,14 +31,14 @@ import (
 func TestAddressAccess(t *testing.T) {
 	someAccountAddress := common.Address{1}
 
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	contract, receipt, err := DeployContract(net, accessCost.DeployAccessCost)
+	contract, receipt, err := DeployContract(session, accessCost.DeployAccessCost)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 	// Execute function on an address, cold access
-	receipt, err = net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	receipt, err = session.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return contract.TouchAddress(opts, someAccountAddress)
 	})
 	require.NoError(t, err)
@@ -71,7 +72,7 @@ func TestAddressAccess(t *testing.T) {
 
 		for name, access := range tests {
 			t.Run(name, func(t *testing.T) {
-				receipt, err = net.Apply(access)
+				receipt, err = session.Apply(access)
 				require.NoError(t, err)
 				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 

--- a/tests/address_access_test.go
+++ b/tests/address_access_test.go
@@ -32,6 +32,7 @@ func TestAddressAccess(t *testing.T) {
 	someAccountAddress := common.Address{1}
 
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	contract, receipt, err := DeployContract(session, accessCost.DeployAccessCost)
 	require.NoError(t, err)

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -38,6 +38,7 @@ import (
 func TestBlobTransaction(t *testing.T) {
 
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	t.Run("blob tx with non-empty blobs is rejected", func(t *testing.T) {
 		testBlobTx_WithBlobsIsRejected(t, session)

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/blobbasefee"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -36,34 +37,34 @@ import (
 
 func TestBlobTransaction(t *testing.T) {
 
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	t.Run("blob tx with non-empty blobs is rejected", func(t *testing.T) {
-		testBlobTx_WithBlobsIsRejected(t, net)
+		testBlobTx_WithBlobsIsRejected(t, session)
 	})
 
 	t.Run("blob tx with empty blobs is executed", func(t *testing.T) {
-		testBlobTx_WithEmptyBlobsIsExecuted(t, net)
-		checkBlocksSanity(t, net)
+		testBlobTx_WithEmptyBlobsIsExecuted(t, session)
+		checkBlocksSanity(t, session)
 	})
 
 	t.Run("blob tx with nil sidecar is executed", func(t *testing.T) {
-		testBlobTx_WithNilSidecarIsExecuted(t, net)
-		checkBlocksSanity(t, net)
+		testBlobTx_WithNilSidecarIsExecuted(t, session)
+		checkBlocksSanity(t, session)
 	})
 
 	t.Run("blob base fee can be read from head, block and history", func(t *testing.T) {
-		testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t, net)
-		checkBlocksSanity(t, net)
+		testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t, session)
+		checkBlocksSanity(t, session)
 	})
 
 	t.Run("blob gas used can be read from block header", func(t *testing.T) {
-		testBlobBaseFee_CanReadBlobGasUsed(t, net)
-		checkBlocksSanity(t, net)
+		testBlobBaseFee_CanReadBlobGasUsed(t, session)
+		checkBlocksSanity(t, session)
 	})
 }
 
-func testBlobTx_WithBlobsIsRejected(t *testing.T, net *IntegrationTestNet) {
+func testBlobTx_WithBlobsIsRejected(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 	nonZeroNumberOfBlobs := 2
 
@@ -74,26 +75,26 @@ func testBlobTx_WithBlobsIsRejected(t *testing.T, net *IntegrationTestNet) {
 		copy(blobs[i], blob[:])
 	}
 
-	tx, err := createTestBlobTransaction(t, net, blobs...)
+	tx, err := createTestBlobTransaction(t, session, blobs...)
 	require.NoError(err)
 
 	// attempt to run tx
-	_, err = net.net.Run(tx)
+	_, err = session.Run(tx)
 	require.ErrorContains(err, "non-empty blob transaction are not supported")
 
 	// repeat same tx (regression against reported repeated tx issue)
-	_, err = net.net.Run(tx)
+	_, err = session.Run(tx)
 	require.ErrorContains(err, "non-empty blob transaction are not supported")
 }
 
-func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, net *IntegrationTestNet) {
+func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 
-	tx, err := createTestBlobTransaction(t, net)
+	tx, err := createTestBlobTransaction(t, session)
 	require.NoError(err)
 
 	// run tx
-	receipt, err := net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(err, "transaction must be accepted")
 	require.Equal(
 		types.ReceiptStatusSuccessful,
@@ -102,14 +103,14 @@ func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, net *IntegrationTestNet) 
 	)
 }
 
-func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, net *IntegrationTestNet) {
+func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 
-	tx, err := createTestBlobTransactionWithNilSidecar(t, net)
+	tx, err := createTestBlobTransactionWithNilSidecar(t, session)
 	require.NoError(err)
 
 	// run tx
-	receipt, err := net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(err, "transaction must be accepted")
 	require.Equal(
 		types.ReceiptStatusSuccessful,
@@ -118,15 +119,15 @@ func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, net *IntegrationTestNet) 
 	)
 }
 
-func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, net *IntegrationTestNet) {
+func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 
 	// Deploy the blob base fee contract.
-	contract, _, err := DeployContract(net, blobbasefee.DeployBlobbasefee)
+	contract, _, err := DeployContract(session, blobbasefee.DeployBlobbasefee)
 	require.NoError(err, "failed to deploy contract; ", err)
 
 	// Collect the current blob base fee from the head state.
-	receipt, err := net.Apply(contract.LogCurrentBlobBaseFee)
+	receipt, err := session.Apply(contract.LogCurrentBlobBaseFee)
 	require.NoError(err, "failed to log current blob base fee; ", err)
 	require.Equal(len(receipt.Logs), 1, "unexpected number of logs; expected 1, got ", len(receipt.Logs))
 
@@ -134,7 +135,7 @@ func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, 
 	require.NoError(err, "failed to parse log; ", err)
 	fromLog := entry.Fee.Uint64()
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
 	defer client.Close()
 
@@ -159,10 +160,10 @@ func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, 
 	require.Equal(fromLog, uint64(*fromRpc), "blob base fee mismatch; from log %v, from rpc %v", fromLog, fromRpc)
 }
 
-func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, net *IntegrationTestNet) {
+func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, session IntegrationTestNetSession) {
 	require := require.New(t)
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
 	defer client.Close()
 
@@ -191,17 +192,17 @@ func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, net *IntegrationTestNet) {
 // Helper Functions
 ////////////////////////////////////////////////////////////////////////////////
 
-func createTestBlobTransaction(t *testing.T, net *IntegrationTestNet, data ...[]byte) (*types.Transaction, error) {
+func createTestBlobTransaction(t *testing.T, session IntegrationTestNetSession, data ...[]byte) (*types.Transaction, error) {
 	require := require.New(t)
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
 	defer client.Close()
 
 	chainId, err := client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(t.Context(), net.net.GetSessionSponsor().Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), session.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	var sidecar *types.BlobTxSidecar
@@ -245,20 +246,20 @@ func createTestBlobTransaction(t *testing.T, net *IntegrationTestNet, data ...[]
 		Sidecar:    sidecar,               // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), net.net.GetSessionSponsor().PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), session.GetSessionSponsor().PrivateKey)
 }
 
-func createTestBlobTransactionWithNilSidecar(t *testing.T, net *IntegrationTestNet) (*types.Transaction, error) {
+func createTestBlobTransactionWithNilSidecar(t *testing.T, session IntegrationTestNetSession) (*types.Transaction, error) {
 	require := require.New(t)
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
 	defer client.Close()
 
 	chainId, err := client.ChainID(t.Context())
 	require.NoError(err, "failed to get chain ID::")
 
-	nonce, err := client.NonceAt(t.Context(), net.net.GetSessionSponsor().Address(), nil)
+	nonce, err := client.NonceAt(t.Context(), session.GetSessionSponsor().Address(), nil)
 	require.NoError(err, "failed to get nonce:")
 
 	// Create and return transaction with the blob data and cryptographic proofs
@@ -275,15 +276,15 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, net *IntegrationTestN
 		Sidecar:    nil,                   // sidecar data in the transaction
 	})
 
-	return types.SignTx(tx, types.NewCancunSigner(chainId), net.net.GetSessionSponsor().PrivateKey)
+	return types.SignTx(tx, types.NewCancunSigner(chainId), session.GetSessionSponsor().PrivateKey)
 }
 
-func checkBlocksSanity(t *testing.T, net *IntegrationTestNet) {
+func checkBlocksSanity(t *testing.T, session IntegrationTestNetSession) {
 	// This check is a regression from an issue found while fetching a block by
 	// number where the last block was not correctly serialized
 	require := require.New(t)
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
 	defer client.Close()
 

--- a/tests/block_hash_test.go
+++ b/tests/block_hash_test.go
@@ -336,6 +336,7 @@ func TestBlockHash_EIP2935_HistoryContractAccumulatesBlockHashes(t *testing.T) {
 	require := req.New(t)
 
 	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	t.Parallel()
 
 	client, err := session.GetClient()
 	require.NoError(err)

--- a/tests/block_hash_test.go
+++ b/tests/block_hash_test.go
@@ -335,16 +335,13 @@ func TestBlockHash_EIP2935_HistoryContractAccumulatesBlockHashes(t *testing.T) {
 
 	require := req.New(t)
 
-	net := StartIntegrationTestNetWithFakeGenesis(t,
-		IntegrationTestNetOptions{
-			Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-		})
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err)
 	defer client.Close()
 
-	readHistoryStorageContract, receipt, err := DeployContract(net, read_history_storage.DeployReadHistoryStorage)
+	readHistoryStorageContract, receipt, err := DeployContract(session, read_history_storage.DeployReadHistoryStorage)
 	require.NoError(err)
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -356,7 +353,7 @@ func TestBlockHash_EIP2935_HistoryContractAccumulatesBlockHashes(t *testing.T) {
 	// Fist loop just issues synchronous transactions to create blocks
 	hashes := make(map[uint64]common.Hash)
 	for range testIterations {
-		receipt, err := net.EndowAccount(NewAccount().Address(), big.NewInt(1e18))
+		receipt, err := session.EndowAccount(NewAccount().Address(), big.NewInt(1e18))
 		require.NoError(err)
 		require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 		hashes[receipt.BlockNumber.Uint64()] = receipt.BlockHash
@@ -364,7 +361,7 @@ func TestBlockHash_EIP2935_HistoryContractAccumulatesBlockHashes(t *testing.T) {
 
 	// second loop queries block hashes of the blocks generated in the first loop
 	for blockNumber, recordedHash := range hashes {
-		receipt, err = net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		receipt, err = session.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
 			return readHistoryStorageContract.ReadHistoryStorage(opts, new(big.Int).SetUint64(blockNumber))
 		})
 		require.NoError(err)

--- a/tests/block_in_archive_test.go
+++ b/tests/block_in_archive_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -34,10 +33,9 @@ import (
 func TestBlockInArchive(t *testing.T) {
 
 	require := require.New(t)
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
-	t.Parallel()
+	net := StartIntegrationTestNet(t)
 
-	client, err := session.GetWebSocketClient()
+	client, err := net.GetWebSocketClient()
 	require.NoError(err, "failed to get client ", err)
 	defer client.Close()
 	done := make(chan struct{})
@@ -57,7 +55,7 @@ func TestBlockInArchive(t *testing.T) {
 
 				// Check if block is in archive
 				var res interface{}
-				err := rpcClient.Call(&res, "eth_getBalance", session.GetSessionSponsor().Address().String(), hexutil.EncodeUint64(blockHeader.Number.Uint64()))
+				err := rpcClient.Call(&res, "eth_getBalance", net.GetSessionSponsor().Address().String(), hexutil.EncodeUint64(blockHeader.Number.Uint64()))
 				require.NoError(err, "failed to call eth_getBalance %v", err)
 
 				// Check that the block number is in order
@@ -77,7 +75,7 @@ func TestBlockInArchive(t *testing.T) {
 		}
 	}()
 
-	contract, _, err := DeployContract(session, transientstorage.DeployTransientstorage)
+	contract, _, err := DeployContract(net, transientstorage.DeployTransientstorage)
 	require.NoError(err, "failed to deploy contract %v", err)
 
 	for {
@@ -85,7 +83,7 @@ func TestBlockInArchive(t *testing.T) {
 		case <-done:
 			return
 		default:
-			txOptions, err := session.GetTransactOptions(session.GetSessionSponsor())
+			txOptions, err := net.GetTransactOptions(net.GetSessionSponsor())
 			require.NoError(err, "failed to get transaction options %v", err)
 			txOptions.Nonce = nil
 			txOptions.GasLimit = 0

--- a/tests/block_in_archive_test.go
+++ b/tests/block_in_archive_test.go
@@ -35,6 +35,7 @@ func TestBlockInArchive(t *testing.T) {
 
 	require := require.New(t)
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	client, err := session.GetWebSocketClient()
 	require.NoError(err, "failed to get client ", err)

--- a/tests/block_in_archive_test.go
+++ b/tests/block_in_archive_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -33,10 +34,9 @@ import (
 func TestBlockInArchive(t *testing.T) {
 
 	require := require.New(t)
-	net := StartIntegrationTestNetWithJsonGenesis(t)
-	defer net.Stop()
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	client, err := net.GetWebSocketClient()
+	client, err := session.GetWebSocketClient()
 	require.NoError(err, "failed to get client ", err)
 	defer client.Close()
 	done := make(chan struct{})
@@ -56,7 +56,7 @@ func TestBlockInArchive(t *testing.T) {
 
 				// Check if block is in archive
 				var res interface{}
-				err := rpcClient.Call(&res, "eth_getBalance", net.account.Address().String(), hexutil.EncodeUint64(blockHeader.Number.Uint64()))
+				err := rpcClient.Call(&res, "eth_getBalance", session.GetSessionSponsor().Address().String(), hexutil.EncodeUint64(blockHeader.Number.Uint64()))
 				require.NoError(err, "failed to call eth_getBalance %v", err)
 
 				// Check that the block number is in order
@@ -76,7 +76,7 @@ func TestBlockInArchive(t *testing.T) {
 		}
 	}()
 
-	contract, _, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	contract, _, err := DeployContract(session, transientstorage.DeployTransientstorage)
 	require.NoError(err, "failed to deploy contract %v", err)
 
 	for {
@@ -84,7 +84,7 @@ func TestBlockInArchive(t *testing.T) {
 		case <-done:
 			return
 		default:
-			txOptions, err := net.GetTransactOptions(net.GetSessionSponsor())
+			txOptions, err := session.GetTransactOptions(session.GetSessionSponsor())
 			require.NoError(err, "failed to get transaction options %v", err)
 			txOptions.Nonce = nil
 			txOptions.GasLimit = 0

--- a/tests/block_override_test.go
+++ b/tests/block_override_test.go
@@ -39,6 +39,7 @@ const (
 func TestBlockOverride(t *testing.T) {
 	require := req.New(t)
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	// Deploy the block override observer contract.
 	_, receipt, err := DeployContract(session, block_override.DeployBlockOverride)

--- a/tests/block_override_test.go
+++ b/tests/block_override_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	"github.com/0xsoniclabs/sonic/opera"
 	block_override "github.com/0xsoniclabs/sonic/tests/contracts/blockoverride"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -37,14 +38,14 @@ const (
 
 func TestBlockOverride(t *testing.T) {
 	require := req.New(t)
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the block override observer contract.
-	_, receipt, err := DeployContract(net, block_override.DeployBlockOverride)
+	_, receipt, err := DeployContract(session, block_override.DeployBlockOverride)
 	require.NoError(err, "failed to deploy contract; %v", err)
 	contractAddress := receipt.ContractAddress
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client; %v", err)
 	defer client.Close()
 
@@ -52,7 +53,7 @@ func TestBlockOverride(t *testing.T) {
 	require.NoError(err, "failed to instantiate contract")
 
 	// Call contract method to be sure it is deployed.
-	receiptObserve, err := net.Apply(contract.Observe)
+	receiptObserve, err := session.Apply(contract.Observe)
 	require.NoError(err, "failed to observe block hash; %v", err)
 	require.Equal(types.ReceiptStatusSuccessful, receiptObserve.Status,
 		"failed to observe block hash; %v", err,
@@ -76,14 +77,14 @@ func TestBlockOverride(t *testing.T) {
 	}
 
 	t.Run("eth_call block override", func(t *testing.T) {
-		newClient, err := net.GetClient()
+		newClient, err := session.GetClient()
 		require.NoError(err, "failed to get client; %v", err)
 		defer newClient.Close()
 		compareCalls(t, newClient.Client(), contractAddress, blockNumber, blockOverrides, makeEthCall)
 	})
 
 	t.Run("debug_traceCall block override", func(t *testing.T) {
-		newClient, err := net.GetClient()
+		newClient, err := session.GetClient()
 		require.NoError(err, "failed to get client; %v", err)
 		defer newClient.Close()
 		compareCalls(t, newClient.Client(), contractAddress, blockNumber, blockOverrides, makeDebugTraceCall)

--- a/tests/bls_onchain_test.go
+++ b/tests/bls_onchain_test.go
@@ -31,6 +31,7 @@ import (
 
 func TestBlsVerificationOnChain(t *testing.T) {
 	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	t.Parallel()
 
 	// Deploy contract with transaction options
 	blsContract, _, err := DeployContract(session, blsContracts.DeployBLS)

--- a/tests/bls_onchain_test.go
+++ b/tests/bls_onchain_test.go
@@ -30,13 +30,10 @@ import (
 )
 
 func TestBlsVerificationOnChain(t *testing.T) {
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
-		Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-	})
-	defer net.Stop()
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
 	// Deploy contract with transaction options
-	blsContract, _, err := DeployContract(net, blsContracts.DeployBLS)
+	blsContract, _, err := DeployContract(session, blsContracts.DeployBLS)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 
 	testVariants := []struct {
@@ -80,7 +77,7 @@ func TestBlsVerificationOnChain(t *testing.T) {
 				pubKeysBytes, signatureBytes, msgBytes, err := parseInputData(pubKeys, signature, msg)
 				require.NoError(t, err, "failed to parse test data; %v", err)
 
-				receipt, err := net.Apply(func(ops *bind.TransactOpts) (*types.Transaction, error) {
+				receipt, err := session.Apply(func(ops *bind.TransactOpts) (*types.Transaction, error) {
 					ops.GasLimit = 10000000
 					return testVariant.updateFunc(ops, pubKeysBytes, signatureBytes, msgBytes)
 				})

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -115,6 +115,7 @@ func TestAccountCreation_CreateCallsProducingCodesTooLargeProduceAUnsuccessfulRe
 	}...)
 
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	client, err := session.GetClient()
 	require.NoError(t, err)

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -114,16 +114,13 @@ func TestAccountCreation_CreateCallsProducingCodesTooLargeProduceAUnsuccessfulRe
 		byte(vm.RETURN),
 	}...)
 
-	upgrade := opera.GetSonicUpgrades()
-	net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
-		Upgrades: &upgrade,
-	})
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	sender := makeAccountWithBalance(t, net, big.NewInt(1e18))
+	sender := makeAccountWithBalance(t, session, big.NewInt(1e18))
 
 	gasPrice, err := client.SuggestGasPrice(t.Context())
 	require.NoError(t, err)
@@ -141,7 +138,7 @@ func TestAccountCreation_CreateCallsProducingCodesTooLargeProduceAUnsuccessfulRe
 	}
 	tx := signTransaction(t, chainId, txData, sender)
 
-	receipt, err := net.Run(tx)
+	receipt, err := session.Run(tx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusFailed, receipt.Status)
 }

--- a/tests/eth_call_test.go
+++ b/tests/eth_call_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -42,9 +43,9 @@ func TestEthCall_CodeLargerThanMaxInitCodeSizeIsAccepted(t *testing.T) {
 			math.MaxUint16 + 1,
 		},
 	}
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err, "Failed to connect to the integration test network")
 	defer client.Close()
 

--- a/tests/eth_call_test.go
+++ b/tests/eth_call_test.go
@@ -44,6 +44,7 @@ func TestEthCall_CodeLargerThanMaxInitCodeSizeIsAccepted(t *testing.T) {
 		},
 	}
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	client, err := session.GetClient()
 	require.NoError(t, err, "Failed to connect to the integration test network")

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestGetAccount(t *testing.T) {
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	// Deploy the transient storage contract
 	_, deployReceipt, err := DeployContract(session, counter.DeployCounter)

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -28,15 +29,15 @@ import (
 )
 
 func TestGetAccount(t *testing.T) {
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the transient storage contract
-	_, deployReceipt, err := DeployContract(net, counter.DeployCounter)
+	_, deployReceipt, err := DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err, "failed to deploy contract")
 
 	addr := deployReceipt.ContractAddress
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err, "failed to get client")
 	defer client.Close()
 

--- a/tests/prevrandao_test.go
+++ b/tests/prevrandao_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestPrevRandao(t *testing.T) {
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	// Deploy the contract.
 	contract, _, err := DeployContract(session, prevrandao.DeployPrevrandao)

--- a/tests/prevrandao_test.go
+++ b/tests/prevrandao_test.go
@@ -20,19 +20,20 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/prevrandao"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrevRandao(t *testing.T) {
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the contract.
-	contract, _, err := DeployContract(net, prevrandao.DeployPrevrandao)
+	contract, _, err := DeployContract(session, prevrandao.DeployPrevrandao)
 	require.NoError(t, err)
 	// Collect the current PrevRandao fee from the head state.
-	receipt, err := net.Apply(contract.LogCurrentPrevRandao)
+	receipt, err := session.Apply(contract.LogCurrentPrevRandao)
 	require.NoError(t, err)
 	require.Len(t, receipt.Logs, 1, "expected exactly one log entry")
 
@@ -40,7 +41,7 @@ func TestPrevRandao(t *testing.T) {
 	require.NoError(t, err, "failed to parse log entry")
 	fromLog := entry.Prevrandao
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -32,13 +32,10 @@ import (
 func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 
 	// start network
-	net := StartIntegrationTestNet(t,
-		IntegrationTestNetOptions{
-			Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-		})
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
 	// create a client
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err, "failed to get client")
 	defer client.Close()
 
@@ -71,7 +68,7 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 			auth, err := types.SignSetCode(account.PrivateKey,
 				types.SetCodeAuthorization{
 					ChainID: *uint256.MustFromBig(chainId),
-					Address: net.GetSessionSponsor().Address(),
+					Address: session.GetSessionSponsor().Address(),
 					Nonce:   0,
 				})
 			require.NoError(t, err)
@@ -89,16 +86,16 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 				account := NewAccount()
 
 				txData := txFactory(t, account)
-				txData = setTransactionDefaults(t, net, txData, account)
+				txData = setTransactionDefaults(t, session, txData, account)
 				tx := signTransaction(t, chainId, txData, account)
 				cost := tx.Cost()
 
 				//  endow account with less than the cost of the transaction
-				receipt, err := net.EndowAccount(account.Address(), new(big.Int).Sub(cost, big.NewInt(1)))
+				receipt, err := session.EndowAccount(account.Address(), new(big.Int).Sub(cost, big.NewInt(1)))
 				require.NoError(t, err)
 				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-				_, err = net.Run(tx)
+				_, err = session.Run(tx)
 				require.ErrorContains(t, err, "insufficient funds")
 			})
 
@@ -106,22 +103,22 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 				account := NewAccount()
 
 				txData := txFactory(t, account)
-				txData = setTransactionDefaults(t, net, txData, account)
+				txData = setTransactionDefaults(t, session, txData, account)
 				tx := signTransaction(t, chainId, txData, account)
 
 				// provide enough funds for successful execution
-				receipt, err := net.EndowAccount(account.Address(), big.NewInt(1e18))
+				receipt, err := session.EndowAccount(account.Address(), big.NewInt(1e18))
 				require.NoError(t, err)
 				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 				// submit transaction once
-				receipt, err = net.Run(tx)
+				receipt, err = session.Run(tx)
 				require.NoError(t, err)
 				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 				for {
 					// submit transaction again
-					_, err := net.Run(tx)
+					_, err := session.Run(tx)
 					require.Error(t, err)
 
 					// Pool may take longer to purge the transaction after its execution.

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -33,6 +33,7 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 
 	// start network
 	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	t.Parallel()
 
 	// create a client
 	client, err := session.GetClient()

--- a/tests/set_code_trace_test.go
+++ b/tests/set_code_trace_test.go
@@ -38,43 +38,41 @@ import (
 // assign fees for a dApp also in this delegate scenario and dApp
 // address will be visible in the trace
 func TestTrace7702Transaction(t *testing.T) {
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
-		Upgrades: AsPointer(opera.GetAllegroUpgrades()),
-	})
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
-	sponsor := makeAccountWithBalance(t, net, big.NewInt(1e18))
-	sponsored := makeAccountWithBalance(t, net, big.NewInt(10))
+	sponsor := makeAccountWithBalance(t, session, big.NewInt(1e18))
+	sponsored := makeAccountWithBalance(t, session, big.NewInt(10))
 
 	// Deploy the contract to forward the call
-	sponsoringDelegate, receipt, err := DeployContract(net, sponsoring.DeploySponsoring)
+	sponsoringDelegate, receipt, err := DeployContract(session, sponsoring.DeploySponsoring)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 	delegateAddress := receipt.ContractAddress
 
 	// Deploy simple contract to increment the counter
-	counterContract, receipt, err := DeployContract(net, counter.DeployCounter)
+	counterContract, receipt, err := DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 	counterAddress := receipt.ContractAddress
 
 	// Prepare calldata for incrementing the counter
-	counterCallData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	counterCallData := getCallData(t, session, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		return counterContract.IncrementCounter(opts)
 	})
 
 	// Prepare calldata for the sponsoring transaction
-	sponsoringCallData := getCallData(t, net, func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	sponsoringCallData := getCallData(t, session, func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		// Increment the counter in the context of the sponsored account
 		return sponsoringDelegate.Execute(opts, counterAddress, big.NewInt(0), counterCallData)
 	})
 
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	// Create a setCode transaction calling the counter contract
 	setCodeTx := makeEip7702Transaction(t, client, sponsor, sponsored, delegateAddress, sponsoringCallData)
-	receipt, err = net.Run(setCodeTx)
+	receipt, err = session.Run(setCodeTx)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 

--- a/tests/set_code_trace_test.go
+++ b/tests/set_code_trace_test.go
@@ -39,6 +39,7 @@ import (
 // address will be visible in the trace
 func TestTrace7702Transaction(t *testing.T) {
 	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	t.Parallel()
 
 	sponsor := makeAccountWithBalance(t, session, big.NewInt(1e18))
 	sponsored := makeAccountWithBalance(t, session, big.NewInt(10))

--- a/tests/storage_override_test.go
+++ b/tests/storage_override_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/storage"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -30,12 +31,10 @@ import (
 )
 
 func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testing.T) {
-	net := StartIntegrationTestNet(t)
-
-	defer net.Stop()
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the contract.
-	contract, receipt, err := DeployContract(net, storage.DeployStorage)
+	contract, receipt, err := DeployContract(session, storage.DeployStorage)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 
 	checkStorage := func(t *testing.T) {
@@ -61,7 +60,7 @@ func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testi
 	addressStr := address.String()
 
 	// get the client to call RPC methods
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(t, err, "failed to get client")
 	defer client.Close()
 
@@ -103,10 +102,10 @@ func TestSetStorage_Contract_Not_On_Blockchain_Executed_With_Extra_Storage(t *te
 	require := require.New(t)
 
 	// start network
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// create a client
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
 	defer client.Close()
 

--- a/tests/storage_override_test.go
+++ b/tests/storage_override_test.go
@@ -32,6 +32,7 @@ import (
 
 func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testing.T) {
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	// Deploy the contract.
 	contract, receipt, err := DeployContract(session, storage.DeployStorage)

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -33,6 +33,7 @@ const enoughGasPrice = 150_000_000_000
 func TestTransactionGasPrice(t *testing.T) {
 
 	sessio := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	client, err := sessio.GetClient()
 	require.NoError(t, err)

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -31,14 +32,14 @@ const enoughGasPrice = 150_000_000_000
 
 func TestTransactionGasPrice(t *testing.T) {
 
-	net := StartIntegrationTestNet(t)
+	sessio := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	client, err := net.GetClient()
+	client, err := sessio.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
 	// use a fresh account to send transactions from
-	account := makeAccountWithBalance(t, net, big.NewInt(1e18))
+	account := makeAccountWithBalance(t, sessio, big.NewInt(1e18))
 
 	t.Run("Legacy transaction, effectivePrice is equal to requested price", func(t *testing.T) {
 
@@ -58,7 +59,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeLegacyTx(t, client, specifiedPrice, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := sessio.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,
@@ -111,7 +112,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeEip1559Transaction(t, client, maxGasPrice, 0, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := sessio.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,
@@ -174,7 +175,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := sessio.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,
@@ -234,7 +235,7 @@ func TestTransactionGasPrice(t *testing.T) {
 		// 2: make & execute transaction
 		tx := makeEip1559Transaction(t, client, maxGasPrice, tip, account, &common.Address{}, nil)
 
-		receipt, err := net.Run(tx)
+		receipt, err := sessio.Run(tx)
 		require.NoError(t, err)
 		require.Equal(t,
 			receipt.Status,

--- a/tests/transientstorage_test.go
+++ b/tests/transientstorage_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	// Deploy the transient storage contract
 	contract, _, err := DeployContract(session, transientstorage.DeployTransientstorage)

--- a/tests/transientstorage_test.go
+++ b/tests/transientstorage_test.go
@@ -19,16 +19,17 @@ package tests
 import (
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// Deploy the transient storage contract
-	contract, _, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	contract, _, err := DeployContract(session, transientstorage.DeployTransientstorage)
 	require.NoError(t, err, "failed to deploy contract")
 
 	// Get the value from the contract before changing it
@@ -36,7 +37,7 @@ func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
 	require.NoError(t, err, "failed to get value")
 
 	// Store the value in transient storage value
-	receipt, err := net.Apply(contract.StoreValue)
+	receipt, err := session.Apply(contract.StoreValue)
 	require.NoError(t, err, "failed to store value")
 
 	// Check that the value was stored during transaction and emitted to logs

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -33,6 +33,7 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 
 	// start network.
 	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	t.Parallel()
 
 	// run endowment to ensure at least one block exists
 	receipt, err := session.EndowAccount(common.Address{42}, big.NewInt(1))

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -31,15 +32,15 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	requireBase := require.New(t)
 
 	// start network.
-	net := StartIntegrationTestNet(t)
+	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 	// run endowment to ensure at least one block exists
-	receipt, err := net.EndowAccount(common.Address{42}, big.NewInt(1))
+	receipt, err := session.EndowAccount(common.Address{42}, big.NewInt(1))
 	requireBase.NoError(err)
 	requireBase.Equal(receipt.Status, types.ReceiptStatusSuccessful, "failed to endow account")
 
 	// get client
-	client, err := net.GetClient()
+	client, err := session.GetClient()
 	requireBase.NoError(err, "Failed to get the client: ", err)
 	defer client.Close()
 


### PR DESCRIPTION
This PR depends on https://github.com/0xsoniclabs/sonic/pull/421

Currently the integration tests take almost 30 minutes in CI, and as we implement new behaviour, more tests will need to be added and this is not sustainable for quick development cycle. 

The main focus of this PR is to replace calls to `StartIntegrationTestNet` with `getIntegrationTestNetSession`, reducing the number of test networks that need to be instantiated. 

Note This PR deals with the most straight forward cases. Other tests be migrated as well but need more changes. To keep the reviews as simple as possible, in this PR there is only replacement of function rename, but no logical chances. 