### PR TITLE
Use thread safe method in TxPool test

### DIFF
--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -3182,7 +3182,7 @@ func TestTxPool_ActivatingOsakaDropsTransactionsWithHighGas(t *testing.T) {
 	newHeader := &EvmHeader{Number: big.NewInt(5), Time: 5, BaseFee: big.NewInt(100)}
 
 	// lowering the gas limit should drop the tx with too high gas
-	blockchain.gasLimit = 1 << 24 // set 16M
+	blockchain.SetGasLimit(1 << 24)
 
 	<-pool.requestReset(oldHeader, newHeader)
 	pool.waitForIdleReorgLoop_forTesting()


### PR DESCRIPTION
This PR prevents a race condition on a struct accessed by multiple threads in a test by changing its state using a method that guards the change with a lock. 