### PR TITLE
Add feature flag for transaction bundles.

### DIFF
--- a/opera/legacy_serialization.go
+++ b/opera/legacy_serialization.go
@@ -124,6 +124,9 @@ func (u Upgrades) EncodeRLP(w io.Writer) error {
 	if u.GasSubsidies {
 		bitmap.V |= gasSubsidiesBit
 	}
+	if u.TransactionBundles {
+		bitmap.V |= transactionBundlesBit
+	}
 	return rlp.Encode(w, &bitmap)
 }
 
@@ -145,6 +148,7 @@ func (u *Upgrades) DecodeRLP(s *rlp.Stream) error {
 
 	u.SingleProposerBlockFormation = (bitmap.V & singleProposerBlockFormationBit) != 0
 	u.GasSubsidies = (bitmap.V & gasSubsidiesBit) != 0
+	u.TransactionBundles = (bitmap.V & transactionBundlesBit) != 0
 	return nil
 }
 

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -146,6 +146,7 @@ func TestUpgradesRLP_CanBeEncodedAndDecoded(t *testing.T) {
 		func(u *Upgrades) { u.SingleProposerBlockFormation = true },
 		func(u *Upgrades) { u.Brio = true },
 		func(u *Upgrades) { u.GasSubsidies = true },
+		func(u *Upgrades) { u.TransactionBundles = true },
 	}
 
 	for mask := range 1 << len(setUpgrade) {

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -48,6 +48,7 @@ const (
 	// optional features
 	singleProposerBlockFormationBit = 1 << 63
 	gasSubsidiesBit                 = 1 << 62
+	transactionBundlesBit           = 1 << 61
 
 	MinimumMaxBlockGas          = 5_000_000_000 // < must be large enough to allow internal transactions to seal blocks
 	MaximumMaxBlockGas          = math.MaxInt64 // < should fit into 64-bit signed integers to avoid parsing errors in third-party libraries
@@ -249,6 +250,20 @@ type Upgrades struct {
 	// It can be enabled or disabled at any time. Changes in the feature state
 	// become effective at the start of the next epoch.
 	GasSubsidies bool
+
+	// TransactionBundles enables the transaction bundles feature, allowing
+	// users to submit bundles of transactions that are executed atomically.
+	// This feature is introduced by V2.2 of the Sonic client. It thus
+	//
+	//    MUST ONLY BE ENABLED WHEN ALL NODES ARE RUNNING V2.2 OR LATER
+	//
+	// Any node not running V2.2 or later will ignore this flag, and
+	// transaction bundles will not be accepted.
+	//
+	// Given the conditions stated above, the feature is considered optional.
+	// It can be enabled or disabled at any time. Changes in the feature state
+	// become effective at the start of the next epoch.
+	TransactionBundles bool
 }
 
 // UpgradeHeight contains the information about the block height at which

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -200,6 +200,11 @@ func TestRules_Copy_CopiesAreDisjoint(t *testing.T) {
 				rule.Upgrades.GasSubsidies = !rule.Upgrades.GasSubsidies
 			},
 		},
+		"upgrade Upgrades.TransactionBundles": {
+			update: func(rule *Rules) {
+				rule.Upgrades.TransactionBundles = !rule.Upgrades.TransactionBundles
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This PR uses the same infrastructure as the last time for the feature flag guarding the bundles.