### PR TITLE
Prevent bundle-only transations from being part of consensus.

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -363,8 +363,7 @@ func removeBundleOnlyTxs(
 	upgrades opera.Upgrades,
 	pendingTxs map[common.Address]types.Transactions) {
 
-	// if neither Brio nor TransactionBundles upgrade is active, there is no need to check for bundle-only transactions
-	if !upgrades.Brio || !upgrades.TransactionBundles {
+	if !upgrades.TransactionBundles {
 		return
 	}
 


### PR DESCRIPTION
This PR filters pending transactions from the transactions forming part of an event payload. 
Therefore, bundle-only transactions cannot be part of consensus and cannot form part of a block without the bundle they are summited for. 