### PR TITLE
Cache results of isSubsidised

### DIFF
--- a/evmcore/subsidies_check_cache.go
+++ b/evmcore/subsidies_check_cache.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package evmcore
+
+import (
+	"time"
+	"unsafe"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	lru "github.com/hashicorp/golang-lru"
+)
+
+// subsidiesCheckerCache is a cache for subsidiesChecker results. Fetch results
+// are cached internally, using an exponential backoff strategy to reduce load
+// on the underlying checker.
+type subsidiesCheckerCache struct {
+	cache *lru.Cache
+}
+
+// newSubsidiesCheckerCache creates a new subsidiesCheckerCache with roughly
+// the given size in bytes. If size is less than or equal to zero, a default
+// size is of 10MiB is used.
+func newSubsidiesCheckerCache(size int) *subsidiesCheckerCache {
+	if size <= 0 {
+		size = 10 * 1024 * 1024 // 10 MiB
+	}
+	capacity := max(size/getSizeOfSubsidiesCheckerCacheEntry(), 1)
+	cache, _ := lru.New(capacity) // only fails if capacity <= 0
+	return &subsidiesCheckerCache{cache: cache}
+}
+
+func (c *subsidiesCheckerCache) get(txHash common.Hash) (subsidiesCheckerCacheEntry, bool) {
+	if entry, ok := c.cache.Get(txHash); ok {
+		return entry.(subsidiesCheckerCacheEntry), true
+	}
+	return subsidiesCheckerCacheEntry{}, false
+}
+
+func (c *subsidiesCheckerCache) put(txHash common.Hash, entry subsidiesCheckerCacheEntry) {
+	c.cache.Add(txHash, entry)
+}
+
+func (c *subsidiesCheckerCache) wrap(checker subsidiesChecker) *cachedSubsidiesChecker {
+	return &cachedSubsidiesChecker{
+		cache:   c,
+		checker: checker,
+	}
+}
+
+// subsidiesCheckerCacheEntry is a single entry in the subsidiesCheckerCache.
+type subsidiesCheckerCacheEntry struct {
+	validUntil       time.Time
+	validityDuration time.Duration
+	covered          bool
+}
+
+func getSizeOfSubsidiesCheckerCacheEntry() int {
+	var entry subsidiesCheckerCacheEntry
+	return int(unsafe.Sizeof(entry))
+}
+
+// cachedSubsidiesChecker is a subsidiesChecker that caches results using a
+// subsidiesCheckerCache.
+type cachedSubsidiesChecker struct {
+	cache   *subsidiesCheckerCache
+	checker subsidiesChecker
+}
+
+// isSponsored checks if the given transaction is sponsored, using the cache
+// to reduce load on the underlying checker. Cache entries have a validity
+// duration that is exponentially increased on each check, up to a maximum.
+func (c *cachedSubsidiesChecker) isSponsored(tx *types.Transaction) bool {
+	return c._isSponsored(tx, time.Now())
+}
+
+// _isSponsored is the internal implementation of isSponsored, allowing to
+// specify the current time (for testing).
+func (c *cachedSubsidiesChecker) _isSponsored(
+	tx *types.Transaction,
+	now time.Time,
+) bool {
+	const (
+		initialValidity = 200 * time.Millisecond
+		maxValidity     = 15 * time.Second
+		scalingFactor   = 2
+	)
+
+	hash := tx.Hash()
+	entry, found := c.cache.get(hash)
+
+	// If the last result is still valid, it can be reused.
+	if found && entry.validUntil.After(now) {
+		// Cache hit, return the cached result
+		return entry.covered
+	}
+
+	// The coverage should be refreshed.
+	entry.covered = c.checker.isSponsored(tx)
+
+	// Exponential backoff of the next check time.
+	entry.validityDuration = max(min(maxValidity, entry.validityDuration*scalingFactor), initialValidity)
+	entry.validUntil = now.Add(entry.validityDuration)
+	c.cache.put(hash, entry)
+
+	return entry.covered
+}

--- a/evmcore/subsidies_check_cache_test.go
+++ b/evmcore/subsidies_check_cache_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package evmcore
+
+import (
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewSubsidiesCheckerCache_CapacityIsEnforced(t *testing.T) {
+	const MiB = 1024 * 1024
+	tests := map[string]struct {
+		input int
+		size  int
+	}{
+		"negative": {input: -10, size: 10 * MiB},
+		"zero":     {input: 0, size: 10 * MiB},
+		"one":      {input: 1, size: 1},
+		"small":    {input: 100, size: 100},
+		"large":    {input: 200 * MiB, size: 200 * MiB},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := newSubsidiesCheckerCache(tc.input)
+
+			// To check the full size, we add entries until one is evicted.
+			i := 0
+			for ; ; i++ {
+				if cache.cache.Add(i, struct{}{}) {
+					break
+				}
+			}
+
+			capacity := max(tc.size/getSizeOfSubsidiesCheckerCacheEntry(), 1)
+			require.Equal(t, capacity, i)
+		})
+	}
+}
+
+func TestSubsidiesCheckerCache_MissingEntry_ReturnsNotFound(t *testing.T) {
+	cache := newSubsidiesCheckerCache(10)
+	_, found := cache.get(common.Hash{})
+	require.False(t, found)
+}
+
+func TestSubsidiesCheckerCache_PresentEntries_AreReturned(t *testing.T) {
+	cache := newSubsidiesCheckerCache(1024)
+
+	entryA := subsidiesCheckerCacheEntry{covered: true}
+	entryB := subsidiesCheckerCacheEntry{covered: false}
+
+	hashA := common.Hash{0x1}
+	hashB := common.Hash{0x2}
+
+	_, found := cache.get(hashA)
+	require.False(t, found)
+	_, found = cache.get(hashB)
+	require.False(t, found)
+
+	// -- add first element --
+	cache.put(hashA, entryA)
+	got, found := cache.get(hashA)
+	require.True(t, found)
+	require.Equal(t, entryA, got)
+
+	_, found = cache.get(hashB)
+	require.False(t, found)
+
+	// -- add second element --
+	cache.put(hashB, entryB)
+	got, found = cache.get(hashA)
+	require.True(t, found)
+	require.Equal(t, entryA, got)
+
+	got, found = cache.get(hashB)
+	require.True(t, found)
+	require.Equal(t, entryB, got)
+}
+
+func TestSubsidiesCheckerCache_Wrap_WrapsCache(t *testing.T) {
+	cache := newSubsidiesCheckerCache(10)
+
+	checker := &cachedSubsidiesChecker{}
+	res := cache.wrap(checker)
+	require.Equal(t, res.cache, cache)
+	require.Equal(t, res.checker, checker)
+}
+
+func TestGetSizeOfSubsidiesCheckerCacheEntry(t *testing.T) {
+	require.Equal(t,
+		int(unsafe.Sizeof(subsidiesCheckerCacheEntry{})),
+		getSizeOfSubsidiesCheckerCacheEntry(),
+	)
+}
+
+func TestCachedSubsidiesChecker_isSponsored_UsesValueFromCache(t *testing.T) {
+	cache := newSubsidiesCheckerCache(1024)
+
+	tx1 := types.NewTx(&types.LegacyTx{Nonce: 1})
+	tx2 := types.NewTx(&types.LegacyTx{Nonce: 2})
+	require.NotEqual(t, tx1.Hash(), tx2.Hash())
+
+	now := time.Now()
+	cache.put(tx1.Hash(), subsidiesCheckerCacheEntry{
+		validUntil: now.Add(time.Minute),
+		covered:    true,
+	})
+	cache.put(tx2.Hash(), subsidiesCheckerCacheEntry{
+		validUntil: now.Add(time.Minute),
+		covered:    false,
+	})
+
+	checker := cache.wrap(nil)
+	require.True(t, checker.isSponsored(tx1))
+	require.False(t, checker.isSponsored(tx2))
+}
+
+func TestCachedSubsidiesChecker_isSponsored_NonCachedValue_FetchesNewValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	checker := NewMocksubsidiesChecker(ctrl)
+
+	cache := newSubsidiesCheckerCache(1024)
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+	_, found := cache.get(tx.Hash())
+	require.False(t, found)
+
+	cachedChecker := cache.wrap(checker)
+
+	// Fetch the value the first time, should call the underlying checker.
+	now := time.Now()
+	checker.EXPECT().isSponsored(tx).Return(true).Times(1)
+	require.True(t, cachedChecker._isSponsored(tx, now))
+
+	// The result should be cached now.
+	entry, found := cache.get(tx.Hash())
+	require.True(t, found)
+	require.True(t, entry.covered)
+	require.True(t, entry.validUntil.After(now))
+	require.Equal(t, entry.validityDuration, 200*time.Millisecond)
+
+	// Second call should use the cache, so no call to the underlying checker.
+	require.True(t, cachedChecker._isSponsored(tx, now.Add(time.Millisecond)))
+}
+
+func TestCachedSubsidiesChecker_isSponsored_OutdatedEntry_FetchesNewValue(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	checker := NewMocksubsidiesChecker(ctrl)
+
+	cache := newSubsidiesCheckerCache(1024)
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+
+	now := time.Now()
+	validInterval := 200 * time.Millisecond
+	cache.put(tx.Hash(), subsidiesCheckerCacheEntry{
+		validUntil:       now.Add(validInterval),
+		validityDuration: validInterval,
+		covered:          true,
+	})
+
+	now = now.Add(validInterval + time.Millisecond)
+
+	// The entry is now outdated, so the underlying checker should be called.
+	cachedChecker := cache.wrap(checker)
+	checker.EXPECT().isSponsored(tx).Return(false)
+	require.False(t, cachedChecker._isSponsored(tx, now))
+
+	// The validity duration should have been increased (exponential backoff).
+	entry, found := cache.get(tx.Hash())
+	require.True(t, found)
+	require.False(t, entry.covered)
+	require.Equal(t, entry.validUntil, now.Add(entry.validityDuration))
+	require.Equal(t, entry.validityDuration, 400*time.Millisecond) // 200ms * 2
+}
+
+func TestCacheSubsidiesChecker_isSponsored_ValidityDurationIsCapped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	checker := NewMocksubsidiesChecker(ctrl)
+
+	cache := newSubsidiesCheckerCache(1024)
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+
+	now := time.Now()
+	validInterval := 10 * time.Second
+	cache.put(tx.Hash(), subsidiesCheckerCacheEntry{
+		validUntil:       now.Add(validInterval),
+		validityDuration: validInterval,
+		covered:          true,
+	})
+
+	now = now.Add(validInterval + time.Millisecond)
+
+	// The entry is now outdated, so the underlying checker should be called.
+	cachedChecker := cache.wrap(checker)
+	checker.EXPECT().isSponsored(tx).Return(true)
+	require.True(t, cachedChecker._isSponsored(tx, now))
+
+	// The validity duration should be capped to the maximum (15s).
+	entry, found := cache.get(tx.Hash())
+	require.True(t, found)
+	require.True(t, entry.covered)
+	require.Equal(t, entry.validUntil, now.Add(entry.validityDuration))
+	require.Equal(t, entry.validityDuration, 15*time.Second)
+}


### PR DESCRIPTION
This PR introduces a cache for determining the funding status of transactions in the transaction pool.

The cache uses a exponential back-off strategy to manage the validity period of results. Initially, the result of the sponsorship coverage is only valid for fractions of a second, but over time, validity is increased up to 15 seconds. This should significantly reduce the load on pools with high numbers of sponsorship request transactions.

In a Norma scenario introducing up to ~48.000 sponsorship requests into a pool, the CPU profile looked like this before this change, where `isSponsored` calls consume ~30s of CPU time:
<img width="804" height="591" alt="image" src="https://github.com/user-attachments/assets/fc2946a5-be7b-4b25-b39c-ac7073902425" />

After the change, the time spend on sponsorship requests got reduced to ~10s of CPU time:
<img width="800" height="562" alt="image" src="https://github.com/user-attachments/assets/7871f5ad-b527-4542-868d-bb9601eabb4e" />

The costs for signature checks are due to a limited size of the signature cache. This will be covered in an independent PR.
