### PR TITLE
Fix flaky endowment test

### DIFF
--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -126,6 +126,8 @@ func testIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T, session Int
 		require.NoError(t, err, "Failed to endow account 1")
 		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
+		WaitForProofOf(t, client, int(receipt.BlockNumber.Uint64()))
+
 		want := balance.Add(balance, big.NewInt(int64(increment)))
 		balance, err = client.BalanceAt(t.Context(), address, nil)
 		require.NoError(t, err, "Failed to get balance for account")


### PR DESCRIPTION
The test `CanEndowAccountsWithTokens` showed flaky behaviour.
The source of the flakiness is that the `getBalance` RPC method consulted archive state.
This PR moves `WaitForProof` method (which waits for the specified block number to be present in archive state) to test utils and uses in the mentioned flaky test. 