### PR TITLE
Have EVM return a list of included transactions with receipts

### DIFF
--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -138,7 +138,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 	return evmcore.NewEvmBlock(h, txs)
 }
 
-func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) types.Receipts {
+func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) []blockproc.IncludedTransaction {
 	evmProcessor := evmcore.NewStateProcessor(p.evmCfg, p.reader)
 	txsOffset := uint(len(p.incomingTxs))
 
@@ -171,7 +171,16 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) typ
 		}
 	}
 
-	return receipts
+	result := make([]blockproc.IncludedTransaction, 0, len(txs)-len(skipped))
+	for i, receipt := range receipts {
+		if receipt != nil && i < len(txs) {
+			result = append(result, blockproc.IncludedTransaction{
+				Transaction: txs[i],
+				Receipt:     receipt,
+			})
+		}
+	}
+	return result
 }
 
 func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts) {

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -67,8 +67,24 @@ type ConfirmedEventsModule interface {
 	Start(bs iblockproc.BlockState, es iblockproc.EpochState) ConfirmedEventsProcessor
 }
 
+// IncludedTransaction represents a transaction that has been included in a
+// block along with its receipt.
+type IncludedTransaction struct {
+	Transaction *types.Transaction
+	Receipt     *types.Receipt
+}
+
 type EVMProcessor interface {
-	Execute(txs types.Transactions, gasLimit uint64) types.Receipts
+	// Execute attempts to run the given transactions within the provided gas
+	// limit on the EVM. It returns a slice of IncludedTransaction, each
+	// containing a transaction and its corresponding receipt. The order of
+	// transactions in the returned slice corresponds to their execution
+	// order, preserving the original order from the input slice.
+	// If a transaction cannot be executed (e.g., due to insufficient gas),
+	// it is skipped and not included in the returned slice. Every transaction
+	// that is successfully executed will have its receipt included in the
+	// result.
+	Execute(txs types.Transactions, gasLimit uint64) []IncludedTransaction
 	Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts)
 }
 

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -391,10 +391,10 @@ func (m *MockEVMProcessor) EXPECT() *MockEVMProcessorMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) types.Receipts {
+func (m *MockEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) []IncludedTransaction {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", txs, gasLimit)
-	ret0, _ := ret[0].(types.Receipts)
+	ret0, _ := ret[0].([]IncludedTransaction)
 	return ret0
 }
 

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -270,7 +270,7 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 				txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
 
 				evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
-				evmProcessor.EXPECT().Execute(_any, _any).Return(types.Receipts{}).MinTimes(1)
+				evmProcessor.EXPECT().Execute(_any, _any).Return(nil).MinTimes(1)
 				evmProcessor.EXPECT().Finalize().Return(&evmcore.EvmBlock{
 					EvmHeader: evmcore.EvmHeader{
 						BaseFee: big.NewInt(0),


### PR DESCRIPTION
This PR updates the `EVMProcessor` interface to produce a list of included transactions, instead of a list of receipts.

This modification has the following effects:
- it allows the EVM processor to introduce additional transactions as a side-effect of processing other transactions
- it eliminates the need for the users of the EVM processor to manually match transactions with receipts using indices
- it eliminates the need for the users of the EVM processor to filter out skipped transactions based on nil-receipts