### PR TITLE
TxPool purges transactions with gas over rule limit

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1703,12 +1703,12 @@ func (pool *TxPool) demoteUnexecutables() {
 // discardTxsWithTooLargeGasOsaka removes transactions that exceed the maximum gas limit,
 // if the reset is already in Osaka.
 func (pool *TxPool) discardTxsWithTooLargeGasOsaka(oldHead, newHead *EvmHeader) {
-	if (newHead == nil && oldHead == nil) ||
-		(newHead == oldHead) {
+	if newHead == nil || oldHead == nil || newHead == oldHead {
 		return
 	}
 	// Discard the transactions with the gas limit higher than the cap.
-	if pool.chainconfig.IsOsaka(newHead.Number, uint64(newHead.Time)) {
+	if pool.chainconfig.IsOsaka(newHead.Number, uint64(newHead.Time)) &&
+		!pool.chainconfig.IsOsaka(oldHead.Number, uint64(oldHead.Time)) {
 		var hashes []common.Hash
 		pool.all.Range(func(hash common.Hash, tx *types.Transaction, local bool) bool {
 			if tx.Gas() > params.MaxTxGas {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1270,6 +1270,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	}
 	pool.mu.Lock()
 	if reset != nil {
+		pool.discardTxsWithTooLargeGasOsaka(reset)
 		// Reset from the old head to the new, rescheduling any reorged transactions
 		pool.reset(reset.oldHead, reset.newHead)
 
@@ -1695,6 +1696,27 @@ func (pool *TxPool) demoteUnexecutables() {
 		// Delete the entire pending entry if it became empty.
 		if list.Empty() {
 			delete(pool.pending, addr)
+		}
+	}
+}
+
+// discardTxsWithTooLargeGasOsaka removes transactions that exceed the maximum gas limit,
+// if the reset is already in Osaka.
+func (pool *TxPool) discardTxsWithTooLargeGasOsaka(reset *txpoolResetRequest) {
+	if reset.newHead != nil && reset.oldHead != nil {
+
+		// Discard the transactions with the gas limit higher than the cap.
+		if pool.chainconfig.IsOsaka(reset.newHead.Number, uint64(reset.newHead.Time)) && !pool.chainconfig.IsOsaka(reset.oldHead.Number, uint64(reset.oldHead.Time)) {
+			var hashes []common.Hash
+			pool.all.Range(func(hash common.Hash, tx *types.Transaction, local bool) bool {
+				if tx.Gas() > params.MaxTxGas {
+					hashes = append(hashes, hash)
+				}
+				return true
+			}, true, true) // we want to get both local and remote txs
+			for _, hash := range hashes {
+				pool.removeTx(hash, true)
+			}
 		}
 	}
 }

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"math/rand/v2"
 	"os"
@@ -3132,6 +3133,49 @@ func TestSampleHashesManySenders(t *testing.T) {
 			t.Errorf("expected tx %x (nonce %d) present in samples in more occurrences than expected", txHash, tx.Nonce())
 		}
 	}
+}
+
+func TestTxPool_ResetDropsTransactionsWithHighGas(t *testing.T) {
+
+	statedb := newTestTxPoolStateDb()
+	blockchain := NewTestBlockChain(statedb)
+	blockchain.SetGasLimit(params.MaxTxGas * 2)
+	testChainConfig := params.TestChainConfig
+
+	pool := NewTxPool(testTxPoolConfig, testChainConfig, blockchain)
+	defer pool.Stop()
+
+	// make a transaction with over params.MaxTxGas gas and nonce 0
+	key, _ := crypto.GenerateKey()
+	tx := pricedTransaction(0, params.MaxTxGas+1, big.NewInt(1), key)
+	testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(math.MaxInt64))
+
+	err := pool.addRemoteSync(tx)
+	require.NoError(t, err, "failed to add transaction: %v", err)
+
+	// make a transaction with little gas and nonce 1
+	smallTx := pricedTransaction(1, 21000, big.NewInt(1), key)
+	err = pool.addRemoteSync(smallTx)
+	require.NoError(t, err, "failed to add transaction: %v", err)
+
+	pending, queued := pool.stats()
+	require.Equal(t, 2, pending, "pending list should have 2 tx but has: %d", pending)
+	require.Equal(t, 0, queued, "queued list should be empty but has: %d", queued)
+
+	someTime := uint64(5)
+	testChainConfig.OsakaTime = &someTime
+
+	// Number and BaseFee are not relevant for the test, but are necessary to simulate "normal" behavior
+	oldHeader := &EvmHeader{Number: big.NewInt(4), Time: 4}
+	newHeader := &EvmHeader{Number: big.NewInt(5), Time: 5, BaseFee: big.NewInt(100)}
+	<-pool.requestReset(oldHeader, newHeader)
+
+	pool.waitForIdleReorgLoop_forTesting()
+
+	// transaction with nonce 0 should be dropped, nonce 1 should be moved to queued
+	pending, queued = pool.stats()
+	require.Equal(t, 0, pending, "pending list should be empty but has: %d", pending)
+	require.Equal(t, 1, queued, "queued list should have 1 tx but has: %d", queued)
 }
 
 // Benchmarks the speed of validating the contents of the pending queue of the

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -135,7 +135,7 @@ type testBlockChain struct {
 }
 
 func NewTestBlockChain(statedb *testTxPoolStateDb) *testBlockChain {
-	return &testBlockChain{statedb, 10000000, new(event.Feed), &params.ChainConfig{}, sync.RWMutex{}}
+	return &testBlockChain{statedb, 10000000, new(event.Feed), nil, sync.RWMutex{}}
 }
 
 func (bc *testBlockChain) changeStateDB(statedb *testTxPoolStateDb) {

--- a/tests/network_rules_update/network_rules_update_test.go
+++ b/tests/network_rules_update/network_rules_update_test.go
@@ -253,20 +253,20 @@ func TestNetworkRules_UpdateToBrio_DropsLargeGasTxs(t *testing.T) {
 	require.Equal(1, len(content["queued"]), "expected the high gas tx to be in the queued section of the tx pool")
 
 	type rulesType struct {
-		Economy  struct{ GasRules opera.GasRules }
+		Economy  struct{ Gas opera.GasRules }
 		Upgrades struct{ Brio bool }
 	}
 
 	var originalRules rulesType
 	err = client.Client().Call(&originalRules, "eth_getRules", "latest")
 	require.NoError(err)
-	require.NotNil(originalRules.Economy.GasRules, "GasRules should be filled")
-	require.NotEqual(0, originalRules.Economy.GasRules.MaxEventGas, "GasRules should be filled")
+	require.NotNil(originalRules.Economy.Gas, "GasRules should be filled")
+	require.NotEqual(0, originalRules.Economy.Gas.MaxEventGas, "GasRules should be filled")
 
 	updatedRules := originalRules
 	defaultGasRules := opera.DefaultGasRules()
 	defaultGasRules.MaxEventGas = 2 >> 24 // 16,777,216
-	updatedRules.Economy.GasRules = defaultGasRules
+	updatedRules.Economy.Gas = defaultGasRules
 	updatedRules.Upgrades.Brio = true
 
 	// Update network rules

--- a/tests/network_rules_update/network_rules_update_test.go
+++ b/tests/network_rules_update/network_rules_update_test.go
@@ -222,7 +222,7 @@ func TestNetworkRule_Update_Restart_Recovers_Original_Value(t *testing.T) {
 	require.GreaterOrEqual(blockAfter.BaseFee().Int64(), newMinBaseFee, "BaseFee should reflect new MinBaseFee")
 }
 
-func TestNetworkRules_UpdateToBrio_DropsLargeGasTxs(t *testing.T) {
+func TestNetworkRules_UpdateMaxEventGas_DropsLargeGasTxs(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
@@ -267,7 +267,6 @@ func TestNetworkRules_UpdateToBrio_DropsLargeGasTxs(t *testing.T) {
 	defaultGasRules := opera.DefaultGasRules()
 	defaultGasRules.MaxEventGas = 16_777_216 // inspired by params.MaxTxGas
 	updatedRules.Economy.Gas = defaultGasRules
-	updatedRules.Upgrades.Brio = true
 
 	// Update network rules
 	tests.UpdateNetworkRules(t, net, updatedRules)

--- a/tests/network_rules_update/network_rules_update_test.go
+++ b/tests/network_rules_update/network_rules_update_test.go
@@ -265,7 +265,7 @@ func TestNetworkRules_UpdateToBrio_DropsLargeGasTxs(t *testing.T) {
 
 	updatedRules := originalRules
 	defaultGasRules := opera.DefaultGasRules()
-	defaultGasRules.MaxEventGas = 2 >> 24 // 16,777,216
+	defaultGasRules.MaxEventGas = 16_777_216 // inspired by params.MaxTxGas
 	updatedRules.Economy.Gas = defaultGasRules
 	updatedRules.Upgrades.Brio = true
 


### PR DESCRIPTION
This PR depends on https://github.com/0xsoniclabs/sonic/pull/472 and resolves https://github.com/0xsoniclabs/sonic-admin/issues/364

This PR adds two tests to verify that when `MaxEventGas` is updated, then all existing transactions with gas the over limit set by the rules should be discarded.

In the reference implementation this is done with a newly introduced purge before resets in [`runReorg`](https://github.com/ethereum/go-ethereum/blob/master/core/txpool/legacypool/legacypool.go#L1255). Geth needs to handle it this way because they have no other way of enforcing the new gas limit. 

Since in Sonic the new max gas cap (introduced with EIP7825) shall be instead set by a network parameter ([here](https://github.com/0xsoniclabs/sonic/blob/main/evmcore/tx_pool.go#L1422) in the TxPool, whose value contribution comes from [`MaxEventGas`](https://github.com/0xsoniclabs/sonic/blob/main/gossip/evm_state_reader.go#L55)) and `TxPool.currentMaxGas` parameter is used to drop transactions during [demoteUnexecutables](https://github.com/0xsoniclabs/sonic/blob/main/evmcore/tx_pool.go#L1658) and [promoteExecutables](https://github.com/0xsoniclabs/sonic/blob/main/evmcore/tx_pool.go#L1462), transactions with a higher gas will be dropped during the resets following the update of `MaxEventGas` without the need to introduce code that would execute only once in all history. 

