### PR TITLE
[NOMERGE] Use Carmen with bundle tx support and single dimension undo list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ module github.com/0xsoniclabs/sonic
 go 1.25.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20260223152719-2b3b9e285151
+	github.com/0xsoniclabs/carmen/go v0.0.0-20260304132233-897e1e2f3e60
 	github.com/0xsoniclabs/tosca v0.0.0-20260223084600-d2ea7c5c23ff
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20260223152719-2b3b9e285151 h1:/uLEUvEz15Y+vsuNziXIoT3YPTjVRwgDzXzbOnG7Uw4=
-github.com/0xsoniclabs/carmen/go v0.0.0-20260223152719-2b3b9e285151/go.mod h1:cvyFCIXOrt4yc67R4BGcAJADchtyggVFlf2fB2jZsxQ=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260304132233-897e1e2f3e60 h1:rtnpVYFNPVbR7y6iRUBTTlJgNZHd2uJVelwa9IDipvM=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260304132233-897e1e2f3e60/go.mod h1:cvyFCIXOrt4yc67R4BGcAJADchtyggVFlf2fB2jZsxQ=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260226121708-94eae637e0f2 h1:hAmPqu/GzhcIK7/Sr1RTHfp4sMjyvBWTxNVpcKvB4sY=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260226121708-94eae637e0f2/go.mod h1:TlbbIilsvHx5hhDGx0sdKnAPRv0S2cp1XRKr4L21ioc=
 github.com/0xsoniclabs/tosca v0.0.0-20260223084600-d2ea7c5c23ff h1:tGxXBrRkehB3yuEroobo/PPramvXx6yQrx8u0cBkUn0=


### PR DESCRIPTION
This PR dumps the carmen version to use one that supports transaction revert functionalities needed for the bundle transactions.
The Carmen commit referenced here is the following: https://github.com/0xsoniclabs/carmen/commit/897e1e2f3e60a0b77369ee9fb7ccd030d135fcba
The purpose of this PR is to verify that the integration would not require changes on the Sonic client side.