### PR TITLE
[WIP] Integration test net package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,23 @@ sonic-image:
 		--network=host \
 		-f ./Dockerfile -t "sonic:$(TAG)" .
 
+# Define the specific path to your slow integration tests
+SLOW_PKG := ./tests/...
+
+# Find all other packages by listing everything and filtering out the slow package
+# We use 'shell' to execute the go list command
+FAST_PKGS := $(shell go list ./... | grep -v $(SLOW_PKG))
+
+TEST_PACKAGES := $(SLOW_PKG) $(FAST_PKGS)
+
 .PHONY: test
 test:
-	go test --timeout 30m ./...
+	go test --timeout 30m $(TEST_PACKAGES)
 
 .PHONY: coverage
 coverage:
 	@mkdir -p build ;\
-	go test -coverpkg=./... --timeout=30m -coverprofile=build/coverage.cov ./... && \
+	go test -coverpkg=./... --timeout=30m -coverprofile=build/coverage.cov $(TEST_PACKAGES) && \
 	go tool cover -html build/coverage.cov -o build/coverage.html &&\
 	echo "Coverage report generated in build/coverage.html"
 

--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -29,10 +29,10 @@ import (
 
 	sonictool "github.com/0xsoniclabs/sonic/cmd/sonictool/app"
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/genesis"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	ogenesis "github.com/0xsoniclabs/sonic/opera/genesis"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/0xsoniclabs/sonic/utils/prompt"
 	"github.com/ethereum/go-ethereum/common"
@@ -83,7 +83,7 @@ func TestSonicTool_check_ExecutesWithoutErrors(t *testing.T) {
 
 func TestSonicTool_compact_ExecutesWithoutErrors(t *testing.T) {
 
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
@@ -191,7 +191,7 @@ func TestSonicTool_genesis_ReturnsErrorIfHardforkIsInvalid(t *testing.T) {
 func TestSonicTool_genesis_ExportsAndSigns_WithoutErrors(t *testing.T) {
 
 	// Create a history by running some transactions
-	net := tests.StartIntegrationTestNetWithFakeGenesis(t)
+	net := testnet.StartIntegrationTestNetWithFakeGenesis(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
@@ -231,10 +231,10 @@ func TestSonicTool_genesis_ExportsAndSigns_WithoutErrors(t *testing.T) {
 }
 
 func TestSonicTool_heal_ExecutesWithoutErrors(t *testing.T) {
-	net := tests.StartIntegrationTestNet(
+	net := testnet.StartIntegrationTestNet(
 		t,
-		tests.IntegrationTestNetOptions{
-			Upgrades:             tests.AsPointer(opera.GetSonicUpgrades()),
+		testnet.IntegrationTestNetOptions{
+			Upgrades:             testnet.AsPointer(opera.GetSonicUpgrades()),
 			ClientExtraArguments: []string{"--statedb.checkpointinterval", "1"},
 		},
 	)
@@ -247,7 +247,7 @@ func TestSonicTool_heal_ExecutesWithoutErrors(t *testing.T) {
 
 func TestSonicTool_config_ExecutesWithoutErrors(t *testing.T) {
 
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
@@ -279,7 +279,7 @@ func TestSonicTool_config_ExecutesWithoutErrors(t *testing.T) {
 }
 
 func TestSonicTool_events_ExecutesWithoutErrors(t *testing.T) {
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 2)
 	net.Stop()
 
@@ -298,11 +298,11 @@ func TestSonicTool_events_ExecutesWithoutErrors(t *testing.T) {
 }
 
 func TestSonicTool_EventsExport_ExecutesWithoutErrors_ForEpochRange(t *testing.T) {
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	numEpochs := 5
 	for range numEpochs {
 		generateNBlocks(t, net, 3)
-		tests.AdvanceEpochAndWaitForBlocks(t, net)
+		testnet.AdvanceEpochAndWaitForBlocks(t, net)
 	}
 
 	net.Stop()
@@ -317,7 +317,7 @@ func TestSonicTool_EventsExport_ExecutesWithoutErrors_ForEpochRange(t *testing.T
 }
 
 func TestSonicTool_EventsExport_ReturnsError_ForEpochOutOfRange(t *testing.T) {
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 3)
 
 	client, err := net.GetClient()
@@ -326,7 +326,7 @@ func TestSonicTool_EventsExport_ReturnsError_ForEpochOutOfRange(t *testing.T) {
 
 	current, err := client.BlockNumber(t.Context())
 	require.NoError(t, err)
-	currentEpoch := tests.GetEpochOfBlock(t, client, int(current))
+	currentEpoch := testnet.GetEpochOfBlock(t, client, int(current))
 
 	net.Stop()
 
@@ -339,7 +339,7 @@ func TestSonicTool_EventsExport_ReturnsError_ForEpochOutOfRange(t *testing.T) {
 }
 
 func TestSonicTool_EventExport_ReturnsError_ForInvalidRange(t *testing.T) {
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 3)
 	net.Stop()
 
@@ -352,7 +352,7 @@ func TestSonicTool_EventExport_ReturnsError_ForInvalidRange(t *testing.T) {
 }
 
 func TestSonicTool_EventsExport_ReturnsError_ForEpochsWithNoEvents(t *testing.T) {
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 1)
 	net.Stop()
 
@@ -367,7 +367,7 @@ func TestSonicTool_EventsExport_ReturnsError_ForEpochsWithNoEvents(t *testing.T)
 
 func TestSonicTool_EventsExport_ReturnsError_ForWrongNumberOfArguments(t *testing.T) {
 
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	generateNBlocks(t, net, 3)
 	net.Stop()
 
@@ -494,14 +494,14 @@ func generatePrivateKeyFile(file string) (*ecdsa.PrivateKey, error) {
 // generateNBlocks generates n blocks in the blockchain.
 // The transactions executed are not important, only the fact that they are
 // executed synchronously and n blocks exist after the function returns.
-func generateNBlocks(t *testing.T, net *tests.IntegrationTestNet, n int) {
+func generateNBlocks(t *testing.T, net *testnet.IntegrationTestNet, n int) {
 	t.Helper()
 	for i := 0; i < n; i++ {
 		createAccount(t, net)
 	}
 }
 
-func createAccount(t *testing.T, net *tests.IntegrationTestNet) {
+func createAccount(t *testing.T, net *testnet.IntegrationTestNet) {
 	t.Helper()
 
 	var addr common.Address

--- a/integrationtestnet/account.go
+++ b/integrationtestnet/account.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package testnet
 
 import (
 	"crypto/ecdsa"

--- a/integrationtestnet/integration_test_net.go
+++ b/integrationtestnet/integration_test_net.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package testnet
 
 import (
 	"bytes"
@@ -66,12 +66,12 @@ type IntegrationTestNetSession interface {
 	// GetUpgrades returns the upgrades the network has been started with.
 	GetUpgrades() opera.Upgrades
 
-	// EndowAccount sends a requested amount of tokens to the given account. This is
+	// EndowAccount sends a requested amount of tokens to the given Account. This is
 	// mainly intended to provide funds to accounts for testing purposes.
 	EndowAccount(address common.Address, value *big.Int) (*types.Receipt, error)
 
 	// EndowAccounts sends the requested amount of tokens to each of the given
-	// accounts. This is a faster than calling EndowAccount for each account since
+	// accounts. This is a faster than calling EndowAccount for each Account since
 	// multiple endowments may get bundled in the same block.
 	EndowAccounts(addresses []common.Address, value *big.Int) ([]*types.Receipt, error)
 
@@ -90,14 +90,14 @@ type IntegrationTestNetSession interface {
 	GetReceipts(txHash []common.Hash) ([]*types.Receipt, error)
 
 	// GetTransactOptions provides transaction options to be used to send a transaction
-	// from the given account.
-	GetTransactOptions(account *Account) (*bind.TransactOpts, error)
+	// from the given Account.
+	GetTransactOptions(Account *Account) (*bind.TransactOpts, error)
 
-	// Apply sends a transaction to the network using the session account.
+	// Apply sends a transaction to the network using the session Account.
 	// and waits for the transaction to be processed. The resulting receipt is returned.
 	Apply(issue func(*bind.TransactOpts) (*types.Transaction, error)) (*types.Receipt, error)
 
-	// GetSessionSponsor returns the default account of the session. This account is used
+	// GetSessionSponsor returns the default Account of the session. This Account is used
 	// to sign transactions and pay for gas when using the Apply and EndowAccount methods.
 	GetSessionSponsor() *Account
 
@@ -109,7 +109,7 @@ type IntegrationTestNetSession interface {
 	GetChainId() *big.Int
 
 	// SpawnSession creates a new test session on the network based from the
-	// network's sponsor account. This should be done before entering a new
+	// network's sponsor Account. This should be done before entering a new
 	// parallel context to prevent conflicting nonces inside.
 	SpawnSession(t *testing.T) IntegrationTestNetSession
 
@@ -171,13 +171,13 @@ type IntegrationTestNetOptions struct {
 	SkipCleanUp bool
 }
 
-// IntegrationTestNet is a in-process test network for integration tests. When
+// IntegrationTestNet is a in-process test network for integration  When
 // started, it runs full Sonic nodes maintaining a chain within the process
 // containing this object. The network can be used to run transactions on and
 // to perform queries against.
 //
 // The main purpose of this network is to facilitate end-to-end debugging of
-// client code in the controlled scope of individual unit tests. When running
+// client code in the controlled scope of individual unit  When running
 // tests against an integration test network instance, break-points can be set
 // in the client code, thereby facilitating debugging.
 //
@@ -277,7 +277,7 @@ func startHeapProfiler(tb testing.TB) {
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-// StartIntegrationTestNet starts a single-node test network for integration tests.
+// StartIntegrationTestNet starts a single-node test network for integration
 // The node serving the network is started in the same process as the caller. This
 // is intended to facilitate debugging of client code in the context of a running
 // node.
@@ -334,7 +334,7 @@ func StartIntegrationTestNetWithFakeGenesis(
 // StartIntegrationTestNetWithJsonGenesis starts a single-node test network for
 // integration tests using the JSON-Genesis procedure. The JSON genesis procedure
 // is the genesis procedure used in long-running production networks like the
-// Sonic mainnet and the testnet.
+// Sonic mainnet and the
 func StartIntegrationTestNetWithJsonGenesis(
 	t testing.TB,
 	options ...IntegrationTestNetOptions,
@@ -388,7 +388,7 @@ func startIntegrationTestNet(
 	net := &IntegrationTestNet{
 		options: options,
 		Session: Session{
-			account: Account{evmcore.FakeKey(1)},
+			Account: Account{evmcore.FakeKey(1)},
 		},
 		nodes: make([]integrationTestNode, len(options.ValidatorsStake)),
 	}
@@ -793,7 +793,7 @@ func (n *IntegrationTestNet) GetHeaders() ([]*types.Header, error) {
 }
 
 // SpawnSession creates a new test session on the network.
-// The session is backed by an account which will be used to sign and pay for
+// The session is backed by an Account which will be used to sign and pay for
 // transactions. By using this function, multiple test sessions can be run in
 // parallel on the same network, without conflicting nonce issues, since the
 // accounts are isolated.
@@ -816,18 +816,18 @@ func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSessio
 		PrivateKey: key,
 	}
 	receipt, err := n.EndowAccount(nextSessionAccount.Address(), new(big.Int).SetUint64(math.MaxUint64))
-	require.NoError(t, err, "Failed to endow account")
-	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "Failed to endow account")
+	require.NoError(t, err, "Failed to endow Account")
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status, "Failed to endow Account")
 
 	return &Session{
 		net:     n,
-		account: nextSessionAccount,
+		Account: nextSessionAccount,
 	}
 }
 
 // AdvanceEpoch trigger the sealing of an epoch and the epoch number to progress by the given number.
 // The function blocks until the final epoch has been reached. This method can only be called
-// on a validator account.
+// on a validator Account.
 func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 	t.Helper()
 	client, err := n.GetClient()
@@ -859,7 +859,7 @@ func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 }
 
 // DeployContract is a utility function handling the deployment of a contract on the network.
-// The contract is deployed with by the network's validator account. The function returns the
+// The contract is deployed with by the network's validator Account. The function returns the
 // deployed contract instance and the transaction receipt.
 func DeployContract[T any](n IntegrationTestNetSession, deploy contractDeployer[T]) (*T, *types.Receipt, error) {
 	client, err := n.GetClient()
@@ -896,13 +896,13 @@ func DeployContract[T any](n IntegrationTestNetSession, deploy contractDeployer[
 // contractDeployer is the type of the deployment functions generated by abigen.
 type contractDeployer[T any] func(*bind.TransactOpts, bind.ContractBackend) (common.Address, *types.Transaction, *T, error)
 
-// Session is a test session on the network. It is backed by an account which
+// Session is a test session on the network. It is backed by an Account which
 // will be used to sign and pay for transactions.
 // Its purpose is to isolate transaction issuing accounts, so that multiple test
 // sessions can be run in parallel on the same network without conflicting nonce issues.
 type Session struct {
 	net     *IntegrationTestNet
-	account Account
+	Account Account
 }
 
 func (s *Session) SpawnSession(t *testing.T) IntegrationTestNetSession {
@@ -913,7 +913,7 @@ func (s *Session) GetUpgrades() opera.Upgrades {
 	return *s.net.options.Upgrades
 }
 
-// EndowAccount sends a requested amount of tokens to the given account. This is
+// EndowAccount sends a requested amount of tokens to the given Account. This is
 // mainly intended to provide funds to accounts for testing purposes.
 func (s *Session) EndowAccount(
 	address common.Address,
@@ -927,7 +927,7 @@ func (s *Session) EndowAccount(
 }
 
 // EndowAccounts sends the requested amount of tokens to each of the given
-// accounts. This is a faster than calling EndowAccount for each account since
+// accounts. This is a faster than calling EndowAccount for each Account since
 // multiple endowments may get bundled in the same block.
 func (s *Session) EndowAccounts(
 	addresses []common.Address,
@@ -944,8 +944,8 @@ func (s *Session) EndowAccounts(
 		return nil, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
-	// The requested funds are moved from the validator account to the target account.
-	nonce, err := client.PendingNonceAt(context.Background(), s.account.Address())
+	// The requested funds are moved from the validator Account to the target Account.
+	nonce, err := client.PendingNonceAt(context.Background(), s.Account.Address())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get nonce: %w", err)
 	}
@@ -964,7 +964,7 @@ func (s *Session) EndowAccounts(
 			To:       &address,
 			Value:    value,
 			Nonce:    nonce,
-		}), types.NewLondonSigner(chainId), s.account.PrivateKey)
+		}), types.NewLondonSigner(chainId), s.Account.PrivateKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to sign transaction: %w", err)
 		}
@@ -1087,12 +1087,12 @@ func runParallelWithClient(
 	)
 }
 
-// Apply sends a transaction to the network using the session account
+// Apply sends a transaction to the network using the session Account
 // and waits for the transaction to be processed. The resulting receipt is returned.
 func (s *Session) Apply(
 	issue func(*bind.TransactOpts) (*types.Transaction, error),
 ) (*types.Receipt, error) {
-	txOpts, err := s.GetTransactOptions(&s.account)
+	txOpts, err := s.GetTransactOptions(&s.Account)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get transaction options: %w", err)
 	}
@@ -1104,11 +1104,11 @@ func (s *Session) Apply(
 }
 
 // GetTransactOptions provides transaction options to be used to send a transaction
-// with the given account. The options include the chain ID, a suggested gas price,
-// the next free nonce of the given account, and a hard-coded gas limit of 1e6.
+// with the given Account. The options include the chain ID, a suggested gas price,
+// the next free nonce of the given Account, and a hard-coded gas limit of 1e6.
 // The main purpose of this function is to provide a convenient way to collect all
 // the necessary information required to create a transaction in one place.
-func (s *Session) GetTransactOptions(account *Account) (*bind.TransactOpts, error) {
+func (s *Session) GetTransactOptions(Account *Account) (*bind.TransactOpts, error) {
 	client, err := s.GetClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
@@ -1126,12 +1126,12 @@ func (s *Session) GetTransactOptions(account *Account) (*bind.TransactOpts, erro
 		return nil, fmt.Errorf("failed to get gas price suggestion: %w", err)
 	}
 
-	nonce, err := client.PendingNonceAt(ctxt, account.Address())
+	nonce, err := client.PendingNonceAt(ctxt, Account.Address())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get nonce: %w", err)
 	}
 
-	txOpts, err := bind.NewKeyedTransactorWithChainID(account.PrivateKey, chainId)
+	txOpts, err := bind.NewKeyedTransactorWithChainID(Account.PrivateKey, chainId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transaction options: %w", err)
 	}
@@ -1142,7 +1142,7 @@ func (s *Session) GetTransactOptions(account *Account) (*bind.TransactOpts, erro
 }
 
 func (s *Session) GetSessionSponsor() *Account {
-	return &s.account
+	return &s.Account
 }
 
 // GetChainId returns the chain ID of the network.

--- a/integrationtestnet/integration_test_net_test.go
+++ b/integrationtestnet/integration_test_net_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package testnet
 
 import (
 	"fmt"
@@ -112,7 +112,7 @@ func testIntegrationTestNet_CanFetchInformationFromTheNetwork(t *testing.T, net 
 }
 
 // testIntegrationTestNet_CanEndowAccountsWithTokens needs its own session because it
-// modifies the state of the network by endowing an account with tokens, otherwise
+// modifies the state of the network by endowing an Account with tokens, otherwise
 // it can trigger a transaction replacement with a transaction from another test.
 func testIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T, session IntegrationTestNetSession) {
 	client, err := session.GetClient()
@@ -121,21 +121,21 @@ func testIntegrationTestNet_CanEndowAccountsWithTokens(t *testing.T, session Int
 
 	address := common.Address{0x01}
 	balance, err := client.BalanceAt(t.Context(), address, nil)
-	require.NoError(t, err, "Failed to get balance for account")
+	require.NoError(t, err, "Failed to get balance for Account")
 
 	for i := 0; i < 10; i++ {
 		increment := int64(1000)
 
 		receipt, err := session.EndowAccount(address, big.NewInt(increment))
-		require.NoError(t, err, "Failed to endow account 1")
+		require.NoError(t, err, "Failed to endow Account 1")
 		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 		WaitForProofOf(t, client, int(receipt.BlockNumber.Uint64()))
 
 		want := balance.Add(balance, big.NewInt(int64(increment)))
 		balance, err = client.BalanceAt(t.Context(), address, nil)
-		require.NoError(t, err, "Failed to get balance for account")
-		require.Equal(t, want.Uint64(), balance.Uint64(), "Unexpected balance for account after endowment")
+		require.NoError(t, err, "Failed to get balance for Account")
+		require.Equal(t, want.Uint64(), balance.Uint64(), "Unexpected balance for Account after endowment")
 
 		balance = want
 	}
@@ -222,11 +222,11 @@ func TestIntegrationTestNet_CanRunMultipleNodes(t *testing.T) {
 
 			// check that all accounts are different
 			seen := make(map[string]struct{})
-			for _, account := range accounts {
-				if _, found := seen[account]; found {
-					t.Fatalf("Duplicate account %v", account)
+			for _, Account := range accounts {
+				if _, found := seen[Account]; found {
+					t.Fatalf("Duplicate Account %v", Account)
 				}
-				seen[account] = struct{}{}
+				seen[Account] = struct{}{}
 			}
 		})
 	}
@@ -293,7 +293,7 @@ func TestIntegrationTestNet_AccountsToBeDeployedWithGenesisCanBeCalled(t *testin
 	}...)
 	accounts := []makefakegenesis.Account{
 		{
-			Name:    "account",
+			Name:    "Account",
 			Address: address,
 			Code:    code,
 			Nonce:   1,

--- a/integrationtestnet/main_test.go
+++ b/integrationtestnet/main_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package testnet
 
 import (
 	"os"

--- a/integrationtestnet/session_dispenser.go
+++ b/integrationtestnet/session_dispenser.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package testnet
 
 import (
 	"crypto/sha256"
@@ -31,7 +31,7 @@ import (
 // Upgrade.
 var activeTestNetInstances map[common.Hash]*IntegrationTestNet
 
-// getIntegrationTestNetSession creates a new session for network running on the
+// GetIntegrationTestNetSession creates a new session for network running on the
 // given Upgrade. If there is no network running with this Upgrade, a new one
 // will be initialized.
 // If a tests can run in parallel, the call to t.Parallel() should be done
@@ -40,14 +40,14 @@ var activeTestNetInstances map[common.Hash]*IntegrationTestNet
 // A typical use case would look as follows:
 //
 //	t.Run("test_case", func(t *testing.T) {
-//		session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+//		session := GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 //		t.Parallel()
 //		< use session instead of net of the rest of the test >
 //	})
 //
 // This function uses a global state that is cleaned up after the execution of
 // the tests in `tests` package.
-func getIntegrationTestNetSession(t *testing.T, upgrades opera.Upgrades) IntegrationTestNetSession {
+func GetIntegrationTestNetSession(t *testing.T, upgrades opera.Upgrades) IntegrationTestNetSession {
 	if activeTestNetInstances == nil {
 		activeTestNetInstances = make(map[common.Hash]*IntegrationTestNet)
 	}

--- a/integrationtestnet/test_utils.go
+++ b/integrationtestnet/test_utils.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package testnet
 
 import (
 	"context"
@@ -41,31 +41,31 @@ import (
 )
 
 // CreateTransaction fills the given tx with acceptable values for the given
-// session, signs it with the given account, and returns the signed transaction.
+// session, signs it with the given Account, and returns the signed transaction.
 // The values modified if defaults are:
 //   - ChainID: It replaces the ChainID of the transaction with the chainID of
 //     the given session.
 //   - If nonce is zeroed: It configures the nonce of the transaction to be the
-//     current nonce of the sender account
+//     current nonce of the sender Account
 //   - If gas price or gas fee cap is zeroed: It configures the gas price of the
 //     transaction to be the suggested gas price
 //   - If gas is zeroed: It configures the gas of the transaction to be the
 //     minimum gas required to execute the transaction
-//     Filled gas is a static minimum value, it does not account for the gas
+//     Filled gas is a static minimum value, it does not Account for the gas
 //     costs of the contract opcodes.
-func CreateTransaction(t *testing.T, session IntegrationTestNetSession, tx types.TxData, account *Account) *types.Transaction {
+func CreateTransaction(t *testing.T, session IntegrationTestNetSession, tx types.TxData, Account *Account) *types.Transaction {
 	t.Helper()
 	signedTx := SignTransaction(
 		t,
 		session.GetChainId(),
-		SetTransactionDefaults(t, session, tx, account),
-		account,
+		SetTransactionDefaults(t, session, tx, Account),
+		Account,
 	)
 	return signedTx
 }
 
 // SignTransaction is a testing helper that signs a transaction with the
-// key from the provided account
+// key from the provided Account
 func SignTransaction(
 	t *testing.T,
 	chainId *big.Int,
@@ -84,12 +84,12 @@ func SignTransaction(
 // SetTransactionDefaults defaults the transaction common fields to meaningful values
 //
 //   - If nonce is zeroed: It configures the nonce of the transaction to be the
-//     current nonce of the sender account
+//     current nonce of the sender Account
 //   - If gas price or gas fee cap is zeroed: It configures the gas price of the
 //     transaction to be the suggested gas price
 //   - If gas is zeroed: It configures the gas of the transaction to be the
 //     minimum gas required to execute the transaction
-//     Filled gas is a static minimum value, it does not account for the gas
+//     Filled gas is a static minimum value, it does not Account for the gas
 //     costs of the contract opcodes.
 //
 // Notice that this function is generic, returning the same type as the input, this
@@ -319,17 +319,17 @@ func GetEpochOfBlock(t *testing.T, client *PooledEhtClient, blockNumber int) int
 	return int(result.Epoch)
 }
 
-// MakeAccountWithBalance creates a new account and endows it with the given balance.
-// Creating the account this way allows to get access to the private key to sign transactions.
+// MakeAccountWithBalance creates a new Account and endows it with the given balance.
+// Creating the Account this way allows to get access to the private key to sign transactions.
 func MakeAccountWithBalance(t *testing.T, net IntegrationTestNetSession, balance *big.Int) *Account {
 	t.Helper()
-	account := NewAccount()
-	receipt, err := net.EndowAccount(account.Address(), balance)
+	Account := NewAccount()
+	receipt, err := net.EndowAccount(Account.Address(), balance)
 	require.NoError(t, err)
 	require.Equal(t,
 		receipt.Status, types.ReceiptStatusSuccessful,
-		"endowing account failed")
-	return account
+		"endowing Account failed")
+	return Account
 }
 
 // GenerateTestDataBasedOnModificationCombinations generates all possible versions of a
@@ -445,7 +445,7 @@ func AdvanceEpochAndWaitForBlocks(t *testing.T, net *IntegrationTestNet) {
 	require.NoError(err, "failed to wait for the next two blocks after epoch change")
 }
 
-// getProofFor retrieves the account proof for the given block number.
+// getProofFor retrieves the Account proof for the given block number.
 // This is meant to be a testing only function, hence having a *testing.T
 // unused parameter.
 func getProofFor(_ *testing.T, client *PooledEhtClient, blockNumber int) ([]string, error) {
@@ -465,13 +465,13 @@ func getProofFor(_ *testing.T, client *PooledEhtClient, blockNumber int) ([]stri
 func GetStateRoot(t *testing.T, client *PooledEhtClient, blockNumber int) common.Hash {
 
 	accountProof, err := getProofFor(t, client, blockNumber)
-	require.NoError(t, err, "failed to get account proof for block %d", blockNumber)
+	require.NoError(t, err, "failed to get Account proof for block %d", blockNumber)
 
-	// The hash of the first element of the account proof is the state root.
-	require.NotEqual(t, 0, len(accountProof), "no account proof found")
+	// The hash of the first element of the Account proof is the state root.
+	require.NotEqual(t, 0, len(accountProof), "no Account proof found")
 
 	data, err := hexutil.Decode(accountProof[0])
-	require.NoError(t, err, "failed to decode account proof element")
+	require.NoError(t, err, "failed to decode Account proof element")
 
 	return common.BytesToHash(crypto.Keccak256(data))
 }

--- a/integrationtestnet/test_utils_test.go
+++ b/integrationtestnet/test_utils_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package tests
+package testnet
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 )
 
 func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := GetIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 	t.Parallel()
 
 	client, err := session.GetClient()
@@ -137,9 +137,9 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		makeAuthList := func(t *testing.T, chainId *big.Int, accounts int) []types.SetCodeAuthorization {
 			authList := make([]types.SetCodeAuthorization, accounts)
 			for i := range authList {
-				account := NewAccount()
+				Account := NewAccount()
 
-				auth, err := types.SignSetCode(account.PrivateKey,
+				auth, err := types.SignSetCode(Account.PrivateKey,
 					types.SetCodeAuthorization{
 						ChainID: *uint256.MustFromBig(chainId),
 						Address: common.BigToAddress(big.NewInt(int64(i))),
@@ -278,7 +278,7 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		// utilizes manual nonce setting to issue multiple transactions asynchronously
 		session := session.SpawnSession(t)
 		t.Parallel()
-		// account has a non-zero nonce
+		// Account has a non-zero nonce
 		receipt, err := session.EndowAccount(common.Address{}, big.NewInt(1))
 		require.NoError(t, err)
 		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
@@ -295,7 +295,7 @@ func TestSetTransactionDefaults_CanInitializeAllTransactionTypes(t *testing.T) {
 		session := session.SpawnSession(t)
 		t.Parallel()
 
-		// endowments modify the account nonce
+		// endowments modify the Account nonce
 		var receipt *types.Receipt
 		var err error
 		for range 2 {
@@ -393,7 +393,7 @@ func TestSetTransactionDefaults_IsCorrectAfterUpgradesChange(t *testing.T) {
 }
 
 func TestWaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := GetIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 	t.Parallel()
 
 	// TODO: this test can benefit from using synctest once it is available
@@ -403,14 +403,14 @@ func TestWaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(t *testing.T)
 	require.NoError(t, err)
 	defer client.Close()
 
-	account := MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	Account := MakeAccountWithBalance(t, session, big.NewInt(1e18))
 
 	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
-	txData := SetTransactionDefaults(t, session, &types.LegacyTx{}, account)
+	txData := SetTransactionDefaults(t, session, &types.LegacyTx{}, Account)
 	txData.Nonce = 1
-	txInvalidNonce := SignTransaction(t, chainId, txData, account)
+	txInvalidNonce := SignTransaction(t, chainId, txData, Account)
 
 	err = client.SendTransaction(t.Context(), txInvalidNonce)
 	require.NoError(t, err)
@@ -421,7 +421,7 @@ func TestWaitUntilTransactionIsRetiredFromPool_waitsFromCompletion(t *testing.T)
 	require.ErrorContains(t, err, "wait timeout")
 
 	txData.Nonce = 0
-	txCorrectNonce := SignTransaction(t, chainId, txData, account)
+	txCorrectNonce := SignTransaction(t, chainId, txData, Account)
 
 	err = client.SendTransaction(t.Context(), txCorrectNonce)
 	require.NoError(t, err)

--- a/scc/light_client/fake_net_provider_test.go
+++ b/scc/light_client/fake_net_provider_test.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/0xsoniclabs/sonic/tests"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -136,11 +136,11 @@ func TestServer_CanRequestMaxNumberOfResults(t *testing.T) {
 // helper functions
 ////////////////////////////////////////
 
-func startNetAndGetClient(t *testing.T) (*tests.IntegrationTestNet, *rpc.Client) {
+func startNetAndGetClient(t *testing.T) (*testnet.IntegrationTestNet, *rpc.Client) {
 	t.Helper()
 	require := require.New(t)
 	// start network
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 
 	client, err := net.GetClient()
 	require.NoError(err)

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -36,7 +36,7 @@ Here are some considerations to keep in mind when adding new integration tests:
 	- The network is going to have more than one node.
 	- The network is going to have have a specified config file, or a specific non-default configuration parameter.
 	
-	Then use an exclusive new network `net := StartIntegrationTestNet(t)`.
+	Then use an exclusive new network `net :=testnet.StartIntegrationTestNet(t)`.
 	For example:
 	```Go
 	import (
@@ -48,26 +48,26 @@ Here are some considerations to keep in mind when adding new integration tests:
 	func TestNetworkRule_Update(t *testing.T){
 
 		require := require.New(t)
-		net := tests.StartIntegrationTestNet(t)
+		net := testnet.StartIntegrationTestNet(t)
 
-		current := tests.GetNetworkRules(t, net)
+		current := testnet.GetNetworkRules(t, net)
 		modified := myRuleModifications(current)
-		tests.UpdateNetworkRules(t, net, modified)
+		testnet.UpdateNetworkRules(t, net, modified)
 		AdvanceEpochAndWaitForBlocks(t, net)
 
 		net.Restart()
-		newConfig := tests.GetNetworkRules(t, net)
+		newConfig := testnet.GetNetworkRules(t, net)
 		require.Equal(modified, newConfig)
 	}	
 	```
 
-	Otherwise we highly encourage you to use `session := getIntegrationTestNetSession(t, Upgrade)`
+	Otherwise we highly encourage you to use `session := testnet.GetIntegrationTestNetSession(t, Upgrade)`
 
 	`Upgrades` indicates which hard fork options the network uses. `opera.Sonic` hard fork is used as a default.
 
 	```Go
 	func TestMultipleSessions_CanSendLegacyTransactionsInBulk(t *testing.T) {
-		session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+		session := testnet.GetIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 
 		chainId := session.GetChainId()
 		txs := types.Transaction[]{}
@@ -88,7 +88,7 @@ Here are some considerations to keep in mind when adding new integration tests:
 
 	```Go
 	func TestType_ManyProperties(t *testing.T){
-		session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+		session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
 		t.Run("someProperty", func (t *testing.T){
 			subSession := session.SpawnSession(t)
@@ -114,7 +114,7 @@ Networks or sessions can produce `Client`s connected to the different nodes. The
 
 ```Go
 func TestSendTransaction_Asynchronously(t *testing.T){
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	chainId := session.GetChainId()
 
 	client, err := session.GetClient()
@@ -177,11 +177,11 @@ The following commands can be used to install the needed dependencies are needed
 ```Go
 func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the counter contract.
-	contract, receipt, err := DeployContract(session, counter.DeployCounter)
+	contract, receipt, err := testnet.DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 

--- a/tests/address_access_test.go
+++ b/tests/address_access_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	accessCost "github.com/0xsoniclabs/sonic/tests/contracts/access_cost"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -31,10 +32,10 @@ import (
 func TestAddressAccess(t *testing.T) {
 	someAccountAddress := common.Address{1}
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
-	contract, receipt, err := DeployContract(session, accessCost.DeployAccessCost)
+	contract, receipt, err := testnet.DeployContract(session, accessCost.DeployAccessCost)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 

--- a/tests/basefee_test.go
+++ b/tests/basefee_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/basefee"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -26,11 +27,11 @@ import (
 )
 
 func TestBaseFee_CanReadBaseFeeFromHeadAndBlockAndHistory(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the base fee contract.
-	contract, _, err := DeployContract(session, basefee.DeployBasefee)
+	contract, _, err := testnet.DeployContract(session, basefee.DeployBasefee)
 	require.NoError(t, err)
 
 	// Collect the current base fee from the head state.

--- a/tests/blob_tx_test.go
+++ b/tests/blob_tx_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/blobbasefee"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -37,7 +38,7 @@ import (
 
 func TestBlobTransaction(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	t.Run("blob tx with non-empty blobs is rejected", func(t *testing.T) {
@@ -65,7 +66,7 @@ func TestBlobTransaction(t *testing.T) {
 	})
 }
 
-func testBlobTx_WithBlobsIsRejected(t *testing.T, session IntegrationTestNetSession) {
+func testBlobTx_WithBlobsIsRejected(t *testing.T, session testnet.IntegrationTestNetSession) {
 	require := require.New(t)
 	nonZeroNumberOfBlobs := 2
 
@@ -88,7 +89,7 @@ func testBlobTx_WithBlobsIsRejected(t *testing.T, session IntegrationTestNetSess
 	require.ErrorContains(err, "non-empty blob transaction are not supported")
 }
 
-func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, session IntegrationTestNetSession) {
+func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, session testnet.IntegrationTestNetSession) {
 	require := require.New(t)
 
 	tx, err := createTestBlobTransaction(t, session)
@@ -104,7 +105,7 @@ func testBlobTx_WithEmptyBlobsIsExecuted(t *testing.T, session IntegrationTestNe
 	)
 }
 
-func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, session IntegrationTestNetSession) {
+func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, session testnet.IntegrationTestNetSession) {
 	require := require.New(t)
 
 	tx, err := createTestBlobTransactionWithNilSidecar(t, session)
@@ -120,11 +121,11 @@ func testBlobTx_WithNilSidecarIsExecuted(t *testing.T, session IntegrationTestNe
 	)
 }
 
-func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, session IntegrationTestNetSession) {
+func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, session testnet.IntegrationTestNetSession) {
 	require := require.New(t)
 
 	// Deploy the blob base fee contract.
-	contract, _, err := DeployContract(session, blobbasefee.DeployBlobbasefee)
+	contract, _, err := testnet.DeployContract(session, blobbasefee.DeployBlobbasefee)
 	require.NoError(err, "failed to deploy contract; ", err)
 
 	// Collect the current blob base fee from the head state.
@@ -161,7 +162,7 @@ func testBlobBaseFee_CanReadBlobBaseFeeFromHeadAndBlockAndHistory(t *testing.T, 
 	require.Equal(fromLog, uint64(*fromRpc), "blob base fee mismatch; from log %v, from rpc %v", fromLog, fromRpc)
 }
 
-func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, session IntegrationTestNetSession) {
+func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, session testnet.IntegrationTestNetSession) {
 	require := require.New(t)
 
 	client, err := session.GetClient()
@@ -193,7 +194,7 @@ func testBlobBaseFee_CanReadBlobGasUsed(t *testing.T, session IntegrationTestNet
 // Helper Functions
 ////////////////////////////////////////////////////////////////////////////////
 
-func createTestBlobTransaction(t *testing.T, session IntegrationTestNetSession, data ...[]byte) (*types.Transaction, error) {
+func createTestBlobTransaction(t *testing.T, session testnet.IntegrationTestNetSession, data ...[]byte) (*types.Transaction, error) {
 	require := require.New(t)
 
 	client, err := session.GetClient()
@@ -250,7 +251,7 @@ func createTestBlobTransaction(t *testing.T, session IntegrationTestNetSession, 
 	return types.SignTx(tx, types.NewCancunSigner(chainId), session.GetSessionSponsor().PrivateKey)
 }
 
-func createTestBlobTransactionWithNilSidecar(t *testing.T, session IntegrationTestNetSession) (*types.Transaction, error) {
+func createTestBlobTransactionWithNilSidecar(t *testing.T, session testnet.IntegrationTestNetSession) (*types.Transaction, error) {
 	require := require.New(t)
 
 	client, err := session.GetClient()
@@ -280,7 +281,7 @@ func createTestBlobTransactionWithNilSidecar(t *testing.T, session IntegrationTe
 	return types.SignTx(tx, types.NewCancunSigner(chainId), session.GetSessionSponsor().PrivateKey)
 }
 
-func checkBlocksSanity(t *testing.T, session IntegrationTestNetSession) {
+func checkBlocksSanity(t *testing.T, session testnet.IntegrationTestNetSession) {
 	// This check is a regression from an issue found while fetching a block by
 	// number where the last block was not correctly serialized
 	require := require.New(t)

--- a/tests/block_by_hash/block_by_hash_test.go
+++ b/tests/block_by_hash/block_by_hash_test.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter_event_emitter"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -30,14 +30,14 @@ import (
 
 func TestRPCGetLogs_BlockWithSkippedTransaction_HasCorrectTxIndexes(t *testing.T) {
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: tests.AsPointer(opera.GetBrioUpgrades()),
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
+		Upgrades: testnet.AsPointer(opera.GetBrioUpgrades()),
 		ClientExtraArguments: []string{
 			"--disable-txPool-validation",
 		},
 	})
 
-	contract, receipt, err := tests.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
+	contract, receipt, err := testnet.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -51,9 +51,9 @@ func TestRPCGetLogs_BlockWithSkippedTransaction_HasCorrectTxIndexes(t *testing.T
 	for range 5 {
 
 		// Make a transaction to be skipped.
-		accountSkipped := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+		accountSkipped := testnet.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 		initCode := make([]byte, 50000)
-		txSkip := tests.CreateTransaction(t, net, &types.LegacyTx{
+		txSkip := testnet.CreateTransaction(t, net, &types.LegacyTx{
 			Gas:  10_000_000,
 			To:   nil, // address 0x00 for contract creation
 			Data: initCode,

--- a/tests/block_in_archive_test.go
+++ b/tests/block_in_archive_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -33,7 +34,7 @@ import (
 func TestBlockInArchive(t *testing.T) {
 
 	require := require.New(t)
-	net := StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 
 	client, err := net.GetWebSocketClient()
 	require.NoError(err, "failed to get client ", err)
@@ -75,7 +76,7 @@ func TestBlockInArchive(t *testing.T) {
 		}
 	}()
 
-	contract, _, err := DeployContract(net, transientstorage.DeployTransientstorage)
+	contract, _, err := testnet.DeployContract(net, transientstorage.DeployTransientstorage)
 	require.NoError(err, "failed to deploy contract %v", err)
 
 	for {

--- a/tests/block_override_test.go
+++ b/tests/block_override_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	block_override "github.com/0xsoniclabs/sonic/tests/contracts/blockoverride"
 	"github.com/ethereum/go-ethereum/common"
@@ -38,11 +39,11 @@ const (
 
 func TestBlockOverride(t *testing.T) {
 	require := req.New(t)
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the block override observer contract.
-	contract, receipt, err := DeployContract(session, block_override.DeployBlockOverride)
+	contract, receipt, err := testnet.DeployContract(session, block_override.DeployBlockOverride)
 	require.NoError(err, "failed to deploy contract; %v", err)
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "Deployment Unsuccessful")
 	contractAddress := receipt.ContractAddress

--- a/tests/block_parameters_test.go
+++ b/tests/block_parameters_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/block_parameters"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -62,8 +63,8 @@ func TestBlockParameters_BlockHeaderMatchesObservableBlockParameters(t *testing.
 					upgrades := upgrades
 					upgrades.SingleProposerBlockFormation = singleProposer
 
-					net := StartIntegrationTestNetWithJsonGenesis(t,
-						IntegrationTestNetOptions{
+					net := testnet.StartIntegrationTestNetWithJsonGenesis(t,
+						testnet.IntegrationTestNetOptions{
 							Upgrades: &upgrades,
 							NumNodes: 2,
 						},
@@ -78,10 +79,10 @@ func TestBlockParameters_BlockHeaderMatchesObservableBlockParameters(t *testing.
 
 func testBlockHeaderMatchesObservableBlockParameters(
 	t *testing.T,
-	net *IntegrationTestNet,
+	net *testnet.IntegrationTestNet,
 ) {
 	require := require.New(t)
-	contract, receipt, err := DeployContract(net, block_parameters.DeployBlockParameters)
+	contract, receipt, err := testnet.DeployContract(net, block_parameters.DeployBlockParameters)
 	require.NoError(err, "Failed to deploy BlockParameters contract")
 
 	// Collect a few samples of block parameters from within transactions.

--- a/tests/bls_onchain_test.go
+++ b/tests/bls_onchain_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/scc/bls"
 	"github.com/0xsoniclabs/sonic/tests/contracts/blsContracts"
@@ -30,11 +31,11 @@ import (
 )
 
 func TestBlsVerificationOnChain(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 	t.Parallel()
 
 	// Deploy contract with transaction options
-	blsContract, _, err := DeployContract(session, blsContracts.DeployBLS)
+	blsContract, _, err := testnet.DeployContract(session, blsContracts.DeployBLS)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 
 	testVariants := []struct {

--- a/tests/chainid_test.go
+++ b/tests/chainid_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/ethapi"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,8 +33,8 @@ import (
 )
 
 func TestChainId(t *testing.T) {
-	net := StartIntegrationTestNet(t,
-		IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t,
+		testnet.IntegrationTestNetOptions{
 			ModifyConfig: func(config *config.Config) {
 				// The transactions signed with the Homestead are not replay protected.
 				// The default configuration rejects this sort of transaction,
@@ -42,7 +43,7 @@ func TestChainId(t *testing.T) {
 			},
 		})
 
-	account := MakeAccountWithBalance(t, net, big.NewInt(1e18))
+	account := testnet.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 
 	t.Run("RejectsAllTxsSignedWithWrongChainId", func(t *testing.T) {
 		t.Parallel()
@@ -57,8 +58,8 @@ func TestChainId(t *testing.T) {
 
 func testChainId_RejectsAllTxSignedWithWrongChainId(
 	t *testing.T,
-	net *IntegrationTestNet,
-	account *Account,
+	net *testnet.IntegrationTestNet,
+	account *testnet.Account,
 ) {
 
 	client, err := net.GetClient()
@@ -139,8 +140,8 @@ func testChainId_RejectsAllTxSignedWithWrongChainId(
 
 func testChainId_AcceptsLegacyTxSignedWithHomestead(
 	t *testing.T,
-	net *IntegrationTestNet,
-	account *Account) {
+	net *testnet.IntegrationTestNet,
+	account *testnet.Account) {
 
 	client, err := net.GetClient()
 	require.NoError(t, err, "failed to get client")
@@ -187,7 +188,7 @@ func testChainId_AcceptsLegacyTxSignedWithHomestead(
 
 func TestChainId_InternalTransactionHasCorrectChainId(t *testing.T) {
 
-	net := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	net := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	client, err := net.GetClient()

--- a/tests/counter_test.go
+++ b/tests/counter_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -30,11 +31,11 @@ import (
 
 func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the counter contract.
-	contract, receipt, err := DeployContract(session, counter.DeployCounter)
+	contract, receipt, err := testnet.DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 
@@ -51,10 +52,10 @@ func TestCounter_CanIncrementAndReadCounterFromHead(t *testing.T) {
 
 func TestCounter_CanReadHistoricCounterValues(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 	// Deploy the counter contract.
-	contract, receipt, err := DeployContract(session, counter.DeployCounter)
+	contract, receipt, err := testnet.DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -37,7 +38,7 @@ func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *te
 
 	for name, version := range versions {
 		t.Run(name, func(t *testing.T) {
-			net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
+			net := testnet.StartIntegrationTestNetWithJsonGenesis(t, testnet.IntegrationTestNetOptions{
 				Upgrades: &version,
 				ClientExtraArguments: []string{
 					"--disable-txPool-validation",
@@ -48,7 +49,7 @@ func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *te
 			require.NoError(t, err)
 			defer client.Close()
 
-			sender := MakeAccountWithBalance(t, net, big.NewInt(1e18))
+			sender := testnet.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 
 			gasPrice, err := client.SuggestGasPrice(t.Context())
 			require.NoError(t, err)
@@ -65,7 +66,7 @@ func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *te
 				Value:    big.NewInt(0),
 				Data:     initCode,
 			}
-			tx := SignTransaction(t, chainId, txData, sender)
+			tx := testnet.SignTransaction(t, chainId, txData, sender)
 
 			// Check balance before sending the transaction
 			preBalance, err := client.BalanceAt(t.Context(), sender.Address(), nil)
@@ -114,14 +115,14 @@ func TestAccountCreation_CreateCallsProducingCodesTooLargeProduceAUnsuccessfulRe
 		byte(vm.RETURN),
 	}...)
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	client, err := session.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	sender := MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	sender := testnet.MakeAccountWithBalance(t, session, big.NewInt(1e18))
 
 	gasPrice, err := client.SuggestGasPrice(t.Context())
 	require.NoError(t, err)
@@ -137,7 +138,7 @@ func TestAccountCreation_CreateCallsProducingCodesTooLargeProduceAUnsuccessfulRe
 		Value:    big.NewInt(0),
 		Data:     initCode,
 	}
-	tx := SignTransaction(t, chainId, txData, sender)
+	tx := testnet.SignTransaction(t, chainId, txData, sender)
 
 	receipt, err := session.Run(tx)
 	require.NoError(t, err)

--- a/tests/eth_call_test.go
+++ b/tests/eth_call_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
@@ -43,7 +44,7 @@ func TestEthCall_CodeLargerThanMaxInitCodeSizeIsAccepted(t *testing.T) {
 			math.MaxUint16 + 1,
 		},
 	}
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	client, err := session.GetClient()

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
@@ -201,9 +202,9 @@ func makeTestEngine(gdb *gossip.Store) (*abft.Lachesis, *vecmt.Index) {
 
 func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 
-	net := StartIntegrationTestNet(t,
-		IntegrationTestNetOptions{
-			Upgrades: AsPointer(opera.GetBrioUpgrades()),
+	net := testnet.StartIntegrationTestNet(t,
+		testnet.IntegrationTestNetOptions{
+			Upgrades: testnet.AsPointer(opera.GetBrioUpgrades()),
 		})
 
 	client, err := net.GetClient()
@@ -272,15 +273,15 @@ func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 	require.NoError(t, err, "eth_getRules failed")
 
 	rules.Upgrades.GasSubsidies = true
-	UpdateNetworkRules(t, net, rules)
-	AdvanceEpochAndWaitForBlocks(t, net)
+	testnet.UpdateNetworkRules(t, net, rules)
+	testnet.AdvanceEpochAndWaitForBlocks(t, net)
 
 	// get current block to confirm epoch advancement
 	currentBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(t, err, "could not get current block after epoch advancement")
 	require.Greater(t, currentBlock.NumberU64(), block1.NumberU64(), "block number did not advance after epoch advancement")
 
-	WaitForProofOf(t, client, int(currentBlock.NumberU64()))
+	testnet.WaitForProofOf(t, client, int(currentBlock.NumberU64()))
 
 	// get new config
 	err = client.Client().Call(&response, "eth_config")

--- a/tests/flags/flags_test.go
+++ b/tests/flags/flags_test.go
@@ -24,14 +24,14 @@ import (
 	"testing"
 
 	sonicd "github.com/0xsoniclabs/sonic/cmd/sonicd/app"
-	"github.com/0xsoniclabs/sonic/tests"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestSonicTool_DefaultConfig_HasDefaultValues(t *testing.T) {
 
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	net.Stop()
 
 	configFile := filepath.Join(net.GetDirectory(), "config.toml")
@@ -55,7 +55,7 @@ NonDominatingTimeout = 100`)
 
 func TestSonicTool_CustomThrottlerConfig_AreApplied(t *testing.T) {
 
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	net.Stop()
 
 	configFile := filepath.Join(net.GetDirectory(), "config.toml")

--- a/tests/gas_cost/gas_cost_test.go
+++ b/tests/gas_cost/gas_cost_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -64,7 +64,7 @@ func TestGasCostTest_Sonic(t *testing.T) {
 func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 	upgrades := opera.GetSonicUpgrades()
 	upgrades.SingleProposerBlockFormation = singleProposer
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -89,9 +89,9 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
 				test.txPayload.Gas = test.txPayload.Gas - 1
-				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = testnet.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := testnet.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				err := client.SendTransaction(t.Context(), tx)
@@ -107,8 +107,8 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 		session := net.SpawnSession(t)
 		for test := range makeGasCostTestInputs(t, session) {
 			t.Run(test.String(), func(t *testing.T) {
-				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
-				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = testnet.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				tx := testnet.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
@@ -130,9 +130,9 @@ func testGasCosts_Sonic(t *testing.T, singleProposer bool) {
 
 				// Increase gas by 20% to make sure we have some unused gas
 				test.txPayload.Gas = uint64(float32(test.txPayload.Gas) * 1.2)
-				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = testnet.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := testnet.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
@@ -163,7 +163,7 @@ func TestGasCostTest_Allegro(t *testing.T) {
 func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 	upgrades := opera.GetAllegroUpgrades()
 	upgrades.SingleProposerBlockFormation = singleProposer
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -204,9 +204,9 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 			t.Run(test.String(), func(t *testing.T) {
 
 				test.txPayload.Gas = computeEIP7623GasCost(t, test.txPayload) - 1
-				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = testnet.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := testnet.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				err := client.SendTransaction(t.Context(), tx)
@@ -231,9 +231,9 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 					corrections++
 				}
 				test.txPayload.Gas = correctedGasCost
-				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = testnet.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := testnet.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				receipt, err := session.Run(tx)
@@ -268,9 +268,9 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 				}
 
 				test.txPayload.Gas = incremented
-				test.txPayload = tests.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
+				test.txPayload = testnet.SetTransactionDefaults(t, session, test.txPayload, session.GetSessionSponsor())
 
-				tx := tests.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
+				tx := testnet.SignTransaction(t, chainId, test.txPayload, session.GetSessionSponsor())
 				require.NoError(t, err)
 
 				expectedCost, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
@@ -301,7 +301,7 @@ func testGasCosts_Allegro(t *testing.T, singleProposer bool) {
 
 func makeGasCostTestInputs(
 	t *testing.T,
-	session tests.IntegrationTestNetSession,
+	session testnet.IntegrationTestNetSession,
 ) iter.Seq[TestCase] {
 	t.Helper()
 
@@ -313,7 +313,7 @@ func makeGasCostTestInputs(
 	require.NoError(t, err)
 
 	existingAccountAddress := session.GetSessionSponsor().Address()
-	nonExistingAccountAddress := tests.NewAccount().Address()
+	nonExistingAccountAddress := testnet.NewAccount().Address()
 
 	withCallData := func(size, zeroes int) txModification {
 		return func(tx *types.AccessListTx) {
@@ -342,7 +342,7 @@ func makeGasCostTestInputs(
 		return func(tx *types.AccessListTx) {
 			tx.AccessList = make([]types.AccessTuple, accounts)
 			for i := 0; i < accounts; i++ {
-				tx.AccessList[i].Address = tests.NewAccount().Address()
+				tx.AccessList[i].Address = testnet.NewAccount().Address()
 				tx.AccessList[i].StorageKeys = make([]common.Hash, storageKeysPerAccount)
 				for j := 0; j < storageKeysPerAccount; j++ {
 					tx.AccessList[i].StorageKeys[j] = common.Hash{0x42}
@@ -351,7 +351,7 @@ func makeGasCostTestInputs(
 		}
 	}
 
-	return tests.GenerateTestDataBasedOnModificationCombinations(
+	return testnet.GenerateTestDataBasedOnModificationCombinations(
 		func() TestCase {
 			t.Helper()
 
@@ -461,11 +461,11 @@ func TestExcessGasCharges_DisabledInSingleProposerModeInNewAndHistoricRuns(t *te
 	require := require.New(t)
 
 	upgrades := opera.GetAllegroUpgrades()
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
-	account := tests.NewAccount()
+	account := testnet.NewAccount()
 	_, err := net.EndowAccount(account.Address(), big.NewInt(1e18))
 	require.NoError(err)
 
@@ -499,7 +499,7 @@ func TestExcessGasCharges_DisabledInSingleProposerModeInNewAndHistoricRuns(t *te
 	receipts = append(receipts, receipt)
 
 	// Switch to single proposer mode.
-	tests.UpdateNetworkRules(t, net, map[string]map[string]bool{
+	testnet.UpdateNetworkRules(t, net, map[string]map[string]bool{
 		"Upgrades": {
 			"SingleProposerBlockFormation": true,
 		},

--- a/tests/gas_estimate_test.go
+++ b/tests/gas_estimate_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/data_reader"
 	"github.com/ethereum/go-ethereum"
@@ -34,10 +35,10 @@ import (
 
 func TestEstimateGas(t *testing.T) {
 	t.Run("Sonic", func(t *testing.T) {
-		session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+		session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 		t.Parallel()
 
-		dataContract, receipt, err := DeployContract(session, data_reader.DeployDataReader)
+		dataContract, receipt, err := testnet.DeployContract(session, data_reader.DeployDataReader)
 		require.NoError(t, err, "failed to deploy contract; %v", err)
 		require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 		dataContractAddress := receipt.ContractAddress
@@ -45,10 +46,10 @@ func TestEstimateGas(t *testing.T) {
 		doTestEstimate(t, session, makeTestCases(t, session, dataContract, dataContractAddress))
 	})
 	t.Run("Allegro", func(t *testing.T) {
-		session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+		session := testnet.GetIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 		t.Parallel()
 
-		dataContract, receipt, err := DeployContract(session, data_reader.DeployDataReader)
+		dataContract, receipt, err := testnet.DeployContract(session, data_reader.DeployDataReader)
 		require.NoError(t, err, "failed to deploy contract; %v", err)
 		require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 		dataContractAddress := receipt.ContractAddress
@@ -59,7 +60,7 @@ func TestEstimateGas(t *testing.T) {
 
 func makeTestCases(
 	t *testing.T,
-	session IntegrationTestNetSession,
+	session testnet.IntegrationTestNetSession,
 	contract *data_reader.DataReader,
 	contractAddress common.Address,
 ) map[string]types.TxData {
@@ -119,7 +120,7 @@ func makeTestCases(
 
 func makeAllegroCases(
 	t *testing.T,
-	session IntegrationTestNetSession,
+	session testnet.IntegrationTestNetSession,
 	contract *data_reader.DataReader,
 	contractAddress common.Address,
 ) map[string]types.TxData {
@@ -128,7 +129,7 @@ func makeAllegroCases(
 	cases := makeTestCases(t, session, contract, contractAddress)
 
 	// create authorization, use new account to avoid altering session sponsor state
-	account := MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	account := testnet.MakeAccountWithBalance(t, session, big.NewInt(1e18))
 	auth, err := types.SignSetCode(account.PrivateKey,
 		types.SetCodeAuthorization{
 			ChainID: *uint256.MustFromBig(session.GetChainId()),
@@ -156,10 +157,10 @@ func makeAllegroCases(
 
 func doTestEstimate(
 	t *testing.T,
-	session IntegrationTestNetSession,
+	session testnet.IntegrationTestNetSession,
 	tests map[string]types.TxData) {
 
-	account := MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	account := testnet.MakeAccountWithBalance(t, session, big.NewInt(1e18))
 	netUpgrades := session.GetUpgrades()
 
 	client, err := session.GetClient()

--- a/tests/gas_price_suggestion_test.go
+++ b/tests/gas_price_suggestion_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -31,7 +32,7 @@ import (
 func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 	require := require.New(t)
 
-	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
@@ -67,7 +68,7 @@ func TestGasPrice_SuggestedGasPricesApproximateActualBaseFees(t *testing.T) {
 func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 	require := require.New(t)
 
-	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	client, err := session.GetClient()
 	require.NoError(err, "failed to get client")
@@ -82,7 +83,7 @@ func TestGasPrice_UnderpricedTransactionsAreRejected(t *testing.T) {
 
 	// SetCode transactions are restricted to a max of one in-flight transaction
 	// per address, so we need to use a different account.
-	setCodeAccount := MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	setCodeAccount := testnet.MakeAccountWithBalance(t, session, big.NewInt(1e18))
 	setCodeFactory := &txFactory{
 		senderKey: setCodeAccount.PrivateKey,
 		chainId:   chainId,

--- a/tests/gas_subsidies/all_tx_types_test.go
+++ b/tests/gas_subsidies/all_tx_types_test.go
@@ -20,8 +20,8 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -56,7 +56,7 @@ func TestGasSubsidies_SupportAllTxTypes(t *testing.T) {
 	upgrades := opera.GetAllegroUpgrades()
 	upgrades.GasSubsidies = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -67,7 +67,7 @@ func TestGasSubsidies_SupportAllTxTypes(t *testing.T) {
 	for name, tx := range transactions {
 		t.Run(name, func(t *testing.T) {
 
-			sponsee := tests.NewAccount()
+			sponsee := testnet.NewAccount()
 
 			// The sponsorship donation needs to be high enough to cover the gas
 			// fees of the sponsored tx and the fees of the internal payment tx.

--- a/tests/gas_subsidies/block_verifiability_test.go
+++ b/tests/gas_subsidies/block_verifiability_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/gossip/evmstore"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
@@ -73,7 +73,7 @@ func testBlockVerifiability(t *testing.T, upgrades opera.Upgrades) {
 	updates := opera.GetSonicUpgrades()
 	updates.GasSubsidies = true
 
-	net := tests.StartIntegrationTestNetWithJsonGenesis(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNetWithJsonGenesis(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &updates,
 	})
 
@@ -95,7 +95,7 @@ func testBlockVerifiability(t *testing.T, upgrades opera.Upgrades) {
 	require.NoError(err)
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 
-	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
+	testnet.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	// Check sponsorship balance.
 	state, err := reg.Sponsorships(nil, id)
@@ -103,7 +103,7 @@ func testBlockVerifiability(t *testing.T, upgrades opera.Upgrades) {
 	require.Equal(big.NewInt(1e18), state.Funds)
 
 	// Run some sponsored transactions interacting with the registry.
-	account := tests.NewAccount()
+	account := testnet.NewAccount()
 	signer := types.LatestSignerForChainID(net.GetChainId())
 	txs := []*types.Transaction{}
 	for i := range N {

--- a/tests/gas_subsidies/blockgas_test.go
+++ b/tests/gas_subsidies/blockgas_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/revert"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
@@ -49,7 +49,7 @@ func TestGasSubsidies_TooLargeForBlock(t *testing.T) {
 func testGasSubsidies_tooLargeForBlock(t *testing.T, upgrades opera.Upgrades) {
 	// Step 1: Create a network with a single block proposer
 	upgrades.GasSubsidies = true
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -57,11 +57,11 @@ func testGasSubsidies_tooLargeForBlock(t *testing.T, upgrades opera.Upgrades) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	revertContract, receipt, err := tests.DeployContract(net, revert.DeployRevert)
+	revertContract, receipt, err := testnet.DeployContract(net, revert.DeployRevert)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-	sender := tests.NewAccount()
+	sender := testnet.NewAccount()
 
 	reg, err := registry.NewRegistry(registry.GetAddress(), client)
 	require.NoError(t, err)
@@ -78,12 +78,12 @@ func testGasSubsidies_tooLargeForBlock(t *testing.T, upgrades opera.Upgrades) {
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
 	// Step 3: Update rules to have maximum block gas limit of 3 million
-	current := tests.GetNetworkRules(t, net)
+	current := testnet.GetNetworkRules(t, net)
 	modified := current.Copy()
 	modified.Blocks.MaxBlockGas = 3_000_000
-	tests.UpdateNetworkRules(t, net, modified)
+	testnet.UpdateNetworkRules(t, net, modified)
 	net.AdvanceEpoch(t, 1)
-	updatedRules := tests.GetNetworkRules(t, net)
+	updatedRules := testnet.GetNetworkRules(t, net)
 	require.Equal(t, uint64(3_000_000), updatedRules.Blocks.MaxBlockGas)
 
 	// Step 4: Send a sponsored transaction that uses almost all the gas in the block

--- a/tests/gas_subsidies/gas_subsidies_test.go
+++ b/tests/gas_subsidies/gas_subsidies_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +32,7 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 	require := require.New(t)
 
 	// The network is initially started using the distributed protocol.
-	net := tests.StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 	// a sliced is used here to ensure the forks get updated in an acceptable order.
 	upgrades := []struct {
 		name    string
@@ -49,11 +49,11 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 			defer client.Close()
 
 			// enforce the current upgrade
-			testRules := tests.GetNetworkRules(t, net)
+			testRules := testnet.GetNetworkRules(t, net)
 			testRules.Upgrades = test.upgrade
-			tests.UpdateNetworkRules(t, net, testRules)
+			testnet.UpdateNetworkRules(t, net, testRules)
 			// Advance the epoch by one to apply the change.
-			tests.AdvanceEpochAndWaitForBlocks(t, net)
+			testnet.AdvanceEpochAndWaitForBlocks(t, net)
 
 			// check original state
 			type upgrades struct {
@@ -72,7 +72,7 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 			rulesDiff := rulesType{
 				Upgrades: upgrades{GasSubsidies: true},
 			}
-			tests.UpdateNetworkRules(t, net, rulesDiff)
+			testnet.UpdateNetworkRules(t, net, rulesDiff)
 
 			// Advance the epoch by one to apply the change.
 			net.AdvanceEpoch(t, 1)
@@ -85,7 +85,7 @@ func TestGasSubsidies_CanBeEnabledAndDisabled(
 			rulesDiff = rulesType{
 				Upgrades: upgrades{GasSubsidies: false},
 			}
-			tests.UpdateNetworkRules(t, net, rulesDiff)
+			testnet.UpdateNetworkRules(t, net, rulesDiff)
 
 			// Advance the epoch by one to apply the change.
 			net.AdvanceEpoch(t, 1)
@@ -107,15 +107,15 @@ func TestGasSubsidies_CallingRegistryBeforeDeploy_FailsTransaction(t *testing.T)
 	for name, upgrade := range upgrades {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			net := tests.StartIntegrationTestNetWithJsonGenesis(t, tests.IntegrationTestNetOptions{
+			net := testnet.StartIntegrationTestNetWithJsonGenesis(t, testnet.IntegrationTestNetOptions{
 				Upgrades: &upgrade,
 			})
 
 			client, err := net.GetClient()
 			require.NoError(err)
 
-			sponsor := tests.NewAccount()
-			sponsee := tests.NewAccount()
+			sponsor := testnet.NewAccount()
+			sponsee := testnet.NewAccount()
 
 			code, err := client.CodeAt(t.Context(), registry.GetAddress(), nil)
 			require.NoError(err)

--- a/tests/gas_subsidies/insufficient_funds_test.go
+++ b/tests/gas_subsidies/insufficient_funds_test.go
@@ -20,8 +20,8 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,7 +32,7 @@ func TestGasSubsidies_RequestIsRejectedInCaseOfInsufficientFunds(t *testing.T) {
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.GasSubsidies = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -44,7 +44,7 @@ func TestGasSubsidies_RequestIsRejectedInCaseOfInsufficientFunds(t *testing.T) {
 		To:  &common.Address{0x42},
 		Gas: 21000,
 	}
-	sponsee := tests.NewAccount()
+	sponsee := testnet.NewAccount()
 	signedTx := makeSponsorRequestTransaction(t, tx, net.GetChainId(), sponsee)
 
 	// Create a sponsorship fund with 0 initial funds
@@ -85,7 +85,7 @@ func TestGasSubsidies_RequestIsRejectedInCaseOfInsufficientFunds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
+	testnet.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	// Get the funds before resending the transaction
 	ops := &bind.CallOpts{
@@ -108,7 +108,7 @@ func TestGasSubsidies_RequestIsRejectedInCaseOfInsufficientFunds(t *testing.T) {
 	require.NoError(t, err)
 	baseFee = header.BaseFee
 
-	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
+	testnet.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	ops = &bind.CallOpts{
 		BlockNumber: receipt.BlockNumber,

--- a/tests/gas_subsidies/internal_transactions_nonce_test.go
+++ b/tests/gas_subsidies/internal_transactions_nonce_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/contract/driverauth100"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driverauth"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -36,7 +36,7 @@ func TestGasSubsidies_InternalTransaction_HaveConsistentNonces(t *testing.T) {
 
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.GasSubsidies = true
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -44,7 +44,7 @@ func TestGasSubsidies_InternalTransaction_HaveConsistentNonces(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	sponsoredSender := tests.NewAccount()
+	sponsoredSender := testnet.NewAccount()
 	totalValueForSponsorships := new(big.Int).Mul(
 		big.NewInt(1e18),
 		big.NewInt(100),
@@ -58,10 +58,10 @@ func TestGasSubsidies_InternalTransaction_HaveConsistentNonces(t *testing.T) {
 	require.NoError(t, err, "failed to create contract instance")
 
 	tests := map[string]struct {
-		scenario func(t *testing.T, net *tests.IntegrationTestNet)
+		scenario func(t *testing.T, net *testnet.IntegrationTestNet)
 	}{
 		"single sponsored transaction": {
-			scenario: func(t *testing.T, net *tests.IntegrationTestNet) {
+			scenario: func(t *testing.T, net *testnet.IntegrationTestNet) {
 				nonce, err := client.PendingNonceAt(t.Context(), sponsoredSender.Address())
 				require.NoError(t, err)
 				txData := &types.LegacyTx{
@@ -78,7 +78,7 @@ func TestGasSubsidies_InternalTransaction_HaveConsistentNonces(t *testing.T) {
 			},
 		},
 		"multiple sponsored transactions are executed within the same block": {
-			scenario: func(t *testing.T, net *tests.IntegrationTestNet) {
+			scenario: func(t *testing.T, net *testnet.IntegrationTestNet) {
 				// This scenario issues multiple sponsored transactions asynchronously
 				// to facilitate their inclusion in the same block.
 
@@ -113,7 +113,7 @@ func TestGasSubsidies_InternalTransaction_HaveConsistentNonces(t *testing.T) {
 			},
 		},
 		"an sponsored transaction right at epoch change": {
-			scenario: func(t *testing.T, net *tests.IntegrationTestNet) {
+			scenario: func(t *testing.T, net *testnet.IntegrationTestNet) {
 				// This test issues both a sponsored transaction and an epoch change transaction
 				// asynchronously and attempts to have them included in the same block.
 				//

--- a/tests/gas_subsidies/log_order_test.go
+++ b/tests/gas_subsidies/log_order_test.go
@@ -20,8 +20,8 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/indexed_logs"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -33,7 +33,7 @@ func TestGasSubsidies_ProperlyAssignTxIndexToLogsInThePresenceOfSponsoredTransac
 
 	upgrade := opera.GetBrioUpgrades()
 	upgrade.GasSubsidies = true
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrade,
 	})
 
@@ -41,11 +41,11 @@ func TestGasSubsidies_ProperlyAssignTxIndexToLogsInThePresenceOfSponsoredTransac
 	require.NoError(err)
 	defer client.Close()
 
-	sponsee := tests.NewAccount()
+	sponsee := testnet.NewAccount()
 	donation := big.NewInt(1e18)
 	Fund(t, net, sponsee.Address(), donation)
 
-	contract, receipt, err := tests.DeployContract(net, indexed_logs.DeployIndexedLogs)
+	contract, receipt, err := testnet.DeployContract(net, indexed_logs.DeployIndexedLogs)
 	require.NoError(err)
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 

--- a/tests/gas_subsidies/registry_update_test.go
+++ b/tests/gas_subsidies/registry_update_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/proxy"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/sponsor_everything"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
@@ -39,7 +39,7 @@ func TestRegistryUpdate_UpdateContract_SponsoredTransactionsCanBePerformed(t *te
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.GasSubsidies = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -48,7 +48,7 @@ func TestRegistryUpdate_UpdateContract_SponsoredTransactionsCanBePerformed(t *te
 	defer client.Close()
 
 	// Install the replacement contract for the default registry.
-	_, receipt, err := tests.DeployContract(net, sponsor_everything.DeploySponsorEverything)
+	_, receipt, err := testnet.DeployContract(net, sponsor_everything.DeploySponsorEverything)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
@@ -79,7 +79,7 @@ func TestRegistryUpdate_UpdateContract_SponsoredTransactionsCanBePerformed(t *te
 
 	// Run an example sponsored transaction to verify that the new registry
 	// works as expected.
-	sponsee := tests.NewAccount()
+	sponsee := testnet.NewAccount()
 	Fund(t, net, sponsee.Address(), big.NewInt(1e18))
 
 	tx := &types.LegacyTx{Gas: 21000, To: &common.Address{0x42}}
@@ -98,7 +98,7 @@ func TestRegistryUpdate_UpdatesAreEffectiveImmediately(t *testing.T) {
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.GasSubsidies = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
@@ -107,7 +107,7 @@ func TestRegistryUpdate_UpdatesAreEffectiveImmediately(t *testing.T) {
 	defer client.Close()
 
 	// Install the replacement contract for the default registry.
-	_, receipt, err := tests.DeployContract(net, sponsor_everything.DeploySponsorEverything)
+	_, receipt, err := testnet.DeployContract(net, sponsor_everything.DeploySponsorEverything)
 	require.NoError(err)
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 	replacementAddress := receipt.ContractAddress
@@ -121,7 +121,7 @@ func TestRegistryUpdate_UpdatesAreEffectiveImmediately(t *testing.T) {
 	// for this test, and not verified). The first is charged for according to
 	// the old rules, the last according to the new rules.
 
-	sponsee := tests.NewAccount()
+	sponsee := testnet.NewAccount()
 
 	// provide some funds to the sponsee for transaction 1 and 3
 	Fund(t, net, sponsee.Address(), big.NewInt(1e18))

--- a/tests/gas_subsidies/test_utils.go
+++ b/tests/gas_subsidies/test_utils.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
-	"github.com/0xsoniclabs/sonic/tests"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -36,7 +36,7 @@ import (
 // the registry instance for further queries.
 func Fund(
 	t *testing.T,
-	session tests.IntegrationTestNetSession,
+	session testnet.IntegrationTestNetSession,
 	sponsee common.Address,
 	donation *big.Int,
 ) *registry.Registry {
@@ -54,7 +54,7 @@ func Fund(
 	latestBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(t, err)
 
-	tests.WaitForProofOf(t, client, int(latestBlock.NumberU64()))
+	testnet.WaitForProofOf(t, client, int(latestBlock.NumberU64()))
 
 	sponsorshipBefore, err := registry.Sponsorships(nil, fundId)
 	require.NoError(t, err)
@@ -68,7 +68,7 @@ func Fund(
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 
-	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
+	testnet.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	// check that the sponsorshipAfter funds got deposited
 	sponsorshipAfter, err := registry.Sponsorships(nil, fundId)
@@ -83,7 +83,7 @@ func Fund(
 // successful internal transaction that pays for its gas fees.
 func validateSponsoredTxInBlock(
 	t *testing.T,
-	session tests.IntegrationTestNetSession,
+	session testnet.IntegrationTestNetSession,
 	txHash common.Hash) {
 	t.Helper()
 
@@ -137,7 +137,7 @@ func validateSponsoredTxInBlock(
 // makeSponsoredTransactionWithNonce creates a sponsored transaction (with
 // gas price zero) from the given sender to the given receiver with the given
 // nonce.
-func makeSponsorRequestTransaction(t *testing.T, tx types.TxData, chainId *big.Int, sender *tests.Account) *types.Transaction {
+func makeSponsorRequestTransaction(t *testing.T, tx types.TxData, chainId *big.Int, sender *testnet.Account) *types.Transaction {
 	t.Helper()
 	signer := types.LatestSignerForChainID(chainId)
 	switch tx := tx.(type) {
@@ -176,7 +176,7 @@ func makeSponsorRequestTransaction(t *testing.T, tx types.TxData, chainId *big.I
 // receipt in its block, along with the block itself.
 func getTransactionIndexInBlock(
 	t *testing.T,
-	client *tests.PooledEhtClient,
+	client *testnet.PooledEhtClient,
 	receipt *types.Receipt,
 ) (int, *types.Block) {
 	t.Helper()

--- a/tests/gas_subsidies/test_utils_test.go
+++ b/tests/gas_subsidies/test_utils_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -35,12 +35,12 @@ func TestGasSubsidies_HelperFunctions(t *testing.T) {
 
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.GasSubsidies = true
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
-	sponsee := tests.NewAccount()
-	receiver := tests.NewAccount()
+	sponsee := testnet.NewAccount()
+	receiver := testnet.NewAccount()
 	receiverAddress := receiver.Address()
 
 	donation := big.NewInt(1e18)
@@ -73,7 +73,7 @@ func TestGasSubsidies_HelperFunctions(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok, "registry should have a fund ID")
 
-	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
+	testnet.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
 	sponsorship, err := registry.Sponsorships(nil, fundId)
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestMakeSponsorRequestTransaction_CanHandleAllTransactionTypes(t *testing.T
 
 	for _, tx := range txs {
 		t.Run(fmt.Sprintf("%T", tx), func(t *testing.T) {
-			sponsoredTx := makeSponsorRequestTransaction(t, tx, big.NewInt(1), tests.NewAccount())
+			sponsoredTx := makeSponsorRequestTransaction(t, tx, big.NewInt(1), testnet.NewAccount())
 			require.Equal(t, sponsoredTx.GasPrice(), big.NewInt(0))
 			require.Equal(t, sponsoredTx.GasTipCap(), big.NewInt(0))
 			require.True(t, subsidies.IsSponsorshipRequest(sponsoredTx))

--- a/tests/generate_test_data_test.go
+++ b/tests/generate_test_data_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +37,7 @@ func TestCartesianProduct_CountInstantiations(t *testing.T) {
 	countInstances := func(pieces [][]int, modifier func(int, []int) int) int {
 		var count int
 		makeZero := func() int { return 0 }
-		for range GenerateTestDataBasedOnModificationCombinations(makeZero, pieces, modifier) {
+		for range testnet.GenerateTestDataBasedOnModificationCombinations(makeZero, pieces, modifier) {
 			count++
 		}
 		return count
@@ -53,7 +54,7 @@ func TestCartesianProduct_CountInstantiations(t *testing.T) {
 
 func TestCartesianProduct_noPiecesReturnOriginalObject(t *testing.T) {
 	makeOriginal := func() int { return 36 }
-	it := GenerateTestDataBasedOnModificationCombinations(
+	it := testnet.GenerateTestDataBasedOnModificationCombinations(
 		makeOriginal,
 		nil,
 		func(v int, pieces []int) int {
@@ -91,7 +92,7 @@ func TestCartesianProduct_AcceptsFunctionsAsPieces(t *testing.T) {
 	}
 
 	instances := make([]TestType, 0)
-	for v := range GenerateTestDataBasedOnModificationCombinations(
+	for v := range testnet.GenerateTestDataBasedOnModificationCombinations(
 		func() TestType { return TestType{} },
 		[][]modFunc{
 			{setA(1), setA(2)},

--- a/tests/genesis_import_test.go
+++ b/tests/genesis_import_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +29,7 @@ func TestGenesis_NetworkCanCreateNewBlocksAfterExportImport(t *testing.T) {
 	const numBlocks = 3
 	require := require.New(t)
 
-	net := StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 
 	// Produce a few blocks on the network.
 	for range numBlocks {

--- a/tests/get_account_test.go
+++ b/tests/get_account_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/ethereum/go-ethereum/common"
@@ -29,11 +30,11 @@ import (
 )
 
 func TestGetAccount(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the transient storage contract
-	_, deployReceipt, err := DeployContract(session, counter.DeployCounter)
+	_, deployReceipt, err := testnet.DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err, "failed to deploy contract")
 
 	addr := deployReceipt.ContractAddress

--- a/tests/indexed_logs_test.go
+++ b/tests/indexed_logs_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/tests/contracts/indexed_logs"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -26,24 +27,24 @@ import (
 )
 
 func TestClient_IndexedLogsAreInOrder(t *testing.T) {
-	net := StartIntegrationTestNetWithFakeGenesis(t)
+	net := testnet.StartIntegrationTestNetWithFakeGenesis(t)
 
-	contract, receipt, err := DeployContract(net, indexed_logs.DeployIndexedLogs)
+	contract, receipt, err := testnet.DeployContract(net, indexed_logs.DeployIndexedLogs)
 	require.NoError(t, err)
 	contractAddress := receipt.ContractAddress
 
 	// Create logs
-	txReceiptBlock1, err := net.net.Apply(contract.EmitEvents)
+	txReceiptBlock1, err := net.Apply(contract.EmitEvents)
 	require.NoError(t, err)
 	logs := txReceiptBlock1.Logs
 
 	// Create logs in another block
-	txReceiptBlock2, err := net.net.Apply(contract.EmitEvents)
+	txReceiptBlock2, err := net.Apply(contract.EmitEvents)
 	require.NoError(t, err)
 
 	require.NotEqual(t, txReceiptBlock1.BlockNumber, txReceiptBlock2.BlockNumber, "Logs should be in different blocks")
 
-	client, err := net.net.GetClient()
+	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/tests/initcode_test.go
+++ b/tests/initcode_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/contractcreator"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -36,10 +37,10 @@ const sufficientGas = uint64(150_000)
 func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	requireBase := require.New(t)
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
-	contract, receipt, err := DeployContract(session, contractcreator.DeployContractcreator)
+	contract, receipt, err := testnet.DeployContract(session, contractcreator.DeployContractcreator)
 	requireBase.NoError(err)
 	requireBase.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed to deploy contract")
 
@@ -73,7 +74,7 @@ func TestInitCodeSizeLimitAndMetered(t *testing.T) {
 	})
 }
 
-func testForVariant(t *testing.T, session IntegrationTestNetSession,
+func testForVariant(t *testing.T, session testnet.IntegrationTestNetSession,
 	contract *contractcreator.Contractcreator, variant variant,
 	gasForContract, wordCost uint64) {
 
@@ -136,7 +137,7 @@ func testForVariant(t *testing.T, session IntegrationTestNetSession,
 	})
 }
 
-func testForTransaction(t *testing.T, session IntegrationTestNetSession) {
+func testForTransaction(t *testing.T, session testnet.IntegrationTestNetSession) {
 	t.Run("charges depending on the init code size", func(t *testing.T) {
 		require := require.New(t)
 		session := session.SpawnSession(t)
@@ -177,7 +178,7 @@ func testForTransaction(t *testing.T, session IntegrationTestNetSession) {
 	})
 }
 
-func createContractSuccessfully(t *testing.T, session IntegrationTestNetSession,
+func createContractSuccessfully(t *testing.T, session testnet.IntegrationTestNetSession,
 	variant variant, codeLen, gasLimit uint64) *types.Receipt {
 
 	receipt, err := createContractWithCodeLenAndGas(session, variant, codeLen, gasLimit)
@@ -187,7 +188,7 @@ func createContractSuccessfully(t *testing.T, session IntegrationTestNetSession,
 	return receipt
 }
 
-func createContractWithCodeLenAndGas(session IntegrationTestNetSession,
+func createContractWithCodeLenAndGas(session testnet.IntegrationTestNetSession,
 	variant variant, codeLen, gasLimit uint64) (*types.Receipt, error) {
 	return session.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
 		opts.GasLimit = gasLimit
@@ -199,7 +200,7 @@ type variant func(opts *bind.TransactOpts, codeSize *big.Int) (*types.Transactio
 
 func runTransactionWithCodeSizeAndGas(
 	t *testing.T,
-	session IntegrationTestNetSession,
+	session testnet.IntegrationTestNetSession,
 	codeSize, gas uint64,
 ) (*types.Receipt, error) {
 	require := require.New(t)

--- a/tests/invalid_start_test.go
+++ b/tests/invalid_start_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/tests/contracts/invalidstart"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -30,10 +31,10 @@ func TestInvalidStart_IdentifiesInvalidStartContract(t *testing.T) {
 	invalidCode := []byte{0x60, 0xef, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
 	validCode := []byte{0x60, 0xfe, 0x60, 0x00, 0x53, 0x60, 0x01, 0x60, 0x00, 0xf3}
 
-	net := StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 
 	// Deploy the invalid start contract.
-	contract, _, err := DeployContract(net, invalidstart.DeployInvalidstart)
+	contract, _, err := testnet.DeployContract(net, invalidstart.DeployInvalidstart)
 	require.NoError(err)
 
 	// -- invalid codes
@@ -75,7 +76,7 @@ func TestInvalidStart_IdentifiesInvalidStartContract(t *testing.T) {
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status, "failed on transfer to empty receiver with valid code")
 }
 
-func getTransactionWithCodeAndNoReceiver(t testing.TB, code []byte, net *IntegrationTestNet) (*types.Transaction, error) {
+func getTransactionWithCodeAndNoReceiver(t testing.TB, code []byte, net *testnet.IntegrationTestNet) (*types.Transaction, error) {
 	// these values are needed for the transaction but are irrelevant for the test
 	t.Helper()
 	require := require.New(t)

--- a/tests/large_transactions/large_transactions_test.go
+++ b/tests/large_transactions/large_transactions_test.go
@@ -22,8 +22,8 @@ import (
 	"slices"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -32,11 +32,11 @@ import (
 
 func TestLargeTransactions_CanHandleLargeTransactions(t *testing.T) {
 	require := require.New(t)
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: tests.AsPointer(opera.GetBrioUpgrades()),
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
+		Upgrades: testnet.AsPointer(opera.GetBrioUpgrades()),
 	})
 
-	account := tests.NewAccount()
+	account := testnet.NewAccount()
 	_, err := net.EndowAccount(account.Address(), big.NewInt(1e18))
 	require.NoError(err)
 
@@ -98,7 +98,7 @@ func TestLargeTransactions_CanHandleLargeTransactions(t *testing.T) {
 
 func TestLargeTransactions_LargeTransactionLoadTest(t *testing.T) {
 
-	if tests.IsDataRaceDetectionEnabled() {
+	if testnet.IsDataRaceDetectionEnabled() {
 		t.Skip(`Due to the concurrency requirements of this test, 
 		it becomes unstable when running with enabled data race detection.`)
 	}
@@ -140,14 +140,14 @@ func testLargeTransactionLoadTest(
 		numRounds   = 10
 	)
 	require := require.New(t)
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: upgrades,
 		NumNodes: 3,
 	})
 
 	// Increase the gas limit to allow for larger transactions in blocks. These
 	// limits are beyond safe limits acceptable for production.
-	current := tests.GetNetworkRules(t, net)
+	current := testnet.GetNetworkRules(t, net)
 
 	modified := current.Copy()
 	modified.Economy.Gas.MaxEventGas = 1_000_000_000
@@ -155,18 +155,18 @@ func testLargeTransactionLoadTest(
 	modified.Economy.ShortGasPower.MaxAllocPeriod = 50_000_000_000
 	modified.Economy.LongGasPower = modified.Economy.ShortGasPower
 	modified.Emitter.Interval = 200_000_000 // low a bit down to provoke larger events
-	tests.UpdateNetworkRules(t, net, modified)
+	testnet.UpdateNetworkRules(t, net, modified)
 	net.AdvanceEpoch(t, 1)
 
 	// Check that the modification was applied.
-	current = tests.GetNetworkRules(t, net)
+	current = testnet.GetNetworkRules(t, net)
 	require.Equal(modified, current)
 
 	// Create accounts and provide them with funds to run the load test.
-	accounts := make([]*tests.Account, numAccounts)
+	accounts := make([]*testnet.Account, numAccounts)
 	addresses := make([]common.Address, len(accounts))
 	for i := range accounts {
-		accounts[i] = tests.NewAccount()
+		accounts[i] = testnet.NewAccount()
 		addresses[i] = accounts[i].Address()
 	}
 	endowment := new(big.Int).Mul(big.NewInt(100), big.NewInt(1e18))

--- a/tests/log_subscription_test.go
+++ b/tests/log_subscription_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter_event_emitter"
 	"github.com/ethereum/go-ethereum"
@@ -34,9 +35,9 @@ func TestLogSubscription_CanGetCallBacksForLogEvents(t *testing.T) {
 
 	const NumEvents = 10
 	require := require.New(t)
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	contract, _, err := DeployContract(session, counter_event_emitter.DeployCounterEventEmitter)
+	contract, _, err := testnet.DeployContract(session, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(err)
 
 	client, err := session.GetWebSocketClient()
@@ -77,9 +78,9 @@ func TestLogBloom_query(t *testing.T) {
 	// This test can reuse an existing blockchain history, but should not
 	// run concurrently to other tests. It requires logs to exist in at least one
 	// transaction per block while testFunction is running.
-	net := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	net := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 
-	contract, _, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
+	contract, _, err := testnet.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(err)
 
 	stopTest := make(chan struct{})

--- a/tests/max_block_size/max_block_size_test.go
+++ b/tests/max_block_size/max_block_size_test.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -53,9 +53,9 @@ func TestMaxBlockSizeIsEnforced(t *testing.T) {
 	transactionsPerAccount := 10
 	numAccounts := 10
 	genesisAccounts := make([]makefakegenesis.Account, 0, numAccounts)
-	accounts := make([]*tests.Account, 0, numAccounts)
+	accounts := make([]*testnet.Account, 0, numAccounts)
 	for range numAccounts {
-		account := tests.NewAccount()
+		account := testnet.NewAccount()
 		accounts = append(accounts, account)
 
 		genesisAccount := makefakegenesis.Account{
@@ -71,7 +71,7 @@ func TestMaxBlockSizeIsEnforced(t *testing.T) {
 			t.Run(fmt.Sprintf("%s_%s", modeName, upgradeName), func(t *testing.T) {
 
 				upgrade.SingleProposerBlockFormation = singleProposer
-				net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+				net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 					Upgrades: &upgrade,
 					Accounts: genesisAccounts,
 					NumNodes: 3,
@@ -94,7 +94,7 @@ func TestMaxBlockSizeIsEnforced(t *testing.T) {
 							Value: big.NewInt(0),
 							Data:  input,
 						}
-						signedTx := tests.CreateTransaction(t, net, txsPayload, account)
+						signedTx := testnet.CreateTransaction(t, net, txsPayload, account)
 						transactions[i*numAccounts+accountIdx] = signedTx // save txs with the same nonce next to each other
 					}
 				}
@@ -129,10 +129,10 @@ func TestMaxBlockSizeIsEnforced(t *testing.T) {
 	}
 }
 
-func increaseLimits(t *testing.T, net *tests.IntegrationTestNet) {
+func increaseLimits(t *testing.T, net *testnet.IntegrationTestNet) {
 	// Increase the gas limit to allow for larger transactions in blocks. These
 	// limits are beyond safe limits acceptable for production.
-	current := tests.GetNetworkRules(t, net)
+	current := testnet.GetNetworkRules(t, net)
 
 	modified := current.Copy()
 
@@ -142,10 +142,10 @@ func increaseLimits(t *testing.T, net *tests.IntegrationTestNet) {
 	modified.Economy.ShortGasPower.MaxAllocPeriod = 50_000_000_000
 	modified.Economy.LongGasPower = modified.Economy.ShortGasPower
 	modified.Emitter.Interval = inter.Timestamp(1 * time.Second)
-	tests.UpdateNetworkRules(t, net, modified)
+	testnet.UpdateNetworkRules(t, net, modified)
 	net.AdvanceEpoch(t, 1)
 
 	// Check that the modification was applied.
-	current = tests.GetNetworkRules(t, net)
+	current = testnet.GetNetworkRules(t, net)
 	require.Equal(t, modified, current)
 }

--- a/tests/modexp_brio_test.go
+++ b/tests/modexp_brio_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -67,7 +68,7 @@ func TestModExp_BrioFlagEnforcesFusakaUpperBounds(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			session := getIntegrationTestNetSession(t, test.upgrades)
+			session := testnet.GetIntegrationTestNetSession(t, test.upgrades)
 			chainId := session.GetChainId()
 			sender := session.GetSessionSponsor()
 
@@ -90,7 +91,7 @@ func TestModExp_BrioFlagEnforcesFusakaUpperBounds(t *testing.T) {
 				Data:       input,
 				AccessList: types.AccessList{},
 			}
-			signedTx := CreateTransaction(t, session, txsPayload, sender)
+			signedTx := testnet.CreateTransaction(t, session, txsPayload, sender)
 			receipt, err := session.Run(signedTx)
 			require.NoError(t, err)
 
@@ -128,7 +129,7 @@ func TestModExp_MinimumGasPriceIsUpdatedInBrio(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			session := getIntegrationTestNetSession(t, test.upgrades)
+			session := testnet.GetIntegrationTestNetSession(t, test.upgrades)
 			chainId := session.GetChainId()
 			sender := session.GetSessionSponsor()
 
@@ -152,7 +153,7 @@ func TestModExp_MinimumGasPriceIsUpdatedInBrio(t *testing.T) {
 					{Address: common.HexToAddress("0x42")}, // Add random address to access list to increase gas cost
 				},
 			}
-			signedTx := CreateTransaction(t, session, txsPayload, sender)
+			signedTx := testnet.CreateTransaction(t, session, txsPayload, sender)
 			receipt, err := session.Run(signedTx)
 			require.NoError(t, err)
 
@@ -191,7 +192,7 @@ func TestModExp_GasPriceIsUpdatedInBrio(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			session := getIntegrationTestNetSession(t, test.upgrades)
+			session := testnet.GetIntegrationTestNetSession(t, test.upgrades)
 			chainId := session.GetChainId()
 			sender := session.GetSessionSponsor()
 
@@ -217,7 +218,7 @@ func TestModExp_GasPriceIsUpdatedInBrio(t *testing.T) {
 					{Address: common.HexToAddress("0x42")}, // Add random address to access list to increase gas cost
 				},
 			}
-			signedTx := CreateTransaction(t, session, txsPayload, sender)
+			signedTx := testnet.CreateTransaction(t, session, txsPayload, sender)
 			receipt, err := session.Run(signedTx)
 			require.NoError(t, err)
 

--- a/tests/node_restart_test.go
+++ b/tests/node_restart_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,7 @@ func TestNodeRestart_CanRestartAndRestoreItsState(t *testing.T) {
 	const numRestarts = 2
 	require := require.New(t)
 
-	net := StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 
 	// All transaction hashes indexed by their blocks.
 	receipts := map[int]types.Receipts{}

--- a/tests/pacing_of_empty_blocks/pacing_of_empty_blocks_test.go
+++ b/tests/pacing_of_empty_blocks/pacing_of_empty_blocks_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,17 +56,17 @@ func testPacingOfEmptyBlocks(
 	upgrades opera.Upgrades,
 ) {
 	require := require.New(t)
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
 
 	maxEmptyInterval := 4 * time.Second
 
-	rules := tests.GetNetworkRules(t, net)
+	rules := testnet.GetNetworkRules(t, net)
 	rules.Blocks.MaxEmptyBlockSkipPeriod = inter.Timestamp(maxEmptyInterval)
-	tests.UpdateNetworkRules(t, net, rules)
+	testnet.UpdateNetworkRules(t, net, rules)
 
-	rules = tests.GetNetworkRules(t, net)
+	rules = testnet.GetNetworkRules(t, net)
 	require.Equal(inter.Timestamp(maxEmptyInterval), rules.Blocks.MaxEmptyBlockSkipPeriod)
 
 	client, err := net.GetClient()

--- a/tests/pending_transactions_subscription_test.go
+++ b/tests/pending_transactions_subscription_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -29,14 +30,14 @@ import (
 
 func TestPendingTransactionSubscription_ReturnsFullTransaction(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	// This test cannot be parallel because it expects only the specific transaction it sends
 
 	client, err := session.GetWebSocketClient()
 	require.NoError(t, err, "failed to get client ", err)
 	defer client.Close()
 
-	tx := CreateTransaction(t, session,
+	tx := testnet.CreateTransaction(t, session,
 		&types.LegacyTx{
 			To:    &common.Address{0x42},
 			Value: big.NewInt(2),
@@ -63,14 +64,14 @@ func TestPendingTransactionSubscription_ReturnsFullTransaction(t *testing.T) {
 }
 
 func TestPendingTransactionSubscription_ReturnsHashes(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	// This test cannot be parallel because it expects only the specific transaction it sends
 
 	client, err := session.GetWebSocketClient()
 	require.NoError(t, err, "failed to get client ", err)
 	defer client.Close()
 
-	tx := CreateTransaction(t, session, &types.LegacyTx{To: &common.Address{0x42}, Value: big.NewInt(2)}, session.GetSessionSponsor())
+	tx := testnet.CreateTransaction(t, session, &types.LegacyTx{To: &common.Address{0x42}, Value: big.NewInt(2)}, session.GetSessionSponsor())
 
 	pendingTxs := make(chan common.Hash)
 	defer close(pendingTxs)

--- a/tests/prevrandao_test.go
+++ b/tests/prevrandao_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/prevrandao"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -27,11 +28,11 @@ import (
 )
 
 func TestPrevRandao(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the contract.
-	contract, _, err := DeployContract(session, prevrandao.DeployPrevrandao)
+	contract, _, err := testnet.DeployContract(session, prevrandao.DeployPrevrandao)
 	require.NoError(t, err)
 	// Collect the current PrevRandao fee from the head state.
 	receipt, err := session.Apply(contract.LogCurrentPrevRandao)

--- a/tests/randao_test.go
+++ b/tests/randao_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -44,8 +45,8 @@ func TestRandao_randaoIntegrationTest(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			net := StartIntegrationTestNet(t,
-				IntegrationTestNetOptions{
+			net := testnet.StartIntegrationTestNet(t,
+				testnet.IntegrationTestNetOptions{
 					NumNodes: NumNodes,
 					Upgrades: &test,
 				},

--- a/tests/rejected_tx_test.go
+++ b/tests/rejected_tx_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,7 +33,7 @@ import (
 func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 
 	// start network
-	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 	t.Parallel()
 
 	// create a client
@@ -43,27 +44,27 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err, "failed to get chain ID::")
 
-	testTransactions := map[string]func(testing.TB, *Account) types.TxData{
-		"legacy tx": func(testing.TB, *Account) types.TxData {
+	testTransactions := map[string]func(testing.TB, *testnet.Account) types.TxData{
+		"legacy tx": func(testing.TB, *testnet.Account) types.TxData {
 			return &types.LegacyTx{}
 		},
-		"access list no entries ": func(testing.TB, *Account) types.TxData {
+		"access list no entries ": func(testing.TB, *testnet.Account) types.TxData {
 			return &types.AccessListTx{}
 		},
-		"access list tx with one entry": func(testing.TB, *Account) types.TxData {
+		"access list tx with one entry": func(testing.TB, *testnet.Account) types.TxData {
 			return &types.AccessListTx{
 				AccessList: []types.AccessTuple{
 					{Address: common.Address{0x42}, StorageKeys: []common.Hash{{0x42}}},
 				},
 			}
 		},
-		"dynamic fee tx": func(testing.TB, *Account) types.TxData {
+		"dynamic fee tx": func(testing.TB, *testnet.Account) types.TxData {
 			return &types.DynamicFeeTx{}
 		},
-		"blob tx": func(testing.TB, *Account) types.TxData {
+		"blob tx": func(testing.TB, *testnet.Account) types.TxData {
 			return &types.BlobTx{}
 		},
-		"set code tx": func(t testing.TB, account *Account) types.TxData {
+		"set code tx": func(t testing.TB, account *testnet.Account) types.TxData {
 
 			// One authorization is required for SetCodeTx
 			auth, err := types.SignSetCode(account.PrivateKey,
@@ -84,10 +85,10 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			t.Run("is rejected with insufficient balance", func(t *testing.T) {
-				account := NewAccount()
+				account := testnet.NewAccount()
 
 				txData := txFactory(t, account)
-				tx := CreateTransaction(t, session, txData, account)
+				tx := testnet.CreateTransaction(t, session, txData, account)
 				cost := tx.Cost()
 
 				//  endow account with less than the cost of the transaction
@@ -100,10 +101,10 @@ func TestRejectedTx_TransactionsAreRejectedBecauseOfAccountState(t *testing.T) {
 			})
 
 			t.Run("is rejected with nonce too low", func(t *testing.T) {
-				account := NewAccount()
+				account := testnet.NewAccount()
 
 				txData := txFactory(t, account)
-				tx := CreateTransaction(t, session, txData, account)
+				tx := testnet.CreateTransaction(t, session, txData, account)
 
 				// provide enough funds for successful execution
 				receipt, err := session.EndowAccount(account.Address(), big.NewInt(1e18))

--- a/tests/rpc_get_logs_test.go
+++ b/tests/rpc_get_logs_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/indexed_logs"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,10 +31,10 @@ import (
 
 func TestRpc_GetLogs_BlockTimeStampHexEncoded(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	// deploy a contract
-	contract, receipt, err := DeployContract(session, indexed_logs.DeployIndexedLogs)
+	contract, receipt, err := testnet.DeployContract(session, indexed_logs.DeployIndexedLogs)
 	require.NoError(t, err)
 	require.Equal(t, receipt.Status, types.ReceiptStatusSuccessful)
 	contractAddress := receipt.ContractAddress

--- a/tests/rpc_replay_test.go
+++ b/tests/rpc_replay_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -39,16 +40,16 @@ func TestRpcReplay_IsConsistentWithUpgradesAtBlockHeight(t *testing.T) {
 	// floor data cost (EIP-7623) increases the minimum gas cost of a transaction
 	// with large input buffers.
 
-	net := StartIntegrationTestNetWithJsonGenesis(t)
+	net := testnet.StartIntegrationTestNetWithJsonGenesis(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	sender := MakeAccountWithBalance(t, net, big.NewInt(1e18))
+	sender := testnet.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 
-	tx := SignTransaction(t, net.GetChainId(),
-		SetTransactionDefaults(
+	tx := testnet.SignTransaction(t, net.GetChainId(),
+		testnet.SetTransactionDefaults(
 			t, net,
 			&types.LegacyTx{
 				To:    &common.Address{0x42},
@@ -71,11 +72,11 @@ func TestRpcReplay_IsConsistentWithUpgradesAtBlockHeight(t *testing.T) {
 	rulesDiff := rulesType{
 		Upgrades: struct{ Allegro bool }{Allegro: true},
 	}
-	UpdateNetworkRules(t, net, rulesDiff)
-	AdvanceEpochAndWaitForBlocks(t, net)
+	testnet.UpdateNetworkRules(t, net, rulesDiff)
+	testnet.AdvanceEpochAndWaitForBlocks(t, net)
 
-	tx2 := SignTransaction(t, net.GetChainId(),
-		SetTransactionDefaults(
+	tx2 := testnet.SignTransaction(t, net.GetChainId(),
+		testnet.SetTransactionDefaults(
 			t, net,
 			&types.LegacyTx{
 				To:    &common.Address{0x42},
@@ -94,22 +95,22 @@ func TestRpcReplay_IsConsistentWithUpgradesAtBlockHeight(t *testing.T) {
 	lastBlockNumber := receiptAfterUpgrade.BlockNumber
 
 	rpcTx := ethapi.TransactionArgs{
-		From:     (*common.Address)(AsPointer(sender.Address())),
+		From:     (*common.Address)(testnet.AsPointer(sender.Address())),
 		To:       (*common.Address)(tx.To()),
-		Gas:      AsPointer(hexutil.Uint64(tx2.Gas())),
+		Gas:      testnet.AsPointer(hexutil.Uint64(tx2.Gas())),
 		GasPrice: (*hexutil.Big)(tx.GasPrice()),
 		Value:    (*hexutil.Big)(tx.Value()),
-		Data:     AsPointer(hexutil.Bytes(tx2.Data())),
+		Data:     testnet.AsPointer(hexutil.Bytes(tx2.Data())),
 	}
 	t.Run("eth_createAccessList", func(t *testing.T) {
 
 		rpcTx := ethapi.TransactionArgs{
-			From:     (*common.Address)(AsPointer(sender.Address())),
+			From:     (*common.Address)(testnet.AsPointer(sender.Address())),
 			To:       (*common.Address)(tx.To()),
-			Gas:      AsPointer(hexutil.Uint64(tx2.Gas())),
+			Gas:      testnet.AsPointer(hexutil.Uint64(tx2.Gas())),
 			GasPrice: (*hexutil.Big)(tx.GasPrice()),
 			Value:    (*hexutil.Big)(tx.Value()),
-			Data:     AsPointer(hexutil.Bytes(tx2.Data())),
+			Data:     testnet.AsPointer(hexutil.Bytes(tx2.Data())),
 		}
 
 		type accessListResult struct {

--- a/tests/secp256r1_precompile_test.go
+++ b/tests/secp256r1_precompile_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/tosca/go/tosca/vm"
 	"github.com/ethereum/go-ethereum/common"
@@ -52,7 +53,7 @@ func TestSECP256r1_NewPrecompileHasCorrectGasCost(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			session := getIntegrationTestNetSession(t, test.upgrades)
+			session := testnet.GetIntegrationTestNetSession(t, test.upgrades)
 			chainId := session.GetChainId()
 			sender := session.GetSessionSponsor()
 
@@ -72,7 +73,7 @@ func TestSECP256r1_NewPrecompileHasCorrectGasCost(t *testing.T) {
 				},
 			}
 
-			signedTx := CreateTransaction(t, session, txsPayload, sender)
+			signedTx := testnet.CreateTransaction(t, session, txsPayload, sender)
 			receipt, err := session.Run(signedTx)
 			require.NoError(t, err)
 
@@ -133,7 +134,7 @@ func TestSECP256r1_VerifySignatureInBrio(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			recipient := common.BytesToAddress([]byte{0x42})
-			net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
+			net := testnet.StartIntegrationTestNetWithJsonGenesis(t, testnet.IntegrationTestNetOptions{
 				Upgrades: &test.upgrades,
 				Accounts: []makefakegenesis.Account{
 					{
@@ -147,7 +148,7 @@ func TestSECP256r1_VerifySignatureInBrio(t *testing.T) {
 			require.NoError(t, err)
 			defer client.Close()
 
-			sender := MakeAccountWithBalance(t, net, big.NewInt(1e18))
+			sender := testnet.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 			gasPrice, err := client.SuggestGasPrice(t.Context())
 			require.NoError(t, err)
 
@@ -162,7 +163,7 @@ func TestSECP256r1_VerifySignatureInBrio(t *testing.T) {
 				To:       &recipient,
 				Data:     test.input,
 			}
-			tx := SignTransaction(t, chainId, txData, sender)
+			tx := testnet.SignTransaction(t, chainId, txData, sender)
 
 			receipt, err := net.Run(tx)
 			require.NoError(t, err)

--- a/tests/selfdestruct_test.go
+++ b/tests/selfdestruct_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/tests/contracts/selfdestruct"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,7 +31,7 @@ import (
 
 func TestSelfDestruct(t *testing.T) {
 
-	net := StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 
 	t.Run("constructor", func(t *testing.T) {
 		t.Parallel()
@@ -43,7 +44,7 @@ func TestSelfDestruct(t *testing.T) {
 	})
 }
 
-func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
+func testSelfDestruct_Constructor(t *testing.T, net *testnet.IntegrationTestNet) {
 	contractInitialBalance := int64(1234)
 
 	tests := map[string]struct {
@@ -150,7 +151,7 @@ func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
 			require.NoError(err)
 
 			// First transaction deploys contract
-			contract, deployReceipt, err := DeployContract(session,
+			contract, deployReceipt, err := testnet.DeployContract(session,
 				func(to *bind.TransactOpts, cb bind.ContractBackend) (common.Address, *types.Transaction, *selfdestruct.SelfDestruct, error) {
 					return test.deployTx(to, cb, beneficiaryAddress)
 				})
@@ -201,7 +202,7 @@ func testSelfDestruct_Constructor(t *testing.T, net *IntegrationTestNet) {
 	}
 }
 
-func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
+func testSelfDestruct_NestedCall(t *testing.T, net *testnet.IntegrationTestNet) {
 	contractInitialBalance := int64(1234)
 
 	tests := map[string]struct {
@@ -303,7 +304,7 @@ func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
 			require.NoError(err)
 
 			// deploy factory contract
-			factory, receipt, err := DeployContract(session, selfdestruct.DeploySelfDestructFactory)
+			factory, receipt, err := testnet.DeployContract(session, selfdestruct.DeploySelfDestructFactory)
 			require.NoError(err)
 			require.Equal(
 				types.ReceiptStatusSuccessful,
@@ -366,7 +367,7 @@ func testSelfDestruct_NestedCall(t *testing.T, net *IntegrationTestNet) {
 // avoid clashes between tests. This struct will be filled with the results of
 // the each test setup.
 type effectContext struct {
-	client             *PooledEhtClient                  //< client to interact with the network
+	client             *testnet.PooledEhtClient          //< client to interact with the network
 	contract           *selfdestruct.SelfDestruct        //< contract to test (may have selfdestructed)
 	factory            *selfdestruct.SelfDestructFactory //< factory contract to deploy new contracts
 	executionReceipt   *types.Receipt                    //< receipt of the execution transaction for constructor tests

--- a/tests/set_code_trace_test.go
+++ b/tests/set_code_trace_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
 	"github.com/0xsoniclabs/sonic/tests/contracts/sponsoring"
@@ -38,20 +39,20 @@ import (
 // assign fees for a dApp also in this delegate scenario and dApp
 // address will be visible in the trace
 func TestTrace7702Transaction(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetAllegroUpgrades())
 	t.Parallel()
 
-	sponsor := MakeAccountWithBalance(t, session, big.NewInt(1e18))
-	sponsored := MakeAccountWithBalance(t, session, big.NewInt(10))
+	sponsor := testnet.MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	sponsored := testnet.MakeAccountWithBalance(t, session, big.NewInt(10))
 
 	// Deploy the contract to forward the call
-	sponsoringDelegate, receipt, err := DeployContract(session, sponsoring.DeploySponsoring)
+	sponsoringDelegate, receipt, err := testnet.DeployContract(session, sponsoring.DeploySponsoring)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 	delegateAddress := receipt.ContractAddress
 
 	// Deploy simple contract to increment the counter
-	counterContract, receipt, err := DeployContract(session, counter.DeployCounter)
+	counterContract, receipt, err := testnet.DeployContract(session, counter.DeployCounter)
 	require.NoError(t, err)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 	counterAddress := receipt.ContractAddress

--- a/tests/single_proposer/single_proposer_protocol_test.go
+++ b/tests/single_proposer/single_proposer_protocol_test.go
@@ -21,8 +21,8 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/block_header"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -65,7 +65,7 @@ func testSingleProposerProtocol_CanProcessTransactions(
 	upgrades.SingleProposerBlockFormation = true
 
 	require := require.New(t)
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 		NumNodes: numNodes,
 	})
@@ -78,10 +78,10 @@ func testSingleProposerProtocol_CanProcessTransactions(
 
 	// Create NumTxsPerRound accounts and send them each 1e18 wei to allow each
 	// of them to send independent transactions in each round.
-	accounts := make([]*tests.Account, NumTxsPerRound)
+	accounts := make([]*testnet.Account, NumTxsPerRound)
 	addresses := make([]common.Address, NumTxsPerRound)
 	for i := range accounts {
-		accounts[i] = tests.NewAccount()
+		accounts[i] = testnet.NewAccount()
 		addresses[i] = accounts[i].Address()
 	}
 	_, err = net.EndowAccounts(addresses, big.NewInt(1e18))
@@ -174,7 +174,7 @@ func testSingleProposerProtocol_CanBeEnabledAndDisabled(
 
 	// The network is initially started using the distributed protocol.
 	mode.SingleProposerBlockFormation = false
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNet(t, testnet.IntegrationTestNetOptions{
 		NumNodes: numNodes,
 		Upgrades: &mode,
 	})
@@ -212,7 +212,7 @@ func testSingleProposerProtocol_CanBeEnabledAndDisabled(
 			rulesDiff := rulesType{
 				Upgrades: upgrades{SingleProposerBlockFormation: step.flagValue},
 			}
-			tests.UpdateNetworkRules(t, net, rulesDiff)
+			testnet.UpdateNetworkRules(t, net, rulesDiff)
 
 			// The rules only take effect after the epoch change. Make sure that
 			// until then, transactions can be processed.
@@ -247,7 +247,7 @@ func testSingleProposerProtocol_CanBeEnabledAndDisabled(
 // getUsedEventVersion retrieves the current event version used by the network.
 func getUsedEventVersion(
 	t *testing.T,
-	client *tests.PooledEhtClient,
+	client *testnet.PooledEhtClient,
 ) int {
 	t.Helper()
 	require := require.New(t)

--- a/tests/storage_override_test.go
+++ b/tests/storage_override_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/storage"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -31,11 +32,11 @@ import (
 )
 
 func TestSetStorage_PreExisting_Contract_Storage_Temporarily_Overridden(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 	t.Parallel()
 
 	// Deploy the contract.
-	contract, receipt, err := DeployContract(session, storage.DeployStorage)
+	contract, receipt, err := testnet.DeployContract(session, storage.DeployStorage)
 	require.NoError(t, err, "failed to deploy contract; %v", err)
 
 	checkStorage := func(t *testing.T) {
@@ -103,7 +104,7 @@ func TestSetStorage_Contract_Not_On_Blockchain_Executed_With_Extra_Storage(t *te
 	require := require.New(t)
 
 	// start network
-	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 
 	// create a client
 	client, err := session.GetClient()

--- a/tests/transaction_gas_price_test.go
+++ b/tests/transaction_gas_price_test.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,7 +33,7 @@ const enoughGasPrice = 150_000_000_000
 
 func TestTransactionGasPrice(t *testing.T) {
 
-	session := getIntegrationTestNetSession(t, opera.GetBrioUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetBrioUpgrades())
 	t.Parallel()
 
 	client, err := session.GetClient()
@@ -40,7 +41,7 @@ func TestTransactionGasPrice(t *testing.T) {
 	defer client.Close()
 
 	// use a fresh account to send transactions from
-	account := MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	account := testnet.MakeAccountWithBalance(t, session, big.NewInt(1e18))
 
 	t.Run("Legacy transaction, effectivePrice is equal to requested price", func(t *testing.T) {
 
@@ -277,7 +278,7 @@ func TestTransactionGasPrice(t *testing.T) {
 	})
 }
 
-func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *PooledEhtClient) int64 {
+func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *testnet.PooledEhtClient) int64 {
 	t.Helper()
 	block, err := client.BlockByNumber(t.Context(), blockNumber)
 	require.NoError(t, err)
@@ -285,7 +286,7 @@ func getBaseFeeAt(t *testing.T, blockNumber *big.Int, client *PooledEhtClient) i
 	return basefee.Int64()
 }
 
-func getBalance(t *testing.T, client *PooledEhtClient, account common.Address) int64 {
+func getBalance(t *testing.T, client *testnet.PooledEhtClient, account common.Address) int64 {
 	t.Helper()
 	balance, err := client.BalanceAt(t.Context(), account, nil)
 	require.NoError(t, err)
@@ -295,9 +296,9 @@ func getBalance(t *testing.T, client *PooledEhtClient, account common.Address) i
 // makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
 // and gas limit.
 func makeLegacyTx(t *testing.T,
-	client *PooledEhtClient,
+	client *testnet.PooledEhtClient,
 	gasPrice int64,
-	sender *Account,
+	sender *testnet.Account,
 	to *common.Address,
 	data []byte,
 ) *types.Transaction {
@@ -327,10 +328,10 @@ func makeLegacyTx(t *testing.T,
 // makeLegacyTx creates a legacy transaction from a CallMsg, filling in the nonce
 // and gas limit.
 func makeEip1559Transaction(t *testing.T,
-	client *PooledEhtClient,
+	client *testnet.PooledEhtClient,
 	maxFeeCap int64,
 	maxGasTip int64,
-	sender *Account,
+	sender *testnet.Account,
 	to *common.Address,
 	data []byte,
 ) *types.Transaction {

--- a/tests/transaction_order_test.go
+++ b/tests/transaction_order_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/tests/contracts/counter_event_emitter"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -34,20 +35,20 @@ func TestTransactionOrder(t *testing.T) {
 		numBlocks   = uint64(3)
 		numTxs      = numAccounts * numPerAcc
 	)
-	net := StartIntegrationTestNet(t)
+	net := testnet.StartIntegrationTestNet(t)
 
-	contract, _, err := DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
+	contract, _, err := testnet.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
 	require.NoError(t, err)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	accounts := make([]*Account, 0, numAccounts)
+	accounts := make([]*testnet.Account, 0, numAccounts)
 
 	// Only transactions from different accounts can change order.
 	for range numAccounts {
-		accounts = append(accounts, MakeAccountWithBalance(t, net, big.NewInt(1e18)))
+		accounts = append(accounts, testnet.MakeAccountWithBalance(t, net, big.NewInt(1e18)))
 	}
 
 	// Repeat the test for X number of blocks

--- a/tests/transaction_store_test.go
+++ b/tests/transaction_store_test.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -35,9 +36,9 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 	// was executed and check if the transaction is present in the block and the
 	// values match, by comparing the hashes.
 
-	net := StartIntegrationTestNet(t,
-		IntegrationTestNetOptions{
-			Upgrades: AsPointer(opera.GetBrioUpgrades()),
+	net := testnet.StartIntegrationTestNet(t,
+		testnet.IntegrationTestNetOptions{
+			Upgrades: testnet.AsPointer(opera.GetBrioUpgrades()),
 		})
 
 	client, err := net.GetClient()
@@ -47,14 +48,14 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 	chainId, err := client.ChainID(t.Context())
 	require.NoError(t, err)
 
-	sender := MakeAccountWithBalance(t, net, big.NewInt(1e18))
+	sender := testnet.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 	senderAddress := sender.Address()
 
 	// launch one transaction from each type
 	txs := make([]*types.Transaction, 0)
 
 	// Type 0: legacy transaction
-	txs = append(txs, SignTransaction(t, chainId,
+	txs = append(txs, testnet.SignTransaction(t, chainId,
 		&types.LegacyTx{
 			Nonce:    0,
 			To:       &senderAddress,
@@ -64,7 +65,7 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 		sender))
 
 	// Type 1: AccessList transaction
-	txs = append(txs, SignTransaction(t, chainId,
+	txs = append(txs, testnet.SignTransaction(t, chainId,
 		&types.AccessListTx{
 			Nonce:    1,
 			To:       &senderAddress,
@@ -77,7 +78,7 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 		sender))
 
 	// Type 2: DynamicFee transaction
-	txs = append(txs, SignTransaction(t, chainId,
+	txs = append(txs, testnet.SignTransaction(t, chainId,
 		&types.DynamicFeeTx{
 			Nonce:     2,
 			To:        &senderAddress,
@@ -88,7 +89,7 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 		sender))
 
 	// Type 3: Blob transaction
-	txs = append(txs, SignTransaction(t, chainId,
+	txs = append(txs, testnet.SignTransaction(t, chainId,
 		&types.BlobTx{
 			Nonce:     3,
 			Gas:       1e6,
@@ -98,14 +99,14 @@ func TestTransactionStore_CanTransactionsBeRetrievedFromBlocksAfterRestart(t *te
 		sender))
 
 	// Type 4: SetCode transaction
-	authority := NewAccount()
+	authority := testnet.NewAccount()
 	authorization, err := types.SignSetCode(authority.PrivateKey, types.SetCodeAuthorization{
 		ChainID: *uint256.MustFromBig(chainId),
 		Address: common.Address{42},
 		Nonce:   5,
 	})
 	require.NoError(t, err, "failed to sign SetCode authorization")
-	txs = append(txs, SignTransaction(t, chainId,
+	txs = append(txs, testnet.SignTransaction(t, chainId,
 		&types.SetCodeTx{
 			Nonce:     4,
 			To:        senderAddress,

--- a/tests/transientstorage_test.go
+++ b/tests/transientstorage_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests/contracts/transientstorage"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -26,11 +27,11 @@ import (
 )
 
 func TestTransientStorage_TransientStorageIsValidInTransaction(t *testing.T) {
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// Deploy the transient storage contract
-	contract, _, err := DeployContract(session, transientstorage.DeployTransientstorage)
+	contract, _, err := testnet.DeployContract(session, transientstorage.DeployTransientstorage)
 	require.NoError(t, err, "failed to deploy contract")
 
 	// Get the value from the contract before changing it

--- a/tests/validator_stakes/validator_stakes_test.go
+++ b/tests/validator_stakes/validator_stakes_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/contract/sfc100"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera/contracts/sfc"
-	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -38,7 +38,7 @@ func TestValidatorsStakes_AllNodesProduceBlocks_WhenStakeDistributionChanges(t *
 		750, 750, // 75% of stake
 		125, 125, 125, 125, // 25% of stake
 	}
-	net := tests.StartIntegrationTestNetWithJsonGenesis(t, tests.IntegrationTestNetOptions{
+	net := testnet.StartIntegrationTestNetWithJsonGenesis(t, testnet.IntegrationTestNetOptions{
 		ValidatorsStake: initialStake,
 	})
 
@@ -90,14 +90,14 @@ func TestValidatorsStakes_AllNodesProduceBlocks_WhenStakeDistributionChanges(t *
 		})
 }
 
-func increaseValidatorStake(t *testing.T, net *tests.IntegrationTestNet, sfcContract *sfc100.Contract, id idx.ValidatorID, amount *big.Int) {
+func increaseValidatorStake(t *testing.T, net *testnet.IntegrationTestNet, sfcContract *sfc100.Contract, id idx.ValidatorID, amount *big.Int) {
 	t.Helper()
 
 	// First endow the validator account with enough FTM to stake.
 	// If this step is not done, the account calling sfc.Delegate will be
 	// delegating into the stake. The interaction with the sfc is simpler
 	// if there is only one delegator, which is the validator account itself.
-	account := tests.Account{
+	account := testnet.Account{
 		PrivateKey: makefakegenesis.FakeKey(id),
 	}
 	receipt, err := net.EndowAccount(account.Address(), amount)
@@ -158,7 +158,7 @@ func getValidatorsInCurrentEpoch(t *testing.T, sfcContract *sfc100.Contract) (ma
 // requireAllNodesReachSameBlockHeight checks that all nodes in the provided
 // IntegrationTestNet have reached the same block height.
 // In combination with epoch advancement, this ensures that all nodes are producing blocks.
-func requireAllNodesReachSameBlockHeight(t *testing.T, net *tests.IntegrationTestNet) {
+func requireAllNodesReachSameBlockHeight(t *testing.T, net *testnet.IntegrationTestNet) {
 	t.Helper()
 
 	client, err := net.GetClient()
@@ -175,6 +175,6 @@ func requireAllNodesReachSameBlockHeight(t *testing.T, net *tests.IntegrationTes
 		defer nodeClient.Close()
 
 		// all other nodes should reach the same block number
-		tests.WaitForProofOf(t, nodeClient, int(number))
+		testnet.WaitForProofOf(t, nodeClient, int(number))
 	}
 }

--- a/tests/withdrawals_test.go
+++ b/tests/withdrawals_test.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"testing"
 
+	testnet "github.com/0xsoniclabs/sonic/integrationtestnet"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -32,7 +33,7 @@ func TestWithdrawalFieldsInBlocks(t *testing.T) {
 	requireBase := require.New(t)
 
 	// start network.
-	session := getIntegrationTestNetSession(t, opera.GetSonicUpgrades())
+	session := testnet.GetIntegrationTestNetSession(t, opera.GetSonicUpgrades())
 	t.Parallel()
 
 	// run endowment to ensure at least one block exists


### PR DESCRIPTION
**IGNORE THIS PR FOR NOW**

This PR moves the integration test net implementation and tooling to its own package. 

When running tests of all packages the `tests` package took the longest by great margin compared to any other package. The idea here is to move the infrastructure implementation and testing to a different package to allow multiplexing test execution.