### PR TITLE
Remove interception of Log-reporting in EVM processor

### DIFF
--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -41,7 +41,7 @@ import (
 // Process method.
 func (p *StateProcessor) process_iteratively(
 	block *EvmBlock, stateDb state.StateDB, cfg vm.Config, gasLimit uint64,
-	usedGas *uint64, onNewLog func(*types.Log),
+	usedGas *uint64, onNewLog func(*Log),
 ) (
 	types.Receipts, []uint32,
 ) {
@@ -111,8 +111,8 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 				Transactions: transactions,
 			}
 
-			reportedLogs := []*types.Log{}
-			onLog := func(log *types.Log) {
+			reportedLogs := []*Log{}
+			onLog := func(log *Log) {
 				reportedLogs = append(reportedLogs, log)
 			}
 
@@ -159,7 +159,19 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 
 			require.Nil(receipts[3])
 
-			require.Equal([]*types.Log{logMsg0, logMsg2}, reportedLogs)
+			want := []*Log{
+				{
+					Address: logMsg0.Address,
+					Topics:  logMsg0.Topics,
+					Data:    logMsg0.Data,
+				},
+				{
+					Address: logMsg2.Address,
+					Topics:  logMsg2.Topics,
+					Data:    logMsg2.Data,
+				},
+			}
+			require.Equal(want, reportedLogs)
 
 			require.Equal([]uint32{1, 3}, skipped)
 
@@ -576,7 +588,7 @@ type processFunction = func(
 	cfg vm.Config,
 	gasLimit uint64,
 	usedGas *uint64,
-	onNewLog func(*types.Log),
+	onNewLog func(*Log),
 ) (
 	receipts types.Receipts,
 	skipped []uint32,

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/drivertype"
@@ -186,7 +187,7 @@ func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 	return new(big.Int).Add(baseFee, gasTip)
 }
 
-func decodeDataBytes(l *types.Log) ([]byte, error) {
+func decodeDataBytes(l *evmcore.Log) ([]byte, error) {
 	if len(l.Data) < 32 {
 		return nil, io.ErrUnexpectedEOF
 	}
@@ -201,7 +202,7 @@ func decodeDataBytes(l *types.Log) ([]byte, error) {
 	return l.Data[start+32 : start+32+size], nil
 }
 
-func (p *DriverTxListener) OnNewLog(l *types.Log) {
+func (p *DriverTxListener) OnNewLog(l *evmcore.Log) {
 	if l.Address != driver.ContractAddress {
 		return
 	}

--- a/gossip/blockproc/evmmodule/evm_test_mock.go
+++ b/gossip/blockproc/evmmodule/evm_test_mock.go
@@ -12,7 +12,7 @@ package evmmodule
 import (
 	reflect "reflect"
 
-	types "github.com/ethereum/go-ethereum/core/types"
+	evmcore "github.com/0xsoniclabs/sonic/evmcore"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +41,7 @@ func (m *Mock_onNewLog) EXPECT() *Mock_onNewLogMockRecorder {
 }
 
 // OnNewLog mocks base method.
-func (m *Mock_onNewLog) OnNewLog(arg0 *types.Log) {
+func (m *Mock_onNewLog) OnNewLog(arg0 *evmcore.Log) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnNewLog", arg0)
 }

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -34,7 +34,7 @@ import (
 //go:generate mockgen -source=interface.go -package=blockproc -destination=interface_mock.go
 
 type TxListener interface {
-	OnNewLog(*types.Log)
+	OnNewLog(*evmcore.Log)
 	OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int)
 	Finalize() iblockproc.BlockState
 	Update(bs iblockproc.BlockState, es iblockproc.EpochState)
@@ -77,7 +77,7 @@ type EVM interface {
 		block iblockproc.BlockCtx,
 		statedb state.StateDB,
 		reader evmcore.DummyChain,
-		onNewLog func(*types.Log),
+		onNewLog func(*evmcore.Log),
 		net opera.Rules,
 		evmCfg *params.ChainConfig,
 		prevrandao common.Hash,

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -64,7 +64,7 @@ func (mr *MockTxListenerMockRecorder) Finalize() *gomock.Call {
 }
 
 // OnNewLog mocks base method.
-func (m *MockTxListener) OnNewLog(arg0 *types.Log) {
+func (m *MockTxListener) OnNewLog(arg0 *evmcore.Log) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnNewLog", arg0)
 }
@@ -445,7 +445,7 @@ func (m *MockEVM) EXPECT() *MockEVMMockRecorder {
 }
 
 // Start mocks base method.
-func (m *MockEVM) Start(block iblockproc.BlockCtx, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*types.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash) EVMProcessor {
+func (m *MockEVM) Start(block iblockproc.BlockCtx, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*evmcore.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash) EVMProcessor {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", block, statedb, reader, onNewLog, net, evmCfg, prevrandao)
 	ret0, _ := ret[0].(EVMProcessor)

--- a/gossip/blockproc/verwatcher/version_watcher.go
+++ b/gossip/blockproc/verwatcher/version_watcher.go
@@ -22,8 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/logger"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driver"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driver/driverpos"
@@ -62,7 +61,7 @@ func (w *VersionWatcher) Pause() error {
 	return nil
 }
 
-func (w *VersionWatcher) OnNewLog(l *types.Log) {
+func (w *VersionWatcher) OnNewLog(l *evmcore.Log) {
 	if l.Address != driver.ContractAddress {
 		return
 	}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -312,7 +312,7 @@ func consensusCallbackBeginBlockFn(
 				sealer := blockProc.SealerModule.Start(blockCtx, bs, es)
 				sealing := sealer.EpochSealing()
 				txListener := blockProc.TxListenerModule.Start(blockCtx, bs, es, statedb)
-				onNewLogAll := func(l *types.Log) {
+				onNewLogAll := func(l *evmcore.Log) {
 					txListener.OnNewLog(l)
 					// Note: it's possible for logs to get indexed twice by BR and block processing
 					if verWatcher != nil {

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -260,7 +260,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	)
 	evmProcessor := blockProc.EVMModule.Start(
 		blockCtx, b.tmpStateDB, dummyHeaderReturner{b.blocks},
-		func(l *types.Log) { txListener.OnNewLog(l) },
+		txListener.OnNewLog,
 		es.Rules,
 		chainConfig,
 		common.Hash{0x01}, // non-zero PrevRandao necessary to enable Cancun


### PR DESCRIPTION
This PR aims to simplify the implementation of the `OperaEVMProcessor` by eliminating the `onNewLog` interception incrementing the `txIndex`.

The PR does so by:
- introducing a new `Log` type in the `evmcore` package that only covers a subset of the offered fields; in particular, it does not include the `txIndex` field
- updates all log-listeners and call-back functions to use the new `Log` type instead of `types.Log`; this makes sure that no listener depends on the `txIndex` field
- have the `StateProcessor` emit a `Log` instead of a `types.Log`
- move the update of the `txIndex` field for the logs referenced in the receipts to the same location where also the `txIndex` of the receipts are updated; thus, these updates are covered at the same place, and not as a side-effect of a listener callback