### PR TITLE
Wait for processed transaction to leave tx pool

### DIFF
--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -213,6 +214,15 @@ func WaitUntilTransactionIsRetiredFromPool(t *testing.T, client *PooledEhtClient
 	txHash := tx.Hash()
 	txSender, err := types.Sender(types.NewPragueSigner(tx.ChainId()), tx)
 	require.NoError(t, err, "failed to get transaction sender address")
+	return waitUntilTransactionIsRetiredFromPoolByHash(t, client, txHash, txSender)
+}
+
+// WaitUntilTransactionIsRetiredFromPool waits until the transaction of the given hash
+// no longer exists in the transaction pool.
+// Because the transaction pool eviction is asynchronous, executed transactions may remain in the pool
+// for some time after they have been executed.
+// function will eventually time out if the transaction is not retired and an error will be returned.
+func waitUntilTransactionIsRetiredFromPoolByHash(t *testing.T, client *PooledEhtClient, txHash common.Hash, txSender common.Address) error {
 
 	// txpool_content returns a map containing two maps:
 	// - pending: transactions that are pending to be executed
@@ -246,7 +256,6 @@ func WaitUntilTransactionIsRetiredFromPool(t *testing.T, client *PooledEhtClient
 
 		return !found, nil
 	})
-
 }
 
 // UpdateNetworkRules sends a transaction to update the network rules.

--- a/tests/test_utils_test.go
+++ b/tests/test_utils_test.go
@@ -296,16 +296,21 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		t.Parallel()
 
 		// endowments modify the account nonce
-		for range 3 {
-			receipt, err := session.EndowAccount(common.Address{}, big.NewInt(1))
+		var receipt *types.Receipt
+		var err error
+		for range 2 {
+			receipt, err = session.EndowAccount(common.Address{}, big.NewInt(1))
 			require.NoError(t, err)
 			require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 		}
 
+		err = waitUntilTransactionIsRetiredFromPoolByHash(t, client, receipt.TxHash, session.GetSessionSponsor().Address())
+		require.NoError(t, err)
+
 		tx := CreateTransaction(t, session, &types.LegacyTx{Nonce: 1}, session.GetSessionSponsor())
 
 		// the filled values suffice to get the transaction accepted and executed
-		_, err := session.Run(tx)
+		_, err = session.Run(tx)
 		require.ErrorContains(t, err, "nonce too low")
 	})
 

--- a/tests/test_utils_test.go
+++ b/tests/test_utils_test.go
@@ -294,18 +294,18 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 	t.Run("non-zero nonce is not defaulted", func(t *testing.T) {
 		session := session.SpawnSession(t)
 		t.Parallel()
+
 		// endowments modify the account nonce
-		receipt, err := session.EndowAccount(common.Address{}, big.NewInt(1))
-		require.NoError(t, err)
-		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
-		receipt, err = session.EndowAccount(common.Address{}, big.NewInt(1))
-		require.NoError(t, err)
-		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+		for range 3 {
+			receipt, err := session.EndowAccount(common.Address{}, big.NewInt(1))
+			require.NoError(t, err)
+			require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+		}
 
 		tx := CreateTransaction(t, session, &types.LegacyTx{Nonce: 1}, session.GetSessionSponsor())
 
 		// the filled values suffice to get the transaction accepted and executed
-		_, err = session.Run(tx)
+		_, err := session.Run(tx)
 		require.ErrorContains(t, err, "nonce too low")
 	})
 


### PR DESCRIPTION
This PR fixes https://github.com/0xsoniclabs/sonic-admin/issues/340

This PR adds a wait for the transaction with nonce 1 to have left the pool, so that the new transaction will not be miss interpreted as a replacement.