### PR TITLE
Use Hex encoding in RPC methods

### DIFF
--- a/ethapi/bundle_api.go
+++ b/ethapi/bundle_api.go
@@ -56,7 +56,7 @@ const (
 func (a *PublicBundleAPI) GetBundleInfo(
 	ctx context.Context,
 	executionPlanHash common.Hash,
-) (BundleInfo, error) {
+) (RPCBundleInfo, error) {
 
 	// Since there is no global lock on the state, and a bundle can be executed
 	// and removed from the pool in-between checking for the execution info and
@@ -67,17 +67,17 @@ func (a *PublicBundleAPI) GetBundleInfo(
 		// Check whether the given execution plan got already executed.
 		info := a.b.GetBundleExecutionInfo(executionPlanHash)
 		if info != nil {
-			return BundleInfo{
+			return RPCBundleInfo{
 				Status:   BundleStatusExecuted,
-				Block:    &info.BlockNum,
-				Position: &info.Position,
-				Count:    &info.Count,
+				Block:    toBlockNum(info.BlockNum),
+				Position: toHexUint(uint64(info.Position)),
+				Count:    toHexUint(uint64(info.Count)),
 			}, nil
 		}
 
 		// Check whether the given execution plan is pending in the Tx Pool.
 		if isInPool := a.b.IsBundleInPool(executionPlanHash); isInPool {
-			return BundleInfo{
+			return RPCBundleInfo{
 				Status: BundleStatusPending,
 			}, nil
 		}
@@ -85,16 +85,16 @@ func (a *PublicBundleAPI) GetBundleInfo(
 	}
 
 	// Otherwise, the state is unknown (default).
-	return BundleInfo{}, nil
+	return RPCBundleInfo{}, nil
 }
 
-// BundleInfo is the JSON RPC message returned by the GetBundleInfo API, which
+// RPCBundleInfo is the JSON RPC message returned by the GetBundleInfo API, which
 // provides information about the status of a transaction bundle.
-type BundleInfo struct {
-	Status   BundleStatus `json:"status"`
-	Block    *uint64      `json:"block,omitempty"`
-	Position *uint32      `json:"position,omitempty"`
-	Count    *uint32      `json:"count,omitempty"`
+type RPCBundleInfo struct {
+	Status   BundleStatus     `json:"status"`
+	Block    *rpc.BlockNumber `json:"block,omitempty"`
+	Position *hexutil.Uint    `json:"position,omitempty"`
+	Count    *hexutil.Uint    `json:"count,omitempty"`
 }
 
 type PrepareBundleArgs struct {
@@ -111,15 +111,15 @@ type PrepareBundleArgs struct {
 	LatestBlock rpc.BlockNumber `json:"latestBlock"`
 }
 
-// PreparedBundle is the return type of the `sonic_prepareBundle` RPC method
-type PreparedBundle struct {
+// RPCPreparedBundle is the return type of the `sonic_prepareBundle` RPC method
+type RPCPreparedBundle struct {
 	// Transactions specifies the ordered list of transactions to be included in the bundle.
 	// These must be signed exactly as provided by the bundle_prepare RPC method; any modification
 	// will invalidate the execution plan and result in an ill-formed bundle.
 	Transactions []TransactionArgs `json:"transactions"`
 	// Plan contains the execution plan that each bundled transaction references. This is provided
 	// for verification purposes; users may independently compute and validate the execution plan hash.
-	Plan bundle.ExecutionPlan `json:"plan,omitempty"`
+	Plan RPCExecutionPlan `json:"plan,omitempty"`
 }
 
 // PrepareBundle implements the `sonic_prepareBundle` RPC method.
@@ -135,7 +135,7 @@ type PreparedBundle struct {
 func (a *PublicBundleAPI) PrepareBundle(
 	ctx context.Context,
 	args PrepareBundleArgs,
-) (*PreparedBundle, error) {
+) (*RPCPreparedBundle, error) {
 
 	gasCap := a.b.RPCGasCap()
 	basefee := a.b.MinGasPrice()
@@ -192,9 +192,9 @@ func (a *PublicBundleAPI) PrepareBundle(
 		args.Transactions[i] = tx
 	}
 
-	bundle := PreparedBundle{
+	bundle := RPCPreparedBundle{
 		Transactions: args.Transactions,
-		Plan:         plan,
+		Plan:         NewRPCExecutionPlan(plan),
 	}
 
 	return &bundle, nil
@@ -209,7 +209,7 @@ type SubmitBundleArgs struct {
 	// ExecutionPlan contains the execution plan that each bundled transaction references.
 	// This value must be provided as returned by the `sonic_prepareBundle` method;
 	// any modification will invalidate the execution plan and result in an ill-formed bundle.
-	ExecutionPlan bundle.ExecutionPlan `json:"plan,omitempty"`
+	ExecutionPlan RPCExecutionPlan `json:"executionPlan,omitempty"`
 }
 
 // SubmitBundle implements the `sonic_submitBundle` RPC method, which submits a prepared bundle for execution.
@@ -221,8 +221,8 @@ func (a *PublicBundleAPI) SubmitBundle(
 	txBundle := bundle.TransactionBundle{
 		Transactions: make(types.Transactions, len(args.SignedTransactions)),
 		Flags:        args.ExecutionPlan.Flags,
-		Earliest:     args.ExecutionPlan.Earliest,
-		Latest:       args.ExecutionPlan.Latest,
+		Earliest:     uint64(args.ExecutionPlan.Earliest),
+		Latest:       uint64(args.ExecutionPlan.Latest),
 	}
 
 	// 1) Decode bundled transactions and compute total gas requirement
@@ -319,6 +319,8 @@ func asTransaction(msg *core.Message) (*types.Transaction, error) {
 }
 
 type BundleGasLimits struct {
+	// GasLimits contains the estimated gas limit for each transaction in the
+	// bundle, in the same order as the input transactions.
 	GasLimits []hexutil.Uint64 `json:"gasLimits"`
 }
 
@@ -327,8 +329,13 @@ type BundleGasLimits struct {
 // applying state changes from previous transactions when estimating subsequent ones.
 // Transactions that become invalid or fail during execution for later estimations are ignored.
 // This method can help getting gas estimates for mutually depending transactions in bundles.
-func (a *PublicBundleAPI) EstimateGasForTransactions(ctx context.Context, args []TransactionArgs,
-	blockNrOrHash *rpc.BlockNumberOrHash, overrides *StateOverride, blockOverrides *BlockOverrides) (BundleGasLimits, error) {
+func (a *PublicBundleAPI) EstimateGasForTransactions(
+	ctx context.Context,
+	args []TransactionArgs,
+	blockNrOrHash *rpc.BlockNumberOrHash,
+	overrides *StateOverride,
+	blockOverrides *BlockOverrides,
+) (BundleGasLimits, error) {
 
 	if len(args) > 16 {
 		return BundleGasLimits{}, fmt.Errorf("too many transactions to estimate gas for: got %d, max is 16", len(args))
@@ -398,4 +405,43 @@ func doEstimateGasForTransactions(
 			hexutil.Uint64(params.TxAccessListStorageKeyGas) // add gas for execution plan hash
 	}
 	return gasLimits, nil
+}
+
+type RPCExecutionStep struct {
+	From common.Address `json:"from"`
+	Hash common.Hash    `json:"hash"`
+}
+
+type RPCExecutionPlan struct {
+	Flags    bundle.ExecutionFlag `json:"flags"`
+	Steps    []RPCExecutionStep   `json:"steps"`
+	Earliest rpc.BlockNumber      `json:"earliest"`
+	Latest   rpc.BlockNumber      `json:"latest"`
+}
+
+func NewRPCExecutionPlan(plan bundle.ExecutionPlan) RPCExecutionPlan {
+	steps := make([]RPCExecutionStep, len(plan.Steps))
+	for i, step := range plan.Steps {
+		steps[i] = RPCExecutionStep{
+			From: step.From,
+			Hash: step.Hash,
+		}
+	}
+
+	return RPCExecutionPlan{
+		Flags:    plan.Flags,
+		Steps:    steps,
+		Earliest: rpc.BlockNumber(plan.Earliest),
+		Latest:   rpc.BlockNumber(plan.Latest),
+	}
+}
+
+func toBlockNum(num uint64) *rpc.BlockNumber {
+	bNr := rpc.BlockNumber(num)
+	return &bNr
+}
+
+func toHexUint(num uint64) *hexutil.Uint {
+	hNum := hexutil.Uint(num)
+	return &hNum
 }

--- a/ethapi/bundle_api_test.go
+++ b/ethapi/bundle_api_test.go
@@ -17,12 +17,17 @@
 package ethapi
 
 import (
+	"encoding/json"
+	"math/big"
+	reflect "reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -56,4 +61,112 @@ func TestBundleEstimateGas_PreArgsAreConsideredForEveryTransaction(t *testing.T)
 	bundleGasLimit := gasLimit + hexutil.Uint64(params.TxAccessListAddressGas) +
 		hexutil.Uint64(params.TxAccessListStorageKeyGas)
 	require.Equal(t, slices.Repeat([]hexutil.Uint64{bundleGasLimit}, numTransactions), gasLimits)
+}
+
+func TestBundleRPC_JsonIsEthereumConformant(t *testing.T) {
+	// This test ensures that the JSON encoding of the RPC arguments and results
+	// conforms to the Ethereum JSON-RPC specification
+
+	blockNum := rpc.BlockNumber(123)
+	hexUint := hexutil.Uint(10)
+	hexUint64 := hexutil.Uint64(11)
+	big := hexutil.Big(*big.NewInt(12))
+	address := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
+	hash := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+	expectJsonEqual(t, `{
+		  "status": 1,
+		  "block":"0x7b",
+		  "position":"0xa",
+		  "count":"0xa"
+	}`,
+		RPCBundleInfo{
+			Status:   1,
+			Block:    &blockNum,
+			Position: &hexUint,
+			Count:    &hexUint,
+		})
+
+	plan := RPCExecutionPlan{
+		Flags: 3,
+		Steps: []RPCExecutionStep{
+			{
+				From: address,
+				Hash: hash,
+			},
+		},
+		Earliest: blockNum,
+		Latest:   blockNum,
+	}
+	expectJsonEqual(t, `{
+		  "flags": 3,
+		  "steps": [
+			{
+		  		"from":"0x1234567890abcdef1234567890abcdef12345678",
+				"hash":"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+			}
+		  ],
+		  "earliest":"0x7b",
+		  "latest":"0x7b"
+	}`, plan)
+
+	transacton := TransactionArgs{
+		From:     &address,
+		To:       &address,
+		Nonce:    &hexUint64,
+		Gas:      &hexUint64,
+		GasPrice: &big,
+		Value:    &big,
+		Data:     (*hexutil.Bytes)(&[]byte{0x1, 0x2, 0x3}),
+	}
+	expectJsonEqual(t, `{
+		"transactions":[
+			{
+				"from":"0x1234567890abcdef1234567890abcdef12345678",
+				"to":"0x1234567890abcdef1234567890abcdef12345678",
+				"gas":"0xb",
+				"gasPrice":"0xc",
+				"value":"0xc",
+				"nonce":"0xb",
+				"data":"0x010203"
+			}
+		],
+		"plan": {
+		  "flags": 3,
+		  "steps": [
+			{
+		  		"from":"0x1234567890abcdef1234567890abcdef12345678",
+				"hash":"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+			}
+		  ],
+		  "earliest":"0x7b",
+		  "latest":"0x7b"
+		}
+	}`,
+		RPCPreparedBundle{
+			Transactions: []TransactionArgs{transacton},
+			Plan:         plan,
+		})
+
+}
+
+func expectJsonEqual[T any](t testing.TB, expected string, value T) {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err, "failed to marshal BundleRPCInfo to JSON")
+
+	var j1, j2 T
+	err = json.Unmarshal(encoded, &j1)
+	require.NoError(t, err, "failed to unmarshal JSON back to %T", value)
+	err = json.Unmarshal([]byte(expected), &j2)
+	require.NoError(t, err, "failed to unmarshal JSON back to %T", value)
+	v := reflect.DeepEqual(j1, j2)
+	if !v {
+		expected = strings.ReplaceAll(expected, " ", "")
+		expected = strings.ReplaceAll(expected, "\n", "")
+		expected = strings.ReplaceAll(expected, "\t", "")
+		t.Logf("Expected JSON: %s", expected)
+		t.Logf("Actual JSON:   %s", string(encoded))
+		t.FailNow()
+	}
 }

--- a/tests/bundles/bundle_sponsored_test.go
+++ b/tests/bundles/bundle_sponsored_test.go
@@ -111,8 +111,8 @@ func TestBundle_CanRunSponsorshipAndSponsored(t *testing.T) {
 	// 2. the sponsored transaction
 	// 3. the internal transaction that transfer the fee from the sponsee to the sponsor
 	txs := block.Transactions()
-	position := *info.Position
-	require.GreaterOrEqual(t, uint32(len(txs)), position+3)
+	position := uint(*info.Position)
+	require.GreaterOrEqual(t, uint(len(txs)), position+3)
 	require.Equal(t, txs[position].Hash(), bundle.Transactions[0].Hash())
 	require.Equal(t, txs[position+1].Hash(), bundle.Transactions[1].Hash())
 	require.True(t, internaltx.IsInternal(txs[position+2]))

--- a/tests/bundles/concurrent_bundles_test.go
+++ b/tests/bundles/concurrent_bundles_test.go
@@ -106,8 +106,10 @@ func testSucceedingConcurrentBundles(
 	maxBlock := uint64(0)
 	for _, info := range infos {
 		require.Equal(ethapi.BundleStatusExecuted, info.Status)
-		minBlock = min(minBlock, *info.Block)
-		maxBlock = max(maxBlock, *info.Block)
+		if info.Block != nil {
+			minBlock = min(minBlock, uint64(*info.Block))
+			maxBlock = max(maxBlock, uint64(*info.Block))
+		}
 	}
 	fmt.Printf("All bundles got executed in block range %d - %d\n", minBlock, maxBlock)
 

--- a/tests/bundles/run_bundle_test.go
+++ b/tests/bundles/run_bundle_test.go
@@ -121,8 +121,8 @@ func getBundleInfo(
 	ctxt context.Context,
 	client *rpc.Client,
 	executionPlanHash common.Hash,
-) (ethapi.BundleInfo, error) {
-	var info ethapi.BundleInfo
+) (ethapi.RPCBundleInfo, error) {
+	var info ethapi.RPCBundleInfo
 	err := client.CallContext(
 		ctxt,
 		&info,
@@ -136,16 +136,16 @@ func waitForBundleExecution(
 	ctxt context.Context,
 	client *rpc.Client,
 	executionPlanHash common.Hash,
-) (ethapi.BundleInfo, error) {
+) (ethapi.RPCBundleInfo, error) {
 	infos, err := waitForBundlesExecution(
 		ctxt, client,
 		[]common.Hash{executionPlanHash},
 	)
 	if err != nil {
-		return ethapi.BundleInfo{}, err
+		return ethapi.RPCBundleInfo{}, err
 	}
 	if len(infos) != 1 {
-		return ethapi.BundleInfo{}, fmt.Errorf("failed to obtain bundle info")
+		return ethapi.RPCBundleInfo{}, fmt.Errorf("failed to obtain bundle info")
 	}
 	return infos[0], nil
 }
@@ -154,9 +154,9 @@ func waitForBundlesExecution(
 	ctxt context.Context,
 	client *rpc.Client,
 	executionPlanHashes []common.Hash,
-) ([]ethapi.BundleInfo, error) {
+) ([]ethapi.RPCBundleInfo, error) {
 
-	infos := make([]ethapi.BundleInfo, len(executionPlanHashes))
+	infos := make([]ethapi.RPCBundleInfo, len(executionPlanHashes))
 	done := make([]bool, len(executionPlanHashes))
 
 	err := tests.WaitFor(ctxt, func(innerCtx context.Context) (bool, error) {

--- a/tests/bundles/use_bundle_api_test.go
+++ b/tests/bundles/use_bundle_api_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/ethapi"
-	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/increasingly_expensive"
@@ -128,7 +127,6 @@ func checkCompatWithMetaMask(t *testing.T, client *tests.PooledEhtClient, txs []
 		var retrievedTx types.Transaction
 		err = retrievedTx.UnmarshalBinary(mempoolTx)
 		require.NoError(t, err, "failed to unmarshal transaction from mempool")
-
 		require.Equal(t, tx.Hash(), retrievedTx.Hash(), "transaction hash mismatch")
 	}
 }
@@ -151,7 +149,7 @@ func PrepareBundle(
 	t *testing.T, client *tests.PooledEhtClient,
 	earliest, latest uint64,
 	txs []ethereum.CallMsg,
-) (ethapi.PreparedBundle, error) {
+) (ethapi.RPCPreparedBundle, error) {
 
 	nonces := make(map[common.Address]uint64)
 	for _, tx := range txs {
@@ -187,7 +185,7 @@ func PrepareBundle(
 	}
 
 	// Call sonic_prepareBundle to get a bundle with all fields properly filled in and encoded
-	var preparedBundle ethapi.PreparedBundle
+	var preparedBundle ethapi.RPCPreparedBundle
 	err = client.Client().Call(&preparedBundle, "sonic_prepareBundle",
 		ethapi.PrepareBundleArgs{
 			Transactions:  txsArgs,
@@ -205,7 +203,7 @@ func PrepareBundle(
 // point to the api from go programs.
 func SubmitBundle(client *tests.PooledEhtClient,
 	txs []*types.Transaction,
-	plan bundle.ExecutionPlan,
+	plan ethapi.RPCExecutionPlan,
 ) (common.Hash, error) {
 	encodedTransactions := make([]hexutil.Bytes, len(txs))
 	for i, tx := range txs {


### PR DESCRIPTION
Quantities are encoded as hex in the Ethereum RPC methods. Respect the pattern. 