### PR TITLE
Reuse chain for different transaction types

### DIFF
--- a/tests/gas_subsidies/all_tx_types_test.go
+++ b/tests/gas_subsidies/all_tx_types_test.go
@@ -52,19 +52,20 @@ func TestGasSubsidies_SupportAllTxTypes(t *testing.T) {
 		},
 	}
 
+	// Enable allegro to support setCode transactions.
+	upgrades := opera.GetAllegroUpgrades()
+	upgrades.GasSubsidies = true
+
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
 	for name, tx := range transactions {
 		t.Run(name, func(t *testing.T) {
-			// Enable allegro to support setCode transactions.
-			upgrades := opera.GetAllegroUpgrades()
-			upgrades.GasSubsidies = true
-
-			net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-				Upgrades: &upgrades,
-			})
-
-			client, err := net.GetClient()
-			require.NoError(t, err)
-			defer client.Close()
 
 			sponsee := tests.NewAccount()
 


### PR DESCRIPTION
Updates the `TestGasSubsidies_SupportAllTxTypes` to reuse the same network for each transaction type.