### PR TITLE
Add `t.Parallel` to large transaction tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ sonic-image:
 
 .PHONY: test
 test:
-	go test --timeout 30m ./...
+	GOMEMLIMIT=10GiB go test --timeout 30m ./...
 
 .PHONY: coverage
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ sonic-image:
 
 .PHONY: test
 test:
-	GOMEMLIMIT=10GiB go test --timeout 30m ./...
+	go test --timeout 30m ./...
 
 .PHONY: coverage
 coverage:

--- a/tests/large_transactions/large_transactions_test.go
+++ b/tests/large_transactions/large_transactions_test.go
@@ -17,7 +17,6 @@
 package tests
 
 import (
-	"fmt"
 	"math/big"
 	"slices"
 	"testing"
@@ -31,6 +30,8 @@ import (
 )
 
 func TestLargeTransactions_CanHandleLargeTransactions(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
 		Upgrades: tests.AsPointer(opera.GetAllegroUpgrades()),
@@ -97,6 +98,7 @@ func TestLargeTransactions_CanHandleLargeTransactions(t *testing.T) {
 }
 
 func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
+	t.Parallel()
 
 	if tests.IsDataRaceDetectionEnabled() {
 		t.Skip(`Due to the concurrency requirements of this test, 
@@ -114,13 +116,19 @@ func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
 	}
 
 	for name, upgrades := range hardForks {
-		for mode, singleProposer := range modes {
-			t.Run(fmt.Sprintf("%s/%s", name, mode), func(t *testing.T) {
-				effectiveUpgrades := upgrades
-				effectiveUpgrades.SingleProposerBlockFormation = singleProposer
-				testLargeTransactionLoadTest(t, &effectiveUpgrades)
-			})
-		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			for mode, singleProposer := range modes {
+				t.Run(mode, func(t *testing.T) {
+					t.Parallel()
+
+					effectiveUpgrades := upgrades
+					effectiveUpgrades.SingleProposerBlockFormation = singleProposer
+					testLargeTransactionLoadTest(t, &effectiveUpgrades)
+				})
+			}
+		})
 	}
 }
 

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -359,7 +359,7 @@ func _cartesianProductRecursion[T any](current []T, elements [][]T, callback fun
 // arbitrary and was selected by the previous version of this algorithm.
 func WaitFor(ctx context.Context, predicate func(context.Context) (bool, error)) error {
 
-	timedContext, cancel := context.WithTimeout(ctx, 150*time.Second)
+	timedContext, cancel := context.WithTimeout(ctx, 200*time.Second)
 	defer cancel()
 
 	// implement some backoff strategy: sleeps get longer the longer it

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -359,7 +359,7 @@ func _cartesianProductRecursion[T any](current []T, elements [][]T, callback fun
 // arbitrary and was selected by the previous version of this algorithm.
 func WaitFor(ctx context.Context, predicate func(context.Context) (bool, error)) error {
 
-	timedContext, cancel := context.WithTimeout(ctx, 100*time.Second)
+	timedContext, cancel := context.WithTimeout(ctx, 150*time.Second)
 	defer cancel()
 
 	// implement some backoff strategy: sleeps get longer the longer it


### PR DESCRIPTION
This PR adds missing calls to `t.Parallel` in large transaction integration tests.