### PR TITLE
Fix SetCode integration test flakyness

### DIFF
--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -612,6 +612,9 @@ func testAuthorizationsAreExecutedInOrder(t *testing.T, session IntegrationTestN
 	require.NoError(t, err)
 	// because no delegation is set, transaction call to self will succeed
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	// CodeAt looks a the archive state, so we need to wait until
+	// the most recent block is saved in archive.
+	WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	// last delegation is set
 	code, err := client.CodeAt(t.Context(), account.Address(), nil)


### PR DESCRIPTION
The `client.CodeAt` method looks at the archive state, so the test should until the most recent block is updated in archive.