### PR TITLE
Move integration test advance epoch to the correct receiver

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -748,9 +748,9 @@ func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSessio
 // AdvanceEpoch trigger the sealing of an epoch and the epoch number to progress by the given number.
 // The function blocks until the final epoch has been reached. This method can only be called
 // on a validator account.
-func (s *Session) AdvanceEpoch(t testing.TB, epochs int) {
+func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 	t.Helper()
-	client, err := s.GetClient()
+	client, err := n.GetClient()
 	require.NoError(t, err, "failed to connect to the Ethereum client")
 
 	var currentEpoch hexutil.Uint64
@@ -760,7 +760,7 @@ func (s *Session) AdvanceEpoch(t testing.TB, epochs int) {
 	contract, err := driverauth100.NewContract(driverauth.ContractAddress, client)
 	require.NoError(t, err, "failed to create contract instance")
 
-	receipt, err := s.Apply(func(ops *bind.TransactOpts) (*types.Transaction, error) {
+	receipt, err := n.Apply(func(ops *bind.TransactOpts) (*types.Transaction, error) {
 		return contract.AdvanceEpochs(ops, big.NewInt(int64(epochs)))
 	})
 	require.NoError(t, err, "failed to advance epoch")

--- a/tests/rpc_replay_test.go
+++ b/tests/rpc_replay_test.go
@@ -72,7 +72,6 @@ func TestRpcReplay_IsConsistentWithUpgradesAtBlockHeight(t *testing.T) {
 		Upgrades: struct{ Allegro bool }{Allegro: true},
 	}
 	UpdateNetworkRules(t, net, rulesDiff)
-	net.AdvanceEpoch(t, 1)
 	AdvanceEpochAndWaitForBlocks(t, net)
 
 	tx2 := SignTransaction(t, net.GetChainId(),

--- a/tests/test_utils_test.go
+++ b/tests/test_utils_test.go
@@ -375,7 +375,6 @@ func TestSetTransactionDefaults_IsCorrectAfterUpgradesChange(t *testing.T) {
 		Upgrades: struct{ Allegro bool }{Allegro: true},
 	}
 	UpdateNetworkRules(t, net, rulesDiff)
-	net.AdvanceEpoch(t, 1)
 	AdvanceEpochAndWaitForBlocks(t, net)
 
 	// Wait until tx pool updates


### PR DESCRIPTION
This PR removes two unnecessary epoch advancements from two tests, since calling `AdvanceEpochAndWaitForBlocks` already advances an epoch. It also moves the method `AdvanceEpoch` from `Session` to `IntegrationTestNet` as session should never attempt to advance epochs. 