### PR TITLE
Remove remaining TODOs in state processor tests

### DIFF
--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -1350,7 +1350,3 @@ func TestTransactionGenerationUtilities(t *testing.T) {
 	require.False(t, subsidies.IsSponsorshipRequest(regular))
 	require.True(t, subsidies.IsSponsorshipRequest(request))
 }
-
-// TODO:
-//  - test progression of txIndex in sponsored transactions
-//  - test that EVM is progressing txIndex by processed transactions


### PR DESCRIPTION
Removes two left-over TODOs in the `state_processor_test.go` file. 

These TODOs have been covered in the past:
- test progression of txIndex in sponsored transactions: [here](https://github.com/0xsoniclabs/sonic/blob/c5407a899a9518a578bbd3316368d36dbe4b9759/evmcore/state_processor_test.go#L1080-L1129) and [here](https://github.com/0xsoniclabs/sonic/blob/df228cd1943f8d939515ae9f934d3f62ce0294fc/tests/gas_subsidies/log_order_test.go#L97-L103)
- test that EVM is progressing txIndex by processed transactions: [here](https://github.com/0xsoniclabs/sonic/blob/df228cd1943f8d939515ae9f934d3f62ce0294fc/gossip/blockproc/evmmodule/evm_test.go#L193) and [here](https://github.com/0xsoniclabs/sonic/blob/df228cd1943f8d939515ae9f934d3f62ce0294fc/tests/gas_subsidies/log_order_test.go#L97-L103)