### PR TITLE
Fix correct typing for block query.

### DIFF
--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -111,7 +111,7 @@ func (b *EthAPIBackend) ResolveRpcBlockNumberOrHash(ctx context.Context, blockNr
 			return idx.Block(number), nil
 		}
 	} else if h, ok := blockNrOrHash.Hash(); ok {
-		index := b.svc.store.GetBlockIndex(hash.Event(h))
+		index := b.svc.store.GetBlockIndex(h)
 		if index == nil {
 			return 0, errors.New("block not found")
 		}
@@ -131,7 +131,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 
 // HeaderByHash returns evm block header by its (atropos) hash, or nil if not exists.
 func (b *EthAPIBackend) HeaderByHash(ctx context.Context, h common.Hash) (*evmcore.EvmHeader, error) {
-	index := b.svc.store.GetBlockIndex(hash.Event(h))
+	index := b.svc.store.GetBlockIndex(h)
 	if index == nil {
 		return nil, fmt.Errorf("block with hash %s not found", h.String())
 	}
@@ -178,7 +178,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 			header = b.state.GetHeader(common.Hash{}, uint64(number))
 		}
 	} else if h, ok := blockNrOrHash.Hash(); ok {
-		index := b.svc.store.GetBlockIndex(hash.Event(h))
+		index := b.svc.store.GetBlockIndex(h)
 		if index == nil {
 			return nil, nil, errors.New("header not found")
 		}
@@ -317,7 +317,7 @@ func (b *EthAPIBackend) ForEachEpochEvent(ctx context.Context, epoch rpc.BlockNu
 }
 
 func (b *EthAPIBackend) BlockByHash(ctx context.Context, h common.Hash) (*evmcore.EvmBlock, error) {
-	index := b.svc.store.GetBlockIndex(hash.Event(h))
+	index := b.svc.store.GetBlockIndex(h)
 	if index == nil {
 		return nil, nil
 	}
@@ -367,7 +367,7 @@ func (b *EthAPIBackend) GetReceiptsByNumber(ctx context.Context, number rpc.Bloc
 
 // GetReceipts retrieves the receipts for all transactions in a given block.
 func (b *EthAPIBackend) GetReceipts(ctx context.Context, block common.Hash) (types.Receipts, error) {
-	number := b.svc.store.GetBlockIndex(hash.Event(block))
+	number := b.svc.store.GetBlockIndex(block)
 	if number == nil {
 		return nil, nil
 	}

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -46,8 +46,8 @@ func (s *Store) GetGenesisID() *hash.Hash {
 	return &val
 }
 
-func (s *Store) fakeGenesisHash() hash.Event {
-	fakeGenesisHash := hash.Event(*s.GetGenesisID())
+func (s *Store) fakeGenesisHash() common.Hash {
+	fakeGenesisHash := common.Hash(*s.GetGenesisID())
 	for i := range fakeGenesisHash[:8] {
 		fakeGenesisHash[i] = 0
 	}
@@ -115,7 +115,7 @@ func (s *Store) SetBlockIndex(id common.Hash, n idx.Block) {
 }
 
 // GetBlockIndex returns stored block index.
-func (s *Store) GetBlockIndex(id hash.Event) *idx.Block {
+func (s *Store) GetBlockIndex(id common.Hash) *idx.Block {
 	nVal, ok := s.cache.BlockHashes.Get(id)
 	if ok {
 		n, ok := nVal.(idx.Block)


### PR DESCRIPTION
This PR avoids the confusion of addressing blocks by event.Hash. Instead, uses common.Hash which at the time is binary compatible. 

This avoids unnecessary casting as well .