### PR TITLE
Add mising transaction indexing in log retrieval by Hash

### DIFF
--- a/gossip/filters/filter.go
+++ b/gossip/filters/filter.go
@@ -239,7 +239,6 @@ func (f *Filter) unindexedLogs(ctx context.Context, begin, end idx.Block) (logs 
 		}
 		logs = append(logs, found...)
 	}
-
 	return
 }
 
@@ -270,7 +269,6 @@ func (f *Filter) blockLogs(ctx context.Context, header common.Hash) ([]*types.Lo
 			}
 			logs = filterLogs(unfiltered, nil, nil, f.addresses, f.topics)
 		}
-
 		return logs, nil
 	}
 	return nil, nil

--- a/gossip/filters/filter_test.go
+++ b/gossip/filters/filter_test.go
@@ -372,7 +372,6 @@ func TestFilter_IndexedLogsReturnsLogsWithTimestampOrError(t *testing.T) {
 
 			backend.EXPECT().EvmLogIndex().Return(index)
 			index.EXPECT().FindInBlocks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(logs, nil)
-			backend.EXPECT().GetTxPosition(gomock.Any()).Return(&evmstore.TxPosition{})
 
 			test.primeMock(backend)
 

--- a/gossip/filters/filter_test.go
+++ b/gossip/filters/filter_test.go
@@ -397,3 +397,90 @@ func TestFilter_IndexedLogsReturnsLogsWithTimestampOrError(t *testing.T) {
 		})
 	}
 }
+
+func TestFilter_IndexedLogsReturnsCorrectedTransactionIndexes(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+	backend := NewMockBackend(ctrl)
+	index := topicsdb.NewMockIndex(ctrl)
+
+	logs := []*types.Log{
+		{
+			BlockNumber: 1,
+			TxHash:      common.HexToHash("0xabc"),
+			Index:       777, // incorrect index
+		},
+		{
+			BlockNumber: 2,
+			TxHash:      common.HexToHash("0x123"),
+			Index:       123, // incorrect index
+		},
+		{
+			BlockNumber: 2,
+			TxHash:      common.Hash{}, // empty hash
+			Index:       123,           // incorrect index
+		},
+	}
+	txs := map[common.Hash]*evmstore.TxPosition{
+		common.HexToHash("0xabc"): {BlockOffset: 7},
+		common.HexToHash("0x123"): {BlockOffset: 1},
+	}
+
+	backend.EXPECT().EvmLogIndex().Return(index).AnyTimes()
+	backend.EXPECT().GetTxPosition(gomock.Any()).
+		DoAndReturn(func(f common.Hash) *evmstore.TxPosition {
+			return txs[f]
+		}).AnyTimes()
+
+	backend.EXPECT().HeaderByNumber(gomock.Any(), gomock.Any()).
+		Return(&evmcore.EvmHeader{
+			Number: big.NewInt(1),
+		}, nil,
+		).AnyTimes()
+	backend.EXPECT().HeaderByHash(gomock.Any(), gomock.Any()).
+		Return(&evmcore.EvmHeader{
+			Number: big.NewInt(1),
+		}, nil,
+		).AnyTimes()
+	backend.EXPECT().GetLogs(gomock.Any(), gomock.Any()).Return([][]*types.Log{logs}, nil).AnyTimes()
+	index.EXPECT().FindInBlocks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(logs, nil).AnyTimes()
+
+	cases := map[string]*Filter{
+		"filter by block range (unindexed)": {
+			backend: backend,
+			config:  testConfig(),
+			begin:   0,
+			end:     2,
+		},
+		"filter by block range (indexed)": {
+			backend: backend,
+			config:  testConfig(),
+			begin:   0,
+			end:     2,
+			addresses: []common.Address{
+				// some address, this test does not really index, just visits the code path
+				common.HexToAddress("0x42"),
+			},
+		},
+		"filter by block hash": {
+			backend: backend,
+			config:  testConfig(),
+			block:   common.Hash{0x001},
+		},
+	}
+
+	for name, filter := range cases {
+		t.Run(name, func(t *testing.T) {
+			logs, err := filter.Logs(t.Context())
+			require.NoError(t, err)
+
+			for log := range logs {
+				txHash := logs[log].TxHash
+				expectedPosition, ok := txs[txHash]
+				if ok {
+					require.EqualValues(t, expectedPosition.BlockOffset, logs[log].TxIndex, "log tx index not corrected")
+				}
+			}
+		})
+	}
+}

--- a/gossip/filters/filter_test.go
+++ b/gossip/filters/filter_test.go
@@ -331,7 +331,7 @@ func TestSortLogsByBlockNumberAndLogIndex(t *testing.T) {
 	}
 }
 
-func TestFilter_IndexedLogsReturnsLogsWithTimestampOrError(t *testing.T) {
+func TestFilter_FilterLogs_IndexedLogsReturnsLogsWithTimestampOrError(t *testing.T) {
 	timestamp := inter.Timestamp(55)
 	tests := map[string]struct {
 		primeMock     func(*MockBackend)
@@ -398,7 +398,7 @@ func TestFilter_IndexedLogsReturnsLogsWithTimestampOrError(t *testing.T) {
 	}
 }
 
-func TestFilter_LogsReturnsCorrectedTransactionIndexes(t *testing.T) {
+func TestFilter_FilterLogs_ReturnsCorrectedTransactionIndexes(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	backend := NewMockBackend(ctrl)
@@ -567,7 +567,7 @@ func TestFilter_LogsReturnsErrorWithWrongQueries(t *testing.T) {
 	}
 }
 
-func TestFilter_LogsByHashReturnsError_WhenGetLogsCallReturnError(t *testing.T) {
+func TestFilter_FilterLogs_WhenGetLogsCallReturnError_LogsByHashReturnsError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	backend := NewMockBackend(ctrl)
 

--- a/tests/block_by_hash/block_by_hash_test.go
+++ b/tests/block_by_hash/block_by_hash_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package blockbyhash
+
+import (
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/tests/contracts/counter_event_emitter"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRPCGetLogs_BlockWithSkippedTransaction_HasCorrectTxIndexes(t *testing.T) {
+
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: tests.AsPointer(opera.GetAllegroUpgrades()),
+		ClientExtraArguments: []string{
+			"--disable-txPool-validation",
+		},
+	})
+
+	contract, receipt, err := tests.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// This test depends on how the scramblers schedules the 2 transaction sent.
+	// There is a 50% chance of triggering the issue, hence we run it multiple times
+	// as to have a fair chance of stimulating the issue but also not take too long in CI.
+	for range 5 {
+
+		// Make a transaction to be skipped.
+		accountSkipped := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+		initCode := make([]byte, 50000)
+		txSkip := tests.CreateTransaction(t, net, &types.LegacyTx{
+			Gas:  10_000_000,
+			To:   nil, // address 0x00 for contract creation
+			Data: initCode,
+		}, accountSkipped)
+
+		// Send the transaction
+		err = client.SendTransaction(t.Context(), txSkip)
+		require.NoError(t, err)
+
+		// make a transaction to log something
+		receipt, err = net.Apply(contract.Increment)
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+		// get the block from the receipt
+		block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
+		require.NoError(t, err)
+
+		// the test needs to call BlockByHash to reproduce the issue
+		blockByHash, err := client.BlockByHash(t.Context(), block.Hash())
+		require.NoError(t, err)
+		require.NotNil(t, blockByHash)
+
+		// get logs
+		var logs []map[string]any
+		err = client.Client().Call(&logs, "eth_getLogs", map[string]any{
+			"blockHash": block.Hash(),
+		})
+		require.NoError(t, err)
+		require.Greater(t, len(logs), 0)
+
+		for _, log := range logs {
+			txIndexHex := log["transactionIndex"].(string)
+			txIndex, err := strconv.ParseUint(txIndexHex[2:], 16, 64)
+			require.NoError(t, err)
+
+			require.Less(t, txIndex, uint64(len(blockByHash.Transactions())), "tx index out of range")
+
+			tx := blockByHash.Transactions()[txIndex]
+			require.Equal(t, tx.Hash().Hex(), log["transactionHash"].(string))
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a fix for RPC reporting wrong transaction indices in logs. 

Log reporting follows 3 paths:
- by block hash
- by block number range unindexed (no topic/address filtering)
- by block number range indexed (topic/address filtering)

Previously, only one of these three paths indexed transactions. 

The issue may relate to https://github.com/0xsoniclabs/sonic/issues/554 regarding the experienced behavior. Nevertheless, according to the cause. The issue shall always be present, and it is not affected by timing. 