### PR TITLE
Fix in code hash check.

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -697,8 +697,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 func (pool *TxPool) checkDelegationLimit(tx *types.Transaction) error {
 	from, _ := types.Sender(pool.signer, tx) // validated
 
-	hasNoCode := pool.currentState.GetCodeHash(from) == types.EmptyCodeHash ||
-		pool.currentState.GetCodeHash(from) == common.Hash{}
+	codeHash := pool.currentState.GetCodeHash(from)
+	hasNoCode := codeHash == types.EmptyCodeHash || codeHash == common.Hash{}
 
 	// early return if the sender has neither delegation nor pending delegation.
 	if hasNoCode && len(pool.all.auths[from]) == 0 {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -697,8 +697,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 func (pool *TxPool) checkDelegationLimit(tx *types.Transaction) error {
 	from, _ := types.Sender(pool.signer, tx) // validated
 
+	hasNoCode := pool.currentState.GetCodeHash(from) == types.EmptyCodeHash ||
+		pool.currentState.GetCodeHash(from) == common.Hash{}
+
 	// early return if the sender has neither delegation nor pending delegation.
-	if pool.currentState.GetCodeHash(from) == types.EmptyCodeHash && len(pool.all.auths[from]) == 0 {
+	if hasNoCode && len(pool.all.auths[from]) == 0 {
 		return nil
 	}
 	pending := pool.pending[from]

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -880,6 +880,36 @@ func TestSetCodeTransactions(t *testing.T) {
 				}
 			},
 		},
+		"zero value code hash is treated as no code": {
+			pending: 2,
+			test: func(t *testing.T, pool *TxPool) {
+				db.codeHashes[addrA] = common.Hash{}
+
+				// first transaction is accepted
+				if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), keyA)); err != nil {
+					t.Fatalf("failed to add remote transaction: %v", err)
+				}
+				// second transaction should not be rejected
+				if err := pool.addRemoteSync(pricedTransaction(1, 100000, big.NewInt(1), keyA)); err != nil {
+					t.Fatalf("error mismatch: want %v, have %v", ErrInflightTxLimitReached, err)
+				}
+			},
+		},
+		"empty code hash is treated as no code": {
+			pending: 2,
+			test: func(t *testing.T, pool *TxPool) {
+				db.codeHashes[addrA] = types.EmptyCodeHash
+
+				// first transaction is accepted
+				if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), keyA)); err != nil {
+					t.Fatalf("failed to add remote transaction: %v", err)
+				}
+				// second transaction should not be rejected
+				if err := pool.addRemoteSync(pricedTransaction(1, 100000, big.NewInt(1), keyA)); err != nil {
+					t.Fatalf("error mismatch: want %v, have %v", ErrInflightTxLimitReached, err)
+				}
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This PR fixes  `checkDelegationLimit` function, to consider both `types.EmptyHash` as well as the zero value for `common.Hash` as empty codes.