### PR TITLE
Update processor to only report number of skipped transaction

### DIFF
--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -174,12 +174,12 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) typ
 	return receipts
 }
 
-func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs []uint32, receipts types.Receipts) {
+func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts) {
 	evmBlock = p.evmBlockWith(
 		// Filter skipped transactions. Receipts are filtered already
 		filterSkippedTxs(p.incomingTxs, p.skippedTxs),
 	)
-	skippedTxs = p.skippedTxs
+	numSkipped = len(p.skippedTxs)
 	receipts = p.receipts
 
 	// Commit block

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -69,7 +69,7 @@ type ConfirmedEventsModule interface {
 
 type EVMProcessor interface {
 	Execute(txs types.Transactions, gasLimit uint64) types.Receipts
-	Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs []uint32, receipts types.Receipts)
+	Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts)
 }
 
 type EVM interface {

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -405,11 +405,11 @@ func (mr *MockEVMProcessorMockRecorder) Execute(txs, gasLimit any) *gomock.Call 
 }
 
 // Finalize mocks base method.
-func (m *MockEVMProcessor) Finalize() (*evmcore.EvmBlock, []uint32, types.Receipts) {
+func (m *MockEVMProcessor) Finalize() (*evmcore.EvmBlock, int, types.Receipts) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Finalize")
 	ret0, _ := ret[0].(*evmcore.EvmBlock)
-	ret1, _ := ret[1].([]uint32)
+	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(types.Receipts)
 	return ret0, ret1, ret2
 }

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -402,7 +402,7 @@ func consensusCallbackBeginBlockFn(
 						}
 					}
 
-					evmBlock, skippedTxs, allReceipts := evmProcessor.Finalize()
+					evmBlock, numSkippedTxs, allReceipts := evmProcessor.Finalize()
 
 					// Add results of the transaction processing to the block.
 					blockBuilder.
@@ -535,7 +535,7 @@ func consensusCallbackBeginBlockFn(
 						"gas_used", evmBlock.GasUsed,
 						"gas_rate", float64(evmBlock.GasUsed)/blockDuration.Seconds(),
 						"base_fee", evmBlock.BaseFee.String(),
-						"txs", fmt.Sprintf("%d/%d", len(evmBlock.Transactions), len(skippedTxs)),
+						"txs", fmt.Sprintf("%d/%d", len(evmBlock.Transactions), numSkippedTxs),
 						"age", utils.PrettyDuration(blockAge),
 						"t", utils.PrettyDuration(now.Sub(start)),
 						"epoch", evmBlock.Epoch,
@@ -543,7 +543,7 @@ func consensusCallbackBeginBlockFn(
 					blockAgeGauge.Update(int64(blockAge.Nanoseconds()))
 
 					processedTxsMeter.Mark(int64(len(evmBlock.Transactions)))
-					skippedTxsMeter.Mark(int64(len(skippedTxs)))
+					skippedTxsMeter.Mark(int64(numSkippedTxs))
 				}
 				if confirmedEvents.Len() != 0 {
 					atomic.StoreUint32(blockBusyFlag, 1)

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -276,7 +276,7 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 						BaseFee: big.NewInt(0),
 						TxHash:  common.Hash{1, 2, 3},
 					},
-				}, nil, nil)
+				}, 0, nil)
 
 				evmModule := blockproc.NewMockEVM(ctrl)
 				evmModule.EXPECT().

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -284,14 +284,14 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
 	evmProcessor.Execute(internalTxs, es.Rules.Blocks.MaxBlockGas)
 
-	evmBlock, skippedTxs, receipts := evmProcessor.Finalize()
+	evmBlock, numSkippedTxs, receipts := evmProcessor.Finalize()
 	for i, r := range receipts {
 		if r.Status == 0 {
 			return fmt.Errorf("genesis transaction %d of %d reverted", i, len(receipts))
 		}
 	}
-	if len(skippedTxs) != 0 {
-		return fmt.Errorf("genesis transaction is skipped (%v)", skippedTxs)
+	if numSkippedTxs != 0 {
+		return fmt.Errorf("genesis transaction is skipped (num=%d)", numSkippedTxs)
 	}
 	bs = txListener.Finalize()
 	bs.FinalizedStateRoot = hash.Hash(evmBlock.Root)


### PR DESCRIPTION
This PR reduces the amount of information returned by the processor regarding skipped transactions to merely the number of skipped transactions.

Before this change, `EVMProcessor`s returned the list of indexes of issues transactions that got skipped. However, this information is effectively not used in the code. The two only uses are
- in the `c_block_callbacks.go` file, to report the number of skipped transactions
- in the `genesis.go` file, to list the indexes of the failed initialization issues in an error

Since with the upcoming introduction of transactions been introduced by the block processor the indexes of skipped transactions would even be harder to interpret correctly, this PR suggests to reduce the emitted information to merely the number of skipped transactions.

**Note:** as this PR reveals, there is not a single unit test that would verify the content of the skipped transaction list. This PR adds test coverage for the reported number of skipped transactions.