### PR TITLE
Add mechanism to retrieve genesis id from integration test net

### DIFF
--- a/cmd/sonicd/app/app.go
+++ b/cmd/sonicd/app/app.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/0xsoniclabs/sonic/config/flags"
+	"github.com/ethereum/go-ethereum/common"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -37,6 +38,9 @@ type AppControl struct {
 	// Upon a successful start of the sonicd node, the HTTP port used by the HTTP
 	// server is sent to this channel. The channel is closed when the process
 	HttpPortAnnouncement chan<- string
+	// GenesisIdAnnouncement is a channel which communicates the genesis ID of the opened
+	// database once on successful start.
+	GenesisIdAnnouncement chan<- common.Hash
 	// The process is stopped by sending a message through this channel, or by
 	// closing it.
 	Shutdown <-chan struct{}

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -286,7 +286,7 @@ func lachesisMainInternal(
 		cfg.OperaStore.EVM.StateDb.ArchiveCache = archiveCache
 	}
 
-	node, _, nodeClose, err := config.MakeNode(ctx, cfg)
+	node, gossip, nodeClose, err := config.MakeNode(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to initialize the node: %w", err)
 	}
@@ -311,6 +311,10 @@ func lachesisMainInternal(
 
 		if control.HttpPortAnnouncement != nil {
 			control.HttpPortAnnouncement <- node.HTTPEndpoint()
+		}
+
+		if control.GenesisIdAnnouncement != nil {
+			control.GenesisIdAnnouncement <- gossip.GetGenesisId()
 		}
 
 		if control.Shutdown != nil {

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -47,7 +47,7 @@ func ExportGenesis(ctx context.Context, gdb *gossip.Store, includeArchive bool, 
 	}
 
 	header := genesis.Header{
-		GenesisID:   *gdb.GetGenesisID(),
+		GenesisID:   gdb.GetGenesisID(),
 		NetworkID:   gdb.GetEpochState().Rules.NetworkID,
 		NetworkName: gdb.GetEpochState().Rules.Name,
 	}

--- a/gossip/discover.go
+++ b/gossip/discover.go
@@ -66,7 +66,7 @@ func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.
 func currentENREntry(svc *Service, blockHeigh idx.Block, time uint64) *enrEntry {
-	genesisHash := *svc.store.GetGenesisID()
+	genesisHash := svc.store.GetGenesisID()
 	genesisTime := svc.store.GetGenesisTime()
 	return &enrEntry{
 		ForkID: forkid.NewId(

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -556,7 +556,7 @@ func (h *handler) handle(p *peer) error {
 
 	// Execute the handshake
 	var (
-		genesis    = *h.store.GetGenesisID()
+		genesis    = h.store.GetGenesisID()
 		myProgress = h.myProgress()
 	)
 	if err := p.Handshake(h.NetworkID, myProgress, common.Hash(genesis)); err != nil {
@@ -1266,7 +1266,7 @@ func (h *handler) NodeInfo() *NodeInfo {
 	numOfBlocks := h.store.GetLatestBlockIndex()
 	return &NodeInfo{
 		Network:     h.NetworkID,
-		Genesis:     common.Hash(*h.store.GetGenesisID()),
+		Genesis:     common.Hash(h.store.GetGenesisID()),
 		Epoch:       h.store.GetEpoch(),
 		NumOfBlocks: numOfBlocks,
 	}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 	"github.com/Fantom-foundation/lachesis-base/utils/workers"
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	notify "github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -619,6 +620,11 @@ func (s *Service) Start() error {
 	}
 
 	return nil
+}
+
+// GetGenesisId returns the Id from the genesis used to start the chain.
+func (s *Service) GetGenesisId() common.Hash {
+	return common.Hash(s.store.GetGenesisID())
 }
 
 // WaitBlockEnd waits until parallel block processing is complete (if any)

--- a/gossip/store_block.go
+++ b/gossip/store_block.go
@@ -29,25 +29,25 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 )
 
-func (s *Store) GetGenesisID() *hash.Hash {
+func (s *Store) GetGenesisID() hash.Hash {
 	if v := s.cache.Genesis.Load(); v != nil {
 		val := v.(hash.Hash)
-		return &val
+		return val
 	}
 	valBytes, err := s.table.Genesis.Get([]byte("g"))
 	if err != nil {
 		s.Log.Crit("Failed to get key-value", "err", err)
 	}
 	if len(valBytes) == 0 {
-		return nil
+		return hash.Hash{}
 	}
 	val := hash.BytesToHash(valBytes)
 	s.cache.Genesis.Store(val)
-	return &val
+	return val
 }
 
 func (s *Store) fakeGenesisHash() hash.Event {
-	fakeGenesisHash := hash.Event(*s.GetGenesisID())
+	fakeGenesisHash := hash.Event(s.GetGenesisID())
 	for i := range fakeGenesisHash[:8] {
 		fakeGenesisHash[i] = 0
 	}

--- a/tests/integration_test_net_test.go
+++ b/tests/integration_test_net_test.go
@@ -474,5 +474,41 @@ func TestIntegrationTestNet_ValidateAndSanitizeOptions(t *testing.T) {
 			require.Equal(t, test.expectedOptions, options)
 		})
 	}
+}
 
+func TestIntegrationTestNet_GenesisID_CanBeQueried_ForDifferentNetworks(t *testing.T) {
+	// The following test starts three different integration test networks using
+	// different genesis. Hashes produced shall be different.
+	// This test uses two nodes per network to verify that genesis ID is consistent
+	// across multiple nodes.
+
+	net := StartIntegrationTestNetWithFakeGenesis(t,
+		IntegrationTestNetOptions{NumNodes: 2})
+	id1 := net.GetGenesisId()
+	require.NotZero(t, id1)
+	net.Stop()
+
+	net = StartIntegrationTestNetWithJsonGenesis(t,
+		IntegrationTestNetOptions{NumNodes: 2})
+	id2 := net.GetGenesisId()
+	require.NotZero(t, id2)
+	net.Stop()
+
+	net = StartIntegrationTestNetWithJsonGenesis(t,
+		IntegrationTestNetOptions{
+			NumNodes: 2,
+			Accounts: []makefakegenesis.Account{
+				{
+					Name:    "account",
+					Address: common.HexToAddress("0x42"),
+				},
+			},
+		})
+	id3 := net.GetGenesisId()
+	require.NotZero(t, id3)
+	net.Stop()
+
+	require.NotEqual(t, id1, id2)
+	require.NotEqual(t, id1, id3)
+	require.NotEqual(t, id2, id3)
 }


### PR DESCRIPTION
This PR uses applicationControl to retrieve the genesisId of a node after it has opened its db. 
This is a private mechanism to get access to this parameter that creates no changes in the public interface of the sonic tool. 


Depends on   #591 