### PR TITLE
Update integration tests to use Brio features

### DIFF
--- a/tests/block_by_hash/block_by_hash_test.go
+++ b/tests/block_by_hash/block_by_hash_test.go
@@ -31,7 +31,7 @@ import (
 func TestRPCGetLogs_BlockWithSkippedTransaction_HasCorrectTxIndexes(t *testing.T) {
 
 	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: tests.AsPointer(opera.GetAllegroUpgrades()),
+		Upgrades: tests.AsPointer(opera.GetBrioUpgrades()),
 		ClientExtraArguments: []string{
 			"--disable-txPool-validation",
 		},

--- a/tests/block_header/block_header_test.go
+++ b/tests/block_header/block_header_test.go
@@ -55,6 +55,7 @@ func TestBlockHeader_JsonGenesis_SatisfiesInvariants(t *testing.T) {
 	upgrades := map[string]opera.Upgrades{
 		"Sonic":   opera.GetSonicUpgrades(),
 		"Allegro": opera.GetAllegroUpgrades(),
+		"Brio":    opera.GetBrioUpgrades(),
 	}
 	modes := map[string]bool{
 		"DistributedProposer": false,

--- a/tests/block_parameters_test.go
+++ b/tests/block_parameters_test.go
@@ -45,6 +45,14 @@ func TestBlockParameters_BlockHeaderMatchesObservableBlockParameters(t *testing.
 			Sonic:   true,
 			Allegro: true,
 		},
+		"brio": {
+			Berlin:  true,
+			London:  true,
+			Llr:     false,
+			Sonic:   true,
+			Allegro: true,
+			Brio:    true,
+		},
 	}
 
 	for name, upgrades := range hardForks {

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -31,7 +31,7 @@ import (
 func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 	require := require.New(t)
 
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
@@ -67,7 +67,7 @@ func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 	require := require.New(t)
 
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -312,8 +312,10 @@ func StartIntegrationTestNetWithFakeGenesis(
 		upgrades = "sonic"
 	} else if *effectiveOptions.Upgrades == opera.GetAllegroUpgrades() {
 		upgrades = "allegro"
+	} else if *effectiveOptions.Upgrades == opera.GetBrioUpgrades() {
+		upgrades = "brio"
 	} else {
-		t.Fatal("fake genesis only supports sonic and allegro feature sets")
+		t.Fatal("fake genesis only supports sonic, allegro and brio feature sets")
 	}
 
 	numNodesString := fmt.Sprintf("%d", effectiveOptions.NumNodes)

--- a/tests/large_transactions/large_transactions_test.go
+++ b/tests/large_transactions/large_transactions_test.go
@@ -33,7 +33,7 @@ import (
 func TestLargeTransactions_CanHandleLargeTransactions(t *testing.T) {
 	require := require.New(t)
 	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: tests.AsPointer(opera.GetAllegroUpgrades()),
+		Upgrades: tests.AsPointer(opera.GetBrioUpgrades()),
 	})
 
 	account := tests.NewAccount()
@@ -106,6 +106,7 @@ func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
 	hardForks := map[string]opera.Upgrades{
 		"Sonic":   opera.GetSonicUpgrades(),
 		"Allegro": opera.GetAllegroUpgrades(),
+		"Brio":    opera.GetBrioUpgrades(),
 	}
 
 	modes := map[string]bool{

--- a/tests/pacing_of_empty_blocks/pacing_of_empty_blocks_test.go
+++ b/tests/pacing_of_empty_blocks/pacing_of_empty_blocks_test.go
@@ -31,6 +31,7 @@ func TestPacingOfEmptyBlocks(t *testing.T) {
 	hardFork := map[string]opera.Upgrades{
 		"sonic":   opera.GetSonicUpgrades(),
 		"allegro": opera.GetAllegroUpgrades(),
+		"brio":    opera.GetBrioUpgrades(),
 	}
 	modes := map[string]bool{
 		"single proposer":      true,

--- a/tests/randao_test.go
+++ b/tests/randao_test.go
@@ -30,13 +30,14 @@ func TestRandao_randaoIntegrationTest(t *testing.T) {
 	const NumNodes = 3
 
 	tests := map[string]opera.Upgrades{
-		"dag proposal": opera.GetSonicUpgrades(),
+		"dag proposal": opera.GetBrioUpgrades(),
 		"single proposal": {
 			Berlin:                       true,
 			London:                       true,
 			Llr:                          false,
-			Allegro:                      true,
 			Sonic:                        true,
+			Allegro:                      true,
+			Brio:                         true,
 			SingleProposerBlockFormation: true,
 		},
 	}

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -32,7 +32,7 @@ import (
 func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 
 	// start network
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 	t.Parallel()
 
 	// create a client

--- a/tests/revision_forward_test.go
+++ b/tests/revision_forward_test.go
@@ -154,9 +154,6 @@ func TestRevisionIsForwardedCorrectly_BrioEnablesOsakaInBlockProcessing(t *testi
 		upgrades       opera.Upgrades
 		expectedReturn []byte
 	}{
-		"Sonic": {
-			upgrades: opera.GetSonicUpgrades(),
-		},
 		"Allegro": {
 			upgrades: opera.GetAllegroUpgrades(),
 		},

--- a/tests/rpc_get_logs_test.go
+++ b/tests/rpc_get_logs_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestRpc_GetLogs_BlockTimeStampHexEncoded(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	// deploy a contract
 	contract, receipt, err := DeployContract(session, indexed_logs.DeployIndexedLogs)

--- a/tests/single_proposer/single_proposer_protocol_test.go
+++ b/tests/single_proposer/single_proposer_protocol_test.go
@@ -34,8 +34,9 @@ import (
 func TestSingleProposerProtocol_CanProcessTransactions(t *testing.T) {
 
 	upgrades := map[string]opera.Upgrades{
-		"Sonic":   opera.GetSonicUpgrades(),
+		// Single-proposer protocol has been rolled out with Allegro.
 		"Allegro": opera.GetAllegroUpgrades(),
+		"Brio":    opera.GetBrioUpgrades(),
 	}
 
 	for name, upgrades := range upgrades {
@@ -149,6 +150,7 @@ func TestSingleProposerProtocol_CanBeEnabledAndDisabled(t *testing.T) {
 	upgrades := map[string]opera.Upgrades{
 		"Sonic":   opera.GetSonicUpgrades(),
 		"Allegro": opera.GetAllegroUpgrades(),
+		"Brio":    opera.GetBrioUpgrades(),
 	}
 
 	for name, upgrades := range upgrades {

--- a/tests/storage_override_test.go
+++ b/tests/storage_override_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 	t.Parallel()
 
 	// Deploy the contract.
@@ -103,7 +103,7 @@ func TestSetStorage_Contract_Not_On_Blockchain_Executed_With_Extra_Storage(t *te
 	require := require.New(t)
 
 	// start network
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	// create a client
 	client, err := session.GetClient()

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -32,7 +32,7 @@ const enoughGasPrice = 150_000_000_000
 
 func TestTransactionGasPrice(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 	t.Parallel()
 
 	client, err := session.GetClient()

--- a/tests/transaction_receipt_idx_test.go
+++ b/tests/transaction_receipt_idx_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestReceipt_InternalTransactionsDoNotChangeReceiptIndex(t *testing.T) {
-	upgrades := opera.GetSonicUpgrades()
+	upgrades := opera.GetBrioUpgrades()
 	net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})

--- a/tests/transaction_store_test.go
+++ b/tests/transaction_store_test.go
@@ -37,7 +37,7 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 
 	net := StartIntegrationTestNet(t,
 		IntegrationTestNetOptions{
-			Upgrades: AsPointer(opera.GetAllegroUpgrades()),
+			Upgrades: AsPointer(opera.GetBrioUpgrades()),
 		})
 
 	client, err := net.GetClient()


### PR DESCRIPTION
This PR adds or changes the feature set of the integration tests to Brio. 
All tests are updated except for the ones which are hardfork independent, stress a feature introduced in an older hardfork or require a certain revision.