### PR TITLE
Add waits for proof of blocks to prevent flakiness

### DIFF
--- a/tests/gas_subsidies/block_verifiability_test.go
+++ b/tests/gas_subsidies/block_verifiability_test.go
@@ -91,11 +91,14 @@ func testBlockVerifiability(t *testing.T, upgrades opera.Upgrades) {
 	_, id, err := reg.GlobalSponsorshipFundId(nil)
 	require.NoError(err)
 
-	_, err = net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+	receipt, err := net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		opts.Value = big.NewInt(1e18)
 		return reg.Sponsor(opts, id)
 	})
 	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+
+	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	// Check sponsorship balance.
 	state, err := reg.Sponsorships(nil, id)

--- a/tests/gas_subsidies/deducts_funds_test.go
+++ b/tests/gas_subsidies/deducts_funds_test.go
@@ -266,6 +266,8 @@ func testGasSubsidies_SubsidizedTransaction_DeductsSubsidyFunds(t *testing.T, ne
 			// For every block created during test scenario
 			for blockNumber := blockBefore.NumberU64() + 1; blockNumber <= blockAfter.NumberU64(); blockNumber++ {
 
+				tests.WaitForProofOf(t, client, int(blockNumber))
+
 				block, err := client.BlockByNumber(t.Context(), big.NewInt(int64(blockNumber)))
 				require.NoError(t, err)
 
@@ -300,6 +302,8 @@ func testGasSubsidies_SubsidizedTransaction_DeductsSubsidyFunds(t *testing.T, ne
 
 				}
 			}
+
+			tests.WaitForProofOf(t, client, int(blockAfter.NumberU64()))
 
 			_, fundId, err := sponsorshipRegistry.AccountSponsorshipFundId(nil, sponsoredSender.Address())
 			require.NoError(t, err)

--- a/tests/gas_subsidies/insufficient_funds_test.go
+++ b/tests/gas_subsidies/insufficient_funds_test.go
@@ -85,6 +85,8 @@ func TestGasSubsidies_RequestIsRejectedInCaseOfInsufficientFunds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
+	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
+
 	// Get the funds before resending the transaction
 	ops := &bind.CallOpts{
 		BlockNumber: receipt.BlockNumber,
@@ -105,6 +107,8 @@ func TestGasSubsidies_RequestIsRejectedInCaseOfInsufficientFunds(t *testing.T) {
 	header, err = client.HeaderByHash(t.Context(), receipt.BlockHash)
 	require.NoError(t, err)
 	baseFee = header.BaseFee
+
+	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	ops = &bind.CallOpts{
 		BlockNumber: receipt.BlockNumber,

--- a/tests/gas_subsidies/test_utils.go
+++ b/tests/gas_subsidies/test_utils.go
@@ -51,6 +51,11 @@ func Fund(
 	ok, fundId, err := registry.AccountSponsorshipFundId(nil, sponsee)
 	require.NoError(t, err)
 
+	latestBlock, err := client.BlockByNumber(t.Context(), nil)
+	require.NoError(t, err)
+
+	tests.WaitForProofOf(t, client, int(latestBlock.NumberU64()))
+
 	sponsorshipBefore, err := registry.Sponsorships(nil, fundId)
 	require.NoError(t, err)
 
@@ -62,6 +67,8 @@ func Fund(
 	})
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	// check that the sponsorshipAfter funds got deposited
 	sponsorshipAfter, err := registry.Sponsorships(nil, fundId)

--- a/tests/gas_subsidies/test_utils_test.go
+++ b/tests/gas_subsidies/test_utils_test.go
@@ -73,6 +73,8 @@ func TestGasSubsidies_HelperFunctions(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok, "registry should have a fund ID")
 
+	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
+
 	sponsorship, err := registry.Sponsorships(nil, fundId)
 	require.NoError(t, err)
 	require.Less(t, sponsorship.Funds.Uint64(), donation.Uint64())


### PR DESCRIPTION
This PR adds a series of calls to `tests.WaitForProof` to prevent flakiness in several tests.