### PR TITLE
Add calculation of default tx parameters in prepareBundle

### DIFF
--- a/ethapi/bundle_api.go
+++ b/ethapi/bundle_api.go
@@ -138,7 +138,6 @@ type RPCPreparedBundle struct {
 // Bundled transactions with uninitialized gas limits will have their gas estimated by this method, which will take into account
 // potential state changes from previous transactions in the bundle. However, users can also choose to set gas limits on their own;
 // in this case, the provided gas limits will be used without modification.
-// Transactions with gas limit 0 will not have this field modified.
 //
 // Bundled transactions with uninitialized gas price fields (GasPrice for access list transactions,
 // or both MaxFeePerGas and MaxPriorityFeePerGas for EIP-1559 capable transactions) will have their gas price
@@ -176,10 +175,10 @@ func (a *PublicBundleAPI) PrepareBundle(
 	}
 	gasPrice := a.suggestGasPrice()
 	for i, tx := range args.Transactions {
-		if len(gasLimits.GasLimits) != 0 && (tx.Gas == nil) {
+		if len(gasLimits.GasLimits) > i && (tx.Gas == nil) {
 			tx.Gas = &gasLimits.GasLimits[i]
 		}
-		if tx.GasPrice == nil || tx.MaxFeePerGas == nil {
+		if tx.GasPrice == nil && tx.MaxFeePerGas == nil {
 			if tx.MaxPriorityFeePerGas == nil {
 				tx.GasPrice = gasPrice
 			} else {

--- a/ethapi/bundle_api.go
+++ b/ethapi/bundle_api.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/gasprice/gaspricelimits"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -134,6 +135,17 @@ type RPCPreparedBundle struct {
 // and updates each transaction to include the bundler-only marker, ensuring they are executed
 // exclusively as part of the specified plan.
 //
+// Bundled transactions with uninitialized gas limits will have their gas estimated by this method, which will take into account
+// potential state changes from previous transactions in the bundle. However, users can also choose to set gas limits on their own;
+// in this case, the provided gas limits will be used without modification.
+// Transactions with gas limit 0 will not have this field modified.
+//
+// Bundled transactions with uninitialized gas price fields (GasPrice for access list transactions,
+// or both MaxFeePerGas and MaxPriorityFeePerGas for EIP-1559 capable transactions) will have their gas price
+// set to the current suggested gas price by this method.
+// However, users can also choose to set gas price fields on their own; in this case,
+// the provided gas price fields will be used without modification, even if this is zero.
+//
 // The returned transactions must be signed without altering any fields; any modification may
 // invalidate the execution plan and prevent the bundle from being executed.
 func (a *PublicBundleAPI) PrepareBundle(
@@ -144,7 +156,40 @@ func (a *PublicBundleAPI) PrepareBundle(
 	gasCap := a.b.RPCGasCap()
 	basefee := a.b.MinGasPrice()
 
-	// 1) Read transactions from arguments and prepare fields
+	// Fill in transaction fields left empty by users
+	var needsGasEstimation bool
+	for _, tx := range args.Transactions {
+		if tx.Gas == nil || *tx.Gas == 0 {
+			needsGasEstimation = true
+			break
+		}
+	}
+	var gasLimits BundleGasLimits
+	if needsGasEstimation {
+		var err error
+		// If any of the transactions has gas limit set to 0, we need to estimate gas for all of them,
+		// since they might be mutually dependent and affect each other's gas estimation.
+		gasLimits, err = a.EstimateGasForTransactions(ctx, args.Transactions, nil, nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare bundle: gas estimation failed: %w", err)
+		}
+	}
+	gasPrice := a.suggestGasPrice()
+	for i, tx := range args.Transactions {
+		if len(gasLimits.GasLimits) != 0 && (tx.Gas == nil) {
+			tx.Gas = &gasLimits.GasLimits[i]
+		}
+		if tx.GasPrice == nil || tx.MaxFeePerGas == nil {
+			if tx.MaxPriorityFeePerGas == nil {
+				tx.GasPrice = gasPrice
+			} else {
+				tx.MaxFeePerGas = gasPrice
+			}
+		}
+		args.Transactions[i] = tx
+	}
+
+	// Convert transactions *types.Transaction, which can be later serialized
 	from := make([]common.Address, len(args.Transactions))
 	transactions := make([]*types.Transaction, len(args.Transactions))
 	for i, txArgs := range args.Transactions {
@@ -171,7 +216,7 @@ func (a *PublicBundleAPI) PrepareBundle(
 		latest = uint64(*args.LatestBlock)
 	}
 
-	// 2) Prepare execution plan
+	// Prepare execution plan
 	chainID := a.b.ChainID()
 	signer := types.LatestSignerForChainID(chainID)
 	plan := bundle.ExecutionPlan{
@@ -188,7 +233,7 @@ func (a *PublicBundleAPI) PrepareBundle(
 		}
 	}
 
-	// 3) Update bundle transactions with execution plan hash
+	// Update bundle transactions with execution plan hash
 	planHash := plan.Hash()
 	for i := range transactions {
 		tx := args.Transactions[i]
@@ -211,6 +256,12 @@ func (a *PublicBundleAPI) PrepareBundle(
 	}
 
 	return &bundle, nil
+}
+
+func (a *PublicBundleAPI) suggestGasPrice() *hexutil.Big {
+	price := a.b.CurrentBlock().Header().BaseFee
+	price = gaspricelimits.GetSuggestedGasPriceForNewTransactions(price)
+	return (*hexutil.Big)(price)
 }
 
 type SubmitBundleArgs struct {

--- a/tests/bundles/use_bundle_api_test.go
+++ b/tests/bundles/use_bundle_api_test.go
@@ -53,19 +53,15 @@ func Test_CreateBundlesWithRPC(t *testing.T) {
 
 	sender1 := session.GetSessionSponsor()
 
-	gasPrice, err := client.SuggestGasPrice(t.Context())
-	require.NoError(t, err, "failed to suggest gas price")
-
 	// 1) Create a list of transactions to be executed in order atomically.
 	const bundledTxCount = 15
 	txsToBeBundled := make([]ethereum.CallMsg, bundledTxCount)
 
 	for i := range txsToBeBundled {
 		tx := ethereum.CallMsg{
-			From:     sender1.Address(),
-			To:       &receipt.ContractAddress,
-			GasPrice: gasPrice,
-			Data:     input,
+			From: sender1.Address(),
+			To:   &receipt.ContractAddress,
+			Data: input,
 		}
 		txsToBeBundled[i] = tx
 	}
@@ -173,14 +169,6 @@ func PrepareBundle(
 		txsArgs[i] = txArgs
 	}
 
-	var gasLimits ethapi.BundleGasLimits
-	err := client.Client().Call(&gasLimits, "sonic_estimateGasForTransactions", txsArgs, "latest", nil, nil)
-	require.NoError(t, err, "failed to estimate gas for bundle")
-
-	for i := range txsArgs {
-		txsArgs[i].Gas = (*hexutil.Uint64)(&gasLimits.GasLimits[i])
-	}
-
 	var earliestBlock, latestBlock *rpc.BlockNumber
 	if earliest != nil {
 		earliestBlock = (*rpc.BlockNumber)(earliest)
@@ -191,7 +179,7 @@ func PrepareBundle(
 
 	// Call sonic_prepareBundle to get a bundle with all fields properly filled in and encoded
 	var preparedBundle ethapi.RPCPreparedBundle
-	err = client.Client().Call(&preparedBundle, "sonic_prepareBundle",
+	err := client.Client().Call(&preparedBundle, "sonic_prepareBundle",
 		ethapi.PrepareBundleArgs{
 			Transactions:  txsArgs,
 			EarliestBlock: earliestBlock,


### PR DESCRIPTION
This PR adds the option for letting `sonic_prepareBundle` infer gas costs and gas prices to be used in the bundled transactions. 
This feature makes difference between initialized transaction arguments and zeroes. Zeroes are interpreted as user choice and therefore not overwritten. 

Access list is not initialized by default because it requires a slightly larger scope. It is not strictly necessary to contribute to the success of the execution either. 
