### PR TITLE
Don't consider bundleOnly marker for intrinsic gas cost

### DIFF
--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -610,6 +610,6 @@ func wrap(txBundle *bundle.TransactionBundle) *types.Transaction {
 	return types.NewTx(&types.AccessListTx{
 		To:   &bundle.BundleAddress,
 		Data: data,
-		Gas:  gasLimit,
+		Gas:  max(gasLimit, 21240),
 	})
 }

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -492,7 +492,7 @@ func (p pattern) _toTxData(
 		case int:
 			txs = append(txs, &types.AccessListTx{
 				Nonce: uint64(0xF & v),
-				Gas:   21_096,
+				Gas:   21_240,
 			})
 			key := keys[0xF&(v>>4)]
 			keysToSign = append(keysToSign, key)
@@ -559,12 +559,16 @@ func (p pattern) _toTxData(
 	if err != nil {
 		panic(err)
 	}
+	floorDataGas, err := core.FloorDataGas(data)
+	if err != nil {
+		panic(err)
+	}
 
 	// Wrap up bundle into an envelope transaction.
 	return &types.AccessListTx{
 		To:   &bundle.BundleAddress,
 		Data: data,
-		Gas:  max(gasLimit, intrGas),
+		Gas:  max(gasLimit, intrGas, floorDataGas),
 	}
 }
 

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1482,7 +1482,7 @@ func Test_validateBundleTransactions_IfBundledTransactionsAreEnabled_AcceptValid
 	tx := types.NewTx(&types.LegacyTx{
 		To:   &bundle.BundleAddress,
 		Data: bundle.Encode(bundle.TransactionBundle{Version: 1}),
-		Gas:  21096,
+		Gas:  21240,
 	})
 	require.True(bundle.IsTransactionBundle(tx))
 

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1457,7 +1457,7 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunning_RejectBundleTrans
 			tx := types.NewTx(&types.LegacyTx{
 				To:   &bundle.BundleAddress,
 				Data: bundle.Encode(bundle.TransactionBundle{Version: 1}),
-				Gas:  21096,
+				Gas:  21240,
 			})
 			require.True(bundle.IsTransactionBundle(tx))
 

--- a/gossip/blockproc/bundle/validate.go
+++ b/gossip/blockproc/bundle/validate.go
@@ -19,6 +19,7 @@ package bundle
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -71,16 +72,22 @@ func ValidateTransactionBundle(
 		}
 	}
 
+	// if this is a nested bundle, remove the bundleOnly marker before calculating the intrinsic gas
+	accessList := slices.Clone(tx.AccessList())
+	accessList = slices.DeleteFunc(accessList, func(al types.AccessTuple) bool {
+		return al.Address == BundleOnly
+	})
+
 	bundleGas := tx.Gas()
 	// Ensure the transaction has more gas than the basic tx fee.
 	intrGas, err := core.IntrinsicGas(
 		tx.Data(),
-		tx.AccessList(),
-		tx.SetCodeAuthorizations(),
-		tx.To() == nil, // is contract creation
-		true,           // is homestead
-		true,           // is istanbul
-		true,           // is shanghai
+		accessList,
+		nil,   // code auth is not used in the bundle transaction
+		false, // bundle transaction is not a contract creation
+		true,  // is homestead
+		true,  // is istanbul
+		true,  // is shanghai
 	)
 	if err != nil {
 		return nil, nil, err

--- a/gossip/blockproc/bundle/validate.go
+++ b/gossip/blockproc/bundle/validate.go
@@ -95,7 +95,18 @@ func ValidateTransactionBundle(
 	for _, innerTx := range txBundle.Bundle {
 		gasLimit += innerTx.Gas()
 	}
-	if bundleGas != max(gasLimit, intrGas) {
+
+	// EIP-7623 part of Prague revision: Floor data gas
+	// see: https://eips.ethereum.org/EIPS/eip-7623
+	floorDataGas, err := core.FloorDataGas(tx.Data())
+	if err != nil {
+		return nil, nil, err
+	}
+	if tx.Gas() < floorDataGas {
+		return nil, nil, fmt.Errorf("%w: have %d, want %d", core.ErrFloorDataGas, tx.Gas(), floorDataGas)
+	}
+
+	if bundleGas != max(gasLimit, intrGas, floorDataGas) {
 		return nil, nil, fmt.Errorf("%w: bundle gas limit %d but needs %d", ErrBundleGasLimitTooLow, tx.Gas(), max(gasLimit, intrGas))
 	}
 

--- a/gossip/blockproc/bundle/validate.go
+++ b/gossip/blockproc/bundle/validate.go
@@ -103,11 +103,12 @@ func ValidateTransactionBundle(
 		return nil, nil, err
 	}
 	if tx.Gas() < floorDataGas {
-		return nil, nil, fmt.Errorf("%w: have %d, want %d", core.ErrFloorDataGas, tx.Gas(), floorDataGas)
+		return nil, nil, fmt.Errorf("%w: gas should be more than %d", core.ErrFloorDataGas, floorDataGas)
 	}
 
-	if bundleGas != max(gasLimit, intrGas, floorDataGas) {
-		return nil, nil, fmt.Errorf("%w: bundle gas limit %d but needs %d", ErrBundleGasLimitTooLow, tx.Gas(), max(gasLimit, intrGas))
+	gasNeeded := max(gasLimit, intrGas, floorDataGas)
+	if bundleGas != gasNeeded {
+		return nil, nil, fmt.Errorf("%w: bundle gas limit %d but needs %d", ErrBundleGasLimitTooLow, tx.Gas(), gasNeeded)
 	}
 
 	return &txBundle, &plan, nil

--- a/gossip/blockproc/bundle/validate_test.go
+++ b/gossip/blockproc/bundle/validate_test.go
@@ -103,13 +103,13 @@ func TestValidate_AcceptsValidBlockRanges(t *testing.T) {
 		Gas  uint64
 	}{
 		"single-block range": {
-			From: 10, To: 10, Gas: 21096,
+			From: 10, To: 10, Gas: 21240,
 		},
 		"multi-block range": {
-			From: 7, To: 42, Gas: 21096,
+			From: 7, To: 42, Gas: 21240,
 		},
 		"max-size block range": {
-			From: 100, To: 100 + MaxBlockRange - 1, Gas: 21128,
+			From: 100, To: 100 + MaxBlockRange - 1, Gas: 21320,
 		},
 	}
 
@@ -207,7 +207,7 @@ func (gen testBundleGenerator) makeEmptyBundleTx() *types.Transaction {
 	return types.NewTx(&types.LegacyTx{
 		To:   &BundleAddress,
 		Data: bytes,
-		Gas:  21096,
+		Gas:  21240,
 	})
 }
 
@@ -397,7 +397,7 @@ func (gen testBundleGenerator) makeBundleTxWithoutEnoughGasForAllTransactions(t 
 	tx = types.NewTx(&types.LegacyTx{
 		To:   &BundleAddress,
 		Data: tx.Data(),
-		Gas:  30_000, // not enough gas for all transactions in the bundle
+		Gas:  35_000, // not enough gas for all transactions in the bundle
 	})
 	return tx
 }

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -70,7 +70,7 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 					Earliest: 50,
 					Latest:   150,
 				}),
-				Gas: 21112,
+				Gas: 21_280,
 			})
 			_, _, err := bundle.ValidateTransactionBundle(tx, nil)
 			require.NoError(err)
@@ -153,7 +153,7 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 					Earliest: 50,
 					Latest:   150,
 				}),
-				Gas: 21112,
+				Gas: 21_280,
 			})
 			_, _, err := bundle.ValidateTransactionBundle(tx, nil)
 			require.NoError(t, err)

--- a/tests/bundles/make_bundle_test.go
+++ b/tests/bundles/make_bundle_test.go
@@ -67,7 +67,6 @@ func makeBundleTransaction(
 	}
 
 	data := bundle.Encode(bundlePayload)
-
 	intrGas, err := core.IntrinsicGas(
 		data,
 		nil,   // access list is set in the individual transactions
@@ -90,7 +89,7 @@ func makeBundleTransaction(
 		&types.LegacyTx{
 			Nonce: 0,
 			To:    &bundle.BundleAddress,
-			Gas:   max(gas, intrGas, floorDataGas), // set the gas limit to the maximum of intrinsic gas, transactions gas and floor data gas
+			Gas:   max(gas, intrGas, floorDataGas),
 			Data:  data,
 		},
 	)


### PR DESCRIPTION
This PR removes the bundleOnly marker from the access list used to compute the intrinsic gas. This is needed for nested bundles, because the envelope of a nested bundle has the bundle only marker, but its gas was computed without. There is also no reason to consider it in the cost, because the bundleOnly marker is only a marker and not a real access, since the envelope is never executed.

This change is needed for nested bundles.