### PR TITLE
Refactor TxPool to use the sonic state interface

### DIFF
--- a/evmcore/tx_noncer.go
+++ b/evmcore/tx_noncer.go
@@ -19,6 +19,7 @@ package evmcore
 import (
 	"sync"
 
+	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -26,13 +27,13 @@ import (
 // accounts in the pool, falling back to reading from a real state database if
 // an account is unknown.
 type txNoncer struct {
-	fallback TxPoolStateDB
+	fallback state.StateDB
 	nonces   map[common.Address]uint64
 	lock     sync.Mutex
 }
 
 // newTxNoncer creates a new virtual state database to track the pool nonces.
-func newTxNoncer(statedb TxPoolStateDB) *txNoncer {
+func newTxNoncer(statedb state.StateDB) *txNoncer {
 	return &txNoncer{
 		fallback: statedb,
 		nonces:   make(map[common.Address]uint64),

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -35,8 +35,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/holiman/uint256"
 
+	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/signers/gsignercache"
 	"github.com/0xsoniclabs/sonic/utils/txtime"
@@ -150,19 +150,12 @@ const (
 	TxStatusIncluded
 )
 
-type TxPoolStateDB interface {
-	GetNonce(addr common.Address) uint64
-	GetBalance(addr common.Address) *uint256.Int
-	GetCodeHash(addr common.Address) common.Hash
-	Release()
-}
-
 // StateReader provides the state of blockchain and current gas limit to do
 // some pre checks in tx pool and event subscribers.
 type StateReader interface {
 	CurrentBlock() *EvmBlock
 	GetBlock(hash common.Hash, number uint64) *EvmBlock
-	GetTxPoolStateDB() (TxPoolStateDB, error)
+	GetTxPoolStateDB() (state.StateDB, error)
 	GetCurrentBaseFee() *big.Int
 	MaxGasLimit() uint64
 	SubscribeNewBlock(ch chan<- ChainHeadNotify) notify.Subscription
@@ -285,7 +278,7 @@ type TxPool struct {
 	eip7623  bool // Fork indicator whether we are using EIP-7623 floor gas validation.
 	eip7702  bool // Fork indicator whether we are using EIP-7702 type transactions.
 
-	currentState  TxPoolStateDB // Current state in the blockchain head
+	currentState  state.StateDB // Current state in the blockchain head
 	pendingNonces *txNoncer     // Pending state tracking virtual nonces
 	currentMaxGas uint64        // Current gas limit for transaction caps
 

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -29,14 +29,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xsoniclabs/carmen/go/common/witness"
+	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
+
+	geth_state "github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
+	trie_utils "github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -113,16 +120,159 @@ func (t testTxPoolStateDb) GetCodeHash(addr common.Address) common.Hash {
 	return hash
 }
 
-func (t testTxPoolStateDb) SetCode(addr common.Address, code []byte) {
+func (t testTxPoolStateDb) SetCode(addr common.Address, code []byte) []byte {
 	if len(code) == 0 {
 		delete(t.codeHashes, addr)
 	} else {
 		t.codeHashes[addr] = crypto.Keccak256Hash(code)
 	}
+	return code
 }
 
 func (t testTxPoolStateDb) Release() {
 	// no-op
+}
+
+// The following list of methods are included to satisfy the sonic's StateDB interface.
+// they are no used in the tests, and will panic if called.
+
+func (t testTxPoolStateDb) Error() error {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SetTxContext(thash common.Hash, ti int) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) TxIndex() int {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetProof(addr common.Address, keys []common.Hash) (witness.Proof, error) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SetBalance(addr common.Address, amount *uint256.Int) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SetStorage(addr common.Address, storage map[common.Hash]common.Hash) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) Copy() state.StateDB {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetStateHash() common.Hash {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) BeginBlock(number uint64) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) EndBlock(number uint64) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) EndTransaction() {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) CreateAccount(common.Address) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) CreateContract(common.Address) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SetNonce(common.Address, uint64, tracing.NonceChangeReason) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetCode(common.Address) []byte {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetCodeSize(common.Address) int {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AddRefund(uint64) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SubRefund(uint64) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetRefund() uint64 {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetStateAndCommittedState(common.Address, common.Hash) (common.Hash, common.Hash) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetState(common.Address, common.Hash) common.Hash {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SetState(common.Address, common.Hash, common.Hash) common.Hash {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetStorageRoot(addr common.Address) common.Hash {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SetTransientState(addr common.Address, key, value common.Hash) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SelfDestruct(common.Address) uint256.Int {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) HasSelfDestructed(common.Address) bool {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SelfDestruct6780(common.Address) (uint256.Int, bool) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) Exist(common.Address) bool {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) Empty(common.Address) bool {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AddressInAccessList(addr common.Address) bool {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AddAddressToAccessList(addr common.Address) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AddSlotToAccessList(addr common.Address, slot common.Hash) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) PointCache() *trie_utils.PointCache {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) RevertToSnapshot(int) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) Snapshot() int {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AddLog(*types.Log) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AddPreimage(common.Hash, []byte) {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) Witness() *stateless.Witness {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) AccessEvents() *geth_state.AccessEvents {
+	panic("not implemented")
+}
+func (t testTxPoolStateDb) Finalise(bool) {
+	panic("not implemented")
 }
 
 type testBlockChain struct {
@@ -177,7 +327,7 @@ func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *EvmBlock {
 	return bc.CurrentBlock()
 }
 
-func (bc *testBlockChain) GetTxPoolStateDB() (TxPoolStateDB, error) {
+func (bc *testBlockChain) GetTxPoolStateDB() (state.StateDB, error) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 	return bc.statedb, nil

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -29,21 +29,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xsoniclabs/carmen/go/common/witness"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
 
-	geth_state "github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/stateless"
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
-	trie_utils "github.com/ethereum/go-ethereum/trie/utils"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -91,6 +86,8 @@ func (pool *TxPool) waitForIdleReorgLoop_forTesting() {
 }
 
 type testTxPoolStateDb struct {
+	state.StateDB // embedded to ensure interface compliance
+
 	balances   map[common.Address]*uint256.Int
 	nonces     map[common.Address]uint64
 	codeHashes map[common.Address]common.Hash
@@ -131,148 +128,6 @@ func (t testTxPoolStateDb) SetCode(addr common.Address, code []byte) []byte {
 
 func (t testTxPoolStateDb) Release() {
 	// no-op
-}
-
-// The following list of methods are included to satisfy the sonic's StateDB interface.
-// they are no used in the tests, and will panic if called.
-
-func (t testTxPoolStateDb) Error() error {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetLogs(hash common.Hash, blockHash common.Hash) []*types.Log {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SetTxContext(thash common.Hash, ti int) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) TxIndex() int {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetProof(addr common.Address, keys []common.Hash) (witness.Proof, error) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SetBalance(addr common.Address, amount *uint256.Int) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SetStorage(addr common.Address, storage map[common.Hash]common.Hash) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) Copy() state.StateDB {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetStateHash() common.Hash {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) BeginBlock(number uint64) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) EndBlock(number uint64) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) EndTransaction() {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) CreateAccount(common.Address) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) CreateContract(common.Address) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AddBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) uint256.Int {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SetNonce(common.Address, uint64, tracing.NonceChangeReason) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetCode(common.Address) []byte {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetCodeSize(common.Address) int {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AddRefund(uint64) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SubRefund(uint64) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetRefund() uint64 {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetStateAndCommittedState(common.Address, common.Hash) (common.Hash, common.Hash) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetState(common.Address, common.Hash) common.Hash {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SetState(common.Address, common.Hash, common.Hash) common.Hash {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetStorageRoot(addr common.Address) common.Hash {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) GetTransientState(addr common.Address, key common.Hash) common.Hash {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SetTransientState(addr common.Address, key, value common.Hash) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SelfDestruct(common.Address) uint256.Int {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) HasSelfDestructed(common.Address) bool {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SelfDestruct6780(common.Address) (uint256.Int, bool) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) Exist(common.Address) bool {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) Empty(common.Address) bool {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AddressInAccessList(addr common.Address) bool {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) SlotInAccessList(addr common.Address, slot common.Hash) (addressOk bool, slotOk bool) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AddAddressToAccessList(addr common.Address) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AddSlotToAccessList(addr common.Address, slot common.Hash) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) PointCache() *trie_utils.PointCache {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) RevertToSnapshot(int) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) Snapshot() int {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AddLog(*types.Log) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AddPreimage(common.Hash, []byte) {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) Witness() *stateless.Witness {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) AccessEvents() *geth_state.AccessEvents {
-	panic("not implemented")
-}
-func (t testTxPoolStateDb) Finalise(bool) {
-	panic("not implemented")
 }
 
 type testBlockChain struct {

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 
 	"github.com/0xsoniclabs/sonic/gossip/gasprice/gaspricelimits"
+	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -31,7 +32,7 @@ import (
 // poolOptions is a set of options to adjust the validation of transactions
 // according to the current state of the transaction pool.
 type poolOptions struct {
-	currentState TxPoolStateDB // Current state in the blockchain head
+	currentState state.StateDB // Current state in the blockchain head
 	minTip       *big.Int      // Minimum gas tip to enforce for acceptance into the pool
 	locals       *accountSet   // Set of local transaction to exempt from eviction rules
 	isLocal      bool          // Whether the transaction came from a local source
@@ -247,7 +248,7 @@ func ValidateTxForBlock(tx *types.Transaction, blockState blockState) error {
 // Specifically, it ensures the sender has sufficient balance to cover the transaction cost,
 // and that the transaction's nonce is not lower than the sender's nonce in the state.
 // Returns an error if any of these conditions are not met.
-func ValidateTxForState(tx *types.Transaction, state TxPoolStateDB,
+func ValidateTxForState(tx *types.Transaction, state state.StateDB,
 	signer types.Signer) error {
 
 	// Make sure the transaction is signed properly.

--- a/gossip/evm_state_reader.go
+++ b/gossip/evm_state_reader.go
@@ -162,7 +162,7 @@ func (r *EvmStateReader) getBlock(h common.Hash, n idx.Block, readTxs bool) *evm
 }
 
 // GetTxPoolStateDB obtains StateDB for TxPool
-func (r *EvmStateReader) GetTxPoolStateDB() (evmcore.TxPoolStateDB, error) {
+func (r *EvmStateReader) GetTxPoolStateDB() (state.StateDB, error) {
 	return r.store.evm.GetTxPoolStateDB()
 }
 


### PR DESCRIPTION
This PR changes the source of state information from the pool from a scoped interface to the canonical sonic state.

This PR has two compromises:
- New interface has to manually be faked to avoid rewriting the large amount of testing inherited from Geth. 
- The pool has access to the full blockchain, and it is now capable of writing more intrusive and complex operations against the state. 

This PR facilitates later integration of the sponsored txs validation. 