### PR TITLE
Add vmTrace option to the tracing RPC functions

### DIFF
--- a/api/ethapi/tx_trace.go
+++ b/api/ethapi/tx_trace.go
@@ -71,7 +71,8 @@ type evmSetup struct {
 	tracer          *tracing.Hooks // cfg.Tracer at time of EVM creation
 	txTracer        *txtrace.TraceStructLogger
 	stateDiffLogger *txtrace.StateDiffLogger
-	activeState     state.StateDB // may be wrapped with stateDiff hooks
+	vmTraceLogger   *txtrace.VmTraceLogger
+	activeState     state.StateDB // may be wrapped with stateDiff/vmTrace hooks
 }
 
 // setupTracedEVM creates an EVM configured with the requested tracing hooks and
@@ -84,8 +85,7 @@ func setupTracedEVM(
 	block *evmcore.EvmBlock,
 	statedb state.StateDB,
 	index uint64,
-	wantTrace bool,
-	wantStateDiff bool,
+	tracers TraceOptions,
 	noBaseFee bool,
 ) (*evmSetup, context.CancelFunc, error) {
 	header := block.Header()
@@ -99,14 +99,14 @@ func setupTracedEVM(
 
 	setup := &evmSetup{activeState: statedb}
 
-	if wantTrace {
+	if tracers.Trace {
 		setup.txTracer = txtrace.NewTraceStructLogger(block, uint(index))
 		cfg.Tracer = setup.txTracer.Hooks()
 	}
 
-	if wantStateDiff {
+	if tracers.StateDiff {
 		setup.stateDiffLogger = txtrace.NewStateDiffLogger()
-		setup.activeState = evmstore.WrapStateDbWithLogger(statedb, setup.stateDiffLogger.Hooks())
+		setup.activeState = evmstore.WrapStateDbWithLogger(setup.activeState, setup.stateDiffLogger.Hooks())
 
 		sdOnEnter := setup.stateDiffLogger.OnEnter
 		if cfg.Tracer == nil {
@@ -121,6 +121,15 @@ func setupTracedEVM(
 			}
 		}
 	}
+
+	if tracers.VmTrace {
+		setup.vmTraceLogger = txtrace.NewVmTraceLogger()
+		// Wrap activeState so OnStorageChange fires when storage is written.
+		setup.activeState = evmstore.WrapStateDbWithLogger(setup.activeState, setup.vmTraceLogger.Hooks())
+		// Merge VM level hooks into cfg.Tracer.
+		cfg.Tracer = mergeVMHooks(cfg.Tracer, setup.vmTraceLogger.Hooks())
+	}
+
 	setup.tracer = cfg.Tracer
 
 	timeout := defaultTraceTimeout
@@ -153,14 +162,14 @@ func (s *PublicTxTraceAPI) Transaction(ctx context.Context, hash common.Hash) (*
 }
 
 // Call - trace_call function returns transaction inner traces for non historical transactions.
-// Supports "trace" and "stateDiff" trace types, compatible with go-ethereum trace_call format.
+// Supports "trace", "stateDiff" and "vmTrace" trace types.
 func (s *PublicTxTraceAPI) Call(ctx context.Context, args TransactionArgs, traceTypes []string, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (*txtrace.TraceCallResult, error) {
 
 	defer func(start time.Time) {
 		log.Debug("Executing trace_Call call finished", "txArgs", args, "runtime", time.Since(start))
 	}(time.Now())
 
-	wantTrace, wantStateDiff, err := containsTraceType(traceTypes)
+	traceOptions, err := parseTraceOptions(traceTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -193,30 +202,103 @@ func (s *PublicTxTraceAPI) Call(ctx context.Context, args TransactionArgs, trace
 		return nil, err
 	}
 
-	return s.traceCallExec(ctx, block, msg, statedb, tx, uint64(txIndex), wantTrace, wantStateDiff)
+	return s.traceCallExec(ctx, block, msg, statedb, tx, uint64(txIndex), traceOptions)
 }
 
-// containsTraceType checks if the provided trace types include "trace" and/or "stateDiff" and returns corresponding booleans.
-func containsTraceType(traceTypes []string) (bool, bool, error) {
-	wantTrace := false
-	wantStateDiff := false
+type TraceOptions struct {
+	Trace     bool
+	StateDiff bool
+	VmTrace   bool
+}
+
+// parseTraceOptions parses the requested trace types and returns the corresponding booleans.
+func parseTraceOptions(traceTypes []string) (trace TraceOptions, err error) {
 	for _, traceType := range traceTypes {
 		switch traceType {
 		case TraceTypeTrace:
-			wantTrace = true
+			trace.Trace = true
 		case TraceTypeStateDiff:
-			wantStateDiff = true
+			trace.StateDiff = true
 		case TraceTypeVmTrace:
-			return false, false, fmt.Errorf("vmTrace trace type is not supported")
+			trace.VmTrace = true
 		default:
-			return false, false, fmt.Errorf("unrecognized trace type: %s", traceType)
+			return TraceOptions{}, fmt.Errorf("unrecognized trace type: %s", traceType)
 		}
 	}
-	return wantTrace, wantStateDiff, nil
+	return trace, nil
+}
+
+// mergeVMHooks returns a new Hooks that invokes 'orig' hook first, then 'newHooks' hook,
+// for each hook that 'newHooks' defines. Hooks only in 'orig' are preserved unchanged.
+// Either argument may be nil.
+func mergeVMHooks(orig, newHooks *tracing.Hooks) *tracing.Hooks {
+	if orig == nil {
+		return newHooks
+	}
+	if newHooks == nil {
+		return orig
+	}
+	merged := *orig // shallow copy, only overwrite fields that newHooks contributes
+
+	if newHooks.OnTxStart != nil {
+		origFn, newFn := orig.OnTxStart, newHooks.OnTxStart
+		merged.OnTxStart = func(vm *tracing.VMContext, tx *types.Transaction, from common.Address) {
+			if origFn != nil {
+				origFn(vm, tx, from)
+			}
+			newFn(vm, tx, from)
+		}
+	}
+	if newHooks.OnTxEnd != nil {
+		origFn, newFn := orig.OnTxEnd, newHooks.OnTxEnd
+		merged.OnTxEnd = func(receipt *types.Receipt, err error) {
+			if origFn != nil {
+				origFn(receipt, err)
+			}
+			newFn(receipt, err)
+		}
+	}
+	if newHooks.OnEnter != nil {
+		origFn, newFn := orig.OnEnter, newHooks.OnEnter
+		merged.OnEnter = func(depth int, typ byte, from, to common.Address, input []byte, gas uint64, value *big.Int) {
+			if origFn != nil {
+				origFn(depth, typ, from, to, input, gas, value)
+			}
+			newFn(depth, typ, from, to, input, gas, value)
+		}
+	}
+	if newHooks.OnExit != nil {
+		origFn, newFn := orig.OnExit, newHooks.OnExit
+		merged.OnExit = func(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
+			if origFn != nil {
+				origFn(depth, output, gasUsed, err, reverted)
+			}
+			newFn(depth, output, gasUsed, err, reverted)
+		}
+	}
+	if newHooks.OnOpcode != nil {
+		origFn, newFn := orig.OnOpcode, newHooks.OnOpcode
+		merged.OnOpcode = func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+			if origFn != nil {
+				origFn(pc, op, gas, cost, scope, rData, depth, err)
+			}
+			newFn(pc, op, gas, cost, scope, rData, depth, err)
+		}
+	}
+	if newHooks.OnFault != nil {
+		origFn, newFn := orig.OnFault, newHooks.OnFault
+		merged.OnFault = func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, depth int, err error) {
+			if origFn != nil {
+				origFn(pc, op, gas, cost, scope, depth, err)
+			}
+			newFn(pc, op, gas, cost, scope, depth, err)
+		}
+	}
+	return &merged
 }
 
 // traceCallExec executes a simulated transaction and returns a TraceCallResult
-// containing optional trace actions and/or state diff based on the requested types.
+// containing optional trace actions, state diff, and/or vmTrace based on the requested types.
 func (s *PublicTxTraceAPI) traceCallExec(
 	ctx context.Context,
 	block *evmcore.EvmBlock,
@@ -224,10 +306,9 @@ func (s *PublicTxTraceAPI) traceCallExec(
 	statedb state.StateDB,
 	tx *types.Transaction,
 	index uint64,
-	wantTrace bool,
-	wantStateDiff bool,
+	traceOptions TraceOptions,
 ) (*txtrace.TraceCallResult, error) {
-	tracedEVM, cancel, err := setupTracedEVM(ctx, s.b, block, statedb, index, wantTrace, wantStateDiff, true)
+	tracedEVM, cancel, err := setupTracedEVM(ctx, s.b, block, statedb, index, traceOptions, true)
 	if err != nil {
 		return nil, err
 	}
@@ -248,14 +329,17 @@ func (s *PublicTxTraceAPI) traceCallExec(
 	tracedEVM.vmenv.SetTxContext(vmContext)
 
 	// Execute the transaction using core.ApplyMessage to capture raw return data.
-	result, applyErr := core.ApplyMessage(tracedEVM.vmenv, msg, core.NewGasPool(msg.GasLimit))
+	result, err := core.ApplyMessage(tracedEVM.vmenv, msg, core.NewGasPool(msg.GasLimit))
+	if err != nil {
+		return nil, err
+	}
 
 	// Finalize the transaction state regardless of execution outcome.
 	tracedEVM.activeState.EndTransaction()
 
 	// Build a synthetic receipt and call OnTxEnd to finalize the trace.
 	var receipt *types.Receipt
-	if applyErr == nil && result != nil {
+	if result != nil {
 		if result.Failed() {
 			receipt = &types.Receipt{Status: types.ReceiptStatusFailed, GasUsed: result.UsedGas}
 		} else {
@@ -263,7 +347,7 @@ func (s *PublicTxTraceAPI) traceCallExec(
 		}
 	}
 	if tracedEVM.tracer != nil && tracedEVM.tracer.OnTxEnd != nil {
-		tracedEVM.tracer.OnTxEnd(receipt, applyErr)
+		tracedEVM.tracer.OnTxEnd(receipt, result.Err)
 	}
 
 	if tracedEVM.vmenv.Cancelled() {
@@ -272,25 +356,16 @@ func (s *PublicTxTraceAPI) traceCallExec(
 
 	callResult := &txtrace.TraceCallResult{VmTrace: nil}
 
-	if applyErr != nil {
-		// Pre-EVM error (e.g., insufficient gas for intrinsic cost, nonce mismatch).
-		errTrace := txtrace.GetErrorTraceFromMsg(msg, block.Hash, *block.Number, tx.Hash(), index, applyErr)
-		if wantTrace {
-			callResult.Trace = []txtrace.ActionTrace{*errTrace}
-		}
-		if wantStateDiff {
-			callResult.StateDiff = make(txtrace.StateDiff)
-		}
-		return callResult, nil
-	}
-
 	callResult.Output = hexutil.Bytes(result.ReturnData)
 
-	if wantTrace {
+	if traceOptions.Trace {
 		callResult.Trace = *tracedEVM.txTracer.GetResult()
 	}
-	if wantStateDiff {
+	if traceOptions.StateDiff {
 		callResult.StateDiff = tracedEVM.stateDiffLogger.GetResult()
+	}
+	if traceOptions.VmTrace {
+		callResult.VmTrace = tracedEVM.vmTraceLogger.GetResult()
 	}
 
 	return callResult, nil
@@ -482,7 +557,7 @@ func (s *PublicTxTraceAPI) traceTx(
 	index uint64,
 	status uint64,
 ) (*[]txtrace.ActionTrace, error) {
-	tracedEVM, cancel, err := setupTracedEVM(ctx, s.b, block, statedb, index, true, false, true)
+	tracedEVM, cancel, err := setupTracedEVM(ctx, s.b, block, statedb, index, TraceOptions{Trace: true}, true)
 	if err != nil {
 		return nil, err
 	}
@@ -577,10 +652,7 @@ func (s *PublicTxTraceAPI) CallMany(ctx context.Context, calls []CallRequest, bl
 
 	results := make([]*txtrace.TraceCallResult, 0, len(calls))
 	for i, call := range calls {
-		wantTrace := false
-		wantStateDiff := false
-
-		wantTrace, wantStateDiff, err = containsTraceType(call.TraceTypes)
+		traceOptions, err := parseTraceOptions(call.TraceTypes)
 		if err != nil {
 			return nil, fmt.Errorf("call %d: %w", i, err)
 		}
@@ -590,7 +662,7 @@ func (s *PublicTxTraceAPI) CallMany(ctx context.Context, calls []CallRequest, bl
 			return nil, fmt.Errorf("call %d: %w", i, err)
 		}
 
-		result, err := s.traceCallExec(ctx, block, msg, statedb, tx, uint64(i), wantTrace, wantStateDiff)
+		result, err := s.traceCallExec(ctx, block, msg, statedb, tx, uint64(i), traceOptions)
 		if err != nil {
 			return nil, fmt.Errorf("call %d: %w", i, err)
 		}

--- a/api/ethapi/tx_trace_test.go
+++ b/api/ethapi/tx_trace_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -654,4 +655,238 @@ func TestCallMany_BlockNotFound(t *testing.T) {
 	_, err := api.CallMany(t.Context(), []CallRequest{}, rpc.BlockNumberOrHashWithNumber(99), nil)
 
 	require.ErrorIs(t, err, injected)
+}
+
+// recorder accumulates string tokens so tests can assert call order.
+type recorder struct{ calls []string }
+
+func (r *recorder) add(s string) { r.calls = append(r.calls, s) }
+
+func TestMergeVMHooks_BothNil(t *testing.T) {
+	require.Nil(t, mergeVMHooks(nil, nil))
+}
+
+func TestMergeVMHooks_OrigNil_ReturnsNewHooks(t *testing.T) {
+	newHooks := &tracing.Hooks{}
+	require.Same(t, newHooks, mergeVMHooks(nil, newHooks))
+}
+
+func TestMergeVMHooks_NewHooksNil_ReturnsOrig(t *testing.T) {
+	orig := &tracing.Hooks{}
+	require.Same(t, orig, mergeVMHooks(orig, nil))
+}
+
+func TestMergeVMHooks_BothNonNil_ReturnsNewPointer(t *testing.T) {
+	orig := &tracing.Hooks{}
+	newHooks := &tracing.Hooks{}
+	result := mergeVMHooks(orig, newHooks)
+	require.NotNil(t, result)
+	require.NotSame(t, orig, result)
+	require.NotSame(t, newHooks, result)
+}
+
+func TestMergeVMHooks_OnTxStart(t *testing.T) {
+	invoke := func(h *tracing.Hooks) {
+		h.OnTxStart(nil, nil, common.Address{})
+	}
+
+	t.Run("orig only is preserved", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnTxStart: func(_ *tracing.VMContext, _ *types.Transaction, _ common.Address) { rec.add("orig") }}
+		result := mergeVMHooks(orig, &tracing.Hooks{})
+		require.NotNil(t, result.OnTxStart)
+		invoke(result)
+		require.Equal(t, []string{"orig"}, rec.calls)
+	})
+
+	t.Run("new only is installed", func(t *testing.T) {
+		rec := &recorder{}
+		newHooks := &tracing.Hooks{OnTxStart: func(_ *tracing.VMContext, _ *types.Transaction, _ common.Address) { rec.add("new") }}
+		result := mergeVMHooks(&tracing.Hooks{}, newHooks)
+		require.NotNil(t, result.OnTxStart)
+		invoke(result)
+		require.Equal(t, []string{"new"}, rec.calls)
+	})
+
+	t.Run("both: orig called first then new", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnTxStart: func(_ *tracing.VMContext, _ *types.Transaction, _ common.Address) { rec.add("orig") }}
+		newHooks := &tracing.Hooks{OnTxStart: func(_ *tracing.VMContext, _ *types.Transaction, _ common.Address) { rec.add("new") }}
+		invoke(mergeVMHooks(orig, newHooks))
+		require.Equal(t, []string{"orig", "new"}, rec.calls)
+	})
+}
+
+func TestMergeVMHooks_OnTxEnd(t *testing.T) {
+	invoke := func(h *tracing.Hooks) { h.OnTxEnd(nil, nil) }
+
+	t.Run("orig only is preserved", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnTxEnd: func(_ *types.Receipt, _ error) { rec.add("orig") }}
+		result := mergeVMHooks(orig, &tracing.Hooks{})
+		require.NotNil(t, result.OnTxEnd)
+		invoke(result)
+		require.Equal(t, []string{"orig"}, rec.calls)
+	})
+
+	t.Run("new only is installed", func(t *testing.T) {
+		rec := &recorder{}
+		newHooks := &tracing.Hooks{OnTxEnd: func(_ *types.Receipt, _ error) { rec.add("new") }}
+		result := mergeVMHooks(&tracing.Hooks{}, newHooks)
+		require.NotNil(t, result.OnTxEnd)
+		invoke(result)
+		require.Equal(t, []string{"new"}, rec.calls)
+	})
+
+	t.Run("both: orig called first then new", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnTxEnd: func(_ *types.Receipt, _ error) { rec.add("orig") }}
+		newHooks := &tracing.Hooks{OnTxEnd: func(_ *types.Receipt, _ error) { rec.add("new") }}
+		invoke(mergeVMHooks(orig, newHooks))
+		require.Equal(t, []string{"orig", "new"}, rec.calls)
+	})
+}
+
+func TestMergeVMHooks_OnEnter(t *testing.T) {
+	invoke := func(h *tracing.Hooks) {
+		h.OnEnter(0, 0, common.Address{}, common.Address{}, nil, 0, big.NewInt(0))
+	}
+
+	t.Run("orig only is preserved", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnEnter: func(_ int, _ byte, _, _ common.Address, _ []byte, _ uint64, _ *big.Int) { rec.add("orig") }}
+		result := mergeVMHooks(orig, &tracing.Hooks{})
+		require.NotNil(t, result.OnEnter)
+		invoke(result)
+		require.Equal(t, []string{"orig"}, rec.calls)
+	})
+
+	t.Run("new only is installed", func(t *testing.T) {
+		rec := &recorder{}
+		newHooks := &tracing.Hooks{OnEnter: func(_ int, _ byte, _, _ common.Address, _ []byte, _ uint64, _ *big.Int) { rec.add("new") }}
+		result := mergeVMHooks(&tracing.Hooks{}, newHooks)
+		require.NotNil(t, result.OnEnter)
+		invoke(result)
+		require.Equal(t, []string{"new"}, rec.calls)
+	})
+
+	t.Run("both: orig called first then new", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnEnter: func(_ int, _ byte, _, _ common.Address, _ []byte, _ uint64, _ *big.Int) { rec.add("orig") }}
+		newHooks := &tracing.Hooks{OnEnter: func(_ int, _ byte, _, _ common.Address, _ []byte, _ uint64, _ *big.Int) { rec.add("new") }}
+		invoke(mergeVMHooks(orig, newHooks))
+		require.Equal(t, []string{"orig", "new"}, rec.calls)
+	})
+}
+
+func TestMergeVMHooks_OnExit(t *testing.T) {
+	invoke := func(h *tracing.Hooks) { h.OnExit(0, nil, 0, nil, false) }
+
+	t.Run("orig only is preserved", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnExit: func(_ int, _ []byte, _ uint64, _ error, _ bool) { rec.add("orig") }}
+		result := mergeVMHooks(orig, &tracing.Hooks{})
+		require.NotNil(t, result.OnExit)
+		invoke(result)
+		require.Equal(t, []string{"orig"}, rec.calls)
+	})
+
+	t.Run("new only is installed", func(t *testing.T) {
+		rec := &recorder{}
+		newHooks := &tracing.Hooks{OnExit: func(_ int, _ []byte, _ uint64, _ error, _ bool) { rec.add("new") }}
+		result := mergeVMHooks(&tracing.Hooks{}, newHooks)
+		require.NotNil(t, result.OnExit)
+		invoke(result)
+		require.Equal(t, []string{"new"}, rec.calls)
+	})
+
+	t.Run("both: orig called first then new", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnExit: func(_ int, _ []byte, _ uint64, _ error, _ bool) { rec.add("orig") }}
+		newHooks := &tracing.Hooks{OnExit: func(_ int, _ []byte, _ uint64, _ error, _ bool) { rec.add("new") }}
+		invoke(mergeVMHooks(orig, newHooks))
+		require.Equal(t, []string{"orig", "new"}, rec.calls)
+	})
+}
+
+func TestMergeVMHooks_OnOpcode(t *testing.T) {
+	invoke := func(h *tracing.Hooks) { h.OnOpcode(0, 0, 0, 0, nil, nil, 0, nil) }
+
+	t.Run("orig only is preserved", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnOpcode: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ []byte, _ int, _ error) { rec.add("orig") }}
+		result := mergeVMHooks(orig, &tracing.Hooks{})
+		require.NotNil(t, result.OnOpcode)
+		invoke(result)
+		require.Equal(t, []string{"orig"}, rec.calls)
+	})
+
+	t.Run("new only is installed", func(t *testing.T) {
+		rec := &recorder{}
+		newHooks := &tracing.Hooks{OnOpcode: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ []byte, _ int, _ error) { rec.add("new") }}
+		result := mergeVMHooks(&tracing.Hooks{}, newHooks)
+		require.NotNil(t, result.OnOpcode)
+		invoke(result)
+		require.Equal(t, []string{"new"}, rec.calls)
+	})
+
+	t.Run("both: orig called first then new", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnOpcode: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ []byte, _ int, _ error) { rec.add("orig") }}
+		newHooks := &tracing.Hooks{OnOpcode: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ []byte, _ int, _ error) { rec.add("new") }}
+		invoke(mergeVMHooks(orig, newHooks))
+		require.Equal(t, []string{"orig", "new"}, rec.calls)
+	})
+}
+
+func TestMergeVMHooks_OnFault(t *testing.T) {
+	invoke := func(h *tracing.Hooks) { h.OnFault(0, 0, 0, 0, nil, 0, nil) }
+
+	t.Run("orig only is preserved", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnFault: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ int, _ error) { rec.add("orig") }}
+		result := mergeVMHooks(orig, &tracing.Hooks{})
+		require.NotNil(t, result.OnFault)
+		invoke(result)
+		require.Equal(t, []string{"orig"}, rec.calls)
+	})
+
+	t.Run("new only is installed", func(t *testing.T) {
+		rec := &recorder{}
+		newHooks := &tracing.Hooks{OnFault: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ int, _ error) { rec.add("new") }}
+		result := mergeVMHooks(&tracing.Hooks{}, newHooks)
+		require.NotNil(t, result.OnFault)
+		invoke(result)
+		require.Equal(t, []string{"new"}, rec.calls)
+	})
+
+	t.Run("both: orig called first then new", func(t *testing.T) {
+		rec := &recorder{}
+		orig := &tracing.Hooks{OnFault: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ int, _ error) { rec.add("orig") }}
+		newHooks := &tracing.Hooks{OnFault: func(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ int, _ error) { rec.add("new") }}
+		invoke(mergeVMHooks(orig, newHooks))
+		require.Equal(t, []string{"orig", "new"}, rec.calls)
+	})
+}
+
+func TestMergeVMHooks_UnrelatedHooksFromOrigArePreserved(t *testing.T) {
+	// newHooks only contributes OnTxStart; all other hooks from orig must survive unchanged.
+	origOnTxEndCalled := false
+	origOnEnterCalled := false
+
+	orig := &tracing.Hooks{
+		OnTxEnd: func(_ *types.Receipt, _ error) { origOnTxEndCalled = true },
+		OnEnter: func(_ int, _ byte, _, _ common.Address, _ []byte, _ uint64, _ *big.Int) { origOnEnterCalled = true },
+	}
+	newHooks := &tracing.Hooks{
+		OnTxStart: func(_ *tracing.VMContext, _ *types.Transaction, _ common.Address) {},
+	}
+
+	result := mergeVMHooks(orig, newHooks)
+
+	result.OnTxEnd(nil, nil)
+	result.OnEnter(0, 0, common.Address{}, common.Address{}, nil, 0, big.NewInt(0))
+
+	require.True(t, origOnTxEndCalled, "OnTxEnd from orig must be preserved when newHooks does not define it")
+	require.True(t, origOnEnterCalled, "OnEnter from orig must be preserved when newHooks does not define it")
 }

--- a/api/ethapi/tx_trace_test.go
+++ b/api/ethapi/tx_trace_test.go
@@ -84,7 +84,7 @@ func TestSetupTracedEVM_GetVmConfigError(t *testing.T) {
 	injected := fmt.Errorf("db unavailable")
 	backend.EXPECT().GetNetworkRules(gomock.Any(), gomock.Any()).Return(nil, injected)
 
-	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, false, false, false)
+	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, TraceOptions{}, false)
 	defer cancel()
 
 	require.ErrorIs(t, err, injected, "error from GetVmConfig must be propagated")
@@ -102,7 +102,7 @@ func TestSetupTracedEVM_GetEVMError(t *testing.T) {
 	backend.EXPECT().GetEVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil, injected)
 
-	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, false, false, false)
+	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, TraceOptions{}, false)
 	defer cancel()
 
 	require.ErrorContains(t, err, injected.Error(), "error from GetEVM must be propagated")
@@ -158,7 +158,7 @@ func TestSetupTracedEVM_LoggersRespectFlags(t *testing.T) {
 			mockState := state.NewMockStateDB(ctrl)
 			backend := setupBackendForTracing(ctrl, mockState)
 
-			setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, tt.wantTrace, tt.wantStateDiff, false)
+			setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, TraceOptions{Trace: tt.wantTrace, StateDiff: tt.wantStateDiff}, false)
 			defer cancel()
 
 			require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestSetupTracedEVM_NoBaseFeeFlag(t *testing.T) {
 					return makeTestEVM(opera.Upgrades{})(t.Context(), statedb, header, vmConfig, blockContext)
 				})
 
-			setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, false, false, tt.noBaseFee)
+			setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, TraceOptions{}, tt.noBaseFee)
 			defer cancel()
 
 			require.NoError(t, err)
@@ -226,7 +226,7 @@ func TestSetupTracedEVM_ContextHasDeadlineFromRPCTimeout(t *testing.T) {
 			return makeTestEVM(opera.Upgrades{})(ctx, statedb, header, vmConfig, blockContext)
 		})
 
-	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, false, false, false)
+	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, TraceOptions{}, false)
 	defer cancel()
 
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func TestSetupTracedEVM_StateDiffWrapsState(t *testing.T) {
 			return makeTestEVM(opera.Upgrades{})(t.Context(), statedb, header, vmConfig, blockContext)
 		})
 
-	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, false, true, false)
+	setup, cancel, err := setupTracedEVM(t.Context(), backend, traceTestBlock(), mockState, 0, TraceOptions{StateDiff: true}, false)
 	defer cancel()
 
 	require.NoError(t, err)
@@ -282,8 +282,7 @@ func TestTraceCallExec_VmConfigError(t *testing.T) {
 		mockState,
 		traceTestTx(),
 		0,
-		true,
-		false,
+		TraceOptions{Trace: true},
 	)
 
 	require.ErrorIs(t, err, injected)
@@ -311,14 +310,14 @@ func TestTraceCallExec_TraceOnly(t *testing.T) {
 		mockState,
 		traceTestTx(),
 		0,
-		true,  // wantTrace
-		false, // wantStateDiff
+		TraceOptions{Trace: true},
 	)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Trace, "trace must contain at least one action")
 	require.Nil(t, result.StateDiff, "stateDiff must be nil when not requested")
+	require.Nil(t, result.VmTrace, "vmTrace must be nil when not requested")
 }
 
 func TestTraceCallExec_StateDiffOnly(t *testing.T) {
@@ -342,17 +341,17 @@ func TestTraceCallExec_StateDiffOnly(t *testing.T) {
 		mockState,
 		traceTestTx(),
 		0,
-		false, // wantTrace
-		true,  // wantStateDiff
+		TraceOptions{StateDiff: true},
 	)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Nil(t, result.Trace, "trace must be nil when not requested")
 	require.NotNil(t, result.StateDiff, "stateDiff must be non-nil when requested")
+	require.Nil(t, result.VmTrace, "vmTrace must be nil when not requested")
 }
 
-func TestTraceCallExec_BothTypes(t *testing.T) {
+func TestTraceCallExec_VMTraceOnly(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockState := state.NewMockStateDB(ctrl)
 	setExpectedStateCalls(mockState)
@@ -373,14 +372,45 @@ func TestTraceCallExec_BothTypes(t *testing.T) {
 		mockState,
 		traceTestTx(),
 		0,
-		true, // wantTrace
-		true, // wantStateDiff
+		TraceOptions{VmTrace: true},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.Trace, "trace must be nil when not requested")
+	require.Nil(t, result.StateDiff, "stateDiff must be nil when not requested")
+	require.NotNil(t, result.VmTrace, "vmTrace must be non-nil when requested")
+}
+
+func TestTraceCallExec_AllTypes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockState := state.NewMockStateDB(ctrl)
+	setExpectedStateCalls(mockState)
+
+	backend := NewMockBackend(ctrl)
+	backend.EXPECT().GetNetworkRules(gomock.Any(), gomock.Any()).Return(&opera.Rules{}, nil)
+	backend.EXPECT().RPCEVMTimeout().Return(time.Duration(0))
+	backend.EXPECT().GetEVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(makeTestEVM(opera.Upgrades{}))
+
+	api := &PublicTxTraceAPI{b: backend}
+	from, to := common.Address{1}, common.Address{2}
+
+	result, err := api.traceCallExec(
+		t.Context(),
+		traceTestBlock(),
+		traceTestMessage(from, to),
+		mockState,
+		traceTestTx(),
+		0,
+		TraceOptions{Trace: true, StateDiff: true, VmTrace: true},
 	)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.Trace, "trace must contain at least one action")
 	require.NotNil(t, result.StateDiff, "stateDiff must be non-nil when requested")
+	require.NotNil(t, result.VmTrace, "vmTrace must be non-nil when requested")
 }
 
 func TestTraceCallExec_InvalidGasPrice_ReturnsError(t *testing.T) {
@@ -409,8 +439,7 @@ func TestTraceCallExec_InvalidGasPrice_ReturnsError(t *testing.T) {
 				mockState,
 				traceTestTx(),
 				0,
-				true,
-				false,
+				TraceOptions{Trace: true},
 			)
 
 			require.ErrorContains(t, err, "invalid gas price")
@@ -457,13 +486,6 @@ func TestCallMany_TraceTypeValidation(t *testing.T) {
 				{Args: TransactionArgs{}, TraceTypes: []string{"unknownType"}},
 			},
 			wantErrMsg: "unrecognized trace type",
-		},
-		{
-			name: "vmTrace not supported",
-			calls: []CallRequest{
-				{Args: TransactionArgs{}, TraceTypes: []string{TraceTypeVmTrace}},
-			},
-			wantErrMsg: "vmTrace trace type is not supported",
 		},
 	}
 

--- a/txtrace/state_diff.go
+++ b/txtrace/state_diff.go
@@ -31,7 +31,7 @@ type TraceCallResult struct {
 	Output    hexutil.Bytes `json:"output"`
 	StateDiff StateDiff     `json:"stateDiff"`
 	Trace     []ActionTrace `json:"trace"`
-	VmTrace   any           `json:"vmTrace"`
+	VmTrace   *VmTrace      `json:"vmTrace"`
 }
 
 // StateDiff maps addresses to their account state changes during transaction execution.

--- a/txtrace/vm_trace.go
+++ b/txtrace/vm_trace.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package txtrace
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+)
+
+// VmTrace is the top level VM execution trace for a single call frame.
+type VmTrace struct {
+	Code hexutil.Bytes `json:"code"`
+	Ops  []VmOperation `json:"ops"`
+}
+
+// VmOperation represents a single VM opcode step.
+type VmOperation struct {
+	PC   uint64               `json:"pc"`
+	Op   string               `json:"op"`
+	Cost uint64               `json:"cost"`
+	Ex   *VmExecutedOperation `json:"ex"`  // nil when the opcode caused a fault
+	Sub  *VmTrace             `json:"sub"` // non nil for CALL/CREATE sub frames
+}
+
+// VmExecutedOperation captures the observable effects of a successfully executed opcode.
+type VmExecutedOperation struct {
+	Used  uint64        `json:"used"`
+	Push  []hexutil.Big `json:"push"`
+	Mem   *MemoryDiff   `json:"mem"`
+	Store *StorageDiff  `json:"store"`
+}
+
+// MemoryDiff records the full VM memory snapshot at opcode execution time.
+type MemoryDiff struct {
+	Off  uint64        `json:"off"`
+	Data hexutil.Bytes `json:"data"`
+}
+
+// StorageDiff records a write to a storage slot.
+type StorageDiff struct {
+	Key common.Hash `json:"key"`
+	Val common.Hash `json:"val"`
+}
+
+// vmTraceFrame is the call frame state maintained by VmTraceLogger.
+type vmTraceFrame struct {
+	trace       *VmTrace
+	lastOpIdx   int       // index of the most recently appended op, -1 if none
+	lastOp      vm.OpCode // opcode at lastOpIdx
+	memSnapshot []byte    // memory snapshot taken at OnOpcode time for the last op
+}
+
+// VmTraceLogger implements VM tracing hooks to build vmTrace.
+type VmTraceLogger struct {
+	traceStack   []*vmTraceFrame
+	result       *VmTrace
+	stateDB      tracing.StateDB
+	pendingStore *StorageDiff // latest storage write, attributed to the current op
+}
+
+// NewVmTraceLogger creates a new VmTraceLogger.
+func NewVmTraceLogger() *VmTraceLogger {
+	return &VmTraceLogger{}
+}
+
+// Hooks returns the tracing hooks.
+func (l *VmTraceLogger) Hooks() *tracing.Hooks {
+	return &tracing.Hooks{
+		OnTxStart:       l.onTxStart,
+		OnEnter:         l.onEnter,
+		OnExit:          l.onExit,
+		OnOpcode:        l.onOpcode,
+		OnFault:         l.onFault,
+		OnStorageChange: l.OnStorageChange,
+	}
+}
+
+// GetResult returns the completed vmTrace after execution.
+func (l *VmTraceLogger) GetResult() *VmTrace {
+	return l.result
+}
+
+// OnStorageChange records a storage write so it can be attributed to the
+// currently executing opcode.
+func (l *VmTraceLogger) OnStorageChange(_ common.Address, slot common.Hash, _ common.Hash, newVal common.Hash) {
+	l.pendingStore = &StorageDiff{Key: slot, Val: newVal}
+}
+
+// onTxStart captures the StateDB reference for contract code look-ups in OnEnter.
+func (l *VmTraceLogger) onTxStart(vmCtx *tracing.VMContext, _ *types.Transaction, _ common.Address) {
+	l.stateDB = vmCtx.StateDB
+}
+
+// onEnter creates a new VmTrace frame for each call or create.
+func (l *VmTraceLogger) onEnter(depth int, typ byte, _ common.Address, to common.Address, input []byte, gas uint64, _ *big.Int) {
+	var (
+		code    []byte
+		noTrace = false
+	)
+	switch vm.OpCode(typ) {
+	case vm.CREATE, vm.CREATE2:
+		// input is the init bytecode for CREATE/CREATE2
+		code = make([]byte, len(input))
+		copy(code, input)
+	case vm.SELFDESTRUCT:
+		noTrace = true
+	default:
+		// For CALL variants, look up the callee's deployed code
+		if l.stateDB != nil {
+			code = l.stateDB.GetCode(to)
+		}
+	}
+
+	newTrace := &VmTrace{
+		Code: hexutil.Bytes(code),
+		Ops:  make([]VmOperation, 0),
+	}
+
+	frame := &vmTraceFrame{
+		trace:     newTrace,
+		lastOpIdx: -1,
+	}
+
+	// Link this trace to the parent frame's last operation as a sub-trace.
+	if depth > 0 && len(l.traceStack) > 0 {
+		parent := l.traceStack[len(l.traceStack)-1]
+		if parent.lastOpIdx >= 0 && !noTrace {
+			parent.trace.Ops[parent.lastOpIdx].Sub = newTrace
+		}
+	}
+
+	l.traceStack = append(l.traceStack, frame)
+}
+
+// onExit finalizes the exiting frame's last operation and pops the frame.
+func (l *VmTraceLogger) onExit(depth int, _ []byte, _ uint64, _ error, _ bool) {
+	if len(l.traceStack) == 0 {
+		return
+	}
+	frame := l.traceStack[len(l.traceStack)-1]
+	l.traceStack = l.traceStack[:len(l.traceStack)-1]
+
+	// Finalize the last operation's Mem and Store using the saved memory snapshot.
+	if frame.lastOpIdx >= 0 {
+		op := &frame.trace.Ops[frame.lastOpIdx]
+		if op.Ex != nil {
+			memData := frame.memSnapshot
+			if memData == nil {
+				memData = []byte{}
+			}
+			op.Ex.Mem = &MemoryDiff{Off: uint64(len(memData)), Data: hexutil.Bytes(memData)}
+			if l.pendingStore != nil {
+				op.Ex.Store = l.pendingStore
+				l.pendingStore = nil
+			}
+		}
+	}
+
+	// Save the completed root trace so GetResult can return it.
+	if depth == 0 {
+		l.result = frame.trace
+	}
+}
+
+// onOpcode is called before each opcode executes.
+// It finalizes the previous op's Ex using the current post execution
+// state, then records a new operation entry for the current opcode.
+func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, _ []byte, _ int, _ error) {
+	if len(l.traceStack) == 0 {
+		return
+	}
+	frame := l.traceStack[len(l.traceStack)-1]
+
+	// Finalize the previous operation's Push, Mem, and Store now that we have
+	// the post execution state.
+	if frame.lastOpIdx >= 0 {
+		prevOp := &frame.trace.Ops[frame.lastOpIdx]
+		if prevOp.Ex != nil {
+			prevOp.Ex.Push = computePushed(frame.lastOp, scope.StackData())
+			memData := frame.memSnapshot
+			if memData == nil {
+				memData = []byte{}
+			}
+			prevOp.Ex.Mem = &MemoryDiff{Off: uint64(len(memData)), Data: hexutil.Bytes(memData)}
+			if l.pendingStore != nil {
+				prevOp.Ex.Store = l.pendingStore
+				l.pendingStore = nil
+			}
+		}
+	}
+
+	// Create a new operation entry. Ex.Used = gas before this opcode (gasCopy from
+	// interpreter, captured before any gas deduction for this op).
+	newOp := VmOperation{
+		Op:   vm.OpCode(op).String(),
+		PC:   pc,
+		Cost: cost,
+		Ex:   &VmExecutedOperation{Used: gas, Push: []hexutil.Big{}},
+	}
+	frame.trace.Ops = append(frame.trace.Ops, newOp)
+	frame.lastOpIdx = len(frame.trace.Ops) - 1
+	frame.lastOp = vm.OpCode(op)
+
+	// Memory snapshot is taken here. For dynamic gas opcodes this is BEFORE memory
+	// expansion (the interpreter expands memory after firing OnOpcode), so the snapshot
+	// reflects the pre execution memory state of this opcode.
+	curMem := scope.MemoryData()
+	frame.memSnapshot = make([]byte, len(curMem))
+	copy(frame.memSnapshot, curMem)
+}
+
+// onFault is called when an opcode causes a fault.
+// The faulting operation's Ex is set to nil (no successful execution result),
+// except for ErrExecutionReverted which represents a valid REVERT opcode execution.
+func (l *VmTraceLogger) onFault(_ uint64, _ byte, _, _ uint64, _ tracing.OpContext, _ int, err error) {
+	if errors.Is(err, vm.ErrExecutionReverted) {
+		// REVERT is a valid opcode execution; its Ex remains intact.
+		return
+	}
+	if len(l.traceStack) == 0 {
+		return
+	}
+	frame := l.traceStack[len(l.traceStack)-1]
+	if frame.lastOpIdx >= 0 {
+		frame.trace.Ops[frame.lastOpIdx].Ex = nil
+	}
+}
+
+// computePushed returns the values pushed/affected on the VM stack by the previous opcode.
+func computePushed(op vm.OpCode, stack []uint256.Int) []hexutil.Big {
+
+	var count int
+	switch {
+	case op >= vm.PUSH0 && op <= vm.PUSH32:
+		count = 1
+	case op >= vm.SWAP1 && op <= vm.SWAP16:
+		count = int(op-vm.SWAP1) + 2
+	case op >= vm.DUP1 && op <= vm.DUP16:
+		count = int(op-vm.DUP1) + 2
+	}
+	switch op {
+	case vm.CALLDATALOAD, vm.SLOAD, vm.MLOAD, vm.CALLDATASIZE, vm.LT, vm.GT, vm.DIV, vm.SDIV, vm.SAR, vm.AND, vm.EQ, vm.CALLVALUE, vm.ISZERO,
+		vm.ADD, vm.EXP, vm.CALLER, vm.KECCAK256, vm.SUB, vm.ADDRESS, vm.GAS, vm.MUL, vm.RETURNDATASIZE, vm.NOT, vm.SHR, vm.SHL,
+		vm.EXTCODESIZE, vm.SLT, vm.OR, vm.NUMBER, vm.PC, vm.TIMESTAMP, vm.BALANCE, vm.SELFBALANCE, vm.MULMOD, vm.ADDMOD, vm.BASEFEE,
+		vm.BLOCKHASH, vm.BYTE, vm.XOR, vm.ORIGIN, vm.CODESIZE, vm.MOD, vm.SIGNEXTEND, vm.GASLIMIT, vm.DIFFICULTY, vm.SGT, vm.GASPRICE,
+		vm.MSIZE, vm.EXTCODEHASH, vm.SMOD, vm.CHAINID, vm.COINBASE, vm.TLOAD:
+		count = 1
+	}
+
+	if count > 0 {
+		if count > len(stack) {
+			count = len(stack)
+		}
+		result := make([]hexutil.Big, count)
+		for i := range count {
+			result[i] = hexutil.Big(*stack[len(stack)-count+i].ToBig())
+		}
+		return result
+	}
+
+	return []hexutil.Big{}
+}

--- a/txtrace/vm_trace.go
+++ b/txtrace/vm_trace.go
@@ -17,6 +17,7 @@
 package txtrace
 
 import (
+	"bytes"
 	"errors"
 	"math/big"
 
@@ -161,15 +162,12 @@ func (l *VmTraceLogger) onExit(depth int, _ []byte, _ uint64, _ error, _ bool) {
 	frame := l.traceStack[len(l.traceStack)-1]
 	l.traceStack = l.traceStack[:len(l.traceStack)-1]
 
-	// Finalize the last operation's Mem and Store using the saved memory snapshot.
+	// Finalize the last operation's Store. Mem is left nil: terminal ops (STOP,
+	// RETURN, REVERT) do not write memory, and post-execution memory is unavailable
+	// in onExit since scope is gone.
 	if frame.lastOpIdx >= 0 {
 		op := &frame.trace.Ops[frame.lastOpIdx]
 		if op.Ex != nil {
-			memData := frame.memSnapshot
-			if memData == nil {
-				memData = []byte{}
-			}
-			op.Ex.Mem = &MemoryDiff{Off: uint64(len(memData)), Data: hexutil.Bytes(memData)}
 			if l.pendingStore != nil {
 				op.Ex.Store = l.pendingStore
 				l.pendingStore = nil
@@ -198,11 +196,15 @@ func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tra
 		prevOp := &frame.trace.Ops[frame.lastOpIdx]
 		if prevOp.Ex != nil {
 			prevOp.Ex.Push = computePushed(frame.lastOp, scope.StackData())
-			memData := frame.memSnapshot
-			if memData == nil {
-				memData = []byte{}
+			// scope.MemoryData() here is post-execution of the previous op.
+			// Compare against the pre-execution snapshot; only record a Mem diff
+			// when the opcode actually wrote to memory.
+			curMem := scope.MemoryData()
+			if !bytes.Equal(curMem, frame.memSnapshot) {
+				postMem := make([]byte, len(curMem))
+				copy(postMem, curMem)
+				prevOp.Ex.Mem = &MemoryDiff{Off: 0, Data: hexutil.Bytes(postMem)}
 			}
-			prevOp.Ex.Mem = &MemoryDiff{Off: uint64(len(memData)), Data: hexutil.Bytes(memData)}
 			if l.pendingStore != nil {
 				prevOp.Ex.Store = l.pendingStore
 				l.pendingStore = nil

--- a/txtrace/vm_trace.go
+++ b/txtrace/vm_trace.go
@@ -264,7 +264,7 @@ func computePushed(op vm.OpCode, stack []uint256.Int) []hexutil.Big {
 		vm.ADD, vm.EXP, vm.CALLER, vm.KECCAK256, vm.SUB, vm.ADDRESS, vm.GAS, vm.MUL, vm.RETURNDATASIZE, vm.NOT, vm.SHR, vm.SHL,
 		vm.EXTCODESIZE, vm.SLT, vm.OR, vm.NUMBER, vm.PC, vm.TIMESTAMP, vm.BALANCE, vm.SELFBALANCE, vm.MULMOD, vm.ADDMOD, vm.BASEFEE,
 		vm.BLOCKHASH, vm.BYTE, vm.XOR, vm.ORIGIN, vm.CODESIZE, vm.MOD, vm.SIGNEXTEND, vm.GASLIMIT, vm.DIFFICULTY, vm.SGT, vm.GASPRICE,
-		vm.MSIZE, vm.EXTCODEHASH, vm.SMOD, vm.CHAINID, vm.COINBASE, vm.TLOAD:
+		vm.MSIZE, vm.EXTCODEHASH, vm.SMOD, vm.CHAINID, vm.COINBASE, vm.TLOAD, vm.CALL, vm.DELEGATECALL, vm.STATICCALL, vm.CREATE, vm.CREATE2:
 		count = 1
 	}
 

--- a/txtrace/vm_trace_test.go
+++ b/txtrace/vm_trace_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package txtrace
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputePushed_EmptyStacks(t *testing.T) {
+	pushed := computePushed(vm.STOP, nil)
+	require.Empty(t, pushed)
+}
+
+func TestComputePushed_PushOntoEmpty(t *testing.T) {
+	// PUSH1 0x60 onto empty stack → push = [0x60]
+	cur := []uint256.Int{*uint256.NewInt(0x60)}
+	pushed := computePushed(vm.PUSH1, cur)
+	require.Len(t, pushed, 1)
+	require.Equal(t, big.NewInt(0x60), pushed[0].ToInt())
+}
+
+func TestVmTraceLogger_GetResultBeforeExecution(t *testing.T) {
+	l := NewVmTraceLogger()
+	require.Nil(t, l.GetResult(), "result must be nil before any execution")
+}
+
+func TestVmTraceLogger_EmptyFrame(t *testing.T) {
+	// OnEnter + OnExit with no opcodes → trace with empty ops
+	l := NewVmTraceLogger()
+
+	code := []byte{0x60, 0x01} // PUSH1 1
+	l.onEnter(0, 0x00 /* STOP */, addr(1), addr(2), code, 100, big.NewInt(0))
+	l.onExit(0, nil, 0, nil, false)
+
+	result := l.GetResult()
+	require.NotNil(t, result)
+	require.Empty(t, result.Ops)
+}
+
+func TestVmTraceLogger_OnFaultSetsExToNil(t *testing.T) {
+	l := NewVmTraceLogger()
+
+	l.onEnter(0, 0x00, addr(1), addr(2), []byte{0x60}, 1000, big.NewInt(0))
+
+	// Simulate one opcode that then faults
+	l.onOpcode(0, 0x60 /* PUSH1 */, 1000, 3, &mockOpContext{}, nil, 0, nil)
+	l.onFault(0, 0x60, 1000, 3, &mockOpContext{}, 0, errFoo)
+
+	l.onExit(0, nil, 3, errFoo, true)
+
+	result := l.GetResult()
+	require.NotNil(t, result)
+	require.Len(t, result.Ops, 1)
+	require.Nil(t, result.Ops[0].Ex, "Ex must be nil after a fault")
+}
+
+func TestVmTraceLogger_StorageChangeAttributed(t *testing.T) {
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	ctx1 := &mockOpContext{}
+	l.onOpcode(0, 0x55 /* SSTORE */, 1000, 20000, ctx1, nil, 0, nil)
+
+	slot := common.Hash{0x01}
+	val := common.Hash{0xFF}
+	l.OnStorageChange(addr(2), slot, common.Hash{}, val)
+
+	// Next op finalizes the SSTORE op's Ex (including store)
+	ctx2 := &mockOpContext{}
+	l.onOpcode(4, 0x00 /* STOP */, 980, 0, ctx2, nil, 0, nil)
+
+	l.onExit(0, nil, 20000, nil, false)
+
+	result := l.GetResult()
+	require.NotNil(t, result)
+	require.Len(t, result.Ops, 2)
+
+	sstoreOp := result.Ops[0]
+	require.NotNil(t, sstoreOp.Ex)
+	require.NotNil(t, sstoreOp.Ex.Store)
+	require.Equal(t, slot, sstoreOp.Ex.Store.Key)
+	require.Equal(t, val, sstoreOp.Ex.Store.Val)
+}
+
+func TestVmTraceLogger_GasAccountingUsed(t *testing.T) {
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	// PUSH1 costs 3 gas; gas parameter = gas before this op = 1000
+	l.onOpcode(0, 0x60, 1000, 3, &mockOpContext{}, nil, 0, nil)
+	// Next op: gas=997 (gas before STOP = gas after PUSH1)
+	l.onOpcode(2, 0x00, 997, 0, &mockOpContext{}, nil, 0, nil)
+
+	l.onExit(0, nil, 3, nil, false)
+
+	result := l.GetResult()
+	require.NotNil(t, result)
+	require.Len(t, result.Ops, 2)
+
+	// PUSH1 op Ex.Used = gas before PUSH1 = 1000
+	require.Equal(t, uint64(1000), result.Ops[0].Ex.Used)
+
+	// STOP op Ex.Used = gas before STOP = 997
+	require.Equal(t, uint64(997), result.Ops[1].Ex.Used)
+}
+
+func TestVmTraceLogger_SubTraceLinked(t *testing.T) {
+	l := NewVmTraceLogger()
+
+	// Root call
+	l.onEnter(0, 0x00, addr(1), addr(2), []byte{}, 1000, big.NewInt(0))
+
+	// CALL opcode in root
+	l.onOpcode(0, 0xF1 /* CALL */, 1000, 100, &mockOpContext{}, nil, 0, nil)
+
+	// Sub-call enters (depth=1)
+	subCode := []byte{0x60, 0x01}
+	l.onEnter(1, 0xF1, addr(2), addr(3), subCode, 800, big.NewInt(0))
+	l.onExit(1, nil, 10, nil, false)
+
+	// Back in root: next op finalizes the CALL op (with Sub linked)
+	l.onOpcode(10, 0x00 /* STOP */, 890, 0, &mockOpContext{}, nil, 0, nil)
+	l.onExit(0, nil, 110, nil, false)
+
+	result := l.GetResult()
+	require.NotNil(t, result)
+	require.Len(t, result.Ops, 2)
+
+	callOp := result.Ops[0]
+	require.NotNil(t, callOp.Sub, "CALL op must have a sub-trace")
+	require.Empty(t, callOp.Sub.Ops, "sub-trace had no opcodes")
+}
+
+func TestVmTraceLogger_StorageChangeOnLastOp(t *testing.T) {
+	// Verifies that a storage change from an SSTORE that is the very last opcode
+	// (no subsequent onOpcode call before onExit) is correctly attributed to Ex.Store.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	// SSTORE is the only (and last) opcode — no subsequent onOpcode drains pendingStore.
+	l.onOpcode(0, 0x55 /* SSTORE */, 1000, 20000, &mockOpContext{}, nil, 0, nil)
+
+	slot := common.Hash{0x02}
+	val := common.Hash{0xAB}
+	l.OnStorageChange(addr(2), slot, common.Hash{}, val)
+
+	// Frame exits immediately; onExit must consume pendingStore.
+	l.onExit(0, nil, 20000, nil, false)
+
+	result := l.GetResult()
+	require.NotNil(t, result)
+	require.Len(t, result.Ops, 1)
+
+	sstoreOp := result.Ops[0]
+	require.NotNil(t, sstoreOp.Ex, "Ex must not be nil for a non-faulting op")
+	require.NotNil(t, sstoreOp.Ex.Store, "Ex.Store must be populated even when SSTORE is the last op")
+	require.Equal(t, slot, sstoreOp.Ex.Store.Key)
+	require.Equal(t, val, sstoreOp.Ex.Store.Val)
+}
+
+func TestVmTraceLogger_NoOpsOnEmptyExec(t *testing.T) {
+	l := NewVmTraceLogger()
+	// Guard: multiple OnExit calls without matching OnEnter must not panic
+	l.onExit(0, nil, 0, nil, false)
+	require.Nil(t, l.GetResult())
+}
+
+func TestVmTraceLogger_RevertHasNonNilEx(t *testing.T) {
+	// REVERT is a valid opcode execution; onFault with ErrExecutionReverted must not nil Ex.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+	l.onOpcode(0, 0xfd /* REVERT */, 1000, 0, &mockOpContext{}, nil, 0, nil)
+	l.onFault(0, 0xfd, 1000, 0, &mockOpContext{}, 0, vm.ErrExecutionReverted)
+	l.onExit(0, nil, 0, vm.ErrExecutionReverted, true)
+
+	result := l.GetResult()
+	require.NotNil(t, result)
+	require.Len(t, result.Ops, 1)
+	require.NotNil(t, result.Ops[0].Ex, "REVERT must have non-nil Ex")
+	require.Equal(t, uint64(1000), result.Ops[0].Ex.Used)
+}
+
+// --- helpers ---
+
+var errFoo = errors.New("test error")
+
+func addr(n byte) common.Address {
+	return common.Address{n}
+}
+
+// mockOpContext implements tracing.OpContext with configurable stack and memory.
+type mockOpContext struct {
+	stack  []uint256.Int
+	memory []byte
+}
+
+func (m *mockOpContext) MemoryData() []byte       { return m.memory }
+func (m *mockOpContext) StackData() []uint256.Int { return m.stack }
+func (m *mockOpContext) Caller() common.Address   { return common.Address{} }
+func (m *mockOpContext) Address() common.Address  { return common.Address{} }
+func (m *mockOpContext) CallValue() *uint256.Int  { return uint256.NewInt(0) }
+func (m *mockOpContext) CallInput() []byte        { return nil }
+func (m *mockOpContext) ContractCode() []byte     { return nil }

--- a/txtrace/vm_trace_test.go
+++ b/txtrace/vm_trace_test.go
@@ -40,6 +40,154 @@ func TestComputePushed_PushOntoEmpty(t *testing.T) {
 	require.Equal(t, big.NewInt(0x60), pushed[0].ToInt())
 }
 
+// makeStack builds a []uint256.Int from a list of uint64 values.
+func makeStack(vals ...uint64) []uint256.Int {
+	s := make([]uint256.Int, len(vals))
+	for i, v := range vals {
+		s[i] = *uint256.NewInt(v)
+	}
+	return s
+}
+
+func TestComputePushed_PushRange(t *testing.T) {
+	// Every opcode in PUSH0..PUSH32 returns exactly 1 stack item regardless of its push size.
+	tests := []struct {
+		name string
+		op   vm.OpCode
+	}{
+		{"PUSH0", vm.PUSH0},
+		{"PUSH1", vm.PUSH1},
+		{"PUSH16", vm.PUSH16},
+		{"PUSH32", vm.PUSH32},
+	}
+	stack := makeStack(0xAB)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computePushed(tt.op, stack)
+			require.Len(t, result, 1)
+			require.Equal(t, big.NewInt(0xAB), result[0].ToInt())
+		})
+	}
+}
+
+func TestComputePushed_SwapRange(t *testing.T) {
+	// SWAPn or DUPn reads the top n+1 items: SWAP1 → 2, SWAP16 → 17.
+	tests := []struct {
+		name      string
+		op        vm.OpCode
+		wantCount int
+	}{
+		{"SWAP1", vm.SWAP1, 2},
+		{"SWAP4", vm.SWAP4, 5},
+		{"SWAP16", vm.SWAP16, 17},
+		{"DUP1", vm.DUP1, 2},
+		{"DUP4", vm.DUP4, 5},
+		{"DUP16", vm.DUP16, 17},
+	}
+	// Stack large enough for the largest case (17 elements, values 1..17).
+	stack := makeStack(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computePushed(tt.op, stack)
+			require.Len(t, result, tt.wantCount)
+			// Result must be the top wantCount elements from the stack in order.
+			for i := range tt.wantCount {
+				want := big.NewInt(int64(17 - tt.wantCount + 1 + i))
+				require.Equal(t, want, result[i].ToInt(), "index %d", i)
+			}
+		})
+	}
+}
+
+func TestComputePushed_DupRange(t *testing.T) {
+	// DUPn reads the top n+1 items: DUP1 → 2, DUP16 → 17.
+	tests := []struct {
+		name      string
+		op        vm.OpCode
+		wantCount int
+	}{
+		{"DUP1", vm.DUP1, 2},
+		{"DUP4", vm.DUP4, 5},
+		{"DUP16", vm.DUP16, 17},
+	}
+	stack := makeStack(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computePushed(tt.op, stack)
+			require.Len(t, result, tt.wantCount)
+			for i := range tt.wantCount {
+				want := big.NewInt(int64(17 - tt.wantCount + 1 + i))
+				require.Equal(t, want, result[i].ToInt(), "index %d", i)
+			}
+		})
+	}
+}
+
+func TestComputePushed_SingleReturnOpcodes(t *testing.T) {
+	// A sample of the explicit single-return opcodes in the switch statement.
+	ops := []vm.OpCode{
+		vm.ADD, vm.MUL, vm.SUB, vm.DIV, vm.AND, vm.OR, vm.XOR, vm.NOT,
+		vm.LT, vm.GT, vm.EQ, vm.ISZERO,
+		vm.SLOAD, vm.MLOAD, vm.CALLDATALOAD,
+		vm.CALLER, vm.CALLVALUE, vm.ADDRESS, vm.ORIGIN,
+		vm.GAS, vm.GASLIMIT, vm.GASPRICE, vm.BASEFEE,
+		vm.NUMBER, vm.TIMESTAMP, vm.COINBASE,
+		vm.KECCAK256, vm.EXTCODESIZE, vm.EXTCODEHASH, vm.BALANCE, vm.SELFBALANCE,
+		vm.RETURNDATASIZE, vm.CALLDATASIZE, vm.CODESIZE,
+		vm.PC, vm.MSIZE, vm.BLOCKHASH, vm.CHAINID, vm.DIFFICULTY,
+	}
+	stack := makeStack(99)
+	for _, op := range ops {
+		t.Run(op.String(), func(t *testing.T) {
+			result := computePushed(op, stack)
+			require.Len(t, result, 1, "op %s must return exactly 1 item", op)
+			require.Equal(t, big.NewInt(99), result[0].ToInt())
+		})
+	}
+}
+
+func TestComputePushed_ZeroReturnOpcodes(t *testing.T) {
+	// Opcodes not in any push/swap/dup/explicit list return an empty (non-nil) slice.
+	ops := []vm.OpCode{
+		vm.STOP, vm.MSTORE, vm.MSTORE8, vm.SSTORE,
+		vm.JUMP, vm.JUMPI, vm.JUMPDEST,
+		vm.POP, vm.RETURN, vm.REVERT,
+		vm.CALL, vm.DELEGATECALL, vm.STATICCALL,
+		vm.CREATE, vm.CREATE2, vm.SELFDESTRUCT,
+	}
+	stack := makeStack(1, 2, 3)
+	for _, op := range ops {
+		t.Run(op.String(), func(t *testing.T) {
+			result := computePushed(op, stack)
+			require.NotNil(t, result)
+			require.Empty(t, result, "op %s must return no items", op)
+		})
+	}
+}
+
+func TestComputePushed_StackClamp(t *testing.T) {
+	// When the requested count exceeds the actual stack depth, it is clamped to len(stack).
+	tests := []struct {
+		name      string
+		op        vm.OpCode
+		stack     []uint256.Int
+		wantCount int
+	}{
+		// SWAP2 wants 3, but stack has only 2 → clamp to 2.
+		{"SWAP2 stack too small", vm.SWAP2, makeStack(10, 20), 2},
+		// PUSH1 wants 1, but stack is empty → 0.
+		{"PUSH1 empty stack", vm.PUSH1, nil, 0},
+		// DUP4 wants 5, stack has 3 → clamp to 3.
+		{"DUP4 stack too small", vm.DUP4, makeStack(1, 2, 3), 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computePushed(tt.op, tt.stack)
+			require.Len(t, result, tt.wantCount)
+		})
+	}
+}
+
 func TestVmTraceLogger_GetResultBeforeExecution(t *testing.T) {
 	l := NewVmTraceLogger()
 	require.Nil(t, l.GetResult(), "result must be nil before any execution")

--- a/txtrace/vm_trace_test.go
+++ b/txtrace/vm_trace_test.go
@@ -151,9 +151,7 @@ func TestComputePushed_ZeroReturnOpcodes(t *testing.T) {
 	ops := []vm.OpCode{
 		vm.STOP, vm.MSTORE, vm.MSTORE8, vm.SSTORE,
 		vm.JUMP, vm.JUMPI, vm.JUMPDEST,
-		vm.POP, vm.RETURN, vm.REVERT,
-		vm.CALL, vm.DELEGATECALL, vm.STATICCALL,
-		vm.CREATE, vm.CREATE2, vm.SELFDESTRUCT,
+		vm.POP, vm.RETURN, vm.REVERT, vm.SELFDESTRUCT,
 	}
 	stack := makeStack(1, 2, 3)
 	for _, op := range ops {

--- a/txtrace/vm_trace_test.go
+++ b/txtrace/vm_trace_test.go
@@ -368,3 +368,81 @@ func (m *mockOpContext) Address() common.Address  { return common.Address{} }
 func (m *mockOpContext) CallValue() *uint256.Int  { return uint256.NewInt(0) }
 func (m *mockOpContext) CallInput() []byte        { return nil }
 func (m *mockOpContext) ContractCode() []byte     { return nil }
+
+func TestVmTraceLogger_MemNilForNonMemoryOp(t *testing.T) {
+	// PUSH1 does not write memory → Ex.Mem must be nil.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	// Both contexts have empty memory — nothing changes.
+	l.onOpcode(0, byte(vm.PUSH1), 1000, 3, &mockOpContext{}, nil, 0, nil)
+	l.onOpcode(2, byte(vm.STOP), 997, 0, &mockOpContext{}, nil, 0, nil)
+	l.onExit(0, nil, 3, nil, false)
+
+	result := l.GetResult()
+	require.Len(t, result.Ops, 2)
+	require.Nil(t, result.Ops[0].Ex.Mem, "PUSH1 must have Mem=nil (no memory write)")
+}
+
+func TestVmTraceLogger_MemSetAfterMSTORE(t *testing.T) {
+	// MSTORE writes 32 bytes; Ex.Mem must carry the post-execution memory with Off=0.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	// Before MSTORE: memory empty.
+	ctxBeforeMstore := &mockOpContext{memory: []byte{}}
+	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, ctxBeforeMstore, nil, 0, nil)
+
+	// After MSTORE: 32 bytes, last byte = 0x42.
+	memAfter := make([]byte, 32)
+	memAfter[31] = 0x42
+	ctxAfterMstore := &mockOpContext{memory: memAfter}
+	l.onOpcode(33, byte(vm.STOP), 994, 0, ctxAfterMstore, nil, 0, nil)
+
+	l.onExit(0, nil, 6, nil, false)
+
+	result := l.GetResult()
+	require.Len(t, result.Ops, 2)
+
+	mstoreOp := result.Ops[0]
+	require.NotNil(t, mstoreOp.Ex)
+	require.NotNil(t, mstoreOp.Ex.Mem, "MSTORE must have Mem set")
+	require.Equal(t, uint64(0), mstoreOp.Ex.Mem.Off, "Mem.Off must be 0")
+	require.Equal(t, []byte(memAfter), []byte(mstoreOp.Ex.Mem.Data), "Mem.Data must equal post-MSTORE memory")
+}
+
+func TestVmTraceLogger_MemOffAlwaysZero(t *testing.T) {
+	// Off must be 0 regardless of memory size — never len(data).
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{memory: []byte{}}, nil, 0, nil)
+
+	// 64-byte post-execution memory (two MSTORE slots).
+	bigMem := make([]byte, 64)
+	bigMem[31] = 0x01
+	bigMem[63] = 0x02
+	l.onOpcode(33, byte(vm.STOP), 994, 0, &mockOpContext{memory: bigMem}, nil, 0, nil)
+	l.onExit(0, nil, 6, nil, false)
+
+	result := l.GetResult()
+	require.Len(t, result.Ops, 2)
+	mem := result.Ops[0].Ex.Mem
+	require.NotNil(t, mem)
+	require.Equal(t, uint64(0), mem.Off, "Off must be 0, not len(data)")
+	require.NotEqual(t, uint64(len(mem.Data)), mem.Off, "Off must not equal len(Data)")
+}
+
+func TestVmTraceLogger_MemLastOpIsNil(t *testing.T) {
+	// The last op in a frame has no subsequent onOpcode to finalize it,
+	// so Ex.Mem must remain nil (post-execution state unavailable in onExit).
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	l.onOpcode(0, byte(vm.STOP), 1000, 0, &mockOpContext{}, nil, 0, nil)
+	l.onExit(0, nil, 0, nil, false)
+
+	result := l.GetResult()
+	require.Len(t, result.Ops, 1)
+	require.Nil(t, result.Ops[0].Ex.Mem, "last op must have Mem=nil")
+}


### PR DESCRIPTION
This PR adds full VM opcode tracing to the RPC API calls `trace_call` and `trace_callMany`, compatible with Erigon/OpenEthereum formats.