### PR TITLE
Remove parallel from isolated tests.

### DIFF
--- a/tests/gas_cost/gas_cost_test.go
+++ b/tests/gas_cost/gas_cost_test.go
@@ -53,16 +53,10 @@ func (tc *TestCase) String() string {
 }
 
 func TestGasCostTest_Sonic(t *testing.T) {
-	t.Parallel()
-
 	t.Run("with distributed proposers", func(t *testing.T) {
-		t.Parallel()
-
 		testGasCosts_Sonic(t, false)
 	})
 	t.Run("with single proposer", func(t *testing.T) {
-		t.Parallel()
-
 		testGasCosts_Sonic(t, true)
 	})
 }
@@ -91,7 +85,6 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	// > )
 
 	t.Run("reject transactions with insufficient gas", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -111,7 +104,6 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("transactions with exact gas succeed", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -132,7 +124,6 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("Sonic processor charges 10% of unused gas", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -161,16 +152,10 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 }
 
 func TestGasCostTest_Allegro(t *testing.T) {
-	t.Parallel()
-
 	t.Run("with distributed proposers", func(t *testing.T) {
-		t.Parallel()
-
 		testGasCosts_Allegro(t, false)
 	})
 	t.Run("with single proposer", func(t *testing.T) {
-		t.Parallel()
-
 		testGasCosts_Allegro(t, true)
 	})
 }
@@ -214,7 +199,6 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	}
 
 	t.Run("reject transactions with insufficient gas", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
@@ -236,7 +220,6 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("transactions with exact gas succeed", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 
 		var corrections int
@@ -265,7 +248,6 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	})
 
 	t.Run("Sonic processor charges 10% of unused gas", func(t *testing.T) {
-		t.Parallel()
 		session := net.SpawnSession(t)
 
 		var floorGreaterThan20Percent int
@@ -476,8 +458,6 @@ func makeGasCostTestInputs(
 }
 
 func TestExcessGasCharges_DisabledInSingleProposerModeInNewAndHistoricRuns(t *testing.T) {
-	t.Parallel()
-
 	require := require.New(t)
 
 	upgrades := opera.GetAllegroUpgrades()

--- a/tests/gas_subsidies/block_verifiability_test.go
+++ b/tests/gas_subsidies/block_verifiability_test.go
@@ -45,7 +45,6 @@ import (
 )
 
 func TestBlockVerifiability(t *testing.T) {
-	t.Parallel()
 	tests := map[string]opera.Upgrades{
 		"sonic":   opera.GetSonicUpgrades(),
 		"allegro": opera.GetAllegroUpgrades(),
@@ -53,17 +52,14 @@ func TestBlockVerifiability(t *testing.T) {
 
 	for name, upgrades := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			single := upgrades
 			single.SingleProposerBlockFormation = true
 			distributed := upgrades
 			distributed.SingleProposerBlockFormation = false
 			t.Run("single", func(t *testing.T) {
-				t.Parallel()
 				testBlockVerifiability(t, single)
 			})
 			t.Run("distributed", func(t *testing.T) {
-				t.Parallel()
 				testBlockVerifiability(t, distributed)
 			})
 		})

--- a/tests/network_rules_update/network_rules_update_test.go
+++ b/tests/network_rules_update/network_rules_update_test.go
@@ -37,8 +37,6 @@ import (
 )
 
 func TestNetworkRule_Update_RulesChangeIsDelayedUntilNextEpochStart(t *testing.T) {
-	t.Parallel()
-
 	require := require.New(t)
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
 		tests.IntegrationTestNetOptions{
@@ -101,8 +99,6 @@ func TestNetworkRule_Update_RulesChangeIsDelayedUntilNextEpochStart(t *testing.T
 }
 
 func TestNetworkRule_Update_RulesChangeDuringEpoch_PreAllegro(t *testing.T) {
-	t.Parallel()
-
 	require := require.New(t)
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
 		tests.IntegrationTestNetOptions{
@@ -150,8 +146,6 @@ func TestNetworkRule_Update_RulesChangeDuringEpoch_PreAllegro(t *testing.T) {
 }
 
 func TestNetworkRule_Update_Restart_Recovers_Original_Value(t *testing.T) {
-	t.Parallel()
-
 	require := require.New(t)
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
 		tests.IntegrationTestNetOptions{
@@ -223,8 +217,6 @@ func TestNetworkRule_Update_Restart_Recovers_Original_Value(t *testing.T) {
 }
 
 func TestNetworkRules_UpdateMaxEventGas_DropsLargeGasTxs(t *testing.T) {
-	t.Parallel()
-
 	require := require.New(t)
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
 		tests.IntegrationTestNetOptions{
@@ -284,7 +276,6 @@ func TestNetworkRules_UpdateMaxEventGas_DropsLargeGasTxs(t *testing.T) {
 }
 
 func TestNetworkRule_MinEventGas_AllowsChangingRules(t *testing.T) {
-	t.Parallel()
 
 	require := require.New(t)
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
@@ -331,8 +322,6 @@ func TestNetworkRule_MinEventGas_AllowsChangingRules(t *testing.T) {
 }
 
 func TestNetworkRules_PragueFeaturesBecomeAvailableWithAllegroUpgrade(t *testing.T) {
-	t.Parallel()
-
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
 		tests.IntegrationTestNetOptions{
 			// Explicitly set the network to use the Sonic Hard Fork

--- a/tests/pacing_of_empty_blocks/pacing_of_empty_blocks_test.go
+++ b/tests/pacing_of_empty_blocks/pacing_of_empty_blocks_test.go
@@ -39,12 +39,10 @@ func TestPacingOfEmptyBlocks(t *testing.T) {
 
 	for name, upgrades := range hardFork {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			for mode, singleProposer := range modes {
 				upgrades := upgrades
 				upgrades.SingleProposerBlockFormation = singleProposer
 				t.Run(mode, func(t *testing.T) {
-					t.Parallel()
 					testPacingOfEmptyBlocks(t, upgrades)
 				})
 			}


### PR DESCRIPTION
This PR removes internal parallelism for integration tests running in their own process. 
This makes it possible to run all integration tests simultaneously in a single machine with 16 cores and 32 Gb ram without OOM. 