### PR TITLE
Remove internal parallelism from isolated tests

### DIFF
--- a/tests/block_header/block_header_test.go
+++ b/tests/block_header/block_header_test.go
@@ -48,14 +48,11 @@ import (
 )
 
 func TestBlockHeader_FakeGenesis_SatisfiesInvariants(t *testing.T) {
-	t.Parallel()
-
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t)
 	testBlockHeadersOnNetwork(t, net)
 }
 
 func TestBlockHeader_JsonGenesis_SatisfiesInvariants(t *testing.T) {
-	t.Parallel()
 
 	upgrades := map[string]opera.Upgrades{
 		"Sonic":   opera.GetSonicUpgrades(),
@@ -68,11 +65,9 @@ func TestBlockHeader_JsonGenesis_SatisfiesInvariants(t *testing.T) {
 	for name, upgrades := range upgrades {
 		t.Run(name, func(t *testing.T) {
 			upgrades := upgrades
-			t.Parallel()
 			for singleProposer, isSingleProposer := range modes {
 				t.Run(singleProposer, func(t *testing.T) {
 					upgrades := upgrades
-					t.Parallel()
 					upgrades.SingleProposerBlockFormation = isSingleProposer
 					net := tests.StartIntegrationTestNetWithJsonGenesis(t, tests.IntegrationTestNetOptions{
 						Upgrades: &upgrades,

--- a/tests/single_proposer/single_proposer_protocol_test.go
+++ b/tests/single_proposer/single_proposer_protocol_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestSingleProposerProtocol_CanProcessTransactions(t *testing.T) {
-	t.Parallel()
 
 	upgrades := map[string]opera.Upgrades{
 		"Sonic":   opera.GetSonicUpgrades(),
@@ -41,12 +40,8 @@ func TestSingleProposerProtocol_CanProcessTransactions(t *testing.T) {
 
 	for name, upgrades := range upgrades {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
 			for _, numNodes := range []int{1, 3} {
 				t.Run(fmt.Sprintf("numNodes=%d", numNodes), func(t *testing.T) {
-					t.Parallel()
-
 					testSingleProposerProtocol_CanProcessTransactions(t, numNodes, upgrades)
 				})
 			}
@@ -151,7 +146,6 @@ func testSingleProposerProtocol_CanProcessTransactions(
 }
 
 func TestSingleProposerProtocol_CanBeEnabledAndDisabled(t *testing.T) {
-	t.Parallel()
 	upgrades := map[string]opera.Upgrades{
 		"Sonic":   opera.GetSonicUpgrades(),
 		"Allegro": opera.GetAllegroUpgrades(),
@@ -159,12 +153,9 @@ func TestSingleProposerProtocol_CanBeEnabledAndDisabled(t *testing.T) {
 
 	for name, upgrades := range upgrades {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 
 			for _, numNodes := range []int{1, 3} {
 				t.Run(fmt.Sprintf("numNodes=%d", numNodes), func(t *testing.T) {
-					t.Parallel()
-
 					testSingleProposerProtocol_CanBeEnabledAndDisabled(t, numNodes, upgrades)
 				})
 			}


### PR DESCRIPTION
This commit removes the use of `t.Parallel()` from which are already running in parallel by the Go test runner. These tests have a large impact on memory usage and since they are already sharing resources with other tests, removing internal parallelism helps reduce peak memory usage.

This PR reduced execution time from 17m to 12m in my machine because of the reduction of competition for resources. 