### PR TITLE
Remove genesis Id pointer, when values stored in db are always values.

### DIFF
--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -47,7 +47,7 @@ func ExportGenesis(ctx context.Context, gdb *gossip.Store, includeArchive bool, 
 	}
 
 	header := genesis.Header{
-		GenesisID:   *gdb.GetGenesisID(),
+		GenesisID:   gdb.GetGenesisID(),
 		NetworkID:   gdb.GetEpochState().Rules.NetworkID,
 		NetworkName: gdb.GetEpochState().Rules.Name,
 	}

--- a/gossip/discover.go
+++ b/gossip/discover.go
@@ -66,7 +66,7 @@ func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.
 func currentENREntry(svc *Service, blockHeigh idx.Block, time uint64) *enrEntry {
-	genesisHash := *svc.store.GetGenesisID()
+	genesisHash := svc.store.GetGenesisID()
 	genesisTime := svc.store.GetGenesisTime()
 	return &enrEntry{
 		ForkID: forkid.NewId(

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -556,7 +556,7 @@ func (h *handler) handle(p *peer) error {
 
 	// Execute the handshake
 	var (
-		genesis    = *h.store.GetGenesisID()
+		genesis    = h.store.GetGenesisID()
 		myProgress = h.myProgress()
 	)
 	if err := p.Handshake(h.NetworkID, myProgress, common.Hash(genesis)); err != nil {
@@ -1266,7 +1266,7 @@ func (h *handler) NodeInfo() *NodeInfo {
 	numOfBlocks := h.store.GetLatestBlockIndex()
 	return &NodeInfo{
 		Network:     h.NetworkID,
-		Genesis:     common.Hash(*h.store.GetGenesisID()),
+		Genesis:     common.Hash(h.store.GetGenesisID()),
 		Epoch:       h.store.GetEpoch(),
 		NumOfBlocks: numOfBlocks,
 	}

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -29,25 +29,25 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 )
 
-func (s *Store) GetGenesisID() *hash.Hash {
+func (s *Store) GetGenesisID() hash.Hash {
 	if v := s.cache.Genesis.Load(); v != nil {
 		val := v.(hash.Hash)
-		return &val
+		return val
 	}
 	valBytes, err := s.table.Genesis.Get([]byte("g"))
 	if err != nil {
 		s.Log.Crit("Failed to get key-value", "err", err)
 	}
 	if len(valBytes) == 0 {
-		return nil
+		return hash.Hash{}
 	}
 	val := hash.BytesToHash(valBytes)
 	s.cache.Genesis.Store(val)
-	return &val
+	return val
 }
 
 func (s *Store) fakeGenesisHash() hash.Event {
-	fakeGenesisHash := hash.Event(*s.GetGenesisID())
+	fakeGenesisHash := hash.Event(s.GetGenesisID())
 	for i := range fakeGenesisHash[:8] {
 		fakeGenesisHash[i] = 0
 	}


### PR DESCRIPTION
This Pr removes the use of pointer when returning the GenesisId from the store. 

GenesisId is stored by [value](https://github.com/0xsoniclabs/sonic/blob/8bef236719e81b8d109d1389141ad041b9c7aa17/gossip/store_block.go#L57), and computed [here](https://github.com/0xsoniclabs/sonic/blob/8bef236719e81b8d109d1389141ad041b9c7aa17/integration/makefakegenesis/genesis.go#L194)

It is only when retrieving the value in the getter where[ a nil pointer is constructed](https://github.com/0xsoniclabs/sonic/blob/8bef236719e81b8d109d1389141ad041b9c7aa17/gossip/store_block.go#L42). This can only happen if the value stored was a zero value hash, since the error case is log.Crit which stops execution.

This case was never used, if used a panic would be raised by derefing the always unchecked nil pointer. 