### PR TITLE
Return overall execution status from runTransaction

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -171,6 +171,14 @@ func newRunContext(
 	}
 }
 
+type Status int
+
+const (
+	StatusSuccessful Status = 0
+	StatusFailed     Status = 1
+	StatusSkipped    Status = 2
+)
+
 // runTransaction is a helper function to process a list of transactions. It
 // returns a list of ProcessedTransaction, containing the transaction and its
 // receipt (or nil if the transaction was skipped).
@@ -185,25 +193,31 @@ func runTransactions(
 	processed := make([]ProcessedTransaction, 0, len(transactions))
 	for _, tx := range transactions {
 		nextId := len(processed) + txIndexOffset
-		if context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
-			processed = append(processed,
-				context.runner.runSponsoredTransaction(context, tx, nextId)...,
-			)
-		} else {
-			processed = append(processed,
-				context.runner.runRegularTransaction(context, tx, nextId),
-			)
-		}
+		txs, _ := runTransaction(context, tx, nextId)
+		processed = append(processed, txs...)
 	}
 	return processed
+}
+
+func runTransaction(
+	context *runContext,
+	tx *types.Transaction,
+	txIndexOffset int,
+) ([]ProcessedTransaction, Status) {
+	if context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
+		return context.runner.runSponsoredTransaction(context, tx, txIndexOffset)
+	} else {
+		res, status := context.runner.runRegularTransaction(context, tx, txIndexOffset)
+		return []ProcessedTransaction{res}, status
+	}
 }
 
 // _transactionRunner is an interface for components implementing the logic
 // required for running transactions with various rules, e.g. regular or
 // sponsored transactions.
 type _transactionRunner interface {
-	runRegularTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) ProcessedTransaction
-	runSponsoredTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) []ProcessedTransaction
+	runRegularTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) (ProcessedTransaction, Status)
+	runSponsoredTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) ([]ProcessedTransaction, Status)
 }
 
 // transactionRunner implements the _transactionRunner interface by using an
@@ -216,15 +230,24 @@ func (r *transactionRunner) runRegularTransaction(
 	ctxt *runContext,
 	tx *types.Transaction,
 	txIndex int,
-) ProcessedTransaction {
-	return r.evm.runWithBaseFeeCheck(ctxt, tx, txIndex)
+) (ProcessedTransaction, Status) {
+	res := r.evm.runWithBaseFeeCheck(ctxt, tx, txIndex)
+	status := StatusSkipped
+	if res.Receipt != nil {
+		if res.Receipt.Status == types.ReceiptStatusSuccessful {
+			status = StatusSuccessful
+		} else {
+			status = StatusFailed
+		}
+	}
+	return res, status
 }
 
 func (r *transactionRunner) runSponsoredTransaction(
 	ctxt *runContext,
 	tx *types.Transaction,
 	txIndex int,
-) []ProcessedTransaction {
+) ([]ProcessedTransaction, Status) {
 	// Run the IsCovered query in a snapshot to avoid spilling any side-effects
 	// like warm storage slots or refunds into the actual transaction.
 	snapshot := ctxt.statedb.Snapshot()
@@ -234,11 +257,11 @@ func (r *transactionRunner) runSponsoredTransaction(
 	ctxt.statedb.RevertToSnapshot(snapshot)
 	if err != nil {
 		log.Warn("Failed to query subsidies registry", "tx", tx.Hash().Hex(), "err", err)
-		return []ProcessedTransaction{{Transaction: tx}}
+		return []ProcessedTransaction{{Transaction: tx}}, StatusSkipped
 	}
 	if !covered {
 		log.Debug("Transaction is not covered by a subsidy", "tx", tx.Hash().Hex())
-		return []ProcessedTransaction{{Transaction: tx}}
+		return []ProcessedTransaction{{Transaction: tx}}, StatusSkipped
 	}
 
 	// Check the remaining available gas to be used in this block.
@@ -248,14 +271,20 @@ func (r *transactionRunner) runSponsoredTransaction(
 		log.Debug("Not enough gas left in block for sponsored transaction",
 			"tx", tx.Hash().Hex(), "available", available, "needed", needed,
 		)
-		return []ProcessedTransaction{{Transaction: tx}}
+		return []ProcessedTransaction{{Transaction: tx}}, StatusSkipped
 	}
 
 	// Run the sponsored transaction.
 	processed := r.evm.runWithoutBaseFeeCheck(ctxt, tx, txIndex)
 	if processed.Receipt == nil {
 		log.Debug("Sponsored transaction skipped", "tx", tx.Hash().Hex())
-		return []ProcessedTransaction{processed}
+		return []ProcessedTransaction{processed}, StatusSkipped
+	}
+
+	status := StatusSuccessful
+	if processed.Receipt.Status == types.ReceiptStatusFailed {
+		log.Debug("Sponsored transaction failed", "tx", tx.Hash().Hex())
+		status = StatusFailed
 	}
 
 	// Charge the fee for the sponsored transaction to the subsidy fund.
@@ -270,7 +299,7 @@ func (r *transactionRunner) runSponsoredTransaction(
 		// block formation. So we have to let this go. This sponsored
 		// transaction was on the house (meaning on the network).
 		log.Warn("Failed to create fee charging transaction", "sponsored-tx", tx.Hash().Hex(), "err", err)
-		return []ProcessedTransaction{processed}
+		return []ProcessedTransaction{processed}, status
 	}
 	processedDeduction := r.evm.runWithoutBaseFeeCheck(ctxt, feeChargingTx, txIndex+1)
 	if processedDeduction.Receipt == nil {
@@ -284,7 +313,7 @@ func (r *transactionRunner) runSponsoredTransaction(
 		// subsidy fund was not charged.
 		log.Warn("Fee charging transaction failed", "sponsored-tx", tx.Hash().Hex())
 	}
-	return []ProcessedTransaction{processed, processedDeduction}
+	return []ProcessedTransaction{processed, processedDeduction}, status
 }
 
 // _evm is an interface to an EVM instance that can be used to run a single

--- a/evmcore/state_processor_mock.go
+++ b/evmcore/state_processor_mock.go
@@ -43,11 +43,12 @@ func (m *Mock_transactionRunner) EXPECT() *Mock_transactionRunnerMockRecorder {
 }
 
 // runRegularTransaction mocks base method.
-func (m *Mock_transactionRunner) runRegularTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) ProcessedTransaction {
+func (m *Mock_transactionRunner) runRegularTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) (ProcessedTransaction, Status) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "runRegularTransaction", ctxt, tx, txIndex)
 	ret0, _ := ret[0].(ProcessedTransaction)
-	return ret0
+	ret1, _ := ret[1].(Status)
+	return ret0, ret1
 }
 
 // runRegularTransaction indicates an expected call of runRegularTransaction.
@@ -57,11 +58,12 @@ func (mr *Mock_transactionRunnerMockRecorder) runRegularTransaction(ctxt, tx, tx
 }
 
 // runSponsoredTransaction mocks base method.
-func (m *Mock_transactionRunner) runSponsoredTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) []ProcessedTransaction {
+func (m *Mock_transactionRunner) runSponsoredTransaction(ctxt *runContext, tx *types.Transaction, txIndex int) ([]ProcessedTransaction, Status) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "runSponsoredTransaction", ctxt, tx, txIndex)
 	ret0, _ := ret[0].([]ProcessedTransaction)
-	return ret0
+	ret1, _ := ret[1].(Status)
+	return ret0, ret1
 }
 
 // runSponsoredTransaction indicates an expected call of runSponsoredTransaction.

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -766,7 +766,7 @@ func TestRunTransactions_GasSubsidiesEnabled_RunsRegularTransactionWithoutSponso
 		runner:   runner,
 		upgrades: opera.Upgrades{GasSubsidies: true},
 	}
-	runner.EXPECT().runRegularTransaction(context, tx, 0).Return(processed)
+	runner.EXPECT().runRegularTransaction(context, tx, 0).Return(processed, StatusSuccessful)
 	got := runTransactions(context, []*types.Transaction{tx}, 0)
 	require.Equal(t, []ProcessedTransaction{processed}, got)
 }
@@ -781,10 +781,13 @@ func TestRunTransactions_GasSubsidiesEnabled_RunsSponsorshipRequestWithSponsorsh
 		runner:   runner,
 		upgrades: opera.Upgrades{GasSubsidies: true},
 	}
-	runner.EXPECT().runSponsoredTransaction(context, tx, 0).Return([]ProcessedTransaction{{
-		Transaction: tx,
-		Receipt:     nil,
-	}})
+	runner.EXPECT().runSponsoredTransaction(context, tx, 0).Return(
+		[]ProcessedTransaction{{
+			Transaction: tx,
+			Receipt:     nil,
+		}},
+		StatusSuccessful,
+	)
 	processed := runTransactions(context, []*types.Transaction{tx}, 0)
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -876,7 +879,12 @@ func TestRunSponsoredTransaction_InsufficientGas_SkipsTransaction(t *testing.T) 
 			}
 
 			runner := &transactionRunner{evm: evm}
-			got := runner.runSponsoredTransaction(context, tx, 0)
+			got, status := runner.runSponsoredTransaction(context, tx, 0)
+			if test.shouldSkip {
+				require.Equal(t, StatusSkipped, status)
+			} else {
+				require.Equal(t, StatusSuccessful, status)
+			}
 
 			if test.shouldSkip {
 				want := []ProcessedTransaction{{
@@ -915,7 +923,8 @@ func TestRunSponsoredTransaction_SponsorshipNotCovered_ReturnsASkippedTransactio
 	}
 
 	runner := &transactionRunner{}
-	got := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	require.Equal(t, StatusSkipped, status)
 	want := []ProcessedTransaction{{
 		Transaction: tx,
 		Receipt:     nil,
@@ -949,7 +958,8 @@ func TestRunSponsoredTransaction_SponsorshipCoverageCheckFails_ReturnsASkippedTr
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	require.Equal(t, StatusSkipped, status)
 	want := []ProcessedTransaction{{
 		Transaction: tx,
 		Receipt:     nil,
@@ -992,7 +1002,8 @@ func TestRunSponsoredTransaction_SponsoredTransactionIsSkipped_NoFeeDeductionTxI
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	require.Equal(t, StatusSkipped, status)
 	want := []ProcessedTransaction{{
 		Transaction: tx,
 		Receipt:     nil,
@@ -1060,7 +1071,8 @@ func TestRunSponsoredTransaction_FailingCreationOfFeeDeduction_TransactionIsAcce
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	require.Equal(t, StatusSuccessful, status)
 	want := []ProcessedTransaction{processed}
 	require.Equal(t, want, got)
 }
@@ -1113,7 +1125,8 @@ func TestRunSponsoredTransaction_FeeDeductionTxIsSkipped_TransactionIsAcceptedWi
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	require.Equal(t, StatusSuccessful, status)
 	want := []ProcessedTransaction{
 		processedSponsoredTransaction,
 		skippedFeeDeductionTransaction,
@@ -1171,7 +1184,8 @@ func TestRunSponsoredTransaction_FeeDeductionTxFails_TransactionIsAcceptedWithou
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	require.Equal(t, StatusSuccessful, status)
 	want := []ProcessedTransaction{
 		processedSponsoredTransaction,
 		skippedFeeDeductionTransaction,
@@ -1222,7 +1236,8 @@ func TestRunSponsoredTransaction_TxIndexIsIncrementedForFeeDeductionTx(t *testin
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got := runner.runSponsoredTransaction(context, tx, txIndex)
+	got, status := runner.runSponsoredTransaction(context, tx, txIndex)
+	require.Equal(t, StatusFailed, status)
 	require.Len(t, got, 2)
 	require.Equal(t, tx, got[0].Transaction)
 	require.NotNil(t, got[0].Receipt)
@@ -1391,7 +1406,8 @@ func TestRunSponsoredTransaction_CoveredTransaction_ProcessesTwoTransactionsSucc
 
 	// --- start of actual test ---
 
-	processedTransactions := runner.runSponsoredTransaction(context, tx, txIndex)
+	processedTransactions, status := runner.runSponsoredTransaction(context, tx, txIndex)
+	require.Equal(StatusSuccessful, status)
 
 	// the transaction should be sponsored successfully
 	require.Len(processedTransactions, 2)
@@ -1494,7 +1510,8 @@ func TestRunTransaction_InternalTransactions_SkipsTransactionChecksTrue(t *testi
 	require.True(t, internaltx.IsInternal(unsignedTx))
 
 	// run an internal transaction with gas over the max tx gas limit.
-	got := runner.runRegularTransaction(context, unsignedTx, 0)
+	got, status := runner.runRegularTransaction(context, unsignedTx, 0)
+	require.Equal(t, StatusSuccessful, status)
 
 	require.Equal(t, unsignedTx, got.Transaction)
 	require.NotNil(t, got.Receipt)
@@ -1507,7 +1524,8 @@ func TestRunTransaction_InternalTransactions_SkipsTransactionChecksTrue(t *testi
 	regularTx := types.MustSignNewTx(key, signer, &types.LegacyTx{
 		Nonce: 0, To: &common.Address{1}, Gas: maxTxGas * 2, GasPrice: big.NewInt(1),
 	})
-	got = runner.runRegularTransaction(context, regularTx, 0)
+	got, status = runner.runRegularTransaction(context, regularTx, 0)
+	require.Equal(t, StatusSkipped, status)
 	require.Equal(t, regularTx, got.Transaction)
 	require.Nil(t, got.Receipt)
 }
@@ -1518,6 +1536,7 @@ func TestRunTransaction_RegularTransaction(t *testing.T) {
 		rules      opera.Rules
 		stateSetup func(state *state.MockStateDB)
 		validation func(t *testing.T, got ProcessedTransaction)
+		status     Status
 	}{
 		"Brio/Skipped": {
 			rules: opera.FakeNetRules(opera.GetBrioUpgrades()),
@@ -1530,6 +1549,7 @@ func TestRunTransaction_RegularTransaction(t *testing.T) {
 			validation: func(t *testing.T, got ProcessedTransaction) {
 				require.Nil(t, got.Receipt, "expected no receipt for transaction with too high gas")
 			},
+			status: StatusSkipped,
 		},
 		"Pre-Brio/Accepted": {
 			rules: opera.FakeNetRules(opera.GetAllegroUpgrades()),
@@ -1554,6 +1574,7 @@ func TestRunTransaction_RegularTransaction(t *testing.T) {
 				require.NotNil(t, got.Receipt, "expected receipt for accepted transaction")
 				require.Equal(t, types.ReceiptStatusSuccessful, got.Receipt.Status, "expected successful transaction")
 			},
+			status: StatusSuccessful,
 		},
 	}
 
@@ -1616,7 +1637,8 @@ func TestRunTransaction_RegularTransaction(t *testing.T) {
 				Nonce: 0, To: &common.Address{1}, Gas: maxTxGas + 1, GasPrice: big.NewInt(1),
 			})
 
-			got := runner.runRegularTransaction(context, regularTx, 0)
+			got, status := runner.runRegularTransaction(context, regularTx, 0)
+			require.Equal(t, test.status, status)
 
 			require.Equal(t, regularTx, got.Transaction)
 			test.validation(t, got)


### PR DESCRIPTION
This PR returns the "overall" status of a transaction from `runTransaction`. For normal transactions this is `skipped` if the transaction skipped and the status of the receipt otherwise.
For sponsored transactions it is `skipped` if the pre-checks failed or the actual transaction skipped, and the status of the receipt of the actual transaction otherwise, no matter whether the payment for the sponsored transaction succeeded or not.

This is needed in an upcoming PR to be able to run sponsored transactions (and recursive bundles) inside of bundles.