### PR TITLE
Remove unused log output from processor

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -73,10 +73,9 @@ func (p *StateProcessor) Process(
 	block *EvmBlock, statedb state.StateDB, cfg vm.Config, gasLimit uint64,
 	usedGas *uint64, onNewLog func(*types.Log),
 ) (
-	types.Receipts, []*types.Log, []uint32,
+	types.Receipts, []uint32,
 ) {
 	receipts := make(types.Receipts, 0, len(block.Transactions))
-	allLogs := make([]*types.Log, 0, len(block.Transactions)*10) // 10 logs per tx is a reasonable estimate
 	skipped := make([]uint32, 0, len(block.Transactions))
 	var (
 		gp           = new(core.GasPool).AddGas(gasLimit)
@@ -113,9 +112,8 @@ func (p *StateProcessor) Process(
 			continue // skip this transaction, but continue processing the rest of the block
 		}
 		receipts = append(receipts, receipt)
-		allLogs = append(allLogs, receipt.Logs...)
 	}
-	return receipts, allLogs, skipped
+	return receipts, skipped
 }
 
 // BeginBlock starts the processing of a new block and returns a function to

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -146,7 +146,7 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) typ
 
 	// Process txs
 	evmBlock := p.evmBlockWith(txs)
-	receipts, _, skipped := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, func(l *types.Log) {
+	receipts, skipped := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, func(l *types.Log) {
 		// Note: l.Index is properly set before
 		l.TxIndex += txsOffset
 		p.onNewLog(l)


### PR DESCRIPTION
Removes the `allLogs` result from the `StateProcessor` as it is ignored by the [only call site](https://github.com/0xsoniclabs/sonic/blob/fdf3dba7c9f36889ab46d075f4dc9328e07099ab/gossip/blockproc/evmmodule/evm.go#L149) outside of unit tests.