### PR TITLE
remove parallel from integration multi node tests

### DIFF
--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -42,7 +42,6 @@ func TestIntegrationTestNet_CanStartRestartAndStopIntegrationTestNet(t *testing.
 func TestIntegrationTestNet_CanRestartWithGenesisExportAndImport(t *testing.T) {
 	for _, numNodes := range []int{1, 2} {
 		t.Run(fmt.Sprintf("NumNodes=%d", numNodes), func(t *testing.T) {
-			t.Parallel()
 			net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
 				NumNodes: numNodes,
 			})
@@ -191,7 +190,6 @@ func TestIntegrationTestNet_AdvanceEpoch(t *testing.T) {
 func TestIntegrationTestNet_CanRunMultipleNodes(t *testing.T) {
 	for _, numNodes := range []int{1, 2, 3} {
 		t.Run(fmt.Sprintf("NumNodes%d", numNodes), func(t *testing.T) {
-			t.Parallel()
 			net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
 				NumNodes: numNodes,
 			})


### PR DESCRIPTION
Tests with simulate multiple nodes, start multiple instances of the client, hence requiring more memory. The extra memory requirements plus the intense parallelism, excerpt the race detection analysis.

Serializing this tests reduces memory requirements by 3GBs, but increases runtime from ~30 seconds to ~1 minute. This is an acceptable trade off, considering that reducing memory requirements will improve stability of CI. 