### PR TITLE
Introduce feature flag for gas subsidies

### DIFF
--- a/opera/legacy_serialization.go
+++ b/opera/legacy_serialization.go
@@ -121,6 +121,9 @@ func (u Upgrades) EncodeRLP(w io.Writer) error {
 	if u.SingleProposerBlockFormation {
 		bitmap.V |= singleProposerBlockFormationBit
 	}
+	if u.GasSubsidies {
+		bitmap.V |= gasSubsidiesBit
+	}
 	return rlp.Encode(w, &bitmap)
 }
 
@@ -141,6 +144,7 @@ func (u *Upgrades) DecodeRLP(s *rlp.Stream) error {
 	u.Brio = (bitmap.V & brioBit) != 0
 
 	u.SingleProposerBlockFormation = (bitmap.V & singleProposerBlockFormationBit) != 0
+	u.GasSubsidies = (bitmap.V & gasSubsidiesBit) != 0
 	return nil
 }
 

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -145,6 +145,7 @@ func TestUpgradesRLP_CanBeEncodedAndDecoded(t *testing.T) {
 		func(u *Upgrades) { u.Allegro = true },
 		func(u *Upgrades) { u.SingleProposerBlockFormation = true },
 		func(u *Upgrades) { u.Brio = true },
+		func(u *Upgrades) { u.GasSubsidies = true },
 	}
 
 	for mask := range 1 << len(setUpgrade) {

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -229,7 +229,7 @@ type Upgrades struct {
 
 	// GasSubsidies enables the gas subsidies feature, allowing
 	// transactions with zero gas price to be processed, provided
-	// that they are covered by a sponsorship.
+	// that they are subsidized.
 	// This feature is introduced by V2.1.2 of the Sonic client. It thus
 	//
 	//    MUST ONLY BE ENABLED WHEN ALL NODES ARE RUNNING V2.1.2 OR LATER

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -46,6 +46,7 @@ const (
 
 	// optional features
 	singleProposerBlockFormationBit = 1 << 63
+	gasSubsidiesBit                 = 1 << 62
 
 	MinimumMaxBlockGas          = 5_000_000_000 // < must be large enough to allow internal transactions to seal blocks
 	MaximumMaxBlockGas          = math.MaxInt64 // < should fit into 64-bit signed integers to avoid parsing errors in third-party libraries
@@ -225,6 +226,21 @@ type Upgrades struct {
 	// It can be enabled or disabled at any time. Changes in the feature state
 	// become effective at the start of the next epoch.
 	SingleProposerBlockFormation bool
+
+	// GasSubsidies enables the gas subsidies feature, allowing
+	// transactions with zero gas price to be processed, provided
+	// that they are covered by a sponsorship.
+	// This feature is introduced by V2.1.2 of the Sonic client. It thus
+	//
+	//    MUST ONLY BE ENABLED WHEN ALL NODES ARE RUNNING V2.1.2 OR LATER
+	//
+	// Any node not running V2.1.2 or later will ignore this flag, and
+	// transactions with zero gas price will not be accepted.
+	//
+	// Given the conditions stated above, the feature is considered optional.
+	// It can be enabled or disabled at any time. Changes in the feature state
+	// become effective at the start of the next epoch.
+	GasSubsidies bool
 }
 
 // UpgradeHeight contains the information about the block height at which
@@ -333,6 +349,18 @@ func GetAllegroUpgrades() Upgrades {
 		Llr:     false,
 		Sonic:   true,
 		Allegro: true,
+	}
+}
+
+// GetBrioUpgrades contains the feature flags for the Brio upgrade.
+func GetBrioUpgrades() Upgrades {
+	return Upgrades{
+		Berlin:  true,
+		London:  true,
+		Llr:     false,
+		Sonic:   true,
+		Allegro: true,
+		Brio:    true,
 	}
 }
 

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -352,18 +352,6 @@ func GetAllegroUpgrades() Upgrades {
 	}
 }
 
-// GetBrioUpgrades contains the feature flags for the Brio upgrade.
-func GetBrioUpgrades() Upgrades {
-	return Upgrades{
-		Berlin:  true,
-		London:  true,
-		Llr:     false,
-		Sonic:   true,
-		Allegro: true,
-		Brio:    true,
-	}
-}
-
 func MainNetRules() Rules {
 	return Rules{
 		Name:      "main",

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -195,6 +195,11 @@ func TestRules_Copy_CopiesAreDisjoint(t *testing.T) {
 				rule.Upgrades.Brio = !rule.Upgrades.Brio
 			},
 		},
+		"upgrade Upgrades.GasSubsidies": {
+			update: func(rule *Rules) {
+				rule.Upgrades.GasSubsidies = !rule.Upgrades.GasSubsidies
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -237,6 +237,7 @@ func TestCreateTransientEvmChainConfig_ContainsUpgradesBasedOnConstructionTimeBl
 	tests := map[string]Upgrades{
 		"Sonic":   GetSonicUpgrades(),
 		"Allegro": GetAllegroUpgrades(),
+		"Brio":    GetBrioUpgrades(),
 	}
 
 	for name, upgrades := range tests {
@@ -274,10 +275,7 @@ func TestCreateTransientEvmChainConfig_RespectsBlockHeightOfUpgradeHeight(t *tes
 	upgrades := []Upgrades{
 		GetSonicUpgrades(),
 		GetAllegroUpgrades(),
-		{
-			Allegro: true,
-			Brio:    true,
-		},
+		GetBrioUpgrades(),
 	}
 
 	var upgradeHeights []UpgradeHeight

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -237,7 +237,6 @@ func TestCreateTransientEvmChainConfig_ContainsUpgradesBasedOnConstructionTimeBl
 	tests := map[string]Upgrades{
 		"Sonic":   GetSonicUpgrades(),
 		"Allegro": GetAllegroUpgrades(),
-		"Brio":    GetBrioUpgrades(),
 	}
 
 	for name, upgrades := range tests {
@@ -275,7 +274,10 @@ func TestCreateTransientEvmChainConfig_RespectsBlockHeightOfUpgradeHeight(t *tes
 	upgrades := []Upgrades{
 		GetSonicUpgrades(),
 		GetAllegroUpgrades(),
-		GetBrioUpgrades(),
+		{
+			Allegro: true,
+			Brio:    true,
+		},
 	}
 
 	var upgradeHeights []UpgradeHeight

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -287,5 +287,7 @@ func validateUpgrades(old, new Upgrades) error {
 		issues = append(issues, errors.New("Brio upgrade cannot be disabled"))
 	}
 
+	// The GasSubsidies feature can be freely modified.
+
 	return errors.Join(issues...)
 }

--- a/tests/gas_subsidiaries/gas_subsidiaries_test.go
+++ b/tests/gas_subsidiaries/gas_subsidiaries_test.go
@@ -1,0 +1,87 @@
+package gassubsidiaries
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGasSubsidies_CanBeEnabledAndDisabled(t *testing.T) {
+	upgrades := map[string]opera.Upgrades{
+		"Sonic":   opera.GetSonicUpgrades(),
+		"Allegro": opera.GetAllegroUpgrades(),
+		// "Brio":    opera.GetBrioUpgrades(),
+	}
+
+	for name, upgrades := range upgrades {
+		t.Run(name, func(t *testing.T) {
+
+			for _, numNodes := range []int{1, 3} {
+				t.Run(fmt.Sprintf("numNodes=%d", numNodes), func(t *testing.T) {
+					testGasSubsidies_CanBeEnabledAndDisabled(t, numNodes, upgrades)
+				})
+			}
+		})
+	}
+}
+
+func testGasSubsidies_CanBeEnabledAndDisabled(
+	t *testing.T,
+	numNodes int,
+	mode opera.Upgrades,
+) {
+	require := require.New(t)
+
+	// The network is initially started using the distributed protocol.
+	mode.SingleProposerBlockFormation = false
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		NumNodes: numNodes,
+		Upgrades: &mode,
+	})
+
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	// check original state
+	type upgrades struct {
+		GasSubsidies bool
+	}
+	type rulesType struct {
+		Upgrades upgrades
+	}
+
+	var originalRules rulesType
+	err = client.Client().Call(&originalRules, "eth_getRules", "latest")
+	require.NoError(err)
+	require.Equal(false, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be disabled initially")
+
+	// Enable gas subsidies.
+	rulesDiff := rulesType{
+		Upgrades: upgrades{GasSubsidies: true},
+	}
+	tests.UpdateNetworkRules(t, net, rulesDiff)
+
+	// Advance the epoch by one to apply the change.
+	net.AdvanceEpoch(t, 1)
+
+	err = client.Client().Call(&originalRules, "eth_getRules", "latest")
+	require.NoError(err)
+	require.Equal(true, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be disabled initially")
+
+	// Disable gas subsidies.
+	rulesDiff = rulesType{
+		Upgrades: upgrades{GasSubsidies: false},
+	}
+	tests.UpdateNetworkRules(t, net, rulesDiff)
+
+	// Advance the epoch by one to apply the change.
+	net.AdvanceEpoch(t, 1)
+
+	err = client.Client().Call(&originalRules, "eth_getRules", "latest")
+	require.NoError(err)
+	require.Equal(false, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be disabled initially")
+}

--- a/tests/gas_subsidiaries/gas_subsidiaries_test.go
+++ b/tests/gas_subsidiaries/gas_subsidiaries_test.go
@@ -1,3 +1,19 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
 package gassubsidiaries
 
 import (

--- a/tests/gassubsidies/gas_subsidies_test.go
+++ b/tests/gassubsidies/gas_subsidies_test.go
@@ -84,7 +84,7 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 
 			err = client.Client().Call(&originalRules, "eth_getRules", "latest")
 			require.NoError(err)
-			require.Equal(false, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be after the update")
+			require.Equal(false, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be disabled after the update")
 		})
 	}
 }

--- a/tests/gassubsidies/gas_subsidies_test.go
+++ b/tests/gassubsidies/gas_subsidies_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package gassubsidiaries
+package gassubsidies
 
 import (
 	"testing"
@@ -71,7 +71,7 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 
 			err = client.Client().Call(&originalRules, "eth_getRules", "latest")
 			require.NoError(err)
-			require.Equal(true, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be disabled initially")
+			require.Equal(true, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be enabled after the update")
 
 			// Disable gas subsidies.
 			rulesDiff = rulesType{
@@ -84,7 +84,7 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 
 			err = client.Client().Call(&originalRules, "eth_getRules", "latest")
 			require.NoError(err)
-			require.Equal(false, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be disabled initially")
+			require.Equal(false, originalRules.Upgrades.GasSubsidies, "GasSubsidies should be after the update")
 		})
 	}
 }

--- a/tests/gassubsidies/gas_subsidies_test.go
+++ b/tests/gassubsidies/gas_subsidies_test.go
@@ -31,19 +31,23 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 
 	// The network is initially started using the distributed protocol.
 	net := tests.StartIntegrationTestNet(t)
-	upgrades := map[string]opera.Upgrades{
-		"sonic":   opera.GetSonicUpgrades(),
-		"allegro": opera.GetAllegroUpgrades(),
-		//"brio":  opera.GetBrioUpgrades(),
+	// a sliced is used here to ensure the forks get updated in an acceptable order.
+	upgrades := []struct {
+		name    string
+		upgrade opera.Upgrades
+	}{
+		{name: "sonic", upgrade: opera.GetSonicUpgrades()},
+		{name: "allegro", upgrade: opera.GetAllegroUpgrades()},
+		//{name: "brio", upgrade: opera.GetBrioUpgrades()},
 	}
-	for name, upgrade := range upgrades {
-		t.Run(name, func(t *testing.T) {
+	for _, test := range upgrades {
+		t.Run(test.name, func(t *testing.T) {
 			client, err := net.GetClient()
 			require.NoError(err)
 			defer client.Close()
 
 			// enforce the current upgrade
-			tests.UpdateNetworkRules(t, net, upgrade)
+			tests.UpdateNetworkRules(t, net, test.upgrade)
 			// Advance the epoch by one to apply the change.
 			net.AdvanceEpoch(t, 1)
 

--- a/tests/gassubsidies/gas_subsidies_test.go
+++ b/tests/gassubsidies/gas_subsidies_test.go
@@ -38,6 +38,7 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 	}{
 		{name: "sonic", upgrade: opera.GetSonicUpgrades()},
 		{name: "allegro", upgrade: opera.GetAllegroUpgrades()},
+		// Brio is commented out until the gas cap is properly handled for internal transactions.
 		//{name: "brio", upgrade: opera.GetBrioUpgrades()},
 	}
 	for _, test := range upgrades {
@@ -47,9 +48,11 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 			defer client.Close()
 
 			// enforce the current upgrade
-			tests.UpdateNetworkRules(t, net, test.upgrade)
+			testRules := tests.GetNetworkRules(t, net)
+			testRules.Upgrades = test.upgrade
+			tests.UpdateNetworkRules(t, net, testRules)
 			// Advance the epoch by one to apply the change.
-			net.AdvanceEpoch(t, 1)
+			tests.AdvanceEpochAndWaitForBlocks(t, net)
 
 			// check original state
 			type upgrades struct {


### PR DESCRIPTION
This PR introduces a feature flag for the gas subsidies feature.
This PR only introduces the flag and an integration test verifying it can enabled/disabled for the 2 current feature sets.