### PR TITLE
Add CreateTransaction helper function

### DIFF
--- a/tests/network_rules_update/network_rules_update_test.go
+++ b/tests/network_rules_update/network_rules_update_test.go
@@ -369,6 +369,5 @@ func makeSetCodeTx(
 	txData := &types.SetCodeTx{
 		AuthList: []types.SetCodeAuthorization{authorization},
 	}
-	txData = tests.SetTransactionDefaults(t, net, txData, account)
-	return tests.SignTransaction(t, chainID, txData, account)
+	return tests.CreateTransaction(t, net, txData)
 }

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -87,8 +87,7 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 				account := NewAccount()
 
 				txData := txFactory(t, account)
-				txData = SetTransactionDefaults(t, session, txData, account)
-				tx := SignTransaction(t, chainId, txData, account)
+				tx := CreateTransaction(t, session, txData)
 				cost := tx.Cost()
 
 				//  endow account with less than the cost of the transaction
@@ -104,8 +103,7 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 				account := NewAccount()
 
 				txData := txFactory(t, account)
-				txData = SetTransactionDefaults(t, session, txData, account)
-				tx := SignTransaction(t, chainId, txData, account)
+				tx := CreateTransaction(t, session, txData)
 
 				// provide enough funds for successful execution
 				receipt, err := session.EndowAccount(account.Address(), big.NewInt(1e18))

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -37,6 +37,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// CreateTransaction fills the given tx with acceptable values for the given
+// session, signs it, and returns the signed transaction.
+func CreateTransaction(t *testing.T, session IntegrationTestNetSession, tx types.TxData) *types.Transaction {
+	t.Helper()
+	sponsor := session.GetSessionSponsor()
+	signedTx := SignTransaction(
+		t,
+		session.GetChainId(),
+		SetTransactionDefaults(t, session, tx, sponsor),
+		sponsor,
+	)
+	return signedTx
+}
+
 // SignTransaction is a testing helper that signs a transaction with the
 // key from the provided account
 func SignTransaction(

--- a/tests/test_utils_test.go
+++ b/tests/test_utils_test.go
@@ -258,8 +258,7 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 			}
 			nonce++
 
-			txData := SetTransactionDefaults(t, session, tx, session.GetSessionSponsor())
-			tx := SignTransaction(t, chainId, txData, session.GetSessionSponsor())
+			tx := CreateTransaction(t, session, tx)
 
 			// the filled values suffice to get the transaction accepted and executed
 			err := client.SendTransaction(t.Context(), tx)
@@ -284,8 +283,7 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-		txData := SetTransactionDefaults(t, session, &types.LegacyTx{}, session.GetSessionSponsor())
-		tx := SignTransaction(t, chainId, txData, session.GetSessionSponsor())
+		tx := CreateTransaction(t, session, &types.LegacyTx{})
 
 		nonce, err := client.NonceAt(t.Context(), session.GetSessionSponsor().Address(), nil)
 		require.NoError(t, err)
@@ -304,10 +302,7 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-		txData := SetTransactionDefaults(t, session, &types.LegacyTx{
-			Nonce: 1,
-		}, session.GetSessionSponsor())
-		tx := SignTransaction(t, chainId, txData, session.GetSessionSponsor())
+		tx := CreateTransaction(t, session, &types.LegacyTx{Nonce: 1})
 
 		// the filled values suffice to get the transaction accepted and executed
 		_, err = session.Run(tx)
@@ -318,10 +313,7 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		session := session.SpawnSession(t)
 		t.Parallel()
 
-		txData := SetTransactionDefaults(t, session, &types.LegacyTx{
-			Gas: 1,
-		}, session.GetSessionSponsor())
-		tx := SignTransaction(t, chainId, txData, session.GetSessionSponsor())
+		tx := CreateTransaction(t, session, &types.LegacyTx{Gas: 1})
 
 		// the filled values suffice to get the transaction accepted and executed
 		_, err := session.Run(tx)
@@ -332,10 +324,7 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		session := session.SpawnSession(t)
 		t.Parallel()
 
-		txData := SetTransactionDefaults(t, session, &types.LegacyTx{
-			GasPrice: big.NewInt(1),
-		}, session.GetSessionSponsor())
-		tx := SignTransaction(t, chainId, txData, session.GetSessionSponsor())
+		tx := CreateTransaction(t, session, &types.LegacyTx{GasPrice: big.NewInt(1)})
 
 		// the filled values suffice to get the transaction accepted and executed
 		_, err := session.Run(tx)


### PR DESCRIPTION
This PR adds a helper function `CreateTransaction` as [suggested ](https://github.com/0xsoniclabs/sonic/pull/455#discussion_r2304208317). This function simplifies how to fill and sign a transaction.

This PR resolves https://github.com/0xsoniclabs/sonic-admin/issues/337