### PR TITLE
Remove fuzzer targets from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,29 +43,6 @@ coverage:
 	go tool cover -html build/coverage.cov -o build/coverage.html &&\
 	echo "Coverage report generated in build/coverage.html"
 
-.PHONY: fuzz
-fuzz:
-	CGO_ENABLED=1 \
-	mkdir -p ./fuzzing && \
-	go run github.com/dvyukov/go-fuzz/go-fuzz-build -o=./fuzzing/gossip-fuzz.zip ./gossip && \
-	go run github.com/dvyukov/go-fuzz/go-fuzz -workdir=./fuzzing -bin=./fuzzing/gossip-fuzz.zip
-
-
-.PHONY: fuzz-txpool-validatetx-cover
-fuzz-txpool-validatetx-cover: PACKAGES=./...,github.com/ethereum/go-ethereum/core/...
-fuzz-txpool-validatetx-cover: DATE=$(shell date +"%Y-%m-%d-%T")
-fuzz-txpool-validatetx-cover: export GOCOVERDIR=./build/coverage/fuzz-validate/${DATE}
-fuzz-txpool-validatetx-cover: SEEDDIR=$$(go env GOCACHE)/fuzz/github.com/0xsoniclabs/sonic/evmcore/FuzzValidateTransaction/
-fuzz-txpool-validatetx-cover: TEMPSEEDDIR=./evmcore/testdata/fuzz/FuzzValidateTransaction/
-fuzz-txpool-validatetx-cover:
-	@mkdir -p ${GOCOVERDIR} ;\
-     mkdir -p ${TEMPSEEDDIR} ;\
-	 go test -fuzz=FuzzValidateTransaction -fuzztime=2m ./evmcore/ ;\
-     cp -r ${SEEDDIR}* ${TEMPSEEDDIR} ;\
-     go test -v -run FuzzValidateTransaction -coverprofile=${GOCOVERDIR}/fuzz-txpool-validatetx-cover.out -coverpkg=${PACKAGES} ./evmcore/ ;\
-     go tool cover -html ${GOCOVERDIR}/fuzz-txpool-validatetx-cover.out -o ${GOCOVERDIR}/fuzz-txpool-validatetx-coverage.html ;\
-     rm -rf ${TEMPSEEDDIR} ;\
-
 .PHONY: clean
 clean:
 	rm -fr ./build/*


### PR DESCRIPTION
Fuzzing of the sonic client has grown since the time when these targets were written.
Fuzzers now use Golang builtin fuzzing facilities and do not need installation of new tools (since https://github.com/0xsoniclabs/sonic/pull/441). 

The fuzzer tests at the time of this PR are:
```
func FuzzScrambler(f *testing.F) {
func FuzzScheduler_Schedule_PicksLongestPrefixOfAcceptedTransactions(f *testing.F) {
func FuzzGossipHandler(f *testing.F) {
func FuzzEventDeserialization(f *testing.F) {
func FuzzIsValidTurnProgression(f *testing.F) {
func FuzzPayloadDeserialization(f *testing.F) {
func FuzzValidateTransaction(f *testing.F) {
```
Since fuzzers are integrated into the CI scripts, this PR removes the need to maintain makefile targets for each of these. 

This PR and #441 fix https://github.com/0xsoniclabs/sonic/issues/18