### PR TITLE
Increase size of signature cache to 100k entries

### DIFF
--- a/utils/signers/gsignercache/global_cache.go
+++ b/utils/signers/gsignercache/global_cache.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	globalCache, _ = lru.New(40000)
+	globalCache, _ = lru.New(100_000) // ~40 bytes per entry => ~4MB
 )
 
 type WlruCache struct {


### PR DESCRIPTION
In some Norma experiments we are seeing more than 50k transactions being pending or queued. In such cases, the current signature cache size is insufficient.

This PR increases the capacity from 40k to 100k to cover those cases.

In #543 this problem was visible in the CPU profile:
<img width="800" height="562" alt="image" src="https://github.com/user-attachments/assets/7871f5ad-b527-4542-868d-bb9601eabb4e" />

With this change, this overhead is gone:
<img width="800" height="602" alt="image" src="https://github.com/user-attachments/assets/44ff1e7c-3db2-4a21-a2f9-3debc9a447cd" />
