### PR TITLE
Gas subsidies: add insufficient funds test

### DIFF
--- a/tests/gas_subsidies/test_utils.go
+++ b/tests/gas_subsidies/test_utils.go
@@ -61,7 +61,7 @@ func Fund(
 	// check that the sponsorship funds got deposited
 	sponsorship, err := registry.Sponsorships(nil, fundId)
 	require.NoError(t, err)
-	require.Equal(t, donation, sponsorship.Funds)
+	require.Equal(t, donation.Uint64(), sponsorship.Funds.Uint64())
 
 	return registry
 }


### PR DESCRIPTION
This PR ensures transactions are rejected if there is not enough fund to pay for the transaction and its payment.
Note that the `sponsorshipOverheadCost` will be updated after #523.