### PR TITLE
Gas cost package

### DIFF
--- a/tests/gas_cost/gas_cost_test.go
+++ b/tests/gas_cost/gas_cost_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package gas_cost
 
 import (
 	"iter"
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -52,10 +53,16 @@ func (tc *TestCase) String() string {
 }
 
 func TestGasCostTest_Sonic(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with distributed proposers", func(t *testing.T) {
+		t.Parallel()
+
 		testGasCosts_Sonic(t, false)
 	})
 	t.Run("with single proposer", func(t *testing.T) {
+		t.Parallel()
+
 		testGasCosts_Sonic(t, true)
 	})
 }
@@ -63,7 +70,7 @@ func TestGasCostTest_Sonic(t *testing.T) {
 func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	upgrades := opera.GetSonicUpgrades()
 	upgrades.SingleProposerBlockFormation = singleProposer
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -89,9 +96,9 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
 				test.txPayload.Gas = test.txPayload.Gas - 1
-				test.txPayload = SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				err := client.SendTransaction(t.Context(), tx)
@@ -108,8 +115,8 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
-				test.txPayload = SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
-				tx := SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
@@ -132,9 +139,9 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 
 				// Increase gas by 20% to make sure we have some unused gas
 				test.txPayload.Gas = uint64(float32(test.txPayload.Gas) * 1.2)
-				test.txPayload = SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
@@ -154,10 +161,16 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 }
 
 func TestGasCostTest_Allegro(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with distributed proposers", func(t *testing.T) {
+		t.Parallel()
+
 		testGasCosts_Allegro(t, false)
 	})
 	t.Run("with single proposer", func(t *testing.T) {
+		t.Parallel()
+
 		testGasCosts_Allegro(t, true)
 	})
 }
@@ -165,7 +178,7 @@ func TestGasCostTest_Allegro(t *testing.T) {
 func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	upgrades := opera.GetAllegroUpgrades()
 	upgrades.SingleProposerBlockFormation = singleProposer
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -207,9 +220,9 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 			t.Run(test.String(), func(t *testing.T) {
 
 				test.txPayload.Gas = computeEIP7623GasCost(t, test.txPayload) - 1
-				test.txPayload = SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				err := client.SendTransaction(t.Context(), tx)
@@ -235,9 +248,9 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 					corrections++
 				}
 				test.txPayload.Gas = correctedGasCost
-				test.txPayload = SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				receipt, err := session.Run(tx)
@@ -273,9 +286,9 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 				}
 
 				test.txPayload.Gas = incremented
-				test.txPayload = SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
@@ -306,7 +319,7 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 
 func makeGasCostTestInputs(
 	t *testing.T,
-	session IntegrationTestNetSession,
+	session tests.IntegrationTestNetSession,
 ) iter.Seq[TestCase] {
 	t.Helper()
 
@@ -318,7 +331,7 @@ func makeGasCostTestInputs(
 	require.NoError(t, err)
 
 	existingAccountAddress := session.GetSessionSponsor().Address()
-	nonExistingAccountAddress := NewAccount().Address()
+	nonExistingAccountAddress := tests.NewAccount().Address()
 
 	withCallData := func(size, zeroes int) txModification {
 		return func(tx *types.AccessListTx) {
@@ -347,7 +360,7 @@ func makeGasCostTestInputs(
 		return func(tx *types.AccessListTx) {
 			tx.AccessList = make([]types.AccessTuple, accounts)
 			for i := 0; i < accounts; i++ {
-				tx.AccessList[i].Address = NewAccount().Address()
+				tx.AccessList[i].Address = tests.NewAccount().Address()
 				tx.AccessList[i].StorageKeys = make([]common.Hash, storageKeysPerAccount)
 				for j := 0; j < storageKeysPerAccount; j++ {
 					tx.AccessList[i].StorageKeys[j] = common.Hash{0x42}
@@ -356,7 +369,7 @@ func makeGasCostTestInputs(
 		}
 	}
 
-	return GenerateTestDataBasedOnModificationCombinations(
+	return tests.GenerateTestDataBasedOnModificationCombinations(
 		func() TestCase {
 			t.Helper()
 
@@ -463,14 +476,16 @@ func makeGasCostTestInputs(
 }
 
 func TestExcessGasCharges_DisabledInSingleProposerModeInNewAndHistoricRuns(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 
 	upgrades := opera.GetAllegroUpgrades()
-	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
-	account := NewAccount()
+	account := tests.NewAccount()
 	_, err := net.EndowAccount(account.Address(), big.NewInt(1e18))
 	require.NoError(err)
 
@@ -504,7 +519,7 @@ func TestExcessGasCharges_DisabledInSingleProposerModeInNewAndHistoricRuns(t *te
 	receipts = append(receipts, receipt)
 
 	// Switch to single proposer mode.
-	UpdateNetworkRules(t, net, map[string]map[string]bool{
+	tests.UpdateNetworkRules(t, net, map[string]map[string]bool{
 		"Upgrades": {
 			"SingleProposerBlockFormation": true,
 		},


### PR DESCRIPTION
This PR depends on https://github.com/0xsoniclabs/sonic/pull/430.
This PR moves the gas cost test into their own package so that the testing runtime can manage it in parallel to other packages.
This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/258