### PR TITLE
Implement live-archive db synchronization solution to fix RCP inconsistent answers

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Golang dependency
         uses: actions/setup-go@v3
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Static lints
         run: make lint

--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,10 @@
 
 module github.com/0xsoniclabs/sonic
 
-go 1.24.0
+go 1.25.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c
+	github.com/0xsoniclabs/carmen/go v0.0.0-20260226072032-4b363bf4aa48
 	github.com/0xsoniclabs/tosca v0.0.0-20260224095910-31d2f9b784f0
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 )
 
 require (
+	github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb // indirect
 	github.com/DataDog/zstd v1.5.6 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c h1:xWV02BKxkNrFZhqrHHXYdAOzabJlY5dR9BLPvd5Yrpc=
-github.com/0xsoniclabs/carmen/go v0.0.0-20250708101910-3666ec34654c/go.mod h1:pOYoZnXK6Dacga5Yoh7/38ibbOJ57/B3Q54zMxWtqG8=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260226072032-4b363bf4aa48 h1:4MOm8u9GAivdL/plEfkuG1GyJgcxHwcM21G0vuvY5AY=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260226072032-4b363bf4aa48/go.mod h1:xD+Lkm/4WcJydGjUT3tjCvtnVEpMzxhkgSx8nVAkEsQ=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260220094642-cad493048916 h1:aD8IqUUk0QTh21xQuGAn2IQmnUQTfwbszSkNuWoEGvQ=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260220094642-cad493048916/go.mod h1:TlbbIilsvHx5hhDGx0sdKnAPRv0S2cp1XRKr4L21ioc=
 github.com/0xsoniclabs/tosca v0.0.0-20260224095910-31d2f9b784f0 h1:BEKgH4oTLWSz3oe5jAvqgQzvsatjgb+FDEUtlioava4=

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -18,10 +18,12 @@ package evmmodule
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
@@ -181,7 +183,18 @@ func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, numSkipped i
 	evmBlock = p.evmBlockWith(transactions)
 
 	// Commit block
-	p.statedb.EndBlock(evmBlock.Number.Uint64())
+	done := p.statedb.EndBlock(evmBlock.Number.Uint64())
+	// Use asynchronous commit for blocks older than one hour to speed up catching up.
+	// For recent blocks (within the last hour), wait for the commit to complete
+	// to ensure the latest state is available for both live and archive databases.
+	if time.Since(evmBlock.Time.Time()) < 1*time.Hour && done != nil {
+		if err := <-done; err != nil {
+			// the underlying database has collected an error during finalize or
+			// a previous operation. State consistency and its persistence my
+			// have been compromised.
+			log.Error("Failed to finalize block %v: %v", evmBlock.Number, err)
+		}
+	}
 
 	// Get state root
 	evmBlock.Root = p.statedb.GetStateHash()

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -21,8 +21,11 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -311,6 +314,106 @@ func TestOperaEVMProcessor_Finalize_ReportsAggregatedNumberOfSkippedTransactions
 
 	_, numSkipped, _ = processor.Finalize()
 	require.Equal(3, numSkipped)
+}
+
+func TestOperaEVMProcessor_Finalize_DoesNotBlockOnSyncChannel_WhenBlockIsOlderThanOneHour(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stateDb := state.NewMockStateDB(ctrl)
+
+		stateDb.EXPECT().BeginBlock(gomock.Any())
+		stateDb.EXPECT().GetStateHash()
+		// EndBlock should return a channel,but this should be ignored for
+		// blocks older than one hour.
+		stateDb.EXPECT().EndBlock(gomock.Any()).Return(make(<-chan error))
+
+		evmModule := New()
+		blockTime := time.Now().Add(-1*time.Hour - time.Second)
+		processor := evmModule.Start(
+			iblockproc.BlockCtx{
+				Time: inter.FromUnix(blockTime.Unix()),
+			},
+			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+		)
+
+		finalizeDone := false
+		go func() {
+			_, _, _ = processor.Finalize()
+			finalizeDone = true
+		}()
+
+		synctest.Wait()
+		require.True(t, finalizeDone, "Finalize did not finish for blocks older than one hour")
+	})
+}
+
+func TestOperaEVMProcessor_Finalize_DoesNotBlockOnSyncChannel_WhenSyncChannelIsNil(t *testing.T) {
+	// Underlying db implementations may not implement the possibility to wait on
+	// an async finalize operation. The client must work correctly in these cases.
+
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		stateDb := state.NewMockStateDB(ctrl)
+
+		stateDb.EXPECT().BeginBlock(gomock.Any())
+		stateDb.EXPECT().GetStateHash()
+		// If the sync channel is nil, Finalize should not block even for recent blocks.
+		stateDb.EXPECT().EndBlock(gomock.Any()).Return(nil)
+		evmModule := New()
+		blockTime := time.Now().Add(-1*time.Hour + time.Second)
+		processor := evmModule.Start(
+			iblockproc.BlockCtx{
+				Time: inter.FromUnix(blockTime.Unix()),
+			},
+			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+		)
+
+		finalizeDone := false
+		go func() {
+			_, _, _ = processor.Finalize()
+			finalizeDone = true
+		}()
+
+		synctest.Wait()
+		require.True(t, finalizeDone, "Finalize did not finish when sync channel was nil")
+	})
+}
+
+func TestOperaEVMProcessor_Finalize_BlockOnSyncChannel_WhenBlockIsYoungerThanOneHour(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+
+		ctrl := gomock.NewController(t)
+		stateDb := state.NewMockStateDB(ctrl)
+
+		stateDb.EXPECT().BeginBlock(gomock.Any())
+		stateDb.EXPECT().GetStateHash()
+
+		syncChannel := make(chan error)
+		stateDb.EXPECT().EndBlock(gomock.Any()).Return(syncChannel)
+
+		evmModule := New()
+		blockTime := time.Now().Add(-1*time.Hour + time.Second)
+		processor := evmModule.Start(
+			iblockproc.BlockCtx{
+				Time: inter.FromUnix(blockTime.Unix()),
+			},
+			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+		)
+
+		finalizeDone := false
+		go func() {
+			_, _, _ = processor.Finalize()
+			finalizeDone = true
+		}()
+
+		synctest.Wait()
+		require.False(t, finalizeDone, "Finalize finished before sync channel was closed")
+
+		close(syncChannel)
+
+		synctest.Wait()
+		require.True(t, finalizeDone, "Finalize did not finish after sync channel was closed")
+	})
 }
 
 // onNewLog is a helper interface to allow mocking the onNewLog function

--- a/gossip/evmstore/carmen.go
+++ b/gossip/evmstore/carmen.go
@@ -335,10 +335,11 @@ func (c *CarmenStateDB) BeginBlock(number uint64) {
 	}
 }
 
-func (c *CarmenStateDB) EndBlock(number uint64) {
+func (c *CarmenStateDB) EndBlock(number uint64) <-chan error {
 	if db, ok := c.db.(carmen.StateDB); ok {
-		db.EndBlock(number)
+		return db.EndBlock(number)
 	}
+	return nil
 }
 
 func (c *CarmenStateDB) GetStateHash() common.Hash {

--- a/inter/state/adapter.go
+++ b/inter/state/adapter.go
@@ -40,7 +40,7 @@ type StateDB interface {
 	GetStateHash() common.Hash
 
 	BeginBlock(number uint64)
-	EndBlock(number uint64)
+	EndBlock(number uint64) <-chan error
 	EndTransaction()
 	Release()
 }

--- a/inter/state/adapter_mock.go
+++ b/inter/state/adapter_mock.go
@@ -215,9 +215,11 @@ func (mr *MockStateDBMockRecorder) Empty(arg0 any) *gomock.Call {
 }
 
 // EndBlock mocks base method.
-func (m *MockStateDB) EndBlock(number uint64) {
+func (m *MockStateDB) EndBlock(number uint64) <-chan error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "EndBlock", number)
+	ret := m.ctrl.Call(m, "EndBlock", number)
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
 }
 
 // EndBlock indicates an expected call of EndBlock.


### PR DESCRIPTION
This PR cherry picks the sync end block feature from #673 but with the carmen commit that is compatible with [sonic 2.1](https://github.com/0xsoniclabs/carmen/tree/sonic_2.1) (commit 4b363bf4aa487798a19b14bb284f70690aa7c66e)

Note: github workflows testing go version needs to be updated because the new carmen update uses go1.25.