### PR TITLE
Reanme plan to align naming in the two RPC types.

### DIFF
--- a/ethapi/bundle_api.go
+++ b/ethapi/bundle_api.go
@@ -109,9 +109,9 @@ type RPCPreparedBundle struct {
 	// These must be signed exactly as provided by the bundle_prepare RPC method; any modification
 	// will invalidate the execution plan and result in an ill-formed bundle.
 	Transactions []TransactionArgs `json:"transactions"`
-	// Plan contains the execution plan that each bundled transaction references. This is provided
+	// ExecutionPlan contains the execution plan that each bundled transaction references. This is provided
 	// for verification purposes; users may independently compute and validate the execution plan hash.
-	Plan RPCExecutionPlan `json:"plan,omitempty"`
+	ExecutionPlan RPCExecutionPlan `json:"plan,omitempty"`
 }
 
 // PrepareBundle implements the `sonic_prepareBundle` RPC method.
@@ -237,8 +237,8 @@ func (a *PublicBundleAPI) PrepareBundle(
 	}
 
 	bundle := RPCPreparedBundle{
-		Transactions: args.Transactions,
-		Plan:         NewRPCExecutionPlan(plan),
+		Transactions:  args.Transactions,
+		ExecutionPlan: NewRPCExecutionPlan(plan),
 	}
 
 	return &bundle, nil

--- a/ethapi/bundle_api.go
+++ b/ethapi/bundle_api.go
@@ -111,7 +111,7 @@ type RPCPreparedBundle struct {
 	Transactions []TransactionArgs `json:"transactions"`
 	// ExecutionPlan contains the execution plan that each bundled transaction references. This is provided
 	// for verification purposes; users may independently compute and validate the execution plan hash.
-	ExecutionPlan RPCExecutionPlan `json:"plan,omitempty"`
+	ExecutionPlan RPCExecutionPlan `json:"executionPlan,omitempty"`
 }
 
 // PrepareBundle implements the `sonic_prepareBundle` RPC method.

--- a/ethapi/bundle_api_test.go
+++ b/ethapi/bundle_api_test.go
@@ -129,7 +129,7 @@ func TestBundleRPC_JsonIsEthereumConformant(t *testing.T) {
 				"data":"0x010203"
 			}
 		],
-		"plan": {
+		"executionPlan": {
 		  "flags": 3,
 		  "steps": [
 			{
@@ -142,8 +142,8 @@ func TestBundleRPC_JsonIsEthereumConformant(t *testing.T) {
 		}
 	}`,
 		RPCPreparedBundle{
-			Transactions: []TransactionArgs{transacton},
-			Plan:         plan,
+			Transactions:  []TransactionArgs{transacton},
+			ExecutionPlan: plan,
 		})
 
 }

--- a/tests/bundles/use_bundle_api_test.go
+++ b/tests/bundles/use_bundle_api_test.go
@@ -75,7 +75,7 @@ func Test_CreateBundlesWithRPC(t *testing.T) {
 	checkCompatWithMetaMask(t, client, txs)
 
 	// 4) Submit the bundle to the network
-	bundleHash, err := SubmitBundle(client, txs, preparedBundle.Plan)
+	bundleHash, err := SubmitBundle(client, txs, preparedBundle.ExecutionPlan)
 	require.NoError(t, err, "failed to submit bundle")
 
 	_, err = waitForBundleExecution(t.Context(), client.Client(), bundleHash)


### PR DESCRIPTION
Align naming in `RPCPreparedBundle` and `SubmitBundleArgs`