### PR TITLE
Set chain ID for internal transaction in RPC

### DIFF
--- a/ethapi/api.go
+++ b/ethapi/api.go
@@ -209,7 +209,7 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]*RPCTransac
 	for account, txs := range pending {
 		dump := make(map[string]*RPCTransaction)
 		for _, tx := range txs {
-			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee)
+			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee, s.b.ChainID())
 		}
 		content["pending"][account.Hex()] = dump
 	}
@@ -217,7 +217,7 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]*RPCTransac
 	for account, txs := range queue {
 		dump := make(map[string]*RPCTransaction)
 		for _, tx := range txs {
-			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee)
+			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee, s.b.ChainID())
 		}
 		content["queued"][account.Hex()] = dump
 	}
@@ -233,14 +233,14 @@ func (s *PublicTxPoolAPI) ContentFrom(addr common.Address) map[string]map[string
 	// Build the pending transactions
 	dump := make(map[string]*RPCTransaction, len(pending))
 	for _, tx := range pending {
-		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee)
+		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee, s.b.ChainID())
 	}
 	content["pending"] = dump
 
 	// Build the queued transactions
 	dump = make(map[string]*RPCTransaction, len(queue))
 	for _, tx := range queue {
-		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee)
+		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader.BaseFee, s.b.ChainID())
 	}
 	content["queued"] = dump
 
@@ -878,7 +878,7 @@ func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.B
 		if err != nil {
 			return nil, err
 		}
-		return RPCMarshalBlock(block, receipts, true, fullTx)
+		return RPCMarshalBlock(block, receipts, true, fullTx, s.b.ChainID())
 	}
 	return nil, err
 }
@@ -892,7 +892,7 @@ func (s *PublicBlockChainAPI) GetBlockByHash(ctx context.Context, hash common.Ha
 		if err != nil {
 			return nil, err
 		}
-		return RPCMarshalBlock(block, receipts, true, fullTx)
+		return RPCMarshalBlock(block, receipts, true, fullTx, s.b.ChainID())
 	}
 	return nil, err
 }
@@ -1283,7 +1283,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args TransactionA
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlock(block *evmcore.EvmBlock, receipts types.Receipts, inclTx bool, fullTx bool) (*evmcore.EvmBlockJson, error) {
+func RPCMarshalBlock(block *evmcore.EvmBlock, receipts types.Receipts, inclTx bool, fullTx bool, chainId *big.Int) (*evmcore.EvmBlockJson, error) {
 	size := hexutil.Uint64(block.EthBlock().Size()) // RPC encoded storage size
 	json := &evmcore.EvmBlockJson{
 		EvmHeaderJson: block.Header().ToJson(receipts),
@@ -1296,7 +1296,7 @@ func RPCMarshalBlock(block *evmcore.EvmBlock, receipts types.Receipts, inclTx bo
 		}
 		if fullTx {
 			formatTx = func(tx *types.Transaction) (interface{}, error) {
-				return newRPCTransactionFromBlockHash(block, tx.Hash()), nil
+				return newRPCTransactionFromBlockHash(block, tx.Hash(), chainId), nil
 			}
 		}
 		txs := block.Transactions
@@ -1342,7 +1342,7 @@ type RPCTransaction struct {
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int, chainId *big.Int) *RPCTransaction {
 	// Determine the signer. For replay-protected transactions, use the most permissive
 	// signer, because we assume that signers are backwards-compatible with old
 	// transactions. For non-protected transactions, the homestead signer signer is used
@@ -1354,6 +1354,14 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		signer = gsignercache.Wrap(types.HomesteadSigner{})
 	}
 	from, _ := internaltx.Sender(signer, tx)
+
+	// Set the chain id for internal transaction
+	var txChainId *big.Int
+	if from == (common.Address{}) {
+		txChainId = chainId
+	} else {
+		txChainId = tx.ChainId()
+	}
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{
 		Type:     hexutil.Uint64(tx.Type()),
@@ -1365,7 +1373,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		Nonce:    hexutil.Uint64(tx.Nonce()),
 		To:       tx.To(),
 		Value:    (*hexutil.Big)(tx.Value()),
-		ChainID:  (*hexutil.Big)(tx.ChainId()),
+		ChainID:  (*hexutil.Big)(txChainId),
 		V:        (*hexutil.Big)(v),
 		R:        (*hexutil.Big)(r),
 		S:        (*hexutil.Big)(s),
@@ -1427,17 +1435,17 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 }
 
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
-func newRPCPendingTransaction(tx *types.Transaction, baseFee *big.Int) *RPCTransaction {
-	return newRPCTransaction(tx, common.Hash{}, 0, 0, baseFee)
+func newRPCPendingTransaction(tx *types.Transaction, baseFee *big.Int, chainId *big.Int) *RPCTransaction {
+	return newRPCTransaction(tx, common.Hash{}, 0, 0, baseFee, chainId)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
-func newRPCTransactionFromBlockIndex(b *evmcore.EvmBlock, index uint64) *RPCTransaction {
+func newRPCTransactionFromBlockIndex(b *evmcore.EvmBlock, index uint64, chainId *big.Int) *RPCTransaction {
 	txs := b.Transactions
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	return newRPCTransaction(txs[index], b.Hash, b.NumberU64(), index, b.BaseFee)
+	return newRPCTransaction(txs[index], b.Hash, b.NumberU64(), index, b.BaseFee, chainId)
 }
 
 // newRPCRawTransactionFromBlockIndex returns the bytes of a transaction given a block and a transaction index.
@@ -1451,10 +1459,10 @@ func newRPCRawTransactionFromBlockIndex(b *evmcore.EvmBlock, index uint64) hexut
 }
 
 // newRPCTransactionFromBlockHash returns a transaction that will serialize to the RPC representation.
-func newRPCTransactionFromBlockHash(b *evmcore.EvmBlock, hash common.Hash) *RPCTransaction {
+func newRPCTransactionFromBlockHash(b *evmcore.EvmBlock, hash common.Hash, chainId *big.Int) *RPCTransaction {
 	for idx, tx := range b.Transactions {
 		if tx.Hash() == hash {
-			return newRPCTransactionFromBlockIndex(b, uint64(idx))
+			return newRPCTransactionFromBlockIndex(b, uint64(idx), chainId)
 		}
 	}
 	return nil
@@ -1612,7 +1620,7 @@ func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByHash(ctx context.Co
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
 func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *RPCTransaction {
 	if block, _ := s.b.BlockByNumber(ctx, blockNr); block != nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index))
+		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainID())
 	}
 	return nil
 }
@@ -1620,7 +1628,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx conte
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
 func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *RPCTransaction {
 	if block, _ := s.b.BlockByHash(ctx, blockHash); block != nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index))
+		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainID())
 	}
 	return nil
 }
@@ -1673,11 +1681,11 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 		if header == nil || err != nil {
 			return nil, err
 		}
-		return newRPCTransaction(tx, header.Hash, blockNumber, index, header.BaseFee), nil
+		return newRPCTransaction(tx, header.Hash, blockNumber, index, header.BaseFee, s.b.ChainID()), nil
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx := s.b.GetPoolTransaction(hash); tx != nil {
-		return newRPCPendingTransaction(tx, s.b.MinGasPrice()), nil
+		return newRPCPendingTransaction(tx, s.b.MinGasPrice(), s.b.ChainID()), nil
 	}
 
 	// Transaction unknown, return as such
@@ -2007,7 +2015,7 @@ func (s *PublicTransactionPoolAPI) PendingTransactions() ([]*RPCTransaction, err
 	for _, tx := range pending {
 		from, _ := internaltx.Sender(s.signer, tx)
 		if _, exists := accounts[from]; exists {
-			transactions = append(transactions, newRPCPendingTransaction(tx, s.b.MinGasPrice()))
+			transactions = append(transactions, newRPCPendingTransaction(tx, s.b.MinGasPrice(), s.b.ChainID()))
 		}
 	}
 	return transactions, nil

--- a/ethapi/api_test.go
+++ b/ethapi/api_test.go
@@ -762,7 +762,7 @@ func TestTransactionJSONSerialization(t *testing.T) {
 			index := uint64(0)
 			baseFee := big.NewInt(1234)
 
-			rpcTx := newRPCTransaction(signed, blockHash, blockNumber, index, baseFee)
+			rpcTx := newRPCTransaction(signed, blockHash, blockNumber, index, baseFee, chainId)
 			require.Equal(t, signed.Hash(), rpcTransactionToTransaction(t, rpcTx).Hash())
 
 			encoded, err := json.Marshal(rpcTx)
@@ -833,7 +833,7 @@ func TestNewRPCTransaction_AllTxSignatureAndHashCanBeVerified(t *testing.T) {
 			require.NoError(t, err)
 			signed := signTransaction(t, chainId, tx, key)
 
-			rpcTx := newRPCTransaction(signed, common.Hash{}, 0, 0, big.NewInt(0))
+			rpcTx := newRPCTransaction(signed, common.Hash{}, 0, 0, big.NewInt(0), chainId)
 			require.Equal(t, signed.Hash(), rpcTx.Hash)
 			require.Equal(t, chainId.Int64(), rpcTx.ChainID.ToInt().Int64())
 
@@ -868,7 +868,7 @@ func TestNewRPCTransaction_LegacyTxSignedWithHomesteadCanBeReproducedAndVerified
 	require.Equal(t, int64(0), signed.ChainId().Int64())
 
 	// convert to RPCTransaction
-	rpcTx := newRPCTransaction(signed, common.Hash{}, 0, 0, big.NewInt(0))
+	rpcTx := newRPCTransaction(signed, common.Hash{}, 0, 0, big.NewInt(0), signed.ChainId())
 	require.Equal(t, signed.Hash(), rpcTx.Hash)
 	require.Equal(t, int64(0), rpcTx.ChainID.ToInt().Int64())
 


### PR DESCRIPTION
This PR sets chain id in RPC for internal transactions. As chain id was added for legacy transactions in PR https://github.com/0xsoniclabs/sonic/pull/221 , it has to be visible in RPC json object. For internal transactions it is not possible to obtain chain id from signature and because of that it has to be added on the RPC layer.

https://github.com/0xsoniclabs/sonic-admin/issues/333