### PR TITLE
Add errors to `getBundleStatus` [prototype]

### DIFF
--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -90,7 +90,6 @@ func (s *BundleIntegrationImplementation) isPending(tx *types.Transaction) bool 
 		chainState: s.chain,
 		stateDB:    s.state,
 	}
-
 	state := GetBundleState(&chain, tx)
 	return state.Executable
 }

--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -90,16 +90,9 @@ func (s *BundleIntegrationImplementation) isPending(tx *types.Transaction) bool 
 		chainState: s.chain,
 		stateDB:    s.state,
 	}
-	// isPending is only used in the txpool to prune transactions that are no
-	// longer executable. GetBundleState always returns an error if the state
-	// is BundleStateNonExecutable, so we only need to check the error, not the
-	// status itself.
-	// The error can be safely dropped because it does not reach any user.
-	// The state can be dropped because if there are no errors then it is
-	// either BundleStateRunnable or BundleStateTemporaryBlocked, and in both
-	// cases the bundle should be kept in the pool for future processing.
-	_, err = GetBundleState(&chain, tx)
-	return err == nil
+
+	state := GetBundleState(&chain, tx)
+	return state.Executable
 }
 
 type preCheckChainAdapter struct {

--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -85,13 +85,16 @@ func (s *BundleIntegrationImplementation) isPending(tx *types.Transaction) bool 
 		return false
 	}
 
-	// Remove permanently blocked bundles.
+	// Remove bundles that cannot be executed.
 	chain := preCheckChainAdapter{
 		chainState: s.chain,
 		stateDB:    s.state,
 	}
-	bundleState := GetBundleState(&chain, tx)
-	return bundleState != BundleStatePermanentlyBlocked
+	bundleState, err := GetBundleState(&chain, tx)
+	if err != nil {
+		return false
+	}
+	return bundleState != BundleStateNonExecutable
 }
 
 type preCheckChainAdapter struct {

--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -90,11 +90,14 @@ func (s *BundleIntegrationImplementation) isPending(tx *types.Transaction) bool 
 		chainState: s.chain,
 		stateDB:    s.state,
 	}
-	bundleState, err := GetBundleState(&chain, tx)
-	if err != nil {
-		return false
-	}
-	return bundleState != BundleStateNonExecutable
+	// Because isPending is only used in the txpool to prune transactions that
+	// are no longer executable, here we only care whether there is an error or
+	// not. The error can be safely dropped because it does not reaches any user.
+	// The state can be dropped because if there are no errors then it is
+	// either BundleStateRunnable or BundleStateTemporaryBlocked, and in both
+	// cases the bundle should be kept in the pool for future processing.
+	_, err = GetBundleState(&chain, tx)
+	return err == nil
 }
 
 type preCheckChainAdapter struct {

--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -91,7 +91,7 @@ func (s *BundleIntegrationImplementation) isPending(tx *types.Transaction) bool 
 		stateDB:    s.state,
 	}
 	state := GetBundleState(&chain, tx)
-	return state.Executable
+	return state.Executable || state.TemporarilyBlocked
 }
 
 type preCheckChainAdapter struct {

--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -90,9 +90,11 @@ func (s *BundleIntegrationImplementation) isPending(tx *types.Transaction) bool 
 		chainState: s.chain,
 		stateDB:    s.state,
 	}
-	// Because isPending is only used in the txpool to prune transactions that
-	// are no longer executable, here we only care whether there is an error or
-	// not. The error can be safely dropped because it does not reaches any user.
+	// isPending is only used in the txpool to prune transactions that are no
+	// longer executable. GetBundleState always returns an error if the state
+	// is BundleStateNonExecutable, so we only need to check the error, not the
+	// status itself.
+	// The error can be safely dropped because it does not reach any user.
 	// The state can be dropped because if there are no errors then it is
 	// either BundleStateRunnable or BundleStateTemporaryBlocked, and in both
 	// cases the bundle should be kept in the pool for future processing.

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -17,7 +17,6 @@
 package evmcore
 
 import (
-	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -35,38 +34,26 @@ import (
 
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
 
-// BundleState describes the state of a bundle in terms of its executability
-// relative to the state of the blockchain. It can be one of the following:
-//   - BundleStateRunnable: The bundle is ready to be executed on the current
-//     state of the blockchain and has a chance to succeed if executed.
-//   - BundleStateTemporaryBlocked: The bundle is not currently executable due to
-//     temporary conditions (e.g., it is too early), but it may become
-//     executable in the future as the blockchain progresses.
-//   - BundleStateNonExecutable: The bundle is not executable and will never
-//     be executable in the future due to permanent conditions (e.g., a
-//     transaction in the bundle uses an already consumed nonce). This state
-//     is always accompanied by an error and should be ignored in favor of the error.
-type BundleState int
-
-const (
-	// BundleStateNonExecutable indicates that the bundle is not executable
-	// and will never be executable in the future due to permanent conditions.
-	BundleStateNonExecutable BundleState = iota
-	// BundleStateRunnable indicates that the bundle is ready to be executed on
-	// a given state of the blockchain and has a chance to succeed if executed.
-	BundleStateRunnable
-	// BundleStateTemporaryBlocked indicates that the bundle is not currently
-	// executable due to temporary conditions, but it may become executable in
-	// the future as the blockchain progresses.
-	BundleStateTemporaryBlocked
-)
+// BundleState represents the current evaluation state of a transaction bundle.
+// It indicates whether the bundle is executable, if it is temporarily blocked from execution,
+// and provides a list of reasons explaining the current state.
+//
+// Fields:
+//   - Executable:         True if the bundle can be executed.
+//   - TemporarilyBlocked: True if the bundle is currently blocked but may become executable later.
+//   - Reasons:            A list of human-readable strings describing why the bundle is not executable or is blocked.
+type BundleState struct {
+	Executable         bool
+	TemporarilyBlocked bool
+	Reasons            []string
+}
 
 // GetBundleState determines the state of the bundle based on the current state
 // of the blockchain and the transactions in the bundle.
 func GetBundleState(
 	chain ChainState,
 	envelop *types.Transaction,
-) (BundleState, error) {
+) BundleState {
 	return getBundleState(chain, envelop, trialRunBundle)
 }
 
@@ -76,21 +63,30 @@ func getBundleState(
 	chain ChainState,
 	envelop *types.Transaction,
 	trialRunner func(*types.Transaction, ChainState, state.StateDB) bool,
-) (BundleState, error) {
+) BundleState {
 
 	// Verify that the bundle is valid.
 	bundle, _, err := bundle.ValidateTransactionBundle(envelop)
 	if err != nil {
-		return BundleStateNonExecutable, errors.Join(ErrBundleTransactionInvalid, err)
+		return BundleState{
+			Executable: false,
+			Reasons:    []string{fmt.Sprintf("invalid bundle: %v", err)},
+		}
 	}
 
 	// Quickest filter: check if the bundle is in the valid block range.
 	currentBlock := chain.GetLatestHeader().Number.Uint64()
 	if bundle.Latest < currentBlock {
-		return BundleStateNonExecutable, ErrBundleLatestPassed
+		return BundleState{
+			Executable: false,
+			Reasons:    []string{ErrBundleLatestPassed.Error()},
+		}
 	}
 	if bundle.Earliest > currentBlock {
-		return BundleStateTemporaryBlocked, nil
+		return BundleState{
+			Executable:         true,
+			TemporarilyBlocked: true,
+		}
 	}
 
 	// Next, check whether there are any nonce conflicts in the execution of
@@ -99,13 +95,14 @@ func getBundleState(
 	chainId := big.NewInt(int64(chain.GetCurrentNetworkRules().NetworkID))
 	signer := types.LatestSignerForChainID(chainId)
 	stateDb := chain.StateDB()
-	state, err := checkForNonceConflicts(bundle, signer, stateDb)
-	if err != nil {
-		return BundleStateNonExecutable,
-			fmt.Errorf("failed to check for nonce conflicts: %w", err)
+	state := checkForNonceConflicts(bundle, signer, stateDb)
+	if !state.Executable {
+		state.Reasons = append([]string{"nonce conflict check failed"}, state.Reasons...)
+		return state
 	}
-	if state == BundleStateTemporaryBlocked {
-		return state, nil
+
+	if state.TemporarilyBlocked {
+		return state
 	}
 
 	// Trial-run the bundle to check whether it can succeed or not. This is the
@@ -125,10 +122,12 @@ func getBundleState(
 	}()
 
 	if success := trialRunner(envelop, chain, stateDb); !success {
-		return BundleStateNonExecutable,
-			fmt.Errorf("bundle trial-run failed. Revise transactions in the plan")
+		return BundleState{
+			Executable: false,
+			Reasons:    []string{"bundle trial-run failed. Revise transactions in the plan"},
+		}
 	}
-	return BundleStateRunnable, nil
+	return BundleState{Executable: true}
 }
 
 type ChainState interface {
@@ -156,16 +155,16 @@ type NonceSource interface {
 
 // checkForNonceConflicts checks whether there are any nonce conflicts in the
 // execution of the bundle.
-// It returns BundleStateNonExecutable and an error if there is a nonce conflict
+// It returns a BundleState with Executable=false and a reason if there is a nonce conflict
 // that will never be resolved.
-// It returns BundleStateTemporaryBlocked if there is a nonce conflict that may
+// It returns a BundleState with Executable=true and TemporarilyBlocked=true if there is a nonce conflict that may
 // be resolved in the future.
-// It returns BundleStateRunnable if there are no nonce conflicts right now.
+// It returns a BundleState with Executable=true if there are no nonce conflicts right now.
 func checkForNonceConflicts(
 	txBundle *bundle.TransactionBundle,
 	signer types.Signer,
 	nonceSource NonceSource,
-) (BundleState, error) {
+) BundleState {
 	// We start by collecting the lowest nonces referenced for each sender in
 	// the bundle.
 	lowest, err := getLowestReferencedNonces(txBundle, signer)
@@ -173,8 +172,10 @@ func checkForNonceConflicts(
 		// If we fail to derive the lowest referenced nonces, it means that the
 		// bundle is malformed (e.g., contains invalid transactions) and we can
 		// consider it as non-executable.
-		return BundleStateNonExecutable,
-			fmt.Errorf("could not get lowest nonce for all accounts: %w", err)
+		return BundleState{
+			Executable: false,
+			Reasons:    []string{fmt.Sprintf("could not get lowest nonce for all accounts: %v", err)},
+		}
 	}
 
 	// We correct the lowest nonces to be at least as high as the current nonces
@@ -192,18 +193,23 @@ func checkForNonceConflicts(
 
 	// If this execution failed, the bundle is non-executable.
 	if success := bundle.RunBundle(txBundle, runner); !success {
-		return BundleStateNonExecutable,
-			fmt.Errorf("bundle nonce check execution failed")
+		return BundleState{
+			Executable: false,
+			Reasons:    []string{"bundle nonce check execution failed"},
+		}
 	}
 
 	// If it succeeded, it depends on whether there is a gap between the lowest
 	// and the current nonces for any sender of an accepted transaction.
 	for sender := range runner.acceptedSender {
 		if nonceSource.GetNonce(sender) < lowest[sender] {
-			return BundleStateTemporaryBlocked, nil
+			return BundleState{
+				Executable:         true,
+				TemporarilyBlocked: true,
+			}
 		}
 	}
-	return BundleStateRunnable, nil
+	return BundleState{Executable: true}
 }
 
 // getLowestReferencedNonces returns the lowest nonce referenced for each sender

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -44,20 +44,21 @@ import (
 //     executable in the future as the blockchain progresses.
 //   - BundleStateNonExecutable: The bundle is not executable and will never
 //     be executable in the future due to permanent conditions (e.g., a
-//     transaction in the bundle uses an already consumed nonce).
+//     transaction in the bundle uses an already consumed nonce). This state
+//     is always accompanied by an error and should be ignored in favor of the error.
 type BundleState int
 
 const (
+	// BundleStateNonExecutable indicates that the bundle is not executable
+	// and will never be executable in the future due to permanent conditions.
+	BundleStateNonExecutable BundleState = iota
 	// BundleStateRunnable indicates that the bundle is ready to be executed on
 	// a given state of the blockchain and has a chance to succeed if executed.
-	BundleStateRunnable BundleState = iota
+	BundleStateRunnable
 	// BundleStateTemporaryBlocked indicates that the bundle is not currently
 	// executable due to temporary conditions, but it may become executable in
 	// the future as the blockchain progresses.
 	BundleStateTemporaryBlocked
-	// BundleStateNonExecutable indicates that the bundle is not executable
-	// and will never be executable in the future due to permanent conditions.
-	BundleStateNonExecutable
 )
 
 // GetBundleState determines the state of the bundle based on the current state
@@ -103,7 +104,7 @@ func getBundleState(
 		return BundleStateNonExecutable,
 			fmt.Errorf("failed to check for nonce conflicts: %w", err)
 	}
-	if state != BundleStateRunnable {
+	if state == BundleStateTemporaryBlocked {
 		return state, nil
 	}
 
@@ -154,10 +155,12 @@ type NonceSource interface {
 }
 
 // checkForNonceConflicts checks whether there are any nonce conflicts in the
-// execution of the bundle. It returns BundleStateNonExecutable if there
-// is a nonce conflict that will never be resolved, BundleStateTemporaryBlocked
-// if there is a nonce conflict that may be resolved in the future, and
-// BundleStateRunnable if there are no nonce conflicts right now.
+// execution of the bundle.
+// It returns BundleStateNonExecutable and an error if there is a nonce conflict
+// that will never be resolved.
+// It returns BundleStateTemporaryBlocked if there is a nonce conflict that may
+// be resolved in the future.
+// It returns BundleStateRunnable if there are no nonce conflicts right now.
 func checkForNonceConflicts(
 	txBundle *bundle.TransactionBundle,
 	signer types.Signer,

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -35,9 +35,9 @@ import (
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
 
 // BundleState represents the current evaluation state of a transaction bundle.
-// It indicates whether the bundle is executable, if it is temporarily blocked
-// from execution. If the bundle is not executable, it also provides a list of
-// reasons explaining why.
+// It indicates whether the bundle is executable as is, may become executable
+// at a later point or will never be executable. If the bundle is not executable
+// as is, it also provides a list of reasons explaining why.
 // The 3 possible cases are:
 //
 //  1. Executable: the bundle can be executed with the current state, and there
@@ -173,7 +173,7 @@ type NonceSource interface {
 // execution of the bundle.
 // It returns a BundleState with Executable=false and a reason if there is a nonce conflict
 // that will never be resolved.
-// It returns a BundleState with Executable=true and TemporarilyBlocked=true if there is a nonce conflict that may
+// It returns a BundleState with Executable=false and TemporarilyBlocked=true if there is a nonce conflict that may
 // be resolved in the future.
 // It returns a BundleState with Executable=true if there are no nonce conflicts right now.
 func checkForNonceConflicts(

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -171,11 +171,15 @@ type NonceSource interface {
 
 // checkForNonceConflicts checks whether there are any nonce conflicts in the
 // execution of the bundle.
-// It returns a BundleState with Executable=false and a reason if there is a nonce conflict
-// that will never be resolved.
-// It returns a BundleState with Executable=false and TemporarilyBlocked=true if there is a nonce conflict that may
-// be resolved in the future.
-// It returns a BundleState with Executable=true if there are no nonce conflicts right now.
+//
+// It returns a BundleState with Executable=false and a reason if there is a
+// nonce conflict that will never be resolved.
+//
+// It returns a BundleState with Executable=false and TemporarilyBlocked=true
+// if there is a nonce conflict that may be resolved in the future.
+//
+// It returns a BundleState with Executable=true if there are no nonce conflicts
+// right now.
 func checkForNonceConflicts(
 	txBundle *bundle.TransactionBundle,
 	signer types.Signer,

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -17,6 +17,7 @@
 package evmcore
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"math"
@@ -41,7 +42,7 @@ import (
 //   - BundleStateTemporaryBlocked: The bundle is not currently executable due to
 //     temporary conditions (e.g., it is too early), but it may become
 //     executable in the future as the blockchain progresses.
-//   - BundleStatePermanentlyBlocked: The bundle is not executable and will never
+//   - BundleStateNonExecutable: The bundle is not executable and will never
 //     be executable in the future due to permanent conditions (e.g., a
 //     transaction in the bundle uses an already consumed nonce).
 type BundleState int
@@ -54,9 +55,9 @@ const (
 	// executable due to temporary conditions, but it may become executable in
 	// the future as the blockchain progresses.
 	BundleStateTemporaryBlocked
-	// BundleStatePermanentlyBlocked indicates that the bundle is not executable
+	// BundleStateNonExecutable indicates that the bundle is not executable
 	// and will never be executable in the future due to permanent conditions.
-	BundleStatePermanentlyBlocked
+	BundleStateNonExecutable
 )
 
 // GetBundleState determines the state of the bundle based on the current state
@@ -64,7 +65,7 @@ const (
 func GetBundleState(
 	chain ChainState,
 	envelop *types.Transaction,
-) BundleState {
+) (BundleState, error) {
 	return getBundleState(chain, envelop, trialRunBundle)
 }
 
@@ -74,21 +75,21 @@ func getBundleState(
 	chain ChainState,
 	envelop *types.Transaction,
 	trialRunner func(*types.Transaction, ChainState, state.StateDB) bool,
-) BundleState {
+) (BundleState, error) {
 
 	// Verify that the bundle is valid.
 	bundle, _, err := bundle.ValidateTransactionBundle(envelop)
 	if err != nil {
-		return BundleStatePermanentlyBlocked
+		return BundleStateNonExecutable, errors.Join(ErrBundleTransactionInvalid, err)
 	}
 
 	// Quickest filter: check if the bundle is in the valid block range.
 	currentBlock := chain.GetLatestHeader().Number.Uint64()
 	if bundle.Latest < currentBlock {
-		return BundleStatePermanentlyBlocked
+		return BundleStateNonExecutable, ErrBundleLatestPassed
 	}
 	if bundle.Earliest > currentBlock {
-		return BundleStateTemporaryBlocked
+		return BundleStateTemporaryBlocked, nil
 	}
 
 	// Next, check whether there are any nonce conflicts in the execution of
@@ -97,9 +98,13 @@ func getBundleState(
 	chainId := big.NewInt(int64(chain.GetCurrentNetworkRules().NetworkID))
 	signer := types.LatestSignerForChainID(chainId)
 	stateDb := chain.StateDB()
-	state := checkForNonceConflicts(bundle, signer, stateDb)
+	state, err := checkForNonceConflicts(bundle, signer, stateDb)
+	if err != nil {
+		return BundleStateNonExecutable,
+			fmt.Errorf("failed to check for nonce conflicts: %w", err)
+	}
 	if state != BundleStateRunnable {
-		return state
+		return state, nil
 	}
 
 	// Trial-run the bundle to check whether it can succeed or not. This is the
@@ -107,7 +112,7 @@ func getBundleState(
 	// checks have passed. If we reach this point, nonces are aligned, so if it
 	// fails, it means that there is something else wrong with the bundle (e.g.,
 	// a missing pre-condition) that will never be resolved, and we can consider
-	// the bundle as permanently blocked.
+	// the bundle as non-executable.
 
 	// Make sure to revert all changes to enable re-using the same StateDB for
 	// multiple calls to GetBundleState without having to create a new StateDB.
@@ -119,9 +124,10 @@ func getBundleState(
 	}()
 
 	if success := trialRunner(envelop, chain, stateDb); !success {
-		return BundleStatePermanentlyBlocked
+		return BundleStateNonExecutable,
+			fmt.Errorf("bundle trial-run failed. Revise transactions in the plan")
 	}
-	return BundleStateRunnable
+	return BundleStateRunnable, nil
 }
 
 type ChainState interface {
@@ -148,7 +154,7 @@ type NonceSource interface {
 }
 
 // checkForNonceConflicts checks whether there are any nonce conflicts in the
-// execution of the bundle. It returns BundleStatePermanentlyBlocked if there
+// execution of the bundle. It returns BundleStateNonExecutable if there
 // is a nonce conflict that will never be resolved, BundleStateTemporaryBlocked
 // if there is a nonce conflict that may be resolved in the future, and
 // BundleStateRunnable if there are no nonce conflicts right now.
@@ -156,15 +162,16 @@ func checkForNonceConflicts(
 	txBundle *bundle.TransactionBundle,
 	signer types.Signer,
 	nonceSource NonceSource,
-) BundleState {
+) (BundleState, error) {
 	// We start by collecting the lowest nonces referenced for each sender in
 	// the bundle.
 	lowest, err := getLowestReferencedNonces(txBundle, signer)
 	if err != nil {
 		// If we fail to derive the lowest referenced nonces, it means that the
 		// bundle is malformed (e.g., contains invalid transactions) and we can
-		// consider it as permanently blocked.
-		return BundleStatePermanentlyBlocked
+		// consider it as non-executable.
+		return BundleStateNonExecutable,
+			fmt.Errorf("could not get lowest nonce for all accounts: %w", err)
 	}
 
 	// We correct the lowest nonces to be at least as high as the current nonces
@@ -180,19 +187,20 @@ func checkForNonceConflicts(
 		acceptedSender: make(map[common.Address]struct{}),
 	}
 
-	// If this execution failed, the bundle is permanently blocked.
+	// If this execution failed, the bundle is non-executable.
 	if success := bundle.RunBundle(txBundle, runner); !success {
-		return BundleStatePermanentlyBlocked
+		return BundleStateNonExecutable,
+			fmt.Errorf("bundle nonce check execution failed")
 	}
 
 	// If it succeeded, it depends on whether there is a gap between the lowest
 	// and the current nonces for any sender of an accepted transaction.
 	for sender := range runner.acceptedSender {
 		if nonceSource.GetNonce(sender) < lowest[sender] {
-			return BundleStateTemporaryBlocked
+			return BundleStateTemporaryBlocked, nil
 		}
 	}
-	return BundleStateRunnable
+	return BundleStateRunnable, nil
 }
 
 // getLowestReferencedNonces returns the lowest nonce referenced for each sender

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -45,7 +45,11 @@ import (
 //  2. Temporarily blocked: the bundle is not executable right now, but it may
 //     become executable later (e.g., because it depends on a future block or on
 //     the execution of other transactions that are not included in the bundle).
-//     Example: BundleState{Executable: true, TemporarilyBlocked: true}
+//     Example: BundleState{
+//     Executable: false,
+//     TemporarilyBlocked: true,
+//     Reasons: []string{"bundle earliest not reached yet"},
+//     }
 //  3. Not executable: the bundle is not executable and there are known issues
 //     with it that will never be resolved (e.g., nonce conflicts that can not be
 //     resolved by waiting for other transactions to be executed).
@@ -92,8 +96,9 @@ func getBundleState(
 	}
 	if bundle.Earliest > currentBlock {
 		return BundleState{
-			Executable:         true,
+			Executable:         false,
 			TemporarilyBlocked: true,
+			Reasons:            []string{"bundle earliest not reached yet"},
 		}
 	}
 
@@ -105,11 +110,7 @@ func getBundleState(
 	stateDb := chain.StateDB()
 	state := checkForNonceConflicts(bundle, signer, stateDb)
 	if !state.Executable {
-		state.Reasons = append([]string{"nonce conflict check failed"}, state.Reasons...)
-		return state
-	}
-
-	if state.TemporarilyBlocked {
+		state.Reasons = append([]string{"nonce check failed"}, state.Reasons...)
 		return state
 	}
 
@@ -132,7 +133,7 @@ func getBundleState(
 	if success := trialRunner(envelop, chain, stateDb); !success {
 		return BundleState{
 			Executable: false,
-			Reasons:    []string{"bundle trial-run failed. Revise transactions in the plan"},
+			Reasons:    []string{"bundle trial-run failed"},
 		}
 	}
 	return BundleState{Executable: true}
@@ -212,8 +213,9 @@ func checkForNonceConflicts(
 	for sender := range runner.acceptedSender {
 		if nonceSource.GetNonce(sender) < lowest[sender] {
 			return BundleState{
-				Executable:         true,
+				Executable:         false,
 				TemporarilyBlocked: true,
+				Reasons:            []string{"gapped nonce"},
 			}
 		}
 	}

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -35,8 +35,9 @@ import (
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
 
 // BundleState represents the current evaluation state of a transaction bundle.
-// It indicates whether the bundle is executable, if it is temporarily blocked from execution,
-// and provides a list of reasons explaining the current state.
+// It indicates whether the bundle is executable, if it is temporarily blocked
+// from execution. If the bundle is not executable, it also provides a list of
+// reasons explaining why.
 //
 // Fields:
 //   - Executable:         True if the bundle can be executed.

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -38,15 +38,22 @@ import (
 // It indicates whether the bundle is executable, if it is temporarily blocked
 // from execution. If the bundle is not executable, it also provides a list of
 // reasons explaining why.
-//
-// Fields:
-//   - Executable:         True if the bundle can be executed.
-//   - TemporarilyBlocked: True if the bundle is currently blocked but may become executable later.
-//   - Reasons:            A list of human-readable strings describing why the bundle is not executable or is blocked.
+// The 3 possible cases are:
+//  1. Executable: the bundle can be executed now or in the future, and there
+//     are no known issues with it.
+//     Example: BundleState{Executable: true}
+//  2. Temporarily blocked: the bundle is not executable right now, but it may
+//     become executable later (e.g., because it depends on a future block or on
+//     the execution of other transactions that are not included in the bundle).
+//     Example: BundleState{Executable: true, TemporarilyBlocked: true}
+//  3. Not executable: the bundle is not executable and there are known issues
+//     with it that will never be resolved (e.g., nonce conflicts that can not be
+//     resolved by waiting for other transactions to be executed).
+//     Example: BundleState{Executable: false, Reasons: []string{"reason 1", "reason 2"}}
 type BundleState struct {
-	Executable         bool
-	TemporarilyBlocked bool
-	Reasons            []string
+	Executable         bool     // True if the bundle can be executed.
+	TemporarilyBlocked bool     // True if the bundle is currently blocked but may become executable later.
+	Reasons            []string // A list of human-readable strings describing why the bundle is not executable or is blocked.
 }
 
 // GetBundleState determines the state of the bundle based on the current state

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -67,6 +67,21 @@ type BundleState struct {
 	Reasons            []string // A list of human-readable strings describing why the bundle is not executable or is blocked.
 }
 
+func makeRunnableState() BundleState {
+	return BundleState{Executable: true}
+}
+
+func makeTemporaryBlockedState(reason string) BundleState {
+	return BundleState{
+		TemporarilyBlocked: true,
+		Reasons:            []string{reason},
+	}
+}
+
+func makePermanentlyBlockedState(reason string) BundleState {
+	return BundleState{Reasons: []string{reason}}
+}
+
 // GetBundleState determines the state of the bundle based on the current state
 // of the blockchain and the transactions in the bundle.
 func GetBundleState(
@@ -87,26 +102,16 @@ func getBundleState(
 	// Verify that the bundle is valid.
 	bundle, _, err := bundle.ValidateTransactionBundle(envelop)
 	if err != nil {
-		return BundleState{
-			Executable: false,
-			Reasons:    []string{fmt.Sprintf("invalid bundle: %v", err)},
-		}
+		return makePermanentlyBlockedState(fmt.Sprintf("invalid bundle: %v", err))
 	}
 
 	// Quickest filter: check if the bundle is in the valid block range.
 	currentBlock := chain.GetLatestHeader().Number.Uint64()
 	if bundle.Latest < currentBlock {
-		return BundleState{
-			Executable: false,
-			Reasons:    []string{ErrBundleLatestPassed.Error()},
-		}
+		return makePermanentlyBlockedState(ErrBundleLatestPassed.Error())
 	}
 	if bundle.Earliest > currentBlock {
-		return BundleState{
-			Executable:         false,
-			TemporarilyBlocked: true,
-			Reasons:            []string{"bundle earliest not reached yet"},
-		}
+		return makeTemporaryBlockedState("bundle earliest not reached yet")
 	}
 
 	// Next, check whether there are any nonce conflicts in the execution of
@@ -138,12 +143,9 @@ func getBundleState(
 	}()
 
 	if success := trialRunner(envelop, chain, stateDb); !success {
-		return BundleState{
-			Executable: false,
-			Reasons:    []string{"bundle trial-run failed"},
-		}
+		return makePermanentlyBlockedState("bundle trial-run failed")
 	}
-	return BundleState{Executable: true}
+	return makeRunnableState()
 }
 
 type ChainState interface {
@@ -192,10 +194,8 @@ func checkForNonceConflicts(
 		// If we fail to derive the lowest referenced nonces, it means that the
 		// bundle is malformed (e.g., contains invalid transactions) and we can
 		// consider it as non-executable.
-		return BundleState{
-			Executable: false,
-			Reasons:    []string{fmt.Sprintf("could not get lowest nonce for all accounts: %v", err)},
-		}
+		return makePermanentlyBlockedState(
+			fmt.Sprintf("could not get lowest nonce for all accounts: %v", err))
 	}
 
 	// We correct the lowest nonces to be at least as high as the current nonces
@@ -213,24 +213,17 @@ func checkForNonceConflicts(
 
 	// If this execution failed, the bundle is non-executable.
 	if success := bundle.RunBundle(txBundle, runner); !success {
-		return BundleState{
-			Executable: false,
-			Reasons:    []string{"bundle nonce check execution failed"},
-		}
+		return makePermanentlyBlockedState("bundle nonce check execution failed")
 	}
 
 	// If it succeeded, it depends on whether there is a gap between the lowest
 	// and the current nonces for any sender of an accepted transaction.
 	for sender := range runner.acceptedSender {
 		if nonceSource.GetNonce(sender) < lowest[sender] {
-			return BundleState{
-				Executable:         false,
-				TemporarilyBlocked: true,
-				Reasons:            []string{"gapped nonce"},
-			}
+			return makeTemporaryBlockedState("gapped nonce")
 		}
 	}
-	return BundleState{Executable: true}
+	return makeRunnableState()
 }
 
 // getLowestReferencedNonces returns the lowest nonce referenced for each sender

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -39,23 +39,30 @@ import (
 // from execution. If the bundle is not executable, it also provides a list of
 // reasons explaining why.
 // The 3 possible cases are:
-//  1. Executable: the bundle can be executed now or in the future, and there
+//
+//  1. Executable: the bundle can be executed with the current state, and there
 //     are no known issues with it.
+//
 //     Example: BundleState{Executable: true}
-//  2. Temporarily blocked: the bundle is not executable right now, but it may
-//     become executable later (e.g., because it depends on a future block or on
-//     the execution of other transactions that are not included in the bundle).
+//
+//  2. Temporarily blocked: the bundle is not executable with the current state,
+//     but it may become executable later (e.g., because it depends on a future
+//     block or on the execution of other transactions that are not included in
+//     the bundle).
+//
 //     Example: BundleState{
 //     Executable: false,
 //     TemporarilyBlocked: true,
 //     Reasons: []string{"bundle earliest not reached yet"},
 //     }
+//
 //  3. Not executable: the bundle is not executable and there are known issues
 //     with it that will never be resolved (e.g., nonce conflicts that can not be
 //     resolved by waiting for other transactions to be executed).
+//
 //     Example: BundleState{Executable: false, Reasons: []string{"reason 1", "reason 2"}}
 type BundleState struct {
-	Executable         bool     // True if the bundle can be executed.
+	Executable         bool     // True if the bundle can be executed with the current state.
 	TemporarilyBlocked bool     // True if the bundle is currently blocked but may become executable later.
 	Reasons            []string // A list of human-readable strings describing why the bundle is not executable or is blocked.
 }

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -96,8 +96,9 @@ func Test_GetBundleState_ReturnsTemporaryBlockedForFutureBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	state := GetBundleState(chainState, envelop)
-	require.True(t, state.Executable)
+	require.False(t, state.Executable)
 	require.True(t, state.TemporarilyBlocked)
+	require.Contains(t, state.Reasons[0], "bundle earliest not reached yet")
 }
 
 func Test_GetBundleState_ReturnsNonExecutable_ForFailedTrialRun(t *testing.T) {
@@ -162,15 +163,24 @@ func Test_GetBundleState_ReturnsRunnableForCurrentBundle(t *testing.T) {
 	state := getBundleState(chainState, envelop, acceptEverything)
 	require.True(t, state.Executable)
 	require.False(t, state.TemporarilyBlocked)
+	require.Empty(t, state.Reasons)
 }
 
 func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 
-	executableBundleState := BundleState{Executable: true}
-	temporarilyBlockedBundleState := BundleState{Executable: true, TemporarilyBlocked: true}
+	executableBundleState := BundleState{
+		Executable: true,
+	}
+	temporarilyBlockedBundleState := BundleState{
+		Executable:         false,
+		TemporarilyBlocked: true,
+		Reasons:            []string{"nonce check failed", "gapped nonce"},
+	}
 	nonExecutableBundleState := BundleState{
 		Executable: false,
-		Reasons:    []string{"nonce conflict check failed", "bundle nonce check execution failed"}}
+		Reasons: []string{
+			"nonce check failed",
+			"bundle nonce check execution failed"}}
 
 	const initialNonce = 1
 	tests := map[string]struct {
@@ -243,7 +253,11 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 
 	executableBundleState := BundleState{Executable: true}
-	temporarilyBlockedBundleState := BundleState{Executable: true, TemporarilyBlocked: true}
+	temporarilyBlockedBundleState := BundleState{
+		Executable:         false,
+		TemporarilyBlocked: true,
+		Reasons:            []string{"gapped nonce"},
+	}
 	nonExecutableBundleState := BundleState{Executable: false,
 		Reasons: []string{"bundle nonce check execution failed"}}
 

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -96,8 +96,8 @@ func Test_GetBundleState_ReturnsTemporaryBlockedForFutureBundle(t *testing.T) {
 	require.NoError(t, err)
 
 	state := GetBundleState(chainState, envelop)
-	require.Equal(t, true, state.Executable)
-	require.Equal(t, true, state.TemporarilyBlocked)
+	require.True(t, state.Executable)
+	require.True(t, state.TemporarilyBlocked)
 }
 
 func Test_GetBundleState_ReturnsNonExecutable_ForFailedTrialRun(t *testing.T) {
@@ -128,7 +128,7 @@ func Test_GetBundleState_ReturnsNonExecutable_ForFailedTrialRun(t *testing.T) {
 	}
 
 	state := getBundleState(chainState, envelop, rejectEverything)
-	require.Equal(t, false, state.Executable)
+	require.False(t, state.Executable)
 	require.Contains(t, state.Reasons[0], "trial-run failed")
 }
 
@@ -160,8 +160,8 @@ func Test_GetBundleState_ReturnsRunnableForCurrentBundle(t *testing.T) {
 	}
 
 	state := getBundleState(chainState, envelop, acceptEverything)
-	require.Equal(t, true, state.Executable)
-	require.Equal(t, false, state.TemporarilyBlocked)
+	require.True(t, state.Executable)
+	require.False(t, state.TemporarilyBlocked)
 }
 
 func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
@@ -391,10 +391,8 @@ func Test_checkForNonceConflicts_ReturnsNonExecutable_WhenLowestReferencedNonces
 	require.Error(t, err)
 
 	got := checkForNonceConflicts(bundle, signer, nil)
-	require.Equal(t,
-		BundleState{Executable: false,
-			Reasons: []string{"could not get lowest nonce for all accounts: failed to derive sender: invalid transaction v, r, s values"}},
-		got)
+	require.False(t, got.Executable)
+	require.Contains(t, got.Reasons[0], "failed to derive sender")
 }
 
 func Test_getLowestReferencedNonces_ReturnsLowestNoncesInBundle(t *testing.T) {

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -244,7 +244,8 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 
 	executableBundleState := BundleState{Executable: true}
 	temporarilyBlockedBundleState := BundleState{Executable: true, TemporarilyBlocked: true}
-	nonExecutableBundleState := BundleState{Executable: false}
+	nonExecutableBundleState := BundleState{Executable: false,
+		Reasons: []string{"bundle nonce check execution failed"}}
 
 	const initialNonce = 1
 	tests := map[string]struct {

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -44,9 +44,9 @@ func Test_GetBundleState_ReturnsNonExecutableForInvalidBundle(t *testing.T) {
 	_, _, err := bundle.ValidateTransactionBundle(invalidBundle)
 	require.Error(t, err)
 
-	state, err := GetBundleState(chainState, invalidBundle)
-	require.ErrorIs(t, err, ErrBundleTransactionInvalid)
-	require.Equal(t, BundleStateNonExecutable, state)
+	state := GetBundleState(chainState, invalidBundle)
+	require.Equal(t, false, state.Executable)
+	require.Contains(t, state.Reasons[0], "invalid bundle")
 }
 
 func Test_GetBundleState_ReturnsNonExecutableForOutdatedBundle(t *testing.T) {
@@ -68,9 +68,9 @@ func Test_GetBundleState_ReturnsNonExecutableForOutdatedBundle(t *testing.T) {
 	_, _, err := bundle.ValidateTransactionBundle(envelop)
 	require.NoError(t, err)
 
-	state, err := GetBundleState(chainState, envelop)
-	require.ErrorIs(t, err, ErrBundleLatestPassed)
-	require.Equal(t, BundleStateNonExecutable, state)
+	state := GetBundleState(chainState, envelop)
+	require.Equal(t, false, state.Executable)
+	require.Contains(t, state.Reasons[0], ErrBundleLatestPassed.Error())
 }
 
 func Test_GetBundleState_ReturnsTemporaryBlockedForFutureBundle(t *testing.T) {
@@ -95,9 +95,9 @@ func Test_GetBundleState_ReturnsTemporaryBlockedForFutureBundle(t *testing.T) {
 	_, _, err := bundle.ValidateTransactionBundle(envelop)
 	require.NoError(t, err)
 
-	state, err := GetBundleState(chainState, envelop)
-	require.NoError(t, err)
-	require.Equal(t, BundleStateTemporaryBlocked, state)
+	state := GetBundleState(chainState, envelop)
+	require.Equal(t, true, state.Executable)
+	require.Equal(t, true, state.TemporarilyBlocked)
 }
 
 func Test_GetBundleState_ReturnsNonExecutable_ForFailedTrialRun(t *testing.T) {
@@ -118,18 +118,18 @@ func Test_GetBundleState_ReturnsNonExecutable_ForFailedTrialRun(t *testing.T) {
 	}).AnyTimes()
 	chainState.EXPECT().StateDB().Return(stateDb).AnyTimes()
 
-	envelop := wrap(&bundle.TransactionBundle{
-		Earliest: currentBlock - 5, // Bundle is valid for current block
-		Latest:   currentBlock + 5,
-	})
+	envelop := bundle.NewBuilder().
+		Earliest(currentBlock - 5).
+		Latest(currentBlock + 5).
+		Build()
 
 	rejectEverything := func(*types.Transaction, ChainState, state.StateDB) bool {
 		return false
 	}
 
-	state, err := getBundleState(chainState, envelop, rejectEverything)
-	require.ErrorContains(t, err, "trial-run failed")
-	require.Equal(t, BundleStateNonExecutable, state)
+	state := getBundleState(chainState, envelop, rejectEverything)
+	require.Equal(t, false, state.Executable)
+	require.Contains(t, state.Reasons[0], "trial-run failed")
 }
 
 func Test_GetBundleState_ReturnsRunnableForCurrentBundle(t *testing.T) {
@@ -159,12 +159,19 @@ func Test_GetBundleState_ReturnsRunnableForCurrentBundle(t *testing.T) {
 		return true
 	}
 
-	state, err := getBundleState(chainState, envelop, acceptEverything)
-	require.NoError(t, err)
-	require.Equal(t, BundleStateRunnable, state)
+	state := getBundleState(chainState, envelop, acceptEverything)
+	require.Equal(t, true, state.Executable)
+	require.Equal(t, false, state.TemporarilyBlocked)
 }
 
 func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
+
+	executableBundleState := BundleState{Executable: true}
+	temporarilyBlockedBundleState := BundleState{Executable: true, TemporarilyBlocked: true}
+	nonExecutableBundleState := BundleState{
+		Executable: false,
+		Reasons:    []string{"nonce conflict check failed", "bundle nonce check execution failed"}}
+
 	const initialNonce = 1
 	tests := map[string]struct {
 		bundle pattern
@@ -172,27 +179,27 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 	}{
 		"bundle with no transactions": {
 			bundle: allOf(), // < will always succeed
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"bundle with one transaction with correct nonce": {
 			bundle: allOf(1), // one tx with nonce 1
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"bundle with future nonce": {
 			bundle: allOf(2), // one tx with nonce 2, which is in the future
-			result: BundleStateTemporaryBlocked,
+			result: temporarilyBlockedBundleState,
 		},
 		"bundle with outdated nonce": {
 			bundle: allOf(0), // one tx with nonce 0, which is outdated
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"bundle with different senders": {
 			bundle: allOf(0xA1, 0xB1), // two txs from different senders with correct nonces
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"bundle with nonce gap": {
 			bundle: allOf(1, 3), // two txs from the same sender with a nonce gap (nonce 2 is missing)
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 	}
 
@@ -227,18 +234,17 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 				return true
 			}
 
-			got, err := getBundleState(chainState, envelop, acceptEverything)
-			if test.result == BundleStateNonExecutable {
-				require.ErrorContains(t, err, "bundle nonce check execution failed")
-			} else {
-				require.NoError(t, err)
-			}
+			got := getBundleState(chainState, envelop, acceptEverything)
 			require.Equal(t, test.result, got)
 		})
 	}
 }
 
 func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
+
+	executableBundleState := BundleState{Executable: true}
+	temporarilyBlockedBundleState := BundleState{Executable: true, TemporarilyBlocked: true}
+	nonExecutableBundleState := BundleState{Executable: false}
 
 	const initialNonce = 1
 	tests := map[string]struct {
@@ -247,108 +253,108 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 	}{
 		"empty all-of bundle is runnable": {
 			bundle: allOf(), // < will always succeed
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"empty one-of bundle is non-executable": {
 			bundle: oneOf(), // < can never succeed
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"single all-of transaction with correct nonce": {
 			bundle: allOf(1), // one tx with nonce 1
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"single one-of transaction with correct nonce": {
 			bundle: oneOf(1),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"single all-of transaction with old nonce": {
 			bundle: allOf(0),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"single one-of transaction with old nonce": {
 			bundle: oneOf(0),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"single all-of transaction with future nonce": {
 			bundle: allOf(2),
-			result: BundleStateTemporaryBlocked,
+			result: temporarilyBlockedBundleState,
 		},
 		"single one-of transaction with future nonce": {
 			bundle: oneOf(2),
-			result: BundleStateTemporaryBlocked,
+			result: temporarilyBlockedBundleState,
 		},
 		"multiple all-of transactions with correct nonce order": {
 			bundle: allOf(1, 2, 3), // three txs with nonces 1, 2, 3
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"multiple one-of transactions with correct nonce order": {
 			bundle: oneOf(1, 2, 3),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"multiple all-of transactions out of order": {
 			bundle: allOf(2, 1, 3),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"multiple one-of transactions out of order": {
 			bundle: oneOf(2, 1, 3),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"multiple all-of with old nonce": {
 			bundle: allOf(0, 1, 2),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"multiple one-of with old nonce": {
 			bundle: oneOf(0, 1, 2),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"all-of with nonce gap": {
 			bundle: allOf(1, 3),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"one-of with nonce gap": {
 			bundle: oneOf(1, 3),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"all-of with nonce gap in the future": {
 			bundle: allOf(2, 4),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"one-of with nonce gap in the future": {
 			bundle: oneOf(2, 4),
-			result: BundleStateTemporaryBlocked,
+			result: temporarilyBlockedBundleState,
 		},
 		"nested all-of with consecutive nonces": {
 			bundle: allOf(1, allOf(2, 3), 4),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"nested all-of with future nonces": {
 			bundle: allOf(2, allOf(3, 4), 5),
-			result: BundleStateTemporaryBlocked,
+			result: temporarilyBlockedBundleState,
 		},
 		"nested all-of with nonce gap": {
 			bundle: allOf(1, allOf(3, 4), 5),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"nested one-of in all-of": {
 			bundle: allOf(1, oneOf(2, 3), 3),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"multiple transactions from different senders with correct nonces": {
 			// two txs from sender A with nonces 1 and 2, one tx from sender B with nonce 1
 			bundle: allOf(0xA1, 0xB1, 0xA2),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 		"multiple transactions from different senders with nonce gap for one sender": {
 			bundle: allOf(0xA1, 0xB1, 0xA3),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"all-of outdated nonce for one sender but not the other": {
 			bundle: allOf(0xA0, 0xB1),
-			result: BundleStateNonExecutable,
+			result: nonExecutableBundleState,
 		},
 		"one-of outdated nonce for one sender but not the other": {
 			bundle: oneOf(0xA0, 0xB1),
-			result: BundleStateRunnable,
+			result: executableBundleState,
 		},
 	}
 
@@ -369,12 +375,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 			bundle, _, err := bundle.ValidateTransactionBundle(envelop)
 			require.NoError(t, err)
 
-			got, err := checkForNonceConflicts(bundle, signer, source)
-			if test.result == BundleStateNonExecutable {
-				require.ErrorContains(t, err, "bundle nonce check execution failed")
-			} else {
-				require.NoError(t, err)
-			}
+			got := checkForNonceConflicts(bundle, signer, source)
 			require.Equal(t, test.result, got)
 		})
 	}
@@ -389,9 +390,11 @@ func Test_checkForNonceConflicts_ReturnsNonExecutable_WhenLowestReferencedNonces
 	_, err := getLowestReferencedNonces(bundle, signer)
 	require.Error(t, err)
 
-	got, err := checkForNonceConflicts(bundle, signer, nil)
-	require.ErrorContains(t, err, "could not get lowest nonce")
-	require.Equal(t, BundleStateNonExecutable, got)
+	got := checkForNonceConflicts(bundle, signer, nil)
+	require.Equal(t,
+		BundleState{Executable: false,
+			Reasons: []string{"could not get lowest nonce for all accounts: failed to derive sender: invalid transaction v, r, s values"}},
+		got)
 }
 
 func Test_getLowestReferencedNonces_ReturnsLowestNoncesInBundle(t *testing.T) {

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -168,19 +168,16 @@ func Test_GetBundleState_ReturnsRunnableForCurrentBundle(t *testing.T) {
 
 func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 
-	executableBundleState := BundleState{
-		Executable: true,
-	}
-	temporarilyBlockedBundleState := BundleState{
-		Executable:         false,
-		TemporarilyBlocked: true,
-		Reasons:            []string{"nonce check failed", "gapped nonce"},
-	}
-	nonExecutableBundleState := BundleState{
-		Executable: false,
-		Reasons: []string{
-			"nonce check failed",
-			"bundle nonce check execution failed"}}
+	temporarilyBlockedBundleState := makeTemporaryBlockedState("nonce check failed")
+	temporarilyBlockedBundleState.Reasons = append(
+		temporarilyBlockedBundleState.Reasons,
+		"gapped nonce",
+	)
+	nonExecutableBundleState := makePermanentlyBlockedState("nonce check failed")
+	nonExecutableBundleState.Reasons = append(
+		nonExecutableBundleState.Reasons,
+		"bundle nonce check execution failed",
+	)
 
 	const initialNonce = 1
 	tests := map[string]struct {
@@ -189,11 +186,11 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 	}{
 		"bundle with no transactions": {
 			bundle: allOf(), // < will always succeed
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"bundle with one transaction with correct nonce": {
 			bundle: allOf(1), // one tx with nonce 1
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"bundle with future nonce": {
 			bundle: allOf(2), // one tx with nonce 2, which is in the future
@@ -205,7 +202,7 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 		},
 		"bundle with different senders": {
 			bundle: allOf(0xA1, 0xB1), // two txs from different senders with correct nonces
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"bundle with nonce gap": {
 			bundle: allOf(1, 3), // two txs from the same sender with a nonce gap (nonce 2 is missing)
@@ -252,15 +249,6 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 
 func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 
-	executableBundleState := BundleState{Executable: true}
-	temporarilyBlockedBundleState := BundleState{
-		Executable:         false,
-		TemporarilyBlocked: true,
-		Reasons:            []string{"gapped nonce"},
-	}
-	nonExecutableBundleState := BundleState{Executable: false,
-		Reasons: []string{"bundle nonce check execution failed"}}
-
 	const initialNonce = 1
 	tests := map[string]struct {
 		bundle pattern
@@ -268,108 +256,108 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 	}{
 		"empty all-of bundle is runnable": {
 			bundle: allOf(), // < will always succeed
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"empty one-of bundle is non-executable": {
 			bundle: oneOf(), // < can never succeed
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"single all-of transaction with correct nonce": {
 			bundle: allOf(1), // one tx with nonce 1
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"single one-of transaction with correct nonce": {
 			bundle: oneOf(1),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"single all-of transaction with old nonce": {
 			bundle: allOf(0),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"single one-of transaction with old nonce": {
 			bundle: oneOf(0),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"single all-of transaction with future nonce": {
 			bundle: allOf(2),
-			result: temporarilyBlockedBundleState,
+			result: makeTemporaryBlockedState("gapped nonce"),
 		},
 		"single one-of transaction with future nonce": {
 			bundle: oneOf(2),
-			result: temporarilyBlockedBundleState,
+			result: makeTemporaryBlockedState("gapped nonce"),
 		},
 		"multiple all-of transactions with correct nonce order": {
 			bundle: allOf(1, 2, 3), // three txs with nonces 1, 2, 3
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"multiple one-of transactions with correct nonce order": {
 			bundle: oneOf(1, 2, 3),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"multiple all-of transactions out of order": {
 			bundle: allOf(2, 1, 3),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"multiple one-of transactions out of order": {
 			bundle: oneOf(2, 1, 3),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"multiple all-of with old nonce": {
 			bundle: allOf(0, 1, 2),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"multiple one-of with old nonce": {
 			bundle: oneOf(0, 1, 2),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"all-of with nonce gap": {
 			bundle: allOf(1, 3),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"one-of with nonce gap": {
 			bundle: oneOf(1, 3),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"all-of with nonce gap in the future": {
 			bundle: allOf(2, 4),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"one-of with nonce gap in the future": {
 			bundle: oneOf(2, 4),
-			result: temporarilyBlockedBundleState,
+			result: makeTemporaryBlockedState("gapped nonce"),
 		},
 		"nested all-of with consecutive nonces": {
 			bundle: allOf(1, allOf(2, 3), 4),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"nested all-of with future nonces": {
 			bundle: allOf(2, allOf(3, 4), 5),
-			result: temporarilyBlockedBundleState,
+			result: makeTemporaryBlockedState("gapped nonce"),
 		},
 		"nested all-of with nonce gap": {
 			bundle: allOf(1, allOf(3, 4), 5),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"nested one-of in all-of": {
 			bundle: allOf(1, oneOf(2, 3), 3),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"multiple transactions from different senders with correct nonces": {
 			// two txs from sender A with nonces 1 and 2, one tx from sender B with nonce 1
 			bundle: allOf(0xA1, 0xB1, 0xA2),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 		"multiple transactions from different senders with nonce gap for one sender": {
 			bundle: allOf(0xA1, 0xB1, 0xA3),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"all-of outdated nonce for one sender but not the other": {
 			bundle: allOf(0xA0, 0xB1),
-			result: nonExecutableBundleState,
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
 		"one-of outdated nonce for one sender but not the other": {
 			bundle: oneOf(0xA0, 0xB1),
-			result: executableBundleState,
+			result: makeRunnableState(),
 		},
 	}
 

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func Test_GetBundleState_ReturnsPermanentlyBlockedForInvalidBundle(t *testing.T) {
+func Test_GetBundleState_ReturnsNonExecutableForInvalidBundle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	chainState := NewMockChainState(ctrl)
 	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
@@ -44,11 +44,12 @@ func Test_GetBundleState_ReturnsPermanentlyBlockedForInvalidBundle(t *testing.T)
 	_, _, err := bundle.ValidateTransactionBundle(invalidBundle)
 	require.Error(t, err)
 
-	state := GetBundleState(chainState, invalidBundle)
-	require.Equal(t, BundleStatePermanentlyBlocked, state)
+	state, err := GetBundleState(chainState, invalidBundle)
+	require.ErrorIs(t, err, ErrBundleTransactionInvalid)
+	require.Equal(t, BundleStateNonExecutable, state)
 }
 
-func Test_GetBundleState_ReturnsPermanentlyBlockedForOutdatedBundle(t *testing.T) {
+func Test_GetBundleState_ReturnsNonExecutableForOutdatedBundle(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	chainState := NewMockChainState(ctrl)
 
@@ -67,8 +68,9 @@ func Test_GetBundleState_ReturnsPermanentlyBlockedForOutdatedBundle(t *testing.T
 	_, _, err := bundle.ValidateTransactionBundle(envelop)
 	require.NoError(t, err)
 
-	state := GetBundleState(chainState, envelop)
-	require.Equal(t, BundleStatePermanentlyBlocked, state)
+	state, err := GetBundleState(chainState, envelop)
+	require.ErrorIs(t, err, ErrBundleLatestPassed)
+	require.Equal(t, BundleStateNonExecutable, state)
 }
 
 func Test_GetBundleState_ReturnsTemporaryBlockedForFutureBundle(t *testing.T) {
@@ -93,8 +95,41 @@ func Test_GetBundleState_ReturnsTemporaryBlockedForFutureBundle(t *testing.T) {
 	_, _, err := bundle.ValidateTransactionBundle(envelop)
 	require.NoError(t, err)
 
-	state := GetBundleState(chainState, envelop)
+	state, err := GetBundleState(chainState, envelop)
+	require.NoError(t, err)
 	require.Equal(t, BundleStateTemporaryBlocked, state)
+}
+
+func Test_GetBundleState_ReturnsNonExecutable_ForFailedTrialRun(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+	chainState := NewMockChainState(ctrl)
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().InterTxSnapshot().Return(12)
+	stateDb.EXPECT().RevertToInterTxSnapshot(12)
+
+	currentBlock := uint64(100)
+	currentHeader := &EvmHeader{
+		Number: big.NewInt(int64(currentBlock)),
+	}
+	chainState.EXPECT().GetLatestHeader().Return(currentHeader).AnyTimes()
+	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
+		NetworkID: 1,
+	}).AnyTimes()
+	chainState.EXPECT().StateDB().Return(stateDb).AnyTimes()
+
+	envelop := wrap(&bundle.TransactionBundle{
+		Earliest: currentBlock - 5, // Bundle is valid for current block
+		Latest:   currentBlock + 5,
+	})
+
+	rejectEverything := func(*types.Transaction, ChainState, state.StateDB) bool {
+		return false
+	}
+
+	state, err := getBundleState(chainState, envelop, rejectEverything)
+	require.ErrorContains(t, err, "trial-run failed")
+	require.Equal(t, BundleStateNonExecutable, state)
 }
 
 func Test_GetBundleState_ReturnsRunnableForCurrentBundle(t *testing.T) {
@@ -124,7 +159,8 @@ func Test_GetBundleState_ReturnsRunnableForCurrentBundle(t *testing.T) {
 		return true
 	}
 
-	state := getBundleState(chainState, envelop, acceptEverything)
+	state, err := getBundleState(chainState, envelop, acceptEverything)
+	require.NoError(t, err)
 	require.Equal(t, BundleStateRunnable, state)
 }
 
@@ -148,7 +184,7 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 		},
 		"bundle with outdated nonce": {
 			bundle: allOf(0), // one tx with nonce 0, which is outdated
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"bundle with different senders": {
 			bundle: allOf(0xA1, 0xB1), // two txs from different senders with correct nonces
@@ -156,7 +192,7 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 		},
 		"bundle with nonce gap": {
 			bundle: allOf(1, 3), // two txs from the same sender with a nonce gap (nonce 2 is missing)
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 	}
 
@@ -191,7 +227,12 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 				return true
 			}
 
-			got := getBundleState(chainState, envelop, acceptEverything)
+			got, err := getBundleState(chainState, envelop, acceptEverything)
+			if test.result == BundleStateNonExecutable {
+				require.ErrorContains(t, err, "bundle nonce check execution failed")
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, test.result, got)
 		})
 	}
@@ -208,9 +249,9 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 			bundle: allOf(), // < will always succeed
 			result: BundleStateRunnable,
 		},
-		"empty one-of bundle is permanently blocked": {
+		"empty one-of bundle is non-executable": {
 			bundle: oneOf(), // < can never succeed
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"single all-of transaction with correct nonce": {
 			bundle: allOf(1), // one tx with nonce 1
@@ -222,11 +263,11 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 		},
 		"single all-of transaction with old nonce": {
 			bundle: allOf(0),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"single one-of transaction with old nonce": {
 			bundle: oneOf(0),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"single all-of transaction with future nonce": {
 			bundle: allOf(2),
@@ -246,7 +287,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 		},
 		"multiple all-of transactions out of order": {
 			bundle: allOf(2, 1, 3),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"multiple one-of transactions out of order": {
 			bundle: oneOf(2, 1, 3),
@@ -254,7 +295,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 		},
 		"multiple all-of with old nonce": {
 			bundle: allOf(0, 1, 2),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"multiple one-of with old nonce": {
 			bundle: oneOf(0, 1, 2),
@@ -262,7 +303,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 		},
 		"all-of with nonce gap": {
 			bundle: allOf(1, 3),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"one-of with nonce gap": {
 			bundle: oneOf(1, 3),
@@ -270,7 +311,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 		},
 		"all-of with nonce gap in the future": {
 			bundle: allOf(2, 4),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"one-of with nonce gap in the future": {
 			bundle: oneOf(2, 4),
@@ -286,7 +327,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 		},
 		"nested all-of with nonce gap": {
 			bundle: allOf(1, allOf(3, 4), 5),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"nested one-of in all-of": {
 			bundle: allOf(1, oneOf(2, 3), 3),
@@ -299,11 +340,11 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 		},
 		"multiple transactions from different senders with nonce gap for one sender": {
 			bundle: allOf(0xA1, 0xB1, 0xA3),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"all-of outdated nonce for one sender but not the other": {
 			bundle: allOf(0xA0, 0xB1),
-			result: BundleStatePermanentlyBlocked,
+			result: BundleStateNonExecutable,
 		},
 		"one-of outdated nonce for one sender but not the other": {
 			bundle: oneOf(0xA0, 0xB1),
@@ -328,13 +369,18 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 			bundle, _, err := bundle.ValidateTransactionBundle(envelop)
 			require.NoError(t, err)
 
-			got := checkForNonceConflicts(bundle, signer, source)
+			got, err := checkForNonceConflicts(bundle, signer, source)
+			if test.result == BundleStateNonExecutable {
+				require.ErrorContains(t, err, "bundle nonce check execution failed")
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, test.result, got)
 		})
 	}
 }
 
-func Test_checkForNonceConflicts_ReturnsPermanentlyBlockedIfLowestReferencedNoncesCannotBeDerived(t *testing.T) {
+func Test_checkForNonceConflicts_ReturnsNonExecutable_WhenLowestReferencedNoncesCannotBeDerived(t *testing.T) {
 	invalidTx := types.NewTx(&types.LegacyTx{})
 	bundle := &bundle.TransactionBundle{
 		Transactions: []*types.Transaction{invalidTx},
@@ -343,8 +389,9 @@ func Test_checkForNonceConflicts_ReturnsPermanentlyBlockedIfLowestReferencedNonc
 	_, err := getLowestReferencedNonces(bundle, signer)
 	require.Error(t, err)
 
-	got := checkForNonceConflicts(bundle, signer, nil)
-	require.Equal(t, BundleStatePermanentlyBlocked, got)
+	got, err := checkForNonceConflicts(bundle, signer, nil)
+	require.ErrorContains(t, err, "could not get lowest nonce")
+	require.Equal(t, BundleStateNonExecutable, got)
 }
 
 func Test_getLowestReferencedNonces_ReturnsLowestNoncesInBundle(t *testing.T) {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -116,7 +116,7 @@ var (
 	ErrBundleTransactionInvalid = errors.New("invalid bundle transaction")
 
 	// ErrBundleInexecutable is returned when a bundle is determined to be currently not executable in the current state.
-	ErrBundleNonExecutable = errors.New("bundle cannot execute")
+	ErrBundleNonExecutable = errors.New("bundle is not executable")
 
 	// ErrBundleLatestPassed is returned when a bundle's latest block has already passed.
 	ErrBundleLatestPassed = errors.New("bundle latest block has already passed")

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -115,8 +115,11 @@ var (
 	// ErrBundleTransactionInvalid is returned when a bundle transaction is invalid.
 	ErrBundleTransactionInvalid = errors.New("invalid bundle transaction")
 
-	// ErrBundlePermanentlyBlocked is returned when a bundle is determined to be permanently blocked.
-	ErrBundlePermanentlyBlocked = errors.New("bundle is permanently blocked")
+	// ErrBundleInexecutable is returned when a bundle is determined to be currently not executable in the current state.
+	ErrBundleNonExecutable = errors.New("bundle cannot execute")
+
+	// ErrBundleLatestPassed is returned when a bundle's latest block has already passed.
+	ErrBundleLatestPassed = errors.New("bundle latest block has already passed")
 )
 
 var (

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
@@ -401,7 +402,7 @@ func validateBundleTransactionsInternal(
 	chainState StateReader,
 	// Although state can be retrieved from chain, it is passed explicitly to avoid extra db-pool accesses
 	stateDb state.StateDB,
-	getBundleState func(ChainState, *types.Transaction) (BundleState, error),
+	getBundleState func(ChainState, *types.Transaction) BundleState,
 ) error {
 	// This check only covers bundle transactions, ignore the rest.
 	if !bundle.IsEnvelope(tx) {
@@ -424,9 +425,11 @@ func validateBundleTransactionsInternal(
 		chainState: chainState,
 		stateDB:    stateDb,
 	}
-	_, err = getBundleState(chainAdapter, tx)
-	if err != nil {
-		return errors.Join(ErrBundleNonExecutable, err)
+	state := getBundleState(chainAdapter, tx)
+	if !state.Executable {
+		return errors.Join(
+			ErrBundleNonExecutable,
+			errors.New(strings.Join(state.Reasons, ".\n")))
 	}
 
 	return nil

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -424,8 +424,8 @@ func validateBundleTransactionsInternal(
 		chainState: chainState,
 		stateDB:    stateDb,
 	}
-	state, err := getBundleState(chainAdapter, tx)
-	if err != nil || state == BundleStateNonExecutable {
+	_, err = getBundleState(chainAdapter, tx)
+	if err != nil {
 		return errors.Join(ErrBundleNonExecutable, err)
 	}
 

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -17,6 +17,7 @@
 package evmcore
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -400,7 +401,7 @@ func validateBundleTransactionsInternal(
 	chainState StateReader,
 	// Although state can be retrieved from chain, it is passed explicitly to avoid extra db-pool accesses
 	stateDb state.StateDB,
-	getBundleState func(ChainState, *types.Transaction) BundleState,
+	getBundleState func(ChainState, *types.Transaction) (BundleState, error),
 ) error {
 	// This check only covers bundle transactions, ignore the rest.
 	if !bundle.IsEnvelope(tx) {
@@ -415,7 +416,7 @@ func validateBundleTransactionsInternal(
 	// If the transaction is a bundle, validate its structure and content.
 	_, _, err := bundle.ValidateTransactionBundle(tx)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrBundleTransactionInvalid, err)
+		return errors.Join(ErrBundleTransactionInvalid, err)
 	}
 
 	// Check that the bundle is runnable.
@@ -423,11 +424,9 @@ func validateBundleTransactionsInternal(
 		chainState: chainState,
 		stateDB:    stateDb,
 	}
-	state := getBundleState(chainAdapter, tx)
-	if state == BundleStatePermanentlyBlocked {
-		// TODO: have `GetBundleState` provide more context on why the bundle is
-		// blocked and include that in the error message.
-		return ErrBundlePermanentlyBlocked
+	state, err := getBundleState(chainAdapter, tx)
+	if err != nil || state == BundleStateNonExecutable {
+		return errors.Join(ErrBundleNonExecutable, err)
 	}
 
 	return nil

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1436,18 +1436,15 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunnable_RejectBundleTran
 
 	tests := map[string]struct {
 		bundleState BundleState
-		valid       bool
 	}{
 		"runnable": {
-			bundleState: BundleStateRunnable,
-			valid:       true,
+			bundleState: BundleState{Executable: true},
 		},
 		"temporary_blocked": {
-			bundleState: BundleStateTemporaryBlocked,
-			valid:       true,
+			bundleState: BundleState{Executable: true, TemporarilyBlocked: true},
 		},
 		"non_executable": {
-			valid: false,
+			bundleState: BundleState{Executable: false, Reasons: []string{"some reason"}},
 		},
 	}
 
@@ -1457,21 +1454,17 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunnable_RejectBundleTran
 			tx := bundle.AllOf()
 			require.True(bundle.IsEnvelope(tx))
 
-			getBundleState := func(ChainState, *types.Transaction) (BundleState, error) {
-				var err error
-				if !test.valid {
-					err = fmt.Errorf("some error")
-				}
-				return test.bundleState, err
+			getBundleState := func(ChainState, *types.Transaction) BundleState {
+				return test.bundleState
 			}
 
 			rules := NetworkRules{}
 			rules.transactionBundles = true
 			err := validateBundleTransactionsInternal(tx, rules, nil, nil, getBundleState)
-			if test.valid {
-				require.NoError(err)
-			} else {
+			if !test.bundleState.Executable {
 				require.ErrorIs(err, ErrBundleNonExecutable)
+			} else {
+				require.NoError(err)
 			}
 		})
 	}
@@ -1482,8 +1475,8 @@ func Test_validateBundleTransactions_IfBundledTransactionsAreEnabled_AcceptValid
 	tx := bundle.AllOf()
 	require.True(bundle.IsEnvelope(tx))
 
-	getBundleState := func(ChainState, *types.Transaction) (BundleState, error) {
-		return BundleStateRunnable, nil
+	getBundleState := func(ChainState, *types.Transaction) BundleState {
+		return BundleState{Executable: true}
 	}
 
 	rules := NetworkRules{}

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1447,8 +1447,7 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunnable_RejectBundleTran
 			valid:       true,
 		},
 		"non_executable": {
-			bundleState: BundleStateNonExecutable,
-			valid:       false,
+			valid: false,
 		},
 	}
 
@@ -1459,7 +1458,11 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunnable_RejectBundleTran
 			require.True(bundle.IsEnvelope(tx))
 
 			getBundleState := func(ChainState, *types.Transaction) (BundleState, error) {
-				return test.bundleState, nil
+				var err error
+				if !test.valid {
+					err = fmt.Errorf("some error")
+				}
+				return test.bundleState, err
 			}
 
 			rules := NetworkRules{}

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1441,7 +1441,7 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunnable_RejectBundleTran
 			bundleState: BundleState{Executable: true},
 		},
 		"temporary_blocked": {
-			bundleState: BundleState{Executable: true, TemporarilyBlocked: true},
+			bundleState: BundleState{Executable: false, TemporarilyBlocked: true},
 		},
 		"non_executable": {
 			bundleState: BundleState{Executable: false, Reasons: []string{"some reason"}},

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1432,7 +1432,7 @@ func Test_validateBundleTransactions_AcceptNonBundleTransactions(t *testing.T) {
 	}
 }
 
-func Test_validateBundleTransactions_IfBundleStateIsNotRunning_RejectBundleTransaction(t *testing.T) {
+func Test_validateBundleTransactions_IfBundleStateIsNotRunnable_RejectBundleTransaction(t *testing.T) {
 
 	tests := map[string]struct {
 		bundleState BundleState
@@ -1446,8 +1446,8 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunning_RejectBundleTrans
 			bundleState: BundleStateTemporaryBlocked,
 			valid:       true,
 		},
-		"permanently_blocked": {
-			bundleState: BundleStatePermanentlyBlocked,
+		"non_executable": {
+			bundleState: BundleStateNonExecutable,
 			valid:       false,
 		},
 	}
@@ -1458,8 +1458,8 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunning_RejectBundleTrans
 			tx := bundle.AllOf()
 			require.True(bundle.IsEnvelope(tx))
 
-			getBundleState := func(ChainState, *types.Transaction) BundleState {
-				return test.bundleState
+			getBundleState := func(ChainState, *types.Transaction) (BundleState, error) {
+				return test.bundleState, nil
 			}
 
 			rules := NetworkRules{}
@@ -1468,7 +1468,7 @@ func Test_validateBundleTransactions_IfBundleStateIsNotRunning_RejectBundleTrans
 			if test.valid {
 				require.NoError(err)
 			} else {
-				require.ErrorIs(err, ErrBundlePermanentlyBlocked)
+				require.ErrorIs(err, ErrBundleNonExecutable)
 			}
 		})
 	}
@@ -1479,8 +1479,8 @@ func Test_validateBundleTransactions_IfBundledTransactionsAreEnabled_AcceptValid
 	tx := bundle.AllOf()
 	require.True(bundle.IsEnvelope(tx))
 
-	getBundleState := func(ChainState, *types.Transaction) BundleState {
-		return BundleStateRunnable
+	getBundleState := func(ChainState, *types.Transaction) (BundleState, error) {
+		return BundleStateRunnable, nil
 	}
 
 	rules := NetworkRules{}
@@ -1521,7 +1521,7 @@ func TestValidateBundleTransactions_RejectsBundleWhenPayloadTransactionIsInvalid
 
 	rules.transactionBundles = true
 	err := validateBundleTransactions(bundleTx, rules, chain, state)
-	require.ErrorContains(err, "bundle is permanently blocked")
+	require.ErrorIs(err, ErrBundleNonExecutable)
 }
 
 func makeValidateTxParameters(t *testing.T) (NetworkRules, *MockStateReader, *state.MockStateDB) {

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -241,7 +241,7 @@ func (em *Emitter) isValidBundleTx(tx *types.Transaction) bool {
 
 func (em *Emitter) isRunnableBundleTxInternal(
 	tx *types.Transaction,
-	getBundleState func(evmcore.ChainState, *types.Transaction) (evmcore.BundleState, error),
+	getBundleState func(evmcore.ChainState, *types.Transaction) evmcore.BundleState,
 ) bool {
 	// Ignore if bundled transactions are not enabled.
 	if !em.world.GetRules().Upgrades.TransactionBundles {
@@ -273,11 +273,7 @@ func (em *Emitter) isRunnableBundleTxInternal(
 
 	// Skip bundles that are not runnable in the current state.
 	adapter := &precheckChainStateAdapter{external: em.world}
-	bundleState, err := getBundleState(adapter, tx)
-	if err != nil {
-		return false
-	}
-	return bundleState == evmcore.BundleStateRunnable
+	return getBundleState(adapter, tx).Executable
 }
 
 type precheckChainStateAdapter struct {

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -236,12 +236,12 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 // isValidBundleTx checks whether the given transaction is a valid bundle that
 // could be emitted by this emitter.
 func (em *Emitter) isValidBundleTx(tx *types.Transaction) bool {
-	return em.isValidBundleTxInternal(tx, evmcore.GetBundleState)
+	return em.isRunnableBundleTxInternal(tx, evmcore.GetBundleState)
 }
 
-func (em *Emitter) isValidBundleTxInternal(
+func (em *Emitter) isRunnableBundleTxInternal(
 	tx *types.Transaction,
-	getBundleState func(evmcore.ChainState, *types.Transaction) evmcore.BundleState,
+	getBundleState func(evmcore.ChainState, *types.Transaction) (evmcore.BundleState, error),
 ) bool {
 	// Ignore if bundled transactions are not enabled.
 	if !em.world.GetRules().Upgrades.TransactionBundles {
@@ -273,7 +273,10 @@ func (em *Emitter) isValidBundleTxInternal(
 
 	// Skip bundles that are not runnable in the current state.
 	adapter := &precheckChainStateAdapter{external: em.world}
-	bundleState := getBundleState(adapter, tx)
+	bundleState, err := getBundleState(adapter, tx)
+	if err != nil {
+		return false
+	}
 	return bundleState == evmcore.BundleStateRunnable
 }
 

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -68,8 +68,8 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 			_, _, err := bundle.ValidateTransactionBundle(tx)
 			require.NoError(err)
 
-			allBundlesRunnable := func(evmcore.ChainState, *types.Transaction) (evmcore.BundleState, error) {
-				return evmcore.BundleStateRunnable, nil
+			allBundlesRunnable := func(evmcore.ChainState, *types.Transaction) evmcore.BundleState {
+				return evmcore.BundleState{Executable: true}
 			}
 
 			require.Equal(bundlesEnabled, emitter.isRunnableBundleTxInternal(tx, allBundlesRunnable))
@@ -140,8 +140,8 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 			_, _, err := bundle.ValidateTransactionBundle(tx)
 			require.NoError(t, err)
 
-			getBundleState := func(evmcore.ChainState, *types.Transaction) (evmcore.BundleState, error) {
-				return evmcore.BundleStateRunnable, nil
+			getBundleState := func(evmcore.ChainState, *types.Transaction) evmcore.BundleState {
+				return evmcore.BundleState{Executable: true}
 			}
 
 			require.Equal(t, !processed, emitter.isRunnableBundleTxInternal(tx, getBundleState))

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -68,11 +68,11 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 			_, _, err := bundle.ValidateTransactionBundle(tx)
 			require.NoError(err)
 
-			allBundlesRunnable := func(evmcore.ChainState, *types.Transaction) evmcore.BundleState {
-				return evmcore.BundleStateRunnable
+			allBundlesRunnable := func(evmcore.ChainState, *types.Transaction) (evmcore.BundleState, error) {
+				return evmcore.BundleStateRunnable, nil
 			}
 
-			require.Equal(bundlesEnabled, emitter.isValidBundleTxInternal(tx, allBundlesRunnable))
+			require.Equal(bundlesEnabled, emitter.isRunnableBundleTxInternal(tx, allBundlesRunnable))
 		})
 	}
 }
@@ -140,11 +140,11 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 			_, _, err := bundle.ValidateTransactionBundle(tx)
 			require.NoError(t, err)
 
-			getBundleState := func(evmcore.ChainState, *types.Transaction) evmcore.BundleState {
-				return evmcore.BundleStateRunnable
+			getBundleState := func(evmcore.ChainState, *types.Transaction) (evmcore.BundleState, error) {
+				return evmcore.BundleStateRunnable, nil
 			}
 
-			require.Equal(t, !processed, emitter.isValidBundleTxInternal(tx, getBundleState))
+			require.Equal(t, !processed, emitter.isRunnableBundleTxInternal(tx, getBundleState))
 		})
 	}
 }

--- a/tests/bundles/bundle_sponsored_test.go
+++ b/tests/bundles/bundle_sponsored_test.go
@@ -61,7 +61,7 @@ func TestBundle_RejectsBundle_WithPayloadSponsorRequest_WithoutSponsorship(t *te
 	// NOTE: once bundle trial-run is implemented this submition will fail.
 	// which is what this test should verify.
 	err = client.SendTransaction(t.Context(), bundleTx)
-	require.ErrorContains(t, err, "bundle is permanently blocked")
+	require.ErrorContains(t, err, "bundle cannot execute")
 }
 
 func TestBundle_CanRunSponsorshipAndSponsored(t *testing.T) {

--- a/tests/bundles/bundle_sponsored_test.go
+++ b/tests/bundles/bundle_sponsored_test.go
@@ -61,7 +61,7 @@ func TestBundle_RejectsBundle_WithPayloadSponsorRequest_WithoutSponsorship(t *te
 	// NOTE: once bundle trial-run is implemented this submition will fail.
 	// which is what this test should verify.
 	err = client.SendTransaction(t.Context(), bundleTx)
-	require.ErrorContains(t, err, "bundle cannot execute")
+	require.ErrorContains(t, err, "bundle is not executable")
 }
 
 func TestBundle_CanRunSponsorshipAndSponsored(t *testing.T) {

--- a/tests/bundles/bundle_test.go
+++ b/tests/bundles/bundle_test.go
@@ -554,7 +554,7 @@ func checkCase(t *testing.T, session tests.IntegrationTestNetSession, accounts *
 		err = client.SendTransaction(t.Context(), envelopeTx)
 		if err != nil {
 			// Check whether the bundle was rejected by the pre-check.
-			require.ErrorContains(t, err, "permanently blocked")
+			require.ErrorContains(t, err, "bundle cannot execute")
 			// This is only allowed for transactions that should fail.
 			require.Zero(t, c.counter)
 			require.Empty(t, c.blockTxIndices)

--- a/tests/bundles/bundle_test.go
+++ b/tests/bundles/bundle_test.go
@@ -554,7 +554,7 @@ func checkCase(t *testing.T, session tests.IntegrationTestNetSession, accounts *
 		err = client.SendTransaction(t.Context(), envelopeTx)
 		if err != nil {
 			// Check whether the bundle was rejected by the pre-check.
-			require.ErrorContains(t, err, "bundle cannot execute")
+			require.ErrorContains(t, err, "bundle is not executable")
 			// This is only allowed for transactions that should fail.
 			require.Zero(t, c.counter)
 			require.Empty(t, c.blockTxIndices)


### PR DESCRIPTION
Since bundles are submitted with the usual `SendTransaction`, when a bundles is rejected, a comprehensive message should be returned so that the user is informed why is the bundle rejected.

This PR adds error messages to `getBundleStatus`, `checkForNonceConflicts` and `validateBundleTransactionsInternal`.

This PR renames the `permanently blocked` error to `non executables`. 