### PR TITLE
Rename event throttler flag

### DIFF
--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -356,7 +356,7 @@ var (
 
 	// Event Emission Throttling
 	EnableThrottlingFlag = cli.BoolFlag{
-		Name:  "event-throttler.enable",
+		Name:  "event-throttler",
 		Usage: "Enable event emission throttling based on network conditions.",
 	}
 	ThrottlingDominantThresholdFlag = cli.Float64Flag{

--- a/tests/flags/flags_test.go
+++ b/tests/flags/flags_test.go
@@ -59,15 +59,15 @@ func TestSonicTool_CustomThrottlerConfig_AreApplied(t *testing.T) {
 	net.Stop()
 
 	configFile := filepath.Join(net.GetDirectory(), "config.toml")
-	require.NoError(t, sonicd.RunWithArgs(
-		[]string{"sonicd",
-			"--datadir", net.GetDirectory() + "/state",
-			"--dump-config", configFile,
-			"--event-throttler.enable",
-			"--event-throttler.dominant-threshold", "0.85",
-			"--event-throttler.dominating-timeout", "5",
-			"--event-throttler.non-dominating-timeout", "111",
-		}, nil))
+	flags := []string{"sonicd",
+		"--datadir", net.GetDirectory() + "/state",
+		"--dump-config", configFile,
+		"--event-throttler",
+		"--event-throttler.dominant-threshold", "0.85",
+		"--event-throttler.dominating-timeout", "5",
+		"--event-throttler.non-dominating-timeout", "111",
+	}
+	require.NoError(t, sonicd.RunWithArgs(flags, nil))
 
 	f, err := os.Open(configFile)
 	require.NoError(t, err)

--- a/tests/validator_stakes/validator_stakes_test.go
+++ b/tests/validator_stakes/validator_stakes_test.go
@@ -42,9 +42,8 @@ func TestValidatorsStakes_AllNodesProduceBlocks_WhenStakeDistributionChanges(t *
 				125, 125, 125, 125, // 25% of stake
 			}
 
-			extraArguments := []string{}
-			if throttlerEnabled {
-				extraArguments = []string{"--event-throttler.enable"}
+			extraArguments := []string{
+				fmt.Sprintf("--event-throttler=%t", throttlerEnabled),
 			}
 
 			net := tests.StartIntegrationTestNetWithJsonGenesis(t, tests.IntegrationTestNetOptions{


### PR DESCRIPTION
This PR renames the flag enabling the event throttler feature for better maintainability in the future. 
The new flag is 
`--event-throttler` or `--event-throttler=true` and it is `false` by default. 