### PR TITLE
RPC test eth_createAccessList preserves Bundle Only marker

### DIFF
--- a/tests/bundles/bundle_tx_test.go
+++ b/tests/bundles/bundle_tx_test.go
@@ -35,7 +35,6 @@ import (
 // not standalone). The RPC must preserve it so the bundle constraint survives
 // access-list recreation by wallets or tooling.
 func TestCreateAccessList_PreservesBundleOnlyMarker(t *testing.T) {
-	t.Parallel()
 
 	session := tests.StartIntegrationTestNet(t)
 


### PR DESCRIPTION
This PR adds an integration test for rpc method `eth_createAccessList` and verifies that `BundleOnly` marker, in form of defined address, preserves in the access list when included in the provided transaction arguments.