### PR TITLE
Move `TestMain` to a test file

### DIFF
--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain is a functionality offered by the testing package that allows
+// us to run some code before and after all tests in the package.
+func TestMain(m *testing.M) {
+
+	m.Run()
+
+	// Stop all active networks after tests are done
+	for _, net := range activeTestNetInstances {
+		net.Stop()
+		for i := range net.nodes {
+			// it is safe to ignore this error since the tests have ended and
+			// the directories are not needed anymore.
+			_ = os.RemoveAll(net.nodes[i].directory)
+		}
+	}
+	activeTestNetInstances = nil
+}

--- a/tests/session_dispenser.go
+++ b/tests/session_dispenser.go
@@ -19,7 +19,6 @@ package tests
 import (
 	"crypto/sha256"
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/opera"
@@ -31,24 +30,6 @@ import (
 // for each test, we keep a map of active networks keyed by the hash of their
 // Upgrade.
 var activeTestNetInstances map[common.Hash]*IntegrationTestNet
-
-// TestMain is a functionality offered by the testing package that allows
-// us to run some code before and after all tests in the package.
-func TestMain(m *testing.M) {
-
-	m.Run()
-
-	// Stop all active networks after tests are done
-	for _, net := range activeTestNetInstances {
-		net.Stop()
-		for i := range net.nodes {
-			// it is safe to ignore this error since the tests have ended and
-			// the directories are not needed anymore.
-			_ = os.RemoveAll(net.nodes[i].directory)
-		}
-	}
-	activeTestNetInstances = nil
-}
 
 // getIntegrationTestNetSession creates a new session for network running on the
 // given Upgrade. If there is no network running with this Upgrade, a new one


### PR DESCRIPTION
This PR moves the `TestMain` function to a test file, as its [documentation](https://pkg.go.dev/testing#hdr-Main) states it must be in a test file.