### PR TITLE
Add brio to fake net  datadir construction.

### DIFF
--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -159,18 +159,13 @@ func TestSonicTool_account_ExecutesWithoutErrors(t *testing.T) {
 
 func TestSonicTool_genesis_CreatesDataDirWithAllowedUpgrades(t *testing.T) {
 
-	upgrades := map[string]struct {
-		expectedError error
-	}{
-		"sonic":   {},
-		"allegro": {},
-		"brio":    {},
-		"invalid": {
-			expectedError: fmt.Errorf("invalid profile invalid - must be 'sonic', 'allegro', or 'brio'"),
-		},
+	upgrades := []string{
+		"sonic",
+		"allegro",
+		"brio",
 	}
 
-	for upgradeName, test := range upgrades {
+	for _, upgradeName := range upgrades {
 		t.Run(upgradeName, func(t *testing.T) {
 			datadir := t.TempDir()
 
@@ -179,14 +174,18 @@ func TestSonicTool_genesis_CreatesDataDirWithAllowedUpgrades(t *testing.T) {
 				"genesis", "fake",
 				"--upgrades", upgradeName,
 				"10")
-
-			if test.expectedError != nil {
-				require.ErrorContains(t, err, test.expectedError.Error())
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 		})
 	}
+}
+
+func TestSonicTool_genesis_ReturnsErrorIfHardforkIsInvalid(t *testing.T) {
+	_, err := executeSonicTool(t,
+		"--datadir", t.TempDir(),
+		"genesis", "fake",
+		"--upgrades", "invalid",
+		"1")
+	require.ErrorContains(t, err, "invalid profile invalid - must be 'sonic', 'allegro', or 'brio'")
 }
 
 func TestSonicTool_genesis_ExportsAndSigns_WithoutErrors(t *testing.T) {

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -172,8 +172,10 @@ func fakeGenesisImport(ctx *cli.Context) (err error) {
 		upgrades = opera.GetSonicUpgrades()
 	case "allegro":
 		upgrades = opera.GetAllegroUpgrades()
+	case "brio":
+		upgrades = opera.GetBrioUpgrades()
 	default:
-		return fmt.Errorf("invalid profile %v - must be 'sonic' or 'allegro'", upgradesString)
+		return fmt.Errorf("invalid profile %v - must be 'sonic', 'allegro', or 'brio'", upgradesString)
 	}
 
 	genesisStore := makefakegenesis.FakeGenesisStore(


### PR DESCRIPTION
Allow sonictool to start fakenet using brio upgrades. 

Provided test checks that parsing and error reporting by the sonic tool is up-to-date, functional checks are done in brio integration tests. 