### PR TITLE
Improve test support when using Apple OS

### DIFF
--- a/cmd/sonicd/app/unlocking_test.go
+++ b/cmd/sonicd/app/unlocking_test.go
@@ -144,7 +144,9 @@ func TestUnlockFlagPasswordFileWrongPassword(t *testing.T) {
 	initFakenetDatadir(datadir, 1)
 	cli := exec(t,
 		"--fakenet", "0/1", "--datadir", datadir, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",
-		"--password", "testdata/wrong-passwords.txt", "--unlock", "7EF5A6135f1FD6a02593eEdC869c6D41D934aef8,289d485D9771714CCe91D3393D764E1311907ACc")
+		"--password", "testdata/wrong-passwords.txt",
+		"--unlock", "7EF5A6135f1FD6a02593eEdC869c6D41D934aef8,289d485D9771714CCe91D3393D764E1311907ACc",
+		"--ipcdisable")
 
 	cli.ExpectExit()
 	expected := "failed to unlock account 7EF5A6135f1FD6a02593eEdC869c6D41D934aef8 (could not decrypt key with given password)"
@@ -160,7 +162,8 @@ func TestUnlockFlagAmbiguous(t *testing.T) {
 	cli := exec(t,
 		"--fakenet", "0/1", "--datadir", datadir, "--keystore", store, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",
 		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a",
-		"--exitwhensynced.epoch", "1")
+		"--exitwhensynced.epoch", "1",
+		"--ipcdisable")
 
 	// Helper for the expect template, returns absolute keystore path.
 	cli.SetTemplateFunc("keypath", func(file string) string {
@@ -198,7 +201,8 @@ func TestUnlockFlagAmbiguousWrongPassword(t *testing.T) {
 	initFakenetDatadir(datadir, 1)
 	cli := exec(t,
 		"--fakenet", "0/1", "--datadir", datadir, "--keystore", store, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",
-		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a")
+		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a",
+		"--ipcdisable")
 
 	// Helper for the expect template, returns absolute keystore path.
 	cli.SetTemplateFunc("keypath", func(file string) string {


### PR DESCRIPTION
The following error was reported while attempting to test some other feature:
"    /Users/luis/code/sonic/cmd/sonicd/app/test_cmd.go:246: (stderr) failed to start the node: error starting protocol stack: listen Unix /var/folders/p9/b72p6b1n49x34qmdcgp8g1340000gn/T/TestUnlockFlagAmbiguousWrongPassword68034954/001/sonic.ipc:"

Although Mac supports unix-sockets, setup seems to be different. The tests edited are not dependent on unix-socket IPC and fixing it should be its own domain. With appropriate IPC testing. 
