### PR TITLE
Add unique-wrapper for iterators

### DIFF
--- a/utils/leap/unique.go
+++ b/utils/leap/unique.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package leap
+
+// Unique wraps an iterator and filters out duplicate consecutive values. The
+// input iterator must yield values in sorted order for Unique to function
+// correctly. The resulting iterator also takes ownership of the input iterator
+// and will call Release on it when Release is called on the unique iterator
+// itself.
+func Unique[T comparable](iterator Iterator[T]) *unique[T] {
+	return &unique[T]{
+		iterator: iterator,
+	}
+}
+
+type unique[T comparable] struct {
+	iterator  Iterator[T]
+	last      T
+	lastValid bool
+}
+
+func (it *unique[T]) Next() bool {
+	for it.iterator.Next() {
+		cur := it.iterator.Current()
+		if !it.lastValid {
+			it.last = cur
+			it.lastValid = true
+			return true
+		}
+		if cur != it.last {
+			it.last = cur
+			return true
+		}
+	}
+	return false
+}
+
+func (it *unique[T]) Current() T {
+	return it.iterator.Current()
+}
+
+func (it *unique[T]) Seek(value T) bool {
+	if !it.iterator.Seek(value) {
+		return false
+	}
+	it.last = it.iterator.Current()
+	it.lastValid = true
+	return true
+}
+
+func (it *unique[T]) Release() {
+	it.iterator.Release()
+}

--- a/utils/leap/unique_test.go
+++ b/utils/leap/unique_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package leap
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUnique_FiltersDuplicates(t *testing.T) {
+	tests := map[string]struct {
+		input    []int
+		expected []int
+	}{
+		"no duplicates": {
+			input:    []int{1, 2, 3, 4, 5},
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		"with duplicates": {
+			input:    []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5},
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		"mixed duplicates": {
+			input:    []int{1, 1, 2, 3, 3, 4, 5, 5, 5},
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		"all duplicates": {
+			input:    []int{1, 1, 1, 1, 1},
+			expected: []int{1},
+		},
+		"empty input": {
+			input:    []int{},
+			expected: nil,
+		},
+		"zero values": {
+			input:    []int{0, 0, 0, 1, 1, 2, 2},
+			expected: []int{0, 1, 2},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := slices.Collect(All(Unique(newIter(tc.input...))))
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestUnique_Seek_SkipsElements(t *testing.T) {
+	tests := map[string]struct {
+		input       []int
+		seekValue   int
+		expectedCur int
+		expectedOk  bool
+	}{
+		"seek existing value": {
+			input:       []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5},
+			seekValue:   3,
+			expectedCur: 3,
+			expectedOk:  true,
+		},
+		"seek non-existing value": {
+			input:       []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5},
+			seekValue:   6,
+			expectedCur: 0,
+			expectedOk:  false,
+		},
+		"seek to first value": {
+			input:       []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5},
+			seekValue:   1,
+			expectedCur: 1,
+			expectedOk:  true,
+		},
+		"seek to last value": {
+			input:       []int{1, 1, 2, 2, 3, 3, 4, 4, 5, 5},
+			seekValue:   5,
+			expectedCur: 5,
+			expectedOk:  true,
+		},
+		"seek beyond last value": {
+			input:       []int{1, 2, 3},
+			seekValue:   4,
+			expectedCur: 0,
+			expectedOk:  false,
+		},
+		"seek before first value": {
+			input:       []int{1, 1, 2, 3},
+			seekValue:   0,
+			expectedCur: 1,
+			expectedOk:  true,
+		},
+		"seek to zero value": {
+			input:       []int{0, 0, 1, 1, 2, 2},
+			seekValue:   0,
+			expectedCur: 0,
+			expectedOk:  true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			uniqueIter := Unique(newIter(tc.input...))
+			ok := uniqueIter.Seek(tc.seekValue)
+			require.Equal(t, tc.expectedOk, ok)
+
+			if ok {
+				cur := uniqueIter.Current()
+				require.Equal(t, tc.expectedCur, cur)
+			}
+
+			// After the seek, ensure that Next continues to yield strictly
+			// increasing values.
+			if uniqueIter.Next() {
+				cur := uniqueIter.Current()
+				require.Greater(t, cur, tc.expectedCur)
+			}
+		})
+	}
+}
+
+func TestUnique_Release_ReleasesUnderlyingIterator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	iter := NewMockIterator[int](ctrl)
+
+	iter.EXPECT().Release()
+	Unique(iter).Release()
+}


### PR DESCRIPTION
This PR adds a wrapper utility to the leap-join package making an underlying iterator unique.

This is a building block for composing more complex iterators for which distinctness of listed elements can not be guaranteed.