### PR TITLE
Fix issue preventing from running live state check on archive db 

### DIFF
--- a/cmd/sonictool/check/live.go
+++ b/cmd/sonictool/check/live.go
@@ -50,7 +50,7 @@ func CheckLiveStateDb(ctx context.Context, dataDir string, cacheRatio cachescale
 }
 
 func checkLiveBlockRoot(dataDir string, cacheRatio cachescale.Func) (err error) {
-	gdb, dbs, err := createGdb(dataDir, cacheRatio, carmen.NoArchive, true)
+	gdb, dbs, err := createGdb(dataDir, cacheRatio, carmen.S5Archive, true)
 	if err != nil {
 		return fmt.Errorf("failed to create gdb and db producer: %w", err)
 	}


### PR DESCRIPTION
This change replaces `carmen.NoArchive`  by `carmen.S5Archive`  when opening the carmen database for checks. 
This allows sonictool checking the live db of an archive instance. An operation which is much faster than checking the full archive.  This is used by test scripts [here](https://scala.fantom.network/job/Sonic/job/RPC-node-sync/).

Fixes: https://github.com/0xsoniclabs/sonic-admin/issues/403