### PR TITLE
Change brio flag

### DIFF
--- a/ethapi/config_test.go
+++ b/ethapi/config_test.go
@@ -99,7 +99,7 @@ func TestForkId_UpgradesProduceDifferentIds(t *testing.T) {
 		},
 		"Brio": {
 			upgradesHeight: opera.MakeUpgradeHeight(opera.GetBrioUpgrades(), 10),
-			want:           forkId{0x5f, 0xc9, 0x8, 0x23},
+			want:           forkId{0x12, 0x7b, 0x69, 0x7b},
 		},
 		// In a real case scenario, SingleProposer and GasSubsidies would be
 		// turned on while another upgrade is activated, so we check that the

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -42,7 +42,8 @@ const (
 	// hard-forks
 	sonicBit   = 1 << 3
 	allegroBit = 1 << 4
-	brioBit    = 1 << 5
+	_unused    = 1 << 5 // reserved, do not use
+	brioBit    = 1 << 6
 
 	// optional features
 	singleProposerBlockFormationBit = 1 << 63


### PR DESCRIPTION
To allow 2.1.x clients dropping from consensus if brio is enabled. This issue is caused because brio flag existed before 2.1 branch, 2.1.x clients cannot detect when the feature is enabled and would remain in the consensus, creating a fork. 