### PR TITLE
block header integration test package

### DIFF
--- a/tests/block_header/block_header.go
+++ b/tests/block_header/block_header.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package block_header_test
+package block_header
 
 import (
 	"testing"

--- a/tests/block_header/block_header_test.go
+++ b/tests/block_header/block_header_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package block_header_test
+package block_header
 
 import (
 	"cmp"

--- a/tests/single_proposer_protocol_test.go
+++ b/tests/single_proposer_protocol_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/opera"
-	block_header_test "github.com/0xsoniclabs/sonic/tests/block_header"
+	"github.com/0xsoniclabs/sonic/tests/block_header"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -236,7 +236,7 @@ func testSingleProposerProtocol_CanBeEnabledAndDisabled(
 	require.NoError(err)
 
 	// Test parent/child relation properties.
-	block_header_test.HeadersParentChildProperties(t, headers)
+	block_header.HeadersParentChildProperties(t, headers)
 }
 
 // getUsedEventVersion retrieves the current event version used by the network.


### PR DESCRIPTION
This PR depends on https://github.com/0xsoniclabs/sonic/pull/430.
This PR moves to block header test into their own package so that the testing runtime can manage it in parallel to other packages. 
This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/258