### PR TITLE
Make state processor report list of processed transactions

### DIFF
--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -68,7 +68,7 @@ type ConfirmedEventsModule interface {
 }
 
 type EVMProcessor interface {
-	Execute(txs types.Transactions, gasLimit uint64) types.Receipts
+	Execute(txs types.Transactions, gasLimit uint64) []evmcore.ProcessedTransaction
 	Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts)
 }
 

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -391,10 +391,10 @@ func (m *MockEVMProcessor) EXPECT() *MockEVMProcessorMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) types.Receipts {
+func (m *MockEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) []evmcore.ProcessedTransaction {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", txs, gasLimit)
-	ret0, _ := ret[0].(types.Receipts)
+	ret0, _ := ret[0].([]evmcore.ProcessedTransaction)
 	return ret0
 }
 

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -334,11 +334,11 @@ func consensusCallbackBeginBlockFn(
 
 				// Execute pre-internal transactions
 				preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
-				preInternalReceipts := evmProcessor.Execute(preInternalTxs, maxBlockGas)
+				preInternalProcessedTxs := evmProcessor.Execute(preInternalTxs, maxBlockGas)
 				bs = txListener.Finalize()
-				for _, r := range preInternalReceipts {
-					if r.Status == 0 {
-						log.Warn("Pre-internal transaction reverted", "txid", r.TxHash.String())
+				for _, tx := range preInternalProcessedTxs {
+					if tx.Receipt == nil || tx.Receipt.Status == 0 {
+						log.Warn("Pre-internal transaction skipped or reverted", "txid", tx.Transaction.Hash().String())
 					}
 				}
 
@@ -372,33 +372,40 @@ func consensusCallbackBeginBlockFn(
 						WithGasLimit(maxBlockGas).
 						WithDuration(blockDuration)
 
-					for i := range preInternalTxs {
-						blockBuilder.AddTransaction(
-							preInternalTxs[i],
-							preInternalReceipts[i],
-						)
+					for _, cur := range preInternalProcessedTxs {
+						if cur.Receipt != nil {
+							blockBuilder.AddTransaction(
+								cur.Transaction,
+								cur.Receipt,
+							)
+						}
 					}
 
 					// Execute post-internal transactions
 					internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
-					internalReceipts := evmProcessor.Execute(internalTxs, maxBlockGas)
-					for _, r := range internalReceipts {
-						if r.Status == 0 {
-							log.Warn("Internal transaction reverted", "txid", r.TxHash.String())
+					internalProcessedTxs := evmProcessor.Execute(internalTxs, maxBlockGas)
+					for _, tx := range internalProcessedTxs {
+						if tx.Receipt == nil || tx.Receipt.Status == 0 {
+							log.Warn("Internal transaction skipped or reverted", "txid", tx.Transaction.Hash().String())
 						}
 					}
 
-					for i := range internalTxs {
-						blockBuilder.AddTransaction(
-							internalTxs[i],
-							internalReceipts[i],
-						)
+					for _, cur := range internalProcessedTxs {
+						if cur.Receipt != nil {
+							blockBuilder.AddTransaction(
+								cur.Transaction,
+								cur.Receipt,
+							)
+						}
 					}
 
 					orderedTxs := proposal.Transactions
-					for i, receipt := range evmProcessor.Execute(orderedTxs, userTransactionGasLimit) {
-						if receipt != nil { // < nil if skipped
-							blockBuilder.AddTransaction(orderedTxs[i], receipt)
+					for _, processed := range evmProcessor.Execute(orderedTxs, userTransactionGasLimit) {
+						if processed.Receipt != nil { // < nil if skipped
+							blockBuilder.AddTransaction(
+								processed.Transaction,
+								processed.Receipt,
+							)
 						}
 					}
 

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -270,7 +270,7 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 				txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
 
 				evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
-				evmProcessor.EXPECT().Execute(_any, _any).Return(types.Receipts{}).MinTimes(1)
+				evmProcessor.EXPECT().Execute(_any, _any).Return(nil).MinTimes(1)
 				evmProcessor.EXPECT().Finalize().Return(&evmcore.EvmBlock{
 					EvmHeader: evmcore.EvmHeader{
 						BaseFee: big.NewInt(0),


### PR DESCRIPTION
This PR updates the `StateProcessor` 's `Process` function to report the list of transactions it attempted to process. 

While in the current version this list is equivalent to the list of transactions being passed to it, upcoming changes will require the function to introduce additional transactions. The introduction of the ability to report the list of processed transactions facilitates this requirement.

The list of processed transactions are also reported by the `EVMProcessor`'s `Execute` function to allow those transactions to be accounted for in the block-formation covered by `c_block_callbacks.go`.