### PR TITLE
Remove deprecated default command arguments

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -434,8 +434,8 @@ func DefaultNodeConfig() node.Config {
 	cfg := NodeDefaultConfig
 	cfg.Name = ClientIdentifier
 	cfg.Version = version.StringWithCommit()
-	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "ftm", "dag", "abft", "web3")
-	cfg.WSModules = append(cfg.WSModules, "eth", "ftm", "dag", "abft", "web3")
+	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "dag", "abft", "web3")
+	cfg.WSModules = append(cfg.WSModules, "eth", "dag", "abft", "web3")
 	cfg.IPCPath = "sonic.ipc"
 	return cfg
 }


### PR DESCRIPTION
Default arguments included deprecated API namespaces, which log a warning. 
This PR removes these from the default command line arguments. 