### PR TITLE
Refactor waiting loops in testing code. 

### DIFF
--- a/tests/gas_cost/gas_cost_test.go
+++ b/tests/gas_cost/gas_cost_test.go
@@ -524,7 +524,7 @@ func TestExcessGasCharges_DisabledInSingleProposerModeInNewAndHistoricRuns(t *te
 			"SingleProposerBlockFormation": true,
 		},
 	})
-	require.NoError(net.AdvanceEpoch(1))
+	net.AdvanceEpoch(t, 1)
 
 	receipt, err = net.Run(types.MustSignNewTx(
 		account.PrivateKey, signer,

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -546,26 +546,13 @@ func (n *IntegrationTestNet) start() error {
 	}
 	defer client.Close()
 
-	const timeout = 300 * time.Second
-	start := time.Now()
-
 	// wait for the node to be ready to serve requests
-	const maxDelay = 100 * time.Millisecond
-	delay := time.Millisecond
-	for {
-		if time.Since(start) > timeout {
-			return fmt.Errorf("failed to successfully start up a test network within %v", timeout)
-		}
-		_, err := client.ChainID(context.Background())
-		if err != nil {
-			time.Sleep(delay)
-			delay = 2 * delay
-			if delay > maxDelay {
-				delay = maxDelay
-			}
-			continue
-		}
-		break
+	err = WaitFor(context.Background(), func(ctx context.Context) (bool, error) {
+		_, err := client.ChainID(ctx)
+		return err == nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to connect to the Ethereum client: %w", err)
 	}
 
 	// Connect the nodes with each other.
@@ -762,45 +749,32 @@ func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSessio
 // The function blocks until the final epoch has been reached. This method can only be called
 // on a validator account.
 func (s *Session) AdvanceEpoch(t testing.TB, epochs int) {
+	t.Helper()
 	client, err := s.GetClient()
-	if err != nil {
-		return fmt.Errorf("failed to connect to the client: %w", err)
-	}
+	require.NoError(t, err, "failed to connect to the Ethereum client")
 
 	var currentEpoch hexutil.Uint64
-	if err := client.Client().Call(&currentEpoch, "eth_currentEpoch"); err != nil {
-		return fmt.Errorf("failed to get current epoch: %w", err)
-	}
+	err = client.Client().Call(&currentEpoch, "eth_currentEpoch")
+	require.NoError(t, err, "failed to get current epoch")
 
 	contract, err := driverauth100.NewContract(driverauth.ContractAddress, client)
-	if err != nil {
-		return fmt.Errorf("failed to create contract: %w", err)
-	}
+	require.NoError(t, err, "failed to create contract instance")
 
 	receipt, err := s.Apply(func(ops *bind.TransactOpts) (*types.Transaction, error) {
 		return contract.AdvanceEpochs(ops, big.NewInt(int64(epochs)))
 	})
-	if err != nil {
-		return fmt.Errorf("failed to send transaction: %w", err)
-	}
-
-	if got, want := receipt.Status, types.ReceiptStatusSuccessful; got != want {
-		return fmt.Errorf("expected status %d, got %d", want, got)
-	}
+	require.NoError(t, err, "failed to advance epoch")
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 	// wait until the epoch is advanced
-	for {
+	err = WaitFor(t.Context(), func(ctx context.Context) (bool, error) {
 		var newEpoch hexutil.Uint64
 		if err := client.Client().Call(&newEpoch, "eth_currentEpoch"); err != nil {
-			return fmt.Errorf("failed to get current epoch: %w", err)
+			return false, fmt.Errorf("failed to get current epoch: %w", err)
 		}
-
-		if newEpoch >= currentEpoch+hexutil.Uint64(epochs) {
-			break
-		}
-	}
-
-	return nil
+		return newEpoch >= currentEpoch+hexutil.Uint64(epochs), nil
+	})
+	require.NoError(t, err, "failed to wait for epoch to advance")
 }
 
 // DeployContract is a utility function handling the deployment of a contract on the network.
@@ -965,27 +939,22 @@ func (s *Session) GetReceipts(txHash []common.Hash) ([]*types.Receipt, error) {
 		len(txHash),
 		func(client *PooledEhtClient, i int) error {
 			hash := txHash[i]
-			// Wait for the response with some exponential backoff.
-			const maxDelay = 100 * time.Millisecond
-			now := time.Now()
-			delay := time.Millisecond
-			for time.Since(now) < 100*time.Second {
-				receipt, err := client.TransactionReceipt(context.Background(), hash)
+
+			err := WaitFor(context.Background(), func(ctx context.Context) (bool, error) {
+				receipt, err := client.TransactionReceipt(ctx, hash)
 				if errors.Is(err, ethereum.NotFound) {
-					time.Sleep(delay)
-					delay = 2 * delay
-					if delay > maxDelay {
-						delay = maxDelay
-					}
-					continue
+					return false, nil // receipt not yet available, keep waiting
 				}
 				if err != nil {
-					return fmt.Errorf("failed to get transaction receipt: %w", err)
+					return false, fmt.Errorf("failed to get transaction receipt: %w", err)
 				}
 				res[i] = receipt
-				return nil
+				return true, nil // receipt available, stop waiting
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get transaction receipt: %w", err)
 			}
-			return fmt.Errorf("failed to get transaction receipt: timeout")
+			return nil
 		},
 	)
 	if err != nil {

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -761,7 +761,7 @@ func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSessio
 // AdvanceEpoch trigger the sealing of an epoch and the epoch number to progress by the given number.
 // The function blocks until the final epoch has been reached. This method can only be called
 // on a validator account.
-func (s *Session) AdvanceEpoch(epochs int) error {
+func (s *Session) AdvanceEpoch(t testing.TB, epochs int) {
 	client, err := s.GetClient()
 	if err != nil {
 		return fmt.Errorf("failed to connect to the client: %w", err)

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -179,8 +179,7 @@ func TestIntegrationTestNet_AdvanceEpoch(t *testing.T) {
 	err = client.Client().Call(&epochBefore, "eth_currentEpoch")
 	require.NoError(t, err)
 
-	err = net.AdvanceEpoch(13)
-	require.NoError(t, err)
+	net.AdvanceEpoch(t, 13)
 
 	var epochAfter hexutil.Uint64
 	err = client.Client().Call(&epochAfter, "eth_currentEpoch")

--- a/tests/large_transactions/large_transactions_test.go
+++ b/tests/large_transactions/large_transactions_test.go
@@ -155,7 +155,7 @@ func testLargeTransactionLoadTest(
 	modified.Economy.LongGasPower = modified.Economy.ShortGasPower
 	modified.Emitter.Interval = 200_000_000 // low a bit down to provoke larger events
 	tests.UpdateNetworkRules(t, net, modified)
-	require.NoError(net.AdvanceEpoch(1))
+	net.AdvanceEpoch(t, 1)
 
 	// Check that the modification was applied.
 	current = tests.GetNetworkRules(t, net)

--- a/tests/rpc_replay_test.go
+++ b/tests/rpc_replay_test.go
@@ -72,8 +72,7 @@ func TestRpcReplay_IsConsistentWithUpgradesAtBlockHeight(t *testing.T) {
 		Upgrades: struct{ Allegro bool }{Allegro: true},
 	}
 	UpdateNetworkRules(t, net, rulesDiff)
-	err = net.AdvanceEpoch(1)
-	require.NoError(t, err)
+	net.AdvanceEpoch(t, 1)
 	AdvanceEpochAndWaitForBlocks(t, net)
 
 	tx2 := SignTransaction(t, net.GetChainId(),

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -377,7 +377,7 @@ func testDelegateCanBeSetAndUnset(t *testing.T, session IntegrationTestNetSessio
 	require.Equal(t, expectedCode, codeSet, "code in account is expected to be delegation designation")
 
 	// wait until previous transaction has been
-	err = waitUntilTransactionIsRetiredFromPool(t, client, setCodeTx)
+	err = WaitUntilTransactionIsRetiredFromPool(t, client, setCodeTx)
 	require.NoError(t, err, "transaction should be retired from the pool")
 
 	// unset by delegating to an empty address

--- a/tests/single_proposer_protocol_test.go
+++ b/tests/single_proposer_protocol_test.go
@@ -129,7 +129,7 @@ func testSingleProposerProtocol_CanProcessTransactions(
 		// processing and the epoch change. Thus, the first epoch will run for
 		// EpochLength/2 rounds, and the rest for EpochLength rounds.
 		if round%EpochLength == EpochLength/2 {
-			require.NoError(net.AdvanceEpoch(1))
+			net.AdvanceEpoch(t, 1)
 		}
 	}
 
@@ -218,7 +218,7 @@ func testSingleProposerProtocol_CanBeEnabledAndDisabled(
 			require.Equal(step.versionBefore, getUsedEventVersion(t, client))
 
 			// Advance the epoch by one, enabling the single-proposer protocol.
-			require.NoError(net.AdvanceEpoch(1))
+			net.AdvanceEpoch(t, 1)
 
 			// Check that transactions can still be processed after the epoch change.
 			for range 5 {

--- a/tests/test_utils_test.go
+++ b/tests/test_utils_test.go
@@ -17,7 +17,6 @@
 package tests
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -387,8 +386,7 @@ func Test_testIntegrationTestNetTools_setTransactionDefaults_IsCorrectAfterUpgra
 		Upgrades: struct{ Allegro bool }{Allegro: true},
 	}
 	UpdateNetworkRules(t, net, rulesDiff)
-	err = net.AdvanceEpoch(1)
-	require.NoError(t, err)
+	net.AdvanceEpoch(t, 1)
 	AdvanceEpochAndWaitForBlocks(t, net)
 
 	// Wait until tx pool updates
@@ -434,7 +432,7 @@ func test_WaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(
 	// Because nonce is set to current nonce + 1, the transaction will not be executed
 	// waiting must time out
 	err = waitUntilTransactionIsRetiredFromPool(t, client, txInvalidNonce)
-	require.ErrorContains(t, err, fmt.Sprintf("transaction %s was not retired from the pool in time", txInvalidNonce.Hash().String()))
+	require.ErrorContains(t, err, "wait timeout")
 
 	txData.Nonce = 0
 	txCorrectNonce := SignTransaction(t, chainId, txData, account)

--- a/tests/test_utils_test.go
+++ b/tests/test_utils_test.go
@@ -29,22 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntegrationTestNetTools(t *testing.T) {
-
-	t.Run("setTransactionDefaults sets the transaction defaults", func(t *testing.T) {
-		session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
-		t.Parallel()
-		testIntegrationTestNetTools_setTransactionDefaults(t, session)
-	})
-
-	t.Run("waitUntilTransactionIsRetiredFromPool waits from completion", func(t *testing.T) {
-		session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
-		t.Parallel()
-		test_WaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(t, session)
-	})
-}
-
-func testIntegrationTestNetTools_setTransactionDefaults(t *testing.T, session IntegrationTestNetSession) {
+func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	t.Parallel()
 
 	client, err := session.GetClient()
 	require.NoError(t, err)
@@ -356,7 +343,7 @@ func testIntegrationTestNetTools_setTransactionDefaults(t *testing.T, session In
 	})
 }
 
-func Test_testIntegrationTestNetTools_setTransactionDefaults_IsCorrectAfterUpgradesChange(t *testing.T) {
+func TestSetTransactionDefaults_IsCorrectAfterUpgradesChange(t *testing.T) {
 	net := StartIntegrationTestNetWithJsonGenesis(t)
 
 	client, err := net.GetClient()
@@ -412,8 +399,12 @@ func Test_testIntegrationTestNetTools_setTransactionDefaults_IsCorrectAfterUpgra
 	require.Greater(t, receipt2.GasUsed, receipt.GasUsed)
 }
 
-func test_WaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(
-	t *testing.T, session IntegrationTestNetSession) {
+func TestWaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(t *testing.T) {
+	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	t.Parallel()
+
+	// TODO: this test can benefit from using synctest once it is available
+	// This test expects some large timers to time-out
 
 	client, err := session.GetClient()
 	require.NoError(t, err)
@@ -433,7 +424,7 @@ func test_WaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(
 
 	// Because nonce is set to current nonce + 1, the transaction will not be executed
 	// waiting must time out
-	err = waitUntilTransactionIsRetiredFromPool(t, client, txInvalidNonce)
+	err = WaitUntilTransactionIsRetiredFromPool(t, client, txInvalidNonce)
 	require.ErrorContains(t, err, "wait timeout")
 
 	txData.Nonce = 0
@@ -444,9 +435,9 @@ func test_WaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(
 
 	// Once the valid nonce transaction is sent, both transactions will be executed
 	// and retired from the pool
-	err = waitUntilTransactionIsRetiredFromPool(t, client, txInvalidNonce)
+	err = WaitUntilTransactionIsRetiredFromPool(t, client, txInvalidNonce)
 	require.NoError(t, err)
-	err = waitUntilTransactionIsRetiredFromPool(t, client, txCorrectNonce)
+	err = WaitUntilTransactionIsRetiredFromPool(t, client, txCorrectNonce)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This PR removes all waiting loops used in integration tests in favor of a unified waiting routine. 
This routine uses the same old 100 seconds timeout defined for -race tests.
This routine implements exponential back-off for sleep waits. 
This routine uses context objects for future integration with [traces](https://go.dev/blog/execution-traces-2024) . 

