### PR TITLE
Remove tracking of indices of skipped transactions

### DIFF
--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -174,12 +174,12 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) typ
 	return receipts
 }
 
-func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs []uint32, receipts types.Receipts) {
+func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts) {
 	evmBlock = p.evmBlockWith(
 		// Filter skipped transactions. Receipts are filtered already
 		filterSkippedTxs(p.incomingTxs, p.skippedTxs),
 	)
-	skippedTxs = p.skippedTxs
+	numSkipped = len(p.skippedTxs)
 	receipts = p.receipts
 
 	// Commit block

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -92,10 +92,11 @@ type OperaEVMProcessor struct {
 
 	gasUsed uint64
 
-	incomingTxs types.Transactions
-	skippedTxs  []uint32
-	receipts    types.Receipts
-	prevRandao  common.Hash
+	numIncomingTxs int
+	numSkippedTxs  int
+	processedTxs   types.Transactions
+	receipts       types.Receipts
+	prevRandao     common.Hash
 
 	rules opera.Rules
 }
@@ -140,7 +141,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 
 func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) types.Receipts {
 	evmProcessor := evmcore.NewStateProcessor(p.evmCfg, p.reader)
-	txsOffset := uint(len(p.incomingTxs))
+	txsOffset := p.numIncomingTxs
 
 	vmConfig := opera.GetVmConfig(p.rules)
 
@@ -148,26 +149,24 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) typ
 	evmBlock := p.evmBlockWith(txs)
 	receipts, _, skipped := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, func(l *types.Log) {
 		// Note: l.Index is properly set before
-		l.TxIndex += txsOffset
+		l.TxIndex += uint(txsOffset)
 		p.onNewLog(l)
 	})
 
 	if txsOffset > 0 {
-		for i, n := range skipped {
-			skipped[i] = n + uint32(txsOffset)
-		}
 		for _, r := range receipts {
 			if r != nil {
-				r.TransactionIndex += txsOffset
+				r.TransactionIndex += uint(txsOffset)
 			}
 		}
 	}
 
-	p.incomingTxs = append(p.incomingTxs, txs...)
-	p.skippedTxs = append(p.skippedTxs, skipped...)
-	for _, receipt := range receipts {
-		if receipt != nil {
+	p.numIncomingTxs += len(txs)
+	p.numSkippedTxs += len(skipped)
+	for i, receipt := range receipts {
+		if receipt != nil && i < len(txs) {
 			p.receipts = append(p.receipts, receipt)
+			p.processedTxs = append(p.processedTxs, txs[i])
 		}
 	}
 
@@ -175,11 +174,8 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) typ
 }
 
 func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts) {
-	evmBlock = p.evmBlockWith(
-		// Filter skipped transactions. Receipts are filtered already
-		filterSkippedTxs(p.incomingTxs, p.skippedTxs),
-	)
-	numSkipped = len(p.skippedTxs)
+	evmBlock = p.evmBlockWith(p.processedTxs)
+	numSkipped = p.numSkippedTxs
 	receipts = p.receipts
 
 	// Commit block
@@ -189,22 +185,4 @@ func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, numSkipped i
 	evmBlock.Root = p.statedb.GetStateHash()
 
 	return
-}
-
-func filterSkippedTxs(txs types.Transactions, skippedTxs []uint32) types.Transactions {
-	if len(skippedTxs) == 0 {
-		// short circuit if nothing to skip
-		return txs
-	}
-	skipCount := 0
-	filteredTxs := make(types.Transactions, 0, len(txs))
-	for i, tx := range txs {
-		if skipCount < len(skippedTxs) && skippedTxs[skipCount] == uint32(i) {
-			skipCount++
-		} else {
-			filteredTxs = append(filteredTxs, tx)
-		}
-	}
-
-	return filteredTxs
 }

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -69,7 +69,7 @@ type ConfirmedEventsModule interface {
 
 type EVMProcessor interface {
 	Execute(txs types.Transactions, gasLimit uint64) types.Receipts
-	Finalize() (evmBlock *evmcore.EvmBlock, skippedTxs []uint32, receipts types.Receipts)
+	Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts)
 }
 
 type EVM interface {

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -405,11 +405,11 @@ func (mr *MockEVMProcessorMockRecorder) Execute(txs, gasLimit any) *gomock.Call 
 }
 
 // Finalize mocks base method.
-func (m *MockEVMProcessor) Finalize() (*evmcore.EvmBlock, []uint32, types.Receipts) {
+func (m *MockEVMProcessor) Finalize() (*evmcore.EvmBlock, int, types.Receipts) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Finalize")
 	ret0, _ := ret[0].(*evmcore.EvmBlock)
-	ret1, _ := ret[1].([]uint32)
+	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(types.Receipts)
 	return ret0, ret1, ret2
 }

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -402,7 +402,7 @@ func consensusCallbackBeginBlockFn(
 						}
 					}
 
-					evmBlock, skippedTxs, allReceipts := evmProcessor.Finalize()
+					evmBlock, numSkippedTxs, allReceipts := evmProcessor.Finalize()
 
 					// Add results of the transaction processing to the block.
 					blockBuilder.
@@ -535,7 +535,7 @@ func consensusCallbackBeginBlockFn(
 						"gas_used", evmBlock.GasUsed,
 						"gas_rate", float64(evmBlock.GasUsed)/blockDuration.Seconds(),
 						"base_fee", evmBlock.BaseFee.String(),
-						"txs", fmt.Sprintf("%d/%d", len(evmBlock.Transactions), len(skippedTxs)),
+						"txs", fmt.Sprintf("%d/%d", len(evmBlock.Transactions), numSkippedTxs),
 						"age", utils.PrettyDuration(blockAge),
 						"t", utils.PrettyDuration(now.Sub(start)),
 						"epoch", evmBlock.Epoch,
@@ -543,7 +543,7 @@ func consensusCallbackBeginBlockFn(
 					blockAgeGauge.Update(int64(blockAge.Nanoseconds()))
 
 					processedTxsMeter.Mark(int64(len(evmBlock.Transactions)))
-					skippedTxsMeter.Mark(int64(len(skippedTxs)))
+					skippedTxsMeter.Mark(int64(numSkippedTxs))
 				}
 				if confirmedEvents.Len() != 0 {
 					atomic.StoreUint32(blockBusyFlag, 1)

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -276,7 +276,7 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 						BaseFee: big.NewInt(0),
 						TxHash:  common.Hash{1, 2, 3},
 					},
-				}, nil, nil)
+				}, 0, nil)
 
 				evmModule := blockproc.NewMockEVM(ctrl)
 				evmModule.EXPECT().

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -284,14 +284,14 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
 	evmProcessor.Execute(internalTxs, es.Rules.Blocks.MaxBlockGas)
 
-	evmBlock, skippedTxs, receipts := evmProcessor.Finalize()
+	evmBlock, numSkippedTxs, receipts := evmProcessor.Finalize()
 	for i, r := range receipts {
 		if r.Status == 0 {
 			return fmt.Errorf("genesis transaction %d of %d reverted", i, len(receipts))
 		}
 	}
-	if len(skippedTxs) != 0 {
-		return fmt.Errorf("genesis transaction is skipped (%v)", skippedTxs)
+	if numSkippedTxs != 0 {
+		return fmt.Errorf("genesis transaction is skipped (num=%d)", numSkippedTxs)
 	}
 	bs = txListener.Finalize()
 	bs.FinalizedStateRoot = hash.Hash(evmBlock.Root)


### PR DESCRIPTION
As #494 removed the need for reporting the indices of skipped transactions, the internal tracking of those within the `OperaEVMProcessor` can be simplified.