### PR TITLE
Integration tests net: improve conectivity.

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -471,8 +471,6 @@ func (n *IntegrationTestNet) start() error {
 				"--statedb.cache", "1024",
 
 				"--ipcpath", fmt.Sprintf("%s/sonic.ipc", tmp),
-
-				"--maxpeers", fmt.Sprintf("%d", len(n.nodes)-1),
 			},
 				// append extra arguments
 				n.options.ClientExtraArguments...,


### PR DESCRIPTION
This PR manually connects every integration test node to each other. 
Some experiments with large number of nodes (> 25)  shown no emission of events by nodes with ID larger than ~20.
This can be attributed to the star pattern where all nodes are connected to the first one. This node may decide not to notify to a subset of the validators.

This PR creates a fully connected net to enable experiments with large node number. Existing infrastructure is not affected by this, low node number shall not see any overhead by the extra connections. 