### PR TITLE
Validate rule updates on all hardforks starting from Allegro

### DIFF
--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -28,8 +28,8 @@ func UpdateRules(src Rules, diff []byte) (Rules, error) {
 	changed.NetworkID = src.NetworkID
 	changed.Name = src.Name
 
-	// check validity of the new rules
-	if changed.Upgrades.Allegro {
+	// check validity of the new rules for all hardforks starting from Allegro
+	if changed.Upgrades.Allegro || changed.Upgrades.Brio {
 		if err := changed.Validate(src); err != nil {
 			return Rules{}, err
 		}

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -207,3 +207,21 @@ func TestGasRulesLLRCompatibilityRLP(t *testing.T) {
 
 	require.Equal(b2, b1)
 }
+
+func TestUpdateRules_RuleValidationIsPerformedStartingFromAllegro(t *testing.T) {
+	hardforks := []string{"Sonic", "Allegro", "Brio"}
+
+	for _, hardfork := range hardforks {
+		base := FakeNetRules(GetSonicUpgrades())
+
+		// send an invalid update and enable the hardfork
+		update := fmt.Sprintf(`{"Dag":{"MaxParents":1}, "Upgrades":{"%s":true}}`, hardfork)
+
+		_, err := UpdateRules(base, []byte(update))
+		if hardfork == "Sonic" {
+			require.NoError(t, err, "should not validate rules for Sonic hardfork")
+		} else {
+			require.Error(t, err, "should validate rules for %s hardfork", hardfork)
+		}
+	}
+}


### PR DESCRIPTION
Rule changes should be validated in all hardforks starting from allegro, this PR fixes the `updateRules` function and adds a unit test.