### PR TITLE
Validate sponsored transactions when added to transaction pool

### DIFF
--- a/config/make_node.go
+++ b/config/make_node.go
@@ -132,7 +132,7 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 		if cfg.TxPool.Journal != "" {
 			cfg.TxPool.Journal = path.Join(cfg.Node.DataDir, cfg.TxPool.Journal)
 		}
-		pool := evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader, evmcore.NewSubsidiesChecker)
+		pool := evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader)
 		cleanup = append(cleanup, pool.Stop)
 		return pool
 	}

--- a/config/make_node.go
+++ b/config/make_node.go
@@ -132,7 +132,7 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 		if cfg.TxPool.Journal != "" {
 			cfg.TxPool.Journal = path.Join(cfg.Node.DataDir, cfg.TxPool.Journal)
 		}
-		pool := evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader)
+		pool := evmcore.NewTxPool(cfg.TxPool, reader.Config(), reader, evmcore.NewSubsidiesChecker)
 		cleanup = append(cleanup, pool.Stop)
 		return pool
 	}

--- a/evmcore/subsidies_integration.go
+++ b/evmcore/subsidies_integration.go
@@ -27,15 +27,15 @@ import (
 
 //go:generate mockgen -source=subsidies_integration.go -destination=subsidies_integration_mock.go -package=evmcore
 
-// SubsidiesChecker is an interface for checking if a transaction is sponsored
+// subsidiesChecker is an interface for checking if a transaction is sponsored
 // by the subsidies contract.
 // it does not include [subsidies.IsCovered] directly to avoid creating dependencies
 // on state for an operation which is pure.
 //
 // This interface facilitates testing and decouples the subsidies integration
 // logic from the transaction pool.
-type SubsidiesChecker interface {
-	IsSponsored(tx *types.Transaction) bool
+type subsidiesChecker interface {
+	isSponsored(tx *types.Transaction) bool
 }
 
 // SubsidiesIntegrationImplementation uses the subsidies contract to determine
@@ -47,15 +47,15 @@ type SubsidiesIntegrationImplementation struct {
 	signer types.Signer
 }
 
-// NewSubsidiesChecker creates a new SubsidiesChecker instance.
+// newSubsidiesChecker creates a new SubsidiesChecker instance.
 // This instance is capable of executing the subsidies contract to determine
 // if a transaction is sponsored.
-func NewSubsidiesChecker(
+func newSubsidiesChecker(
 	rules opera.Rules,
 	chain StateReader,
 	state state.StateDB,
 	signer types.Signer,
-) SubsidiesChecker {
+) subsidiesChecker {
 	return &SubsidiesIntegrationImplementation{
 		rules:  rules,
 		chain:  chain,
@@ -64,7 +64,7 @@ func NewSubsidiesChecker(
 	}
 }
 
-func (s *SubsidiesIntegrationImplementation) IsSponsored(tx *types.Transaction) bool {
+func (s *SubsidiesIntegrationImplementation) isSponsored(tx *types.Transaction) bool {
 	currentBlock := s.chain.CurrentBlock()
 	baseFee := s.chain.GetCurrentBaseFee()
 

--- a/evmcore/subsidies_integration_mock.go
+++ b/evmcore/subsidies_integration_mock.go
@@ -16,40 +16,40 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-// MockSubsidiesChecker is a mock of SubsidiesChecker interface.
-type MockSubsidiesChecker struct {
+// MocksubsidiesChecker is a mock of subsidiesChecker interface.
+type MocksubsidiesChecker struct {
 	ctrl     *gomock.Controller
-	recorder *MockSubsidiesCheckerMockRecorder
+	recorder *MocksubsidiesCheckerMockRecorder
 	isgomock struct{}
 }
 
-// MockSubsidiesCheckerMockRecorder is the mock recorder for MockSubsidiesChecker.
-type MockSubsidiesCheckerMockRecorder struct {
-	mock *MockSubsidiesChecker
+// MocksubsidiesCheckerMockRecorder is the mock recorder for MocksubsidiesChecker.
+type MocksubsidiesCheckerMockRecorder struct {
+	mock *MocksubsidiesChecker
 }
 
-// NewMockSubsidiesChecker creates a new mock instance.
-func NewMockSubsidiesChecker(ctrl *gomock.Controller) *MockSubsidiesChecker {
-	mock := &MockSubsidiesChecker{ctrl: ctrl}
-	mock.recorder = &MockSubsidiesCheckerMockRecorder{mock}
+// NewMocksubsidiesChecker creates a new mock instance.
+func NewMocksubsidiesChecker(ctrl *gomock.Controller) *MocksubsidiesChecker {
+	mock := &MocksubsidiesChecker{ctrl: ctrl}
+	mock.recorder = &MocksubsidiesCheckerMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockSubsidiesChecker) EXPECT() *MockSubsidiesCheckerMockRecorder {
+func (m *MocksubsidiesChecker) EXPECT() *MocksubsidiesCheckerMockRecorder {
 	return m.recorder
 }
 
-// IsSponsored mocks base method.
-func (m *MockSubsidiesChecker) IsSponsored(tx *types.Transaction) bool {
+// isSponsored mocks base method.
+func (m *MocksubsidiesChecker) isSponsored(tx *types.Transaction) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsSponsored", tx)
+	ret := m.ctrl.Call(m, "isSponsored", tx)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// IsSponsored indicates an expected call of IsSponsored.
-func (mr *MockSubsidiesCheckerMockRecorder) IsSponsored(tx any) *gomock.Call {
+// isSponsored indicates an expected call of isSponsored.
+func (mr *MocksubsidiesCheckerMockRecorder) isSponsored(tx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSponsored", reflect.TypeOf((*MockSubsidiesChecker)(nil).IsSponsored), tx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "isSponsored", reflect.TypeOf((*MocksubsidiesChecker)(nil).isSponsored), tx)
 }

--- a/evmcore/subsidies_integration_test.go
+++ b/evmcore/subsidies_integration_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 // static assert interface implementation
-var _ SubsidiesChecker = &SubsidiesIntegrationImplementation{}
+var _ subsidiesChecker = &SubsidiesIntegrationImplementation{}
 
 func TestSubsidiesIntegration_SubsidiesCheckerCanExecuteContracts(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -58,7 +58,7 @@ func TestSubsidiesIntegration_SubsidiesCheckerCanExecuteContracts(t *testing.T) 
 
 	signer := types.LatestSignerForChainID(big.NewInt(1))
 
-	checker := NewSubsidiesChecker(rules, chain, state, signer)
+	checker := newSubsidiesChecker(rules, chain, state, signer)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestSubsidiesIntegration_SubsidiesCheckerCanExecuteContracts(t *testing.T) 
 
 	// This test does not have any expectations on the result of the contract execution,
 	// just that it was executed without error.
-	checker.IsSponsored(tx)
+	checker.isSponsored(tx)
 }
 
 func TestSubsidiesIntegration_SubsidiesCheckerReturnsFalseIfContractIsNotDeployed(t *testing.T) {
@@ -98,7 +98,7 @@ func TestSubsidiesIntegration_SubsidiesCheckerReturnsFalseIfContractIsNotDeploye
 
 	signer := types.LatestSignerForChainID(big.NewInt(1))
 
-	checker := NewSubsidiesChecker(rules, chain, state, signer)
+	checker := newSubsidiesChecker(rules, chain, state, signer)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestSubsidiesIntegration_SubsidiesCheckerReturnsFalseIfContractIsNotDeploye
 		Data:     []byte{},
 	})
 
-	res := checker.IsSponsored(tx)
+	res := checker.isSponsored(tx)
 	require.False(t, res)
 }
 

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -103,6 +103,10 @@ var (
 	// ErrSponsorshipRejected is returned when a sponsored transaction request is
 	// not backed by a valid subsidy.
 	ErrSponsorshipRejected = errors.New("transaction sponsorship rejected")
+
+	// ErrSponsoredTransactionsDisabled is returned when validating a sponsorship
+	// request if gas subsidies are disabled in the current network rules.
+	ErrSponsoredTransactionsDisabled = errors.New("sponsored transactions are disabled")
 )
 
 var (

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -334,6 +334,13 @@ type txpoolResetRequest struct {
 func NewTxPool(
 	config TxPoolConfig,
 	chainconfig *params.ChainConfig,
+	chain StateReader) *TxPool {
+	return newTxPool(config, chainconfig, chain, NewSubsidiesChecker)
+}
+
+func newTxPool(
+	config TxPoolConfig,
+	chainconfig *params.ChainConfig,
 	chain StateReader,
 	subsidiesCheckerFactory subsidiesCheckerFactory,
 ) *TxPool {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -179,7 +179,7 @@ type subsidiesCheckerFactory func(
 	chain StateReader,
 	state state.StateDB,
 	signer types.Signer,
-) SubsidiesChecker
+) subsidiesChecker
 
 // TxPoolConfig are the configuration parameters of the transaction pool.
 type TxPoolConfig struct {
@@ -335,7 +335,7 @@ func NewTxPool(
 	config TxPoolConfig,
 	chainconfig *params.ChainConfig,
 	chain StateReader) *TxPool {
-	return newTxPool(config, chainconfig, chain, NewSubsidiesChecker)
+	return newTxPool(config, chainconfig, chain, newSubsidiesChecker)
 }
 
 func newTxPool(

--- a/evmcore/tx_pool_subsidies_test.go
+++ b/evmcore/tx_pool_subsidies_test.go
@@ -56,11 +56,11 @@ func TestTxPool_SponsoredTransactionsAreIncludedInThePendingSet(t *testing.T) {
 	// mock the external chain dependencies
 	chain := mockChain(ctrl, chainConfig, upgrades)
 
-	subsidiesCheckerMock := NewMockSubsidiesChecker(ctrl)
-	subsidiesCheckerMock.EXPECT().IsSponsored(gomock.Any()).Return(true).AnyTimes()
+	subsidiesCheckerMock := NewMocksubsidiesChecker(ctrl)
+	subsidiesCheckerMock.EXPECT().isSponsored(gomock.Any()).Return(true).AnyTimes()
 
 	// Instantiate the pool
-	factory := func(opera.Rules, StateReader, state.StateDB, types.Signer) SubsidiesChecker {
+	factory := func(opera.Rules, StateReader, state.StateDB, types.Signer) subsidiesChecker {
 		return subsidiesCheckerMock
 	}
 	pool := newTxPool(poolConfig, chainConfig, chain, factory)

--- a/evmcore/tx_pool_subsidies_test.go
+++ b/evmcore/tx_pool_subsidies_test.go
@@ -60,14 +60,10 @@ func TestTxPool_SponsoredTransactionsAreIncludedInThePendingSet(t *testing.T) {
 	subsidiesCheckerMock.EXPECT().IsSponsored(gomock.Any()).Return(true).AnyTimes()
 
 	// Instantiate the pool
-	pool := NewTxPool(poolConfig, chainConfig, chain, func(
-		rules opera.Rules,
-		chain StateReader,
-		state state.StateDB,
-		signer types.Signer,
-	) SubsidiesChecker {
+	factory := func(opera.Rules, StateReader, state.StateDB, types.Signer) SubsidiesChecker {
 		return subsidiesCheckerMock
-	})
+	}
+	pool := newTxPool(poolConfig, chainConfig, chain, factory)
 
 	// transactions per sender
 	const transactionsPerSender = 5

--- a/evmcore/tx_pool_subsidies_test.go
+++ b/evmcore/tx_pool_subsidies_test.go
@@ -56,8 +56,18 @@ func TestTxPool_SponsoredTransactionsAreIncludedInThePendingSet(t *testing.T) {
 	// mock the external chain dependencies
 	chain := mockChain(ctrl, chainConfig, upgrades)
 
+	subsidiesCheckerMock := NewMockSubsidiesChecker(ctrl)
+	subsidiesCheckerMock.EXPECT().IsSponsored(gomock.Any()).Return(true).AnyTimes()
+
 	// Instantiate the pool
-	pool := NewTxPool(poolConfig, chainConfig, chain)
+	pool := NewTxPool(poolConfig, chainConfig, chain, func(
+		rules opera.Rules,
+		chain StateReader,
+		state state.StateDB,
+		signer types.Signer,
+	) SubsidiesChecker {
+		return subsidiesCheckerMock
+	})
 
 	// transactions per sender
 	const transactionsPerSender = 5

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -3394,6 +3394,6 @@ func testSubsidiesCheckerFactory(
 	chain StateReader,
 	state state.StateDB,
 	signer types.Signer,
-) SubsidiesChecker {
+) subsidiesChecker {
 	return nil
 }

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -341,7 +341,7 @@ func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateK
 	blockchain := NewTestBlockChain(newTestTxPoolStateDb())
 
 	key, _ := crypto.GenerateKey()
-	pool := NewTxPool(testTxPoolConfig, config, blockchain)
+	pool := NewTxPool(testTxPoolConfig, config, blockchain, testSubsidiesCheckerFactory)
 
 	return pool, key
 }
@@ -456,7 +456,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	tx0 := transaction(0, 100000, key)
 	tx1 := transaction(1, 100000, key)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	nonce := pool.Nonce(address)
@@ -930,7 +930,7 @@ func TestSetCodeTransactions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			// initialize the pool
-			pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain)
+			pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
 			defer pool.Stop()
 
 			test.test(t, pool)
@@ -955,7 +955,7 @@ func TestSetCodeTransactionsReorg(t *testing.T) {
 	blockchain := NewTestBlockChain(db)
 
 	// initialize the pool
-	pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create the test accounts
@@ -1011,7 +1011,7 @@ func TestSetCodeTransaction_RemoveAuthorityWhenSetCodeTxIsRemoved(t *testing.T) 
 	blockchain := NewTestBlockChain(db)
 
 	// initialize the pool
-	pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create the test accounts
@@ -1446,7 +1446,7 @@ func TestTransactionPostponing(t *testing.T) {
 
 	// Create the pool to test the postponing with
 	blockchain := NewTestBlockChain(newTestTxPoolStateDb())
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create two test accounts to produce different gap profiles with
@@ -1662,7 +1662,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	config.NoLocals = nolocals
 	config.GlobalQueue = config.AccountQueue*3 - 1 // reduce the queue limits to shorten test time (-1 to make it non divisible)
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them (last one will be the local)
@@ -1754,7 +1754,7 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 	config.Lifetime = time.Second
 	config.NoLocals = nolocals
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create two test accounts to ensure remotes expire but locals do not
@@ -1892,7 +1892,7 @@ func TestTransactionQueueTruncating(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalQueue = 2
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	active, _ := crypto.GenerateKey()
@@ -1997,7 +1997,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = config.AccountSlots * 10
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -2101,7 +2101,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 	config.AccountQueue = 2
 	config.GlobalSlots = 8
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -2133,7 +2133,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = 1
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -2173,7 +2173,7 @@ func TestTransactionPool_CanReadMinTipFromPool(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	require.Equal(t, testTxPoolConfig.MinimumTip, pool.MinTip().Uint64(),
@@ -2199,7 +2199,7 @@ func TestTransactionPool_RejectsUnderTippedTransactions(t *testing.T) {
 	// copy the config so we can modify it safely
 	config := testTxPoolConfig
 	config.MinimumTip = minTip.Uint64() + 1
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2237,7 +2237,7 @@ func TestTransactionPool_AcceptsUnderTippedLocals(t *testing.T) {
 	// copy the config so we can modify it safely
 	config := testTxPoolConfig
 	config.MinimumTip = minTip.Uint64() + 1
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2277,7 +2277,7 @@ func TestTransactionPool_DropUnderpricedTransactionsWhenPoolIsFull(t *testing.T)
 	config.GlobalSlots = 2
 	config.GlobalQueue = 2
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2392,7 +2392,7 @@ func TestTransactionPool_DroppingUnderpricedTransactionsDoesNotCreateNonceGaps(t
 	config.GlobalSlots = 128
 	config.GlobalQueue = 0
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2628,7 +2628,7 @@ func TestTransactionDeduplication(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a test account to add transactions with
@@ -2694,7 +2694,7 @@ func TestTransactionReplacement(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2886,7 +2886,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	config.Journal = journal
 	config.Rejournal = time.Second
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 
 	// Create two test accounts to ensure remotes expire but locals do not
 	local, _ := crypto.GenerateKey()
@@ -2923,7 +2923,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	statedb.nonces[crypto.PubkeyToAddress(local.PublicKey)] = 1
 	blockchain = NewTestBlockChain(statedb)
 
-	pool = NewTxPool(config, params.TestChainConfig, blockchain)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 
 	pending, queued = pool.Stats()
 	if queued != 0 {
@@ -2949,7 +2949,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 
 	statedb.nonces[crypto.PubkeyToAddress(local.PublicKey)] = 1
 	blockchain = NewTestBlockChain(statedb)
-	pool = NewTxPool(config, params.TestChainConfig, blockchain)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 
 	pending, queued = pool.Stats()
 	if pending != 0 {
@@ -2979,7 +2979,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create the test accounts to check various transaction statuses with
@@ -3048,7 +3048,7 @@ func TestSampleHashes_AllExpectedTransactionsAreReturned(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	expectedPendingTxs := make(map[common.Hash]int)
@@ -3128,7 +3128,7 @@ func TestSampleHashesManySenders(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	expectedTxs := make(map[common.Hash]int)
@@ -3186,7 +3186,7 @@ func TestTxPool_ActivatingOsakaDropsTransactionsWithHighGas(t *testing.T) {
 	// set a very high gas limit
 	blockchain.SetGasLimit(params.MaxTxGas * 2)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// make a transaction with over params.MaxTxGas gas and nonce 0
@@ -3387,4 +3387,13 @@ func BenchmarkTruncatePending(b *testing.B) {
 	for range b.N {
 		pool.truncatePending()
 	}
+}
+
+func testSubsidiesCheckerFactory(
+	rules opera.Rules,
+	chain StateReader,
+	state state.StateDB,
+	signer types.Signer,
+) SubsidiesChecker {
+	return nil
 }

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -341,7 +341,7 @@ func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateK
 	blockchain := NewTestBlockChain(newTestTxPoolStateDb())
 
 	key, _ := crypto.GenerateKey()
-	pool := NewTxPool(testTxPoolConfig, config, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, config, blockchain, testSubsidiesCheckerFactory)
 
 	return pool, key
 }
@@ -456,7 +456,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	tx0 := transaction(0, 100000, key)
 	tx1 := transaction(1, 100000, key)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
 	defer pool.Stop()
 
 	nonce := pool.Nonce(address)
@@ -930,7 +930,7 @@ func TestSetCodeTransactions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			// initialize the pool
-			pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
+			pool := newTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
 			defer pool.Stop()
 
 			test.test(t, pool)
@@ -955,7 +955,7 @@ func TestSetCodeTransactionsReorg(t *testing.T) {
 	blockchain := NewTestBlockChain(db)
 
 	// initialize the pool
-	pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create the test accounts
@@ -1011,7 +1011,7 @@ func TestSetCodeTransaction_RemoveAuthorityWhenSetCodeTxIsRemoved(t *testing.T) 
 	blockchain := NewTestBlockChain(db)
 
 	// initialize the pool
-	pool := NewTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create the test accounts
@@ -1446,7 +1446,7 @@ func TestTransactionPostponing(t *testing.T) {
 
 	// Create the pool to test the postponing with
 	blockchain := NewTestBlockChain(newTestTxPoolStateDb())
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create two test accounts to produce different gap profiles with
@@ -1662,7 +1662,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	config.NoLocals = nolocals
 	config.GlobalQueue = config.AccountQueue*3 - 1 // reduce the queue limits to shorten test time (-1 to make it non divisible)
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them (last one will be the local)
@@ -1754,7 +1754,7 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 	config.Lifetime = time.Second
 	config.NoLocals = nolocals
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create two test accounts to ensure remotes expire but locals do not
@@ -1892,7 +1892,7 @@ func TestTransactionQueueTruncating(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalQueue = 2
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	active, _ := crypto.GenerateKey()
@@ -1997,7 +1997,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = config.AccountSlots * 10
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -2101,7 +2101,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 	config.AccountQueue = 2
 	config.GlobalSlots = 8
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -2133,7 +2133,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 	config := testTxPoolConfig
 	config.GlobalSlots = 1
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -2173,7 +2173,7 @@ func TestTransactionPool_CanReadMinTipFromPool(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	require.Equal(t, testTxPoolConfig.MinimumTip, pool.MinTip().Uint64(),
@@ -2199,7 +2199,7 @@ func TestTransactionPool_RejectsUnderTippedTransactions(t *testing.T) {
 	// copy the config so we can modify it safely
 	config := testTxPoolConfig
 	config.MinimumTip = minTip.Uint64() + 1
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2237,7 +2237,7 @@ func TestTransactionPool_AcceptsUnderTippedLocals(t *testing.T) {
 	// copy the config so we can modify it safely
 	config := testTxPoolConfig
 	config.MinimumTip = minTip.Uint64() + 1
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2277,7 +2277,7 @@ func TestTransactionPool_DropUnderpricedTransactionsWhenPoolIsFull(t *testing.T)
 	config.GlobalSlots = 2
 	config.GlobalQueue = 2
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2392,7 +2392,7 @@ func TestTransactionPool_DroppingUnderpricedTransactionsDoesNotCreateNonceGaps(t
 	config.GlobalSlots = 128
 	config.GlobalQueue = 0
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2628,7 +2628,7 @@ func TestTransactionDeduplication(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create a test account to add transactions with
@@ -2694,7 +2694,7 @@ func TestTransactionReplacement(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Keep track of transaction events to ensure all executables get announced
@@ -2886,7 +2886,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	config.Journal = journal
 	config.Rejournal = time.Second
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 
 	// Create two test accounts to ensure remotes expire but locals do not
 	local, _ := crypto.GenerateKey()
@@ -2923,7 +2923,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	statedb.nonces[crypto.PubkeyToAddress(local.PublicKey)] = 1
 	blockchain = NewTestBlockChain(statedb)
 
-	pool = NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool = newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 
 	pending, queued = pool.Stats()
 	if queued != 0 {
@@ -2949,7 +2949,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 
 	statedb.nonces[crypto.PubkeyToAddress(local.PublicKey)] = 1
 	blockchain = NewTestBlockChain(statedb)
-	pool = NewTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool = newTxPool(config, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 
 	pending, queued = pool.Stats()
 	if pending != 0 {
@@ -2979,7 +2979,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// Create the test accounts to check various transaction statuses with
@@ -3048,7 +3048,7 @@ func TestSampleHashes_AllExpectedTransactionsAreReturned(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	expectedPendingTxs := make(map[common.Hash]int)
@@ -3128,7 +3128,7 @@ func TestSampleHashesManySenders(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	expectedTxs := make(map[common.Hash]int)
@@ -3186,7 +3186,7 @@ func TestTxPool_ActivatingOsakaDropsTransactionsWithHighGas(t *testing.T) {
 	// set a very high gas limit
 	blockchain.SetGasLimit(params.MaxTxGas * 2)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory)
 	defer pool.Stop()
 
 	// make a transaction with over params.MaxTxGas gas and nonce 0

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -2355,11 +2355,11 @@ func TestTransactionPool_DropUnderpricedTransactionsWhenPoolIsFull(t *testing.T)
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 	// Ensure that adding local transactions can push out even higher priced ones
-	ltx = pricedTransaction(1, 100000, big.NewInt(0), keys[2])
+	ltx = pricedTransaction(1, 100000, big.NewInt(1), keys[2])
 	if err := pool.AddLocal(ltx); err != nil {
 		t.Fatalf("failed to append underpriced local transaction: %v", err)
 	}
-	ltx = pricedTransaction(0, 100000, big.NewInt(0), keys[3])
+	ltx = pricedTransaction(0, 100000, big.NewInt(1), keys[3])
 	if err := pool.AddLocal(ltx); err != nil {
 		t.Fatalf("failed to add new underpriced local transaction: %v", err)
 	}
@@ -2540,11 +2540,11 @@ func TestTransactionPoolUnderpricingDynamicFee(t *testing.T) {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 	// Ensure that adding local transactions can push out even higher priced ones
-	ltx = dynamicFeeTx(1, 100000, big.NewInt(0), big.NewInt(0), keys[2])
+	ltx = dynamicFeeTx(1, 100000, big.NewInt(1), big.NewInt(0), keys[2])
 	if err := pool.AddLocal(ltx); err != nil {
 		t.Fatalf("failed to append underpriced local transaction: %v", err)
 	}
-	ltx = dynamicFeeTx(0, 100000, big.NewInt(0), big.NewInt(0), keys[3])
+	ltx = dynamicFeeTx(0, 100000, big.NewInt(1), big.NewInt(0), keys[3])
 	if err := pool.AddLocal(ltx); err != nil {
 		t.Fatalf("failed to add new underpriced local transaction: %v", err)
 	}

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -73,7 +73,7 @@ func validateTx(
 	netRules NetworkRules,
 	chain StateReader,
 	state state.StateDB, // Although this can be retrieved from chain, it's passed explicitly to avoid extra db-pool accesses
-	subsidiesChecker SubsidiesChecker,
+	subsidiesChecker subsidiesChecker,
 	signer types.Signer,
 ) error {
 
@@ -326,7 +326,7 @@ func validateTxForPool(
 func validateSponsoredTransactions(
 	tx *types.Transaction,
 	netRules NetworkRules,
-	SubsidiesChecker SubsidiesChecker,
+	SubsidiesChecker subsidiesChecker,
 ) error {
 
 	// No check is conducted if gas subsidies are not active.
@@ -340,7 +340,7 @@ func validateSponsoredTransactions(
 	}
 
 	// Sponsored transactions are only valid if they are explicitly marked as sponsored by the subsidies checker.
-	if !SubsidiesChecker.IsSponsored(tx) {
+	if !SubsidiesChecker.isSponsored(tx) {
 		return ErrSponsorshipRejected
 	}
 

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -73,6 +73,7 @@ func validateTx(
 	netRules NetworkRules,
 	chain StateReader,
 	state state.StateDB, // Although this can be retrieved from chain, it's passed explicitly to avoid extra db-pool accesses
+	subsidiesChecker SubsidiesChecker,
 	signer types.Signer,
 ) error {
 
@@ -99,7 +100,9 @@ func validateTx(
 		return err
 	}
 
-	// TODO: check the backing of sponsored transactions
+	if err := validateSponsoredTransactions(tx, netRules, subsidiesChecker); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -314,5 +317,32 @@ func validateTxForPool(
 			opt.minTip, "tx.GasTipCap", tx.GasTipCap())
 		return ErrUnderpriced
 	}
+	return nil
+}
+
+// validateSponsoredTransactions checks if a transaction is a sponsored transaction
+// and if there is any subsidy fund which covers the gas costs
+// If no fund is available, it returns an error rejecting the transaction
+func validateSponsoredTransactions(
+	tx *types.Transaction,
+	netRules NetworkRules,
+	SubsidiesChecker SubsidiesChecker,
+) error {
+
+	// No check is conducted if gas subsidies are not active.
+	if !netRules.gasSubsidies {
+		return nil
+	}
+
+	// If the transaction is not a sponsorship request, skip all sponsored transaction checks.
+	if !subsidies.IsSponsorshipRequest(tx) {
+		return nil
+	}
+
+	// Sponsored transactions are only valid if they are explicitly marked as sponsored by the subsidies checker.
+	if !SubsidiesChecker.IsSponsored(tx) {
+		return ErrSponsorshipRejected
+	}
+
 	return nil
 }

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -331,7 +331,10 @@ func validateSponsoredTransactions(
 
 	// No check is conducted if gas subsidies are not active.
 	if !netRules.gasSubsidies {
-		return nil
+		if !subsidies.IsSponsorshipRequest(tx) {
+			return nil
+		}
+		return ErrSponsoredTransactionsDisabled
 	}
 
 	// If the transaction is not a sponsorship request, skip all sponsored transaction checks.

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -260,7 +260,7 @@ func FuzzValidateTransaction(f *testing.F) {
 
 		signer := types.LatestSignerForChainID(chainId)
 
-		subsidiesChecker := NewMockSubsidiesChecker(ctrl)
+		subsidiesChecker := NewMocksubsidiesChecker(ctrl)
 
 		// Validate the transaction
 		validateErr := validateTx(signedTx, opt, netRules, chain, state, subsidiesChecker, signer)

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -260,8 +260,10 @@ func FuzzValidateTransaction(f *testing.F) {
 
 		signer := types.LatestSignerForChainID(chainId)
 
+		subsidiesChecker := NewMockSubsidiesChecker(ctrl)
+
 		// Validate the transaction
-		validateErr := validateTx(signedTx, opt, netRules, chain, state, signer)
+		validateErr := validateTx(signedTx, opt, netRules, chain, state, subsidiesChecker, signer)
 
 		// create evm to check validateTx is consistent with processor.
 		evm := makeTestEvm(blockNum, int64(baseFee), uint64(baseFee), state, revision, chainId)

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -907,7 +907,7 @@ func TestValidateTx_RejectsTx_whenNetworkValidationFails(t *testing.T) {
 
 			rules := NetworkRules{}
 
-			err := validateTx(types.NewTx(tx), opts, rules, nil, nil, nil)
+			err := validateTx(types.NewTx(tx), opts, rules, nil, nil, nil, nil)
 			require.Error(t, err)
 		})
 	}
@@ -955,8 +955,9 @@ func TestValidateTx_RejectsTx_WhenStaticValidationFails(t *testing.T) {
 			chain := NewMockStateReader(ctrl)
 			chain.EXPECT().GetCurrentBaseFee().Return(big.NewInt(5)).AnyTimes()
 			state := state.NewMockStateDB(ctrl)
+			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, signer)
+			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
 		})
 	}
@@ -1006,8 +1007,9 @@ func TestValidateTx_RejectsTx_WhenBlockValidationFails(t *testing.T) {
 			chain.EXPECT().GetCurrentBaseFee().Return(big.NewInt(5)).AnyTimes()
 			chain.EXPECT().MaxGasLimit().Return(uint64(50_000)).AnyTimes() // lower than tx gas
 			state := state.NewMockStateDB(ctrl)
+			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, signer)
+			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
 		})
 	}
@@ -1062,8 +1064,9 @@ func TestValidateTx_RejectsTx_WhenPoolValidationFails(t *testing.T) {
 				minTip: big.NewInt(20), // transactions are tipping 0, so this will fail
 				locals: newAccountSet(signer),
 			}
+			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, signer)
+			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
 		})
 	}
@@ -1121,7 +1124,9 @@ func TestValidateTx_RejectsTx_WhenStateValidationFails(t *testing.T) {
 				locals:  newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, signer)
+			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+
+			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
 		})
 	}
@@ -1184,19 +1189,88 @@ func TestValidateTx_AcceptsZeroGasPriceTransactions_WhenSubsidiesAreEnabled(t *t
 			state.EXPECT().GetNonce(gomock.Any()).Return(uint64(0)).AnyTimes()
 			state.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(0)).AnyTimes()
 
+			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			SubsidiesChecker.EXPECT().IsSponsored(gomock.Any()).Return(true).AnyTimes()
+
 			opts := poolOptions{
 				minTip:  big.NewInt(0),
 				isLocal: true,
 				locals:  newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, signer)
+			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.NoError(t, err)
 
 			//Check that the same transaction is rejected when gas subsidies are disabled
 			rules.gasSubsidies = false
-			err = validateTx(types.NewTx(tx), opts, rules, chain, state, signer)
+			err = validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidateTx_AllowsSponsoredZeroGasPriceTransactions_WhenSubsidiesAreFunded(t *testing.T) {
+
+	tests := map[string]struct {
+		tx          types.TxData
+		isSponsored bool
+	}{
+		"accept sponsored tx": {
+			tx: &types.LegacyTx{
+				To:       &common.Address{42}, // not a contract creation
+				Gas:      100_000,
+				GasPrice: big.NewInt(0),
+				V:        big.NewInt(27), // not an internal tx
+			},
+			isSponsored: true,
+		},
+		"reject sponsored tx": {
+			tx: &types.LegacyTx{
+				To:       &common.Address{42}, // not a contract creation
+				Gas:      100_000,
+				GasPrice: big.NewInt(0),
+				V:        big.NewInt(27), // not an internal tx
+			},
+			isSponsored: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			rules := NetworkRules{
+				eip2718:      true,
+				eip1559:      true,
+				eip4844:      true,
+				eip7702:      true,
+				gasSubsidies: true,
+			}
+			ctrl := gomock.NewController(t)
+			signer := NewMockSigner(ctrl)
+			signer.EXPECT().Sender(gomock.Any()).Return(common.Address{42}, nil).AnyTimes()
+			signer.EXPECT().Equal(gomock.Any()).Return(false).AnyTimes()
+
+			chain := NewMockStateReader(ctrl)
+			chain.EXPECT().GetCurrentBaseFee().Return(big.NewInt(5))
+			chain.EXPECT().MaxGasLimit().Return(uint64(100_000))
+			state := state.NewMockStateDB(ctrl)
+			state.EXPECT().GetNonce(gomock.Any()).Return(uint64(0)).AnyTimes()
+			state.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(0)).AnyTimes()
+
+			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			SubsidiesChecker.EXPECT().IsSponsored(gomock.Any()).Return(test.isSponsored)
+
+			opts := poolOptions{
+				minTip:  big.NewInt(0),
+				isLocal: true,
+				locals:  newAccountSet(signer),
+			}
+
+			err := validateTx(types.NewTx(test.tx), opts, rules, chain, state, SubsidiesChecker, signer)
+			if test.isSponsored {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, ErrSponsorshipRejected)
+			}
 		})
 	}
 }
@@ -1251,13 +1325,15 @@ func TestValidateTx_Success(t *testing.T) {
 			state.EXPECT().GetNonce(gomock.Any()).Return(uint64(0)).AnyTimes()
 			state.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1_000_000)).AnyTimes()
 
+			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+
 			opts := poolOptions{
 				minTip:  big.NewInt(0),
 				isLocal: true,
 				locals:  newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, signer)
+			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.NoError(t, err)
 		})
 	}

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1217,7 +1217,16 @@ func Test_validateSponsoredTransactions_RejectsSponsoredTransactions(t *testing.
 		configure        func(SubsidiesChecker *MocksubsidiesChecker)
 		expectedError    error
 	}{
-		"ignore sponsored tx when subsidies are disabled": {
+		"ignore non-sponsored tx when subsidies are disabled": {
+			subsidiesEnabled: false,
+			tx: &types.LegacyTx{
+				// contract creation => never sponsored
+				Gas:      100_000,
+				GasPrice: big.NewInt(0),
+				V:        big.NewInt(27), // not an internal tx
+			},
+		},
+		"reject sponsored tx when subsidies are disabled": {
 			subsidiesEnabled: false,
 			tx: &types.LegacyTx{
 				To:       &common.Address{42}, // not a contract creation
@@ -1225,6 +1234,7 @@ func Test_validateSponsoredTransactions_RejectsSponsoredTransactions(t *testing.
 				GasPrice: big.NewInt(0),
 				V:        big.NewInt(27), // not an internal tx
 			},
+			expectedError: ErrSponsoredTransactionsDisabled,
 		},
 		"ignore tx when it is not a sponsor request": {
 			subsidiesEnabled: true,

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -955,7 +955,7 @@ func TestValidateTx_RejectsTx_WhenStaticValidationFails(t *testing.T) {
 			chain := NewMockStateReader(ctrl)
 			chain.EXPECT().GetCurrentBaseFee().Return(big.NewInt(5)).AnyTimes()
 			state := state.NewMockStateDB(ctrl)
-			subsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			subsidiesChecker := NewMocksubsidiesChecker(ctrl)
 
 			err := validateTx(types.NewTx(tx), opts, rules, chain, state, subsidiesChecker, signer)
 			require.Error(t, err)
@@ -1007,7 +1007,7 @@ func TestValidateTx_RejectsTx_WhenBlockValidationFails(t *testing.T) {
 			chain.EXPECT().GetCurrentBaseFee().Return(big.NewInt(5)).AnyTimes()
 			chain.EXPECT().MaxGasLimit().Return(uint64(50_000)).AnyTimes() // lower than tx gas
 			state := state.NewMockStateDB(ctrl)
-			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			SubsidiesChecker := NewMocksubsidiesChecker(ctrl)
 
 			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
@@ -1064,7 +1064,7 @@ func TestValidateTx_RejectsTx_WhenPoolValidationFails(t *testing.T) {
 				minTip: big.NewInt(20), // transactions are tipping 0, so this will fail
 				locals: newAccountSet(signer),
 			}
-			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			SubsidiesChecker := NewMocksubsidiesChecker(ctrl)
 
 			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
@@ -1124,7 +1124,7 @@ func TestValidateTx_RejectsTx_WhenStateValidationFails(t *testing.T) {
 				locals:  newAccountSet(signer),
 			}
 
-			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			SubsidiesChecker := NewMocksubsidiesChecker(ctrl)
 
 			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
 			require.Error(t, err)
@@ -1189,8 +1189,8 @@ func TestValidateTx_AcceptsZeroGasPriceTransactions_WhenSubsidiesAreEnabled(t *t
 			state.EXPECT().GetNonce(gomock.Any()).Return(uint64(0)).AnyTimes()
 			state.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(0)).AnyTimes()
 
-			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
-			SubsidiesChecker.EXPECT().IsSponsored(gomock.Any()).Return(true).AnyTimes()
+			SubsidiesChecker := NewMocksubsidiesChecker(ctrl)
+			SubsidiesChecker.EXPECT().isSponsored(gomock.Any()).Return(true).AnyTimes()
 
 			opts := poolOptions{
 				minTip:  big.NewInt(0),
@@ -1214,7 +1214,7 @@ func Test_validateSponsoredTransactions_RejectsSponsoredTransactions(t *testing.
 	tests := map[string]struct {
 		subsidiesEnabled bool
 		tx               types.TxData
-		configure        func(SubsidiesChecker *MockSubsidiesChecker)
+		configure        func(SubsidiesChecker *MocksubsidiesChecker)
 		expectedError    error
 	}{
 		"ignore sponsored tx when subsidies are disabled": {
@@ -1243,8 +1243,8 @@ func Test_validateSponsoredTransactions_RejectsSponsoredTransactions(t *testing.
 				GasPrice: big.NewInt(0),
 				V:        big.NewInt(27), // not an internal tx
 			},
-			configure: func(subsidiesChecker *MockSubsidiesChecker) {
-				subsidiesChecker.EXPECT().IsSponsored(gomock.Any()).Return(false)
+			configure: func(subsidiesChecker *MocksubsidiesChecker) {
+				subsidiesChecker.EXPECT().isSponsored(gomock.Any()).Return(false)
 			},
 			expectedError: ErrSponsorshipRejected,
 		},
@@ -1254,7 +1254,7 @@ func Test_validateSponsoredTransactions_RejectsSponsoredTransactions(t *testing.
 		t.Run(name, func(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
-			subsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			subsidiesChecker := NewMocksubsidiesChecker(ctrl)
 			if test.configure != nil {
 				test.configure(subsidiesChecker)
 			}
@@ -1320,8 +1320,8 @@ func TestValidateTx_AllowsSponsoredZeroGasPriceTransactions_WhenSubsidiesAreFund
 			state.EXPECT().GetNonce(gomock.Any()).Return(uint64(0)).AnyTimes()
 			state.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(0)).AnyTimes()
 
-			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
-			SubsidiesChecker.EXPECT().IsSponsored(gomock.Any()).Return(test.isSponsored)
+			SubsidiesChecker := NewMocksubsidiesChecker(ctrl)
+			SubsidiesChecker.EXPECT().isSponsored(gomock.Any()).Return(test.isSponsored)
 
 			opts := poolOptions{
 				minTip:  big.NewInt(0),
@@ -1389,7 +1389,7 @@ func TestValidateTx_Success(t *testing.T) {
 			state.EXPECT().GetNonce(gomock.Any()).Return(uint64(0)).AnyTimes()
 			state.EXPECT().GetBalance(gomock.Any()).Return(uint256.NewInt(1_000_000)).AnyTimes()
 
-			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			SubsidiesChecker := NewMocksubsidiesChecker(ctrl)
 
 			opts := poolOptions{
 				minTip:  big.NewInt(0),

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -955,9 +955,9 @@ func TestValidateTx_RejectsTx_WhenStaticValidationFails(t *testing.T) {
 			chain := NewMockStateReader(ctrl)
 			chain.EXPECT().GetCurrentBaseFee().Return(big.NewInt(5)).AnyTimes()
 			state := state.NewMockStateDB(ctrl)
-			SubsidiesChecker := NewMockSubsidiesChecker(ctrl)
+			subsidiesChecker := NewMockSubsidiesChecker(ctrl)
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, SubsidiesChecker, signer)
+			err := validateTx(types.NewTx(tx), opts, rules, chain, state, subsidiesChecker, signer)
 			require.Error(t, err)
 		})
 	}
@@ -1229,13 +1229,13 @@ func Test_validateSponsoredTransactions_RejectsSponsoredTransactions(t *testing.
 		"ignore tx when it is not a sponsor request": {
 			subsidiesEnabled: true,
 			tx: &types.LegacyTx{
-				// contract creation
+				// contract creation => never sponsored
 				Gas:      100_000,
 				GasPrice: big.NewInt(0),
 				V:        big.NewInt(27), // not an internal tx
 			},
 		},
-		"reject tx when soponsorship is not approved": {
+		"reject tx when sponsorship is not approved": {
 			subsidiesEnabled: true,
 			tx: &types.LegacyTx{
 				To:       &common.Address{42}, // not a contract creation

--- a/gossip/handler_fuzz_test.go
+++ b/gossip/handler_fuzz_test.go
@@ -125,7 +125,7 @@ func makeFuzzedHandler(t *testing.T) (*handler, error) {
 		&EvmStateReader{
 			ServiceFeed: feed,
 			store:       store,
-		}, evmcore.NewSubsidiesChecker)
+		})
 	t.Cleanup(txpool.Stop)
 
 	h, err := newHandler(

--- a/gossip/handler_fuzz_test.go
+++ b/gossip/handler_fuzz_test.go
@@ -119,10 +119,13 @@ func makeFuzzedHandler(t *testing.T) (*handler, error) {
 		}},
 		idx.Block(0),
 	)
-	txpool := evmcore.NewTxPool(evmcore.DefaultTxPoolConfig, chainconfig, &EvmStateReader{
-		ServiceFeed: feed,
-		store:       store,
-	})
+	txpool := evmcore.NewTxPool(
+		evmcore.DefaultTxPoolConfig,
+		chainconfig,
+		&EvmStateReader{
+			ServiceFeed: feed,
+			store:       store,
+		}, evmcore.NewSubsidiesChecker)
 	t.Cleanup(txpool.Stop)
 
 	h, err := newHandler(


### PR DESCRIPTION
The transaction pool validates sponsorship transactions requests. 

This PR and the previous one  #521 aim to reduce the amount of test code rewritten in tx_poo_tests.go. 
This is done by introducing a proxy object ( #521)  and segregating tests between two files:
- tx_pool_test.go logic remains untouched and can only test non-sponsored transactions
- tx_pool_subsidies_test.go contain tests which can enable the subsidies feature and use mocks for the state.

The logic of validating the subsidies is added to the tx_validate.go file.
To avoid boilerplate changes during review, the pr is separated in two commits. 