### PR TITLE
WIP: Add event version 4 with block hashes and stake-weighted disagreement

### DIFF
--- a/config/make_node.go
+++ b/config/make_node.go
@@ -166,7 +166,7 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 		}
 		return false
 	}
-	svc, err := gossip.NewService(stack, cfg.Opera, gdb, blockProc, engine, dagIndex, newTxPool, haltCheck)
+	svc, err := gossip.NewService(stack, cfg.Opera, gdb, blockProc, engine, dagIndex, newTxPool, haltCheck, errorLock)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create the gossip service: %w", err)
 	}

--- a/eventcheck/basiccheck/basic_check.go
+++ b/eventcheck/basiccheck/basic_check.go
@@ -26,11 +26,14 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 )
 
+const MaxBlockHashesPerEvent = 64
+
 var (
-	ErrWrongNetForkID = errors.New("wrong network fork ID")
-	ErrZeroTime       = errors.New("event has zero timestamp")
-	ErrNegativeValue  = errors.New("negative value")
-	ErrIntrinsicGas   = errors.New("intrinsic gas too low")
+	ErrWrongNetForkID   = errors.New("wrong network fork ID")
+	ErrZeroTime         = errors.New("event has zero timestamp")
+	ErrNegativeValue    = errors.New("negative value")
+	ErrIntrinsicGas     = errors.New("intrinsic gas too low")
+	ErrTooManyBlockHash = errors.New("too many block hashes in event")
 	// ErrTipAboveFeeCap is a sanity error to ensure no one is able to specify a
 	// transaction with a tip higher than the total fee cap.
 	ErrTipAboveFeeCap = errors.New("max priority fee per gas higher than max fee per gas")
@@ -95,6 +98,9 @@ func (v *Checker) Validate(e inter.EventPayloadI) error {
 	}
 	if err := v.checkTxs(e); err != nil {
 		return err
+	}
+	if len(e.BlockHashes().Hashes) > MaxBlockHashesPerEvent {
+		return ErrTooManyBlockHash
 	}
 
 	return nil

--- a/eventcheck/basiccheck/basic_check.go
+++ b/eventcheck/basiccheck/basic_check.go
@@ -29,11 +29,14 @@ import (
 const MaxBlockHashesPerEvent = 64
 
 var (
-	ErrWrongNetForkID   = errors.New("wrong network fork ID")
-	ErrZeroTime         = errors.New("event has zero timestamp")
-	ErrNegativeValue    = errors.New("negative value")
-	ErrIntrinsicGas     = errors.New("intrinsic gas too low")
-	ErrTooManyBlockHash = errors.New("too many block hashes in event")
+	ErrWrongNetForkID         = errors.New("wrong network fork ID")
+	ErrZeroTime               = errors.New("event has zero timestamp")
+	ErrNegativeValue          = errors.New("negative value")
+	ErrIntrinsicGas           = errors.New("intrinsic gas too low")
+	ErrTooManyBlockHash       = errors.New("too many block hashes in event")
+	ErrBlockHashZeroStart     = errors.New("block hashes present with zero Start")
+	ErrBlockHashZeroEpoch     = errors.New("block hashes present with zero Epoch")
+	ErrBlockHashEpochMismatch = errors.New("block hashes epoch does not match event epoch")
 	// ErrTipAboveFeeCap is a sanity error to ensure no one is able to specify a
 	// transaction with a tip higher than the total fee cap.
 	ErrTipAboveFeeCap = errors.New("max priority fee per gas higher than max fee per gas")
@@ -66,7 +69,6 @@ func validateTx(tx *types.Transaction) error {
 	if tx.Gas() < intrGas {
 		return ErrIntrinsicGas
 	}
-
 	if tx.GasFeeCapIntCmp(tx.GasTipCap()) < 0 {
 		return ErrTipAboveFeeCap
 	}
@@ -99,8 +101,20 @@ func (v *Checker) Validate(e inter.EventPayloadI) error {
 	if err := v.checkTxs(e); err != nil {
 		return err
 	}
-	if len(e.BlockHashes().Hashes) > MaxBlockHashesPerEvent {
+	bh := e.BlockHashes()
+	if len(bh.Hashes) > MaxBlockHashesPerEvent {
 		return ErrTooManyBlockHash
+	}
+	if len(bh.Hashes) > 0 {
+		if bh.Start == 0 {
+			return ErrBlockHashZeroStart
+		}
+		if bh.Epoch == 0 {
+			return ErrBlockHashZeroEpoch
+		}
+		if bh.Epoch != e.Epoch() {
+			return ErrBlockHashEpochMismatch
+		}
 	}
 
 	return nil

--- a/eventcheck/basiccheck/basic_check_test.go
+++ b/eventcheck/basiccheck/basic_check_test.go
@@ -171,3 +171,56 @@ func TestChecker_Validate_AcceptsMaxBlockHashes(t *testing.T) {
 	err := New().Validate(event)
 	require.NoError(t, err)
 }
+
+func TestChecker_Validate_AcceptsEmptyBlockHashesWithZeroMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	event := setupBasicEventMock(ctrl)
+
+	event.EXPECT().BlockHashes().Return(inter.BlockHashes{}).AnyTimes()
+
+	err := New().Validate(event)
+	require.NoError(t, err)
+}
+
+func TestChecker_Validate_RejectsBlockHashesWithZeroStart(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	event := setupBasicEventMock(ctrl)
+
+	event.EXPECT().BlockHashes().Return(inter.BlockHashes{
+		Start:  0,
+		Epoch:  1,
+		Hashes: []hash.Hash{{}},
+	}).AnyTimes()
+
+	err := New().Validate(event)
+	require.ErrorIs(t, err, ErrBlockHashZeroStart)
+}
+
+func TestChecker_Validate_RejectsBlockHashesWithZeroEpoch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	event := setupBasicEventMock(ctrl)
+
+	event.EXPECT().BlockHashes().Return(inter.BlockHashes{
+		Start:  1,
+		Epoch:  0,
+		Hashes: []hash.Hash{{}},
+	}).AnyTimes()
+
+	err := New().Validate(event)
+	require.ErrorIs(t, err, ErrBlockHashZeroEpoch)
+}
+
+func TestChecker_Validate_RejectsBlockHashesWithMismatchedEpoch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	event := setupBasicEventMock(ctrl)
+
+	// setupBasicEventMock sets event Epoch to 1, so use a different epoch here
+	event.EXPECT().BlockHashes().Return(inter.BlockHashes{
+		Start:  1,
+		Epoch:  2,
+		Hashes: []hash.Hash{{}},
+	}).AnyTimes()
+
+	err := New().Validate(event)
+	require.ErrorIs(t, err, ErrBlockHashEpochMismatch)
+}

--- a/eventcheck/basiccheck/basic_check_test.go
+++ b/eventcheck/basiccheck/basic_check_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -59,7 +61,6 @@ func TestChecker_checkTxs_DetectsIssuesInTransactions(t *testing.T) {
 }
 
 func TestChecker_IntrinsicGas_LegacyCalculationDoesNotAccountForInitDataOrAuthList(t *testing.T) {
-
 	tests := map[string]*types.Transaction{
 		"legacyTx": types.NewTx(&types.LegacyTx{
 			To:  nil,
@@ -82,28 +83,23 @@ func TestChecker_IntrinsicGas_LegacyCalculationDoesNotAccountForInitDataOrAuthLi
 			costNew, err := core.IntrinsicGas(tx.Data(), tx.AccessList(),
 				tx.SetCodeAuthorizations(), tx.To() == nil, true, true, true)
 			require.NoError(t, err)
+
 			require.Greater(t, costNew, costLegacy)
 		})
 	}
 }
 
 func TestChecker_IntrinsicGas_LegacyIsCheaperOrSameForAllRevisionCombinations(t *testing.T) {
-
 	trueFalse := []bool{true, false}
-
 	for _, homestead := range trueFalse {
 		for _, istanbul := range trueFalse {
 			for _, shanghai := range trueFalse {
 				t.Run(makeTestName(homestead, istanbul, shanghai), func(t *testing.T) {
-
 					costLegacy, err := intrinsicGasLegacy([]byte("test"), nil, false)
 					require.NoError(t, err)
-
 					costNew, err := core.IntrinsicGas([]byte("test"), nil, nil, false, homestead, istanbul, shanghai)
 					require.NoError(t, err)
-
 					require.GreaterOrEqual(t, costNew, costLegacy)
-
 				})
 			}
 		}
@@ -122,4 +118,56 @@ func makeTestName(homestead, istanbul, shanghai bool) string {
 	name += withWithout(istanbul) + "Istanbul"
 	name += withWithout(shanghai) + "Shanghai"
 	return name
+}
+
+func setupBasicEventMock(ctrl *gomock.Controller) *inter.MockEventPayloadI {
+	event := inter.NewMockEventPayloadI(ctrl)
+
+	// Base checker fields (lachesis-base basiccheck)
+	event.EXPECT().Seq().Return(idx.Event(1)).AnyTimes()
+	event.EXPECT().Epoch().Return(idx.Epoch(1)).AnyTimes()
+	event.EXPECT().Frame().Return(idx.Frame(1)).AnyTimes()
+	event.EXPECT().Lamport().Return(idx.Lamport(1)).AnyTimes()
+	event.EXPECT().Parents().Return(nil).AnyTimes()
+
+	// Sonic basiccheck fields
+	event.EXPECT().NetForkID().Return(uint16(0)).AnyTimes()
+	event.EXPECT().GasPowerUsed().Return(uint64(0)).AnyTimes()
+	event.EXPECT().GasPowerLeft().Return(inter.GasPowerLeft{}).AnyTimes()
+	event.EXPECT().CreationTime().Return(inter.Timestamp(1)).AnyTimes()
+	event.EXPECT().MedianTime().Return(inter.Timestamp(1)).AnyTimes()
+	event.EXPECT().Transactions().Return(nil).AnyTimes()
+	event.EXPECT().Payload().Return(&inter.Payload{}).AnyTimes()
+
+	return event
+}
+
+func TestChecker_Validate_RejectsTooManyBlockHashes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	event := setupBasicEventMock(ctrl)
+
+	hashes := make([]hash.Hash, MaxBlockHashesPerEvent+1)
+	event.EXPECT().BlockHashes().Return(inter.BlockHashes{
+		Start:  1,
+		Epoch:  1,
+		Hashes: hashes,
+	}).AnyTimes()
+
+	err := New().Validate(event)
+	require.ErrorIs(t, err, ErrTooManyBlockHash)
+}
+
+func TestChecker_Validate_AcceptsMaxBlockHashes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	event := setupBasicEventMock(ctrl)
+
+	hashes := make([]hash.Hash, MaxBlockHashesPerEvent)
+	event.EXPECT().BlockHashes().Return(inter.BlockHashes{
+		Start:  1,
+		Epoch:  1,
+		Hashes: hashes,
+	}).AnyTimes()
+
+	err := New().Validate(event)
+	require.NoError(t, err)
 }

--- a/eventcheck/epochcheck/epoch_check.go
+++ b/eventcheck/epochcheck/epoch_check.go
@@ -90,7 +90,12 @@ func CalcGasPowerUsed(e inter.EventPayloadI, rules opera.Rules) uint64 {
 		ersGas = gasCfg.EpochVoteGas
 	}
 
-	return txsGas + parentsGas + extraGas + gasCfg.EventGas + mpsGas + bvsGas + ersGas
+	bhsGas := uint64(0)
+	if e.BlockHashes().Start != 0 {
+		bhsGas = gasCfg.BlockVotesBaseGas + uint64(len(e.BlockHashes().Hashes))*gasCfg.BlockVoteGas
+	}
+
+	return txsGas + parentsGas + extraGas + gasCfg.EventGas + mpsGas + bvsGas + bhsGas + ersGas
 }
 
 func (v *Checker) checkGas(e inter.EventPayloadI, rules opera.Rules) error {
@@ -149,7 +154,9 @@ func (v *Checker) Validate(e inter.EventPayloadI) error {
 	}
 
 	version := uint8(0)
-	if rules.Upgrades.SingleProposerBlockFormation {
+	if rules.Upgrades.BlockHashesOnEvents {
+		version = 4
+	} else if rules.Upgrades.SingleProposerBlockFormation {
 		version = 3
 	} else if rules.Upgrades.Sonic {
 		version = 2

--- a/eventcheck/epochcheck/epoch_check_test.go
+++ b/eventcheck/epochcheck/epoch_check_test.go
@@ -52,6 +52,7 @@ func TestChecker_Validate_SingleProposerIntroducesNewFormat(t *testing.T) {
 			event.EXPECT().TransactionsToMeter().AnyTimes()
 			event.EXPECT().MisbehaviourProofs().AnyTimes()
 			event.EXPECT().BlockVotes().AnyTimes()
+			event.EXPECT().BlockHashes().AnyTimes()
 			event.EXPECT().EpochVote().AnyTimes()
 			event.EXPECT().Creator().Return(creator).AnyTimes()
 

--- a/eventcheck/epochcheck/epoch_check_test.go
+++ b/eventcheck/epochcheck/epoch_check_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
 	base "github.com/Fantom-foundation/lachesis-base/eventcheck/epochcheck"
+	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	pos "github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,6 @@ func TestChecker_Validate_SingleProposerIntroducesNewFormat(t *testing.T) {
 
 	for enabled, version := range versions {
 		t.Run(fmt.Sprintf("singleProposer=%t", enabled), func(t *testing.T) {
-
 			ctrl := gomock.NewController(t)
 			reader := NewMockReader(ctrl)
 			event := inter.NewMockEventPayloadI(ctrl)
@@ -59,6 +59,7 @@ func TestChecker_Validate_SingleProposerIntroducesNewFormat(t *testing.T) {
 			builder := pos.NewBuilder()
 			builder.Set(creator, 10)
 			validators := builder.Build()
+
 			reader.EXPECT().GetEpochValidators().Return(validators, idx.Epoch(0)).AnyTimes()
 
 			rules := opera.Rules{Upgrades: opera.Upgrades{
@@ -81,4 +82,83 @@ func TestChecker_Validate_SingleProposerIntroducesNewFormat(t *testing.T) {
 			require.ErrorIs(t, checker.Validate(event), ErrWrongVersion)
 		})
 	}
+}
+
+func TestChecker_Validate_BlockHashesOnEventsIntroducesVersion4(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	reader := NewMockReader(ctrl)
+	event := inter.NewMockEventPayloadI(ctrl)
+
+	creator := idx.ValidatorID(1)
+	event.EXPECT().Epoch().AnyTimes()
+	event.EXPECT().Parents().AnyTimes()
+	event.EXPECT().Extra().AnyTimes()
+	event.EXPECT().GasPowerUsed().AnyTimes()
+	event.EXPECT().Transactions().AnyTimes()
+	event.EXPECT().TransactionsToMeter().AnyTimes()
+	event.EXPECT().MisbehaviourProofs().AnyTimes()
+	event.EXPECT().BlockVotes().AnyTimes()
+	event.EXPECT().BlockHashes().AnyTimes()
+	event.EXPECT().EpochVote().AnyTimes()
+	event.EXPECT().Creator().Return(creator).AnyTimes()
+
+	builder := pos.NewBuilder()
+	builder.Set(creator, 10)
+	validators := builder.Build()
+
+	reader.EXPECT().GetEpochValidators().Return(validators, idx.Epoch(0)).AnyTimes()
+
+	rules := opera.Rules{Upgrades: opera.Upgrades{
+		Sonic:                        true,
+		SingleProposerBlockFormation: true,
+		BlockHashesOnEvents:          true,
+	}}
+	reader.EXPECT().GetEpochRules().Return(rules, idx.Epoch(0)).AnyTimes()
+
+	checker := Checker{
+		Base:   base.New(reader),
+		reader: reader,
+	}
+
+	// Version 4 should be accepted.
+	event.EXPECT().Version().Return(uint8(4))
+	require.NoError(t, checker.Validate(event))
+
+	// Version 3 should be rejected.
+	event.EXPECT().Version().Return(uint8(3))
+	require.ErrorIs(t, checker.Validate(event), ErrWrongVersion)
+}
+
+func TestCalcGasPowerUsed_IncludesBlockHashesGas(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	rules := opera.FakeNetRules(opera.GetAllegroUpgrades())
+
+	// Without block hashes
+	eventWithout := inter.NewMockEventPayloadI(ctrl)
+	eventWithout.EXPECT().Parents().Return(nil).AnyTimes()
+	eventWithout.EXPECT().Extra().Return(nil).AnyTimes()
+	eventWithout.EXPECT().TransactionsToMeter().Return(nil).AnyTimes()
+	eventWithout.EXPECT().MisbehaviourProofs().Return(nil).AnyTimes()
+	eventWithout.EXPECT().BlockVotes().Return(inter.LlrBlockVotes{}).AnyTimes()
+	eventWithout.EXPECT().EpochVote().Return(inter.LlrEpochVote{}).AnyTimes()
+	eventWithout.EXPECT().BlockHashes().Return(inter.BlockHashes{}).AnyTimes()
+	gasWithout := CalcGasPowerUsed(eventWithout, rules)
+
+	// With block hashes
+	eventWith := inter.NewMockEventPayloadI(ctrl)
+	eventWith.EXPECT().Parents().Return(nil).AnyTimes()
+	eventWith.EXPECT().Extra().Return(nil).AnyTimes()
+	eventWith.EXPECT().TransactionsToMeter().Return(nil).AnyTimes()
+	eventWith.EXPECT().MisbehaviourProofs().Return(nil).AnyTimes()
+	eventWith.EXPECT().BlockVotes().Return(inter.LlrBlockVotes{}).AnyTimes()
+	eventWith.EXPECT().EpochVote().Return(inter.LlrEpochVote{}).AnyTimes()
+	eventWith.EXPECT().BlockHashes().Return(inter.BlockHashes{
+		Start:  1,
+		Epoch:  1,
+		Hashes: []hash.Hash{{1}, {2}, {3}},
+	}).AnyTimes()
+	gasWith := CalcGasPowerUsed(eventWith, rules)
+
+	require.Greater(t, gasWith, gasWithout)
 }

--- a/eventcheck/proposalcheck/proposal_check.go
+++ b/eventcheck/proposalcheck/proposal_check.go
@@ -81,18 +81,18 @@ func New(reader Reader) *Checker {
 // Validate checks whether the event payload is correctly tracking the proposer
 // state and the validity of a potentially included proposal.
 func (v *Checker) Validate(e inter.EventPayloadI) error {
-	// Only version 3 events are allowed to contain proposals.
-	if e.Version() != 3 {
+	// Only version 3 and 4 events are allowed to contain proposals.
+	if e.Version() != 3 && e.Version() != 4 {
 		if payload := e.Payload(); payload != nil {
 			if proposal := payload.Proposal; proposal != nil {
 				return ErrProposalInInvalidEventVersion
 			}
 		}
-		// All remaining checks are only applicable to version 3 events.
+		// All remaining checks are only applicable to version 3/4 events.
 		return nil
 	}
 
-	// Check version 3 properties.
+	// Check version 3/4 properties.
 	if err := checkVersion3EventProperties(e); err != nil {
 		return err
 	}

--- a/eventcheck/proposalcheck/proposal_check_test.go
+++ b/eventcheck/proposalcheck/proposal_check_test.go
@@ -30,12 +30,12 @@ import (
 
 func TestProposalCheck_Validate_NonVersion3WithoutProposal_Passes(t *testing.T) {
 	for version := range uint8(10) {
-		if version == 3 {
+		if version == 3 || version == 4 {
 			continue
 		}
 		ctrl := gomock.NewController(t)
 		event := inter.NewMockEventPayloadI(ctrl)
-		event.EXPECT().Version().Return(version)
+		event.EXPECT().Version().Return(version).AnyTimes()
 		event.EXPECT().Payload().Return(&inter.Payload{})
 
 		checker := New(nil)
@@ -45,12 +45,12 @@ func TestProposalCheck_Validate_NonVersion3WithoutProposal_Passes(t *testing.T) 
 
 func TestProposalCheck_Validate_NonVersion3WithProposal_Fails(t *testing.T) {
 	for version := range uint8(10) {
-		if version == 3 {
+		if version == 3 || version == 4 {
 			continue
 		}
 		ctrl := gomock.NewController(t)
 		event := inter.NewMockEventPayloadI(ctrl)
-		event.EXPECT().Version().Return(version)
+		event.EXPECT().Version().Return(version).AnyTimes()
 		event.EXPECT().Payload().Return(&inter.Payload{
 			Proposal: &inter.Proposal{},
 		})

--- a/gossip/block_hash_check.go
+++ b/gossip/block_hash_check.go
@@ -1,3 +1,19 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
 // Copyright 2024 The Sonic Authors
 // This file is part of the Sonic library.
 //

--- a/gossip/block_hash_check.go
+++ b/gossip/block_hash_check.go
@@ -1,0 +1,109 @@
+// Copyright 2024 The Sonic Authors
+// This file is part of the Sonic library.
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gossip
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+
+	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/utils/errlock"
+)
+
+// blockHashChecker tracks block hash disagreements between the local node
+// and validators' events. When validators representing more than 2/3 of the
+// total stake report block hashes that differ from the local node's hashes,
+// the node permanently stops to prevent operating on a fork.
+type blockHashChecker struct {
+	store     *Store
+	errorLock *errlock.ErrorLock
+
+	epoch      idx.Epoch
+	validators *pos.Validators
+	// Per-block: set of validators that disagree with the local block hash.
+	disagreements map[idx.Block]map[idx.ValidatorID]struct{}
+}
+
+func newBlockHashChecker(store *Store, errorLock *errlock.ErrorLock) *blockHashChecker {
+	return &blockHashChecker{
+		store:         store,
+		errorLock:     errorLock,
+		disagreements: make(map[idx.Block]map[idx.ValidatorID]struct{}),
+	}
+}
+
+// reset clears all tracked disagreements and sets the new epoch and validators.
+// Called on epoch transitions.
+func (c *blockHashChecker) reset(epoch idx.Epoch, validators *pos.Validators) {
+	c.epoch = epoch
+	c.validators = validators
+	c.disagreements = make(map[idx.Block]map[idx.ValidatorID]struct{})
+}
+
+// check inspects the block hashes in an incoming event and compares them
+// against the local block hashes. If disagreeing stake exceeds 2/3 of total
+// weight for any block, the node is permanently stopped.
+func (c *blockHashChecker) check(e *inter.EventPayload) {
+	if c.errorLock == nil {
+		return
+	}
+	bhs := e.BlockHashes()
+	if bhs.Start == 0 || len(bhs.Hashes) == 0 {
+		return
+	}
+	if c.validators == nil {
+		return
+	}
+
+	creator := e.Creator()
+	for i, eventHash := range bhs.Hashes {
+		blockNum := bhs.Start + idx.Block(i)
+
+		localBlock := c.store.GetBlock(blockNum)
+		if localBlock == nil {
+			continue
+		}
+
+		localHash := hash.Hash(localBlock.Hash())
+		if localHash == eventHash {
+			continue
+		}
+
+		// Record disagreement
+		if c.disagreements[blockNum] == nil {
+			c.disagreements[blockNum] = make(map[idx.ValidatorID]struct{})
+		}
+		c.disagreements[blockNum][creator] = struct{}{}
+
+		// Compute total disagreeing stake
+		disagreeingStake := pos.Weight(0)
+		for vid := range c.disagreements[blockNum] {
+			disagreeingStake += c.validators.Get(vid)
+		}
+
+		if disagreeingStake > (c.validators.TotalWeight()*2)/3 {
+			c.errorLock.Permanent(fmt.Errorf(
+				"block hash disagreement: validators with >2/3 stake disagree "+
+					"on block %d (local hash %s, epoch %d)",
+				blockNum, localHash.String(), c.epoch,
+			))
+		}
+	}
+}

--- a/gossip/block_hash_check.go
+++ b/gossip/block_hash_check.go
@@ -14,22 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-// Copyright 2024 The Sonic Authors
-// This file is part of the Sonic library.
-//
-// Sonic is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Sonic is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
-
 package gossip
 
 import (

--- a/gossip/block_hash_check.go
+++ b/gossip/block_hash_check.go
@@ -37,6 +37,7 @@ type blockHashChecker struct {
 
 	epoch      idx.Epoch
 	validators *pos.Validators
+
 	// Per-block: set of validators that disagree with the local block hash.
 	disagreements map[idx.Block]map[idx.ValidatorID]struct{}
 }
@@ -71,33 +72,39 @@ func (c *blockHashChecker) check(e *inter.EventPayload) {
 	if c.validators == nil {
 		return
 	}
+	// Only track disagreements for the current epoch. Events with
+	// block hashes from other epochs are irrelevant to the current
+	// epoch's disagreement tracking and would grow the map unboundedly.
+	if bhs.Epoch != c.epoch {
+		return
+	}
 
 	creator := e.Creator()
 	for i, eventHash := range bhs.Hashes {
 		blockNum := bhs.Start + idx.Block(i)
-
 		localBlock := c.store.GetBlock(blockNum)
 		if localBlock == nil {
 			continue
 		}
-
+		// Defense-in-depth: skip blocks that don't belong to the
+		// current epoch in the local store.
+		if localBlock.Epoch != c.epoch {
+			continue
+		}
 		localHash := hash.Hash(localBlock.Hash())
 		if localHash == eventHash {
 			continue
 		}
-
 		// Record disagreement
 		if c.disagreements[blockNum] == nil {
 			c.disagreements[blockNum] = make(map[idx.ValidatorID]struct{})
 		}
 		c.disagreements[blockNum][creator] = struct{}{}
-
 		// Compute total disagreeing stake
 		disagreeingStake := pos.Weight(0)
 		for vid := range c.disagreements[blockNum] {
 			disagreeingStake += c.validators.Get(vid)
 		}
-
 		if disagreeingStake > (c.validators.TotalWeight()*2)/3 {
 			c.errorLock.Permanent(fmt.Errorf(
 				"block hash disagreement: validators with >2/3 stake disagree "+

--- a/gossip/block_hash_check_test.go
+++ b/gossip/block_hash_check_test.go
@@ -1,0 +1,397 @@
+package gossip
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/inter/pos"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/utils/errlock"
+)
+
+func makeTestBlock(number uint64, epoch idx.Epoch) *inter.Block {
+	return inter.NewBlockBuilder().
+		WithNumber(number).
+		WithParentHash(common.Hash{byte(number)}).
+		WithStateRoot(common.Hash{byte(number + 1)}).
+		WithGasLimit(10_000_000).
+		WithBaseFee(big.NewInt(1000)).
+		WithEpoch(epoch).
+		Build()
+}
+
+func makeTestEvent(creator idx.ValidatorID, start idx.Block, hashes []hash.Hash) *inter.EventPayload {
+	e := &inter.MutableEventPayload{}
+	e.SetCreator(creator)
+	e.SetBlockHashes(inter.BlockHashes{
+		Start:  start,
+		Epoch:  1,
+		Hashes: hashes,
+	})
+	return e.Build()
+}
+
+func makeValidators(stakes map[idx.ValidatorID]pos.Weight) *pos.Validators {
+	builder := pos.NewBuilder()
+	for id, weight := range stakes {
+		builder.Set(id, weight)
+	}
+	return builder.Build()
+}
+
+func TestBlockHashChecker_NilErrorLock(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	checker := newBlockHashChecker(store, nil)
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+	})
+	checker.reset(1, validators)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Event with wrong hash should not panic when errorLock is nil
+	event := makeTestEvent(1, 1, []hash.Hash{{0xFF}})
+	checker.check(event)
+}
+
+func TestBlockHashChecker_NoBlockHashes(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+	})
+	checker.reset(1, validators)
+
+	// Event with no block hashes (Start == 0) should be a no-op
+	e := &inter.MutableEventPayload{}
+	e.SetCreator(1)
+	checker.check(e.Build())
+
+	require.NoError(t, errorLock.Check())
+}
+
+func TestBlockHashChecker_MatchingHashes(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+	})
+	checker.reset(1, validators)
+
+	// Event with matching hash should not trigger
+	event := makeTestEvent(1, 1, []hash.Hash{hash.Hash(block.Hash())})
+	checker.check(event)
+
+	require.NoError(t, errorLock.Check())
+	require.Empty(t, checker.disagreements)
+}
+
+func TestBlockHashChecker_BlockNotInStore(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+	})
+	checker.reset(1, validators)
+
+	// Block 5 is not in the store — should be skipped
+	event := makeTestEvent(1, 5, []hash.Hash{{0xFF}})
+	checker.check(event)
+
+	require.NoError(t, errorLock.Check())
+	require.Empty(t, checker.disagreements)
+}
+
+func TestBlockHashChecker_DisagreementBelowThreshold(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Validator 1 has weight 100 out of 300 total (33% < 67%)
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(1, validators)
+
+	event := makeTestEvent(1, 1, []hash.Hash{{0xFF}})
+	checker.check(event)
+
+	require.NoError(t, errorLock.Check())
+	require.Len(t, checker.disagreements[1], 1)
+}
+
+func TestBlockHashChecker_DisagreementExceedsThreshold(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Total weight = 300, threshold = 200
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(1, validators)
+
+	wrongHash := hash.Hash{0xFF}
+
+	// First disagreement: validator 1 (100/300 = 33%)
+	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
+	require.NoError(t, errorLock.Check())
+
+	// Second disagreement: validator 2 (200/300 = 67%)
+	checker.check(makeTestEvent(2, 1, []hash.Hash{wrongHash}))
+	require.NoError(t, errorLock.Check())
+
+	// Third disagreement: validator 3 (300/300 = 100% > 67%)
+	require.Panics(t, func() {
+		checker.check(makeTestEvent(3, 1, []hash.Hash{wrongHash}))
+	})
+}
+
+func TestBlockHashChecker_ThresholdExactlyTwoThirds(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Total weight = 3, threshold = (3*2)/3 = 2
+	// Disagreement of exactly 2 is NOT > 2, so should not trigger
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 1,
+		2: 1,
+		3: 1,
+	})
+	checker.reset(1, validators)
+
+	wrongHash := hash.Hash{0xFF}
+
+	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(2, 1, []hash.Hash{wrongHash}))
+
+	// 2/3 is exactly the threshold — should NOT panic (need strictly greater)
+	require.NoError(t, errorLock.Check())
+
+	// Third validator tips it over: 3 > 2
+	require.Panics(t, func() {
+		checker.check(makeTestEvent(3, 1, []hash.Hash{wrongHash}))
+	})
+}
+
+func TestBlockHashChecker_SameValidatorCountedOnce(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Validator 1 has weight 100 out of 300 (33%)
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(1, validators)
+
+	wrongHash := hash.Hash{0xFF}
+
+	// Same validator sends multiple events — should still only count once
+	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
+
+	require.NoError(t, errorLock.Check())
+	require.Len(t, checker.disagreements[1], 1)
+}
+
+func TestBlockHashChecker_MultipleBlocks(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block1 := makeTestBlock(1, 1)
+	block2 := makeTestBlock(2, 1)
+	store.SetBlock(1, block1)
+	store.SetBlock(2, block2)
+
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(1, validators)
+
+	// Disagree on block 1 but agree on block 2
+	event := makeTestEvent(1, 1, []hash.Hash{
+		{0xFF},                   // wrong hash for block 1
+		hash.Hash(block2.Hash()), // correct hash for block 2
+	})
+	checker.check(event)
+
+	require.NoError(t, errorLock.Check())
+	require.Len(t, checker.disagreements[1], 1) // block 1 has disagreement
+	require.Empty(t, checker.disagreements[2])  // block 2 has no disagreement
+}
+
+func TestBlockHashChecker_EpochReset(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(1, validators)
+
+	wrongHash := hash.Hash{0xFF}
+
+	// Accumulate disagreements in epoch 1
+	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(2, 1, []hash.Hash{wrongHash}))
+	require.Len(t, checker.disagreements[1], 2)
+
+	// Reset for new epoch — disagreements should be cleared
+	checker.reset(2, validators)
+	require.Empty(t, checker.disagreements)
+
+	// After reset, old disagreements don't carry over
+	require.NoError(t, errorLock.Check())
+}
+
+func TestBlockHashChecker_NilValidators(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+	// Don't call reset — validators is nil
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Should not panic with nil validators
+	event := makeTestEvent(1, 1, []hash.Hash{{0xFF}})
+	checker.check(event)
+
+	require.NoError(t, errorLock.Check())
+}
+
+func TestBlockHashChecker_PartialBlockRange(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	// Only block 2 exists in store, block 3 doesn't
+	block2 := makeTestBlock(2, 1)
+	store.SetBlock(2, block2)
+
+	// Total weight = 3 — single validator with weight 3 exceeds threshold
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 3,
+	})
+	checker.reset(1, validators)
+
+	// Event covers blocks 2 and 3; block 3 is missing so only block 2 is checked
+	event := makeTestEvent(1, 2, []hash.Hash{
+		{0xFF}, // wrong hash for block 2
+		{0xEE}, // block 3 doesn't exist, should be skipped
+	})
+
+	require.Panics(t, func() {
+		checker.check(event)
+	})
+}
+
+func TestBlockHashChecker_IndependentBlockTracking(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block1 := makeTestBlock(1, 1)
+	block2 := makeTestBlock(2, 1)
+	store.SetBlock(1, block1)
+	store.SetBlock(2, block2)
+
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(1, validators)
+
+	// Validator 1 disagrees on block 1
+	checker.check(makeTestEvent(1, 1, []hash.Hash{{0xFF}}))
+	// Validator 2 disagrees on block 2
+	checker.check(makeTestEvent(2, 2, []hash.Hash{{0xEE}}))
+
+	// Neither block has reached 2/3 threshold
+	require.NoError(t, errorLock.Check())
+	require.Len(t, checker.disagreements[1], 1)
+	require.Len(t, checker.disagreements[2], 1)
+}

--- a/gossip/block_hash_check_test.go
+++ b/gossip/block_hash_check_test.go
@@ -41,12 +41,12 @@ func makeTestBlock(number uint64, epoch idx.Epoch) *inter.Block {
 		Build()
 }
 
-func makeTestEvent(creator idx.ValidatorID, start idx.Block, hashes []hash.Hash) *inter.EventPayload {
+func makeTestEvent(creator idx.ValidatorID, start idx.Block, epoch idx.Epoch, hashes []hash.Hash) *inter.EventPayload {
 	e := &inter.MutableEventPayload{}
 	e.SetCreator(creator)
 	e.SetBlockHashes(inter.BlockHashes{
 		Start:  start,
-		Epoch:  1,
+		Epoch:  epoch,
 		Hashes: hashes,
 	})
 	return e.Build()
@@ -75,7 +75,7 @@ func TestBlockHashChecker_NilErrorLock(t *testing.T) {
 	store.SetBlock(1, block)
 
 	// Event with wrong hash should not panic when errorLock is nil
-	event := makeTestEvent(1, 1, []hash.Hash{{0xFF}})
+	event := makeTestEvent(1, 1, 1, []hash.Hash{{0xFF}})
 	checker.check(event)
 }
 
@@ -95,7 +95,6 @@ func TestBlockHashChecker_NoBlockHashes(t *testing.T) {
 	e := &inter.MutableEventPayload{}
 	e.SetCreator(1)
 	checker.check(e.Build())
-
 	require.NoError(t, errorLock.Check())
 }
 
@@ -116,9 +115,8 @@ func TestBlockHashChecker_MatchingHashes(t *testing.T) {
 	checker.reset(1, validators)
 
 	// Event with matching hash should not trigger
-	event := makeTestEvent(1, 1, []hash.Hash{hash.Hash(block.Hash())})
+	event := makeTestEvent(1, 1, 1, []hash.Hash{hash.Hash(block.Hash())})
 	checker.check(event)
-
 	require.NoError(t, errorLock.Check())
 	require.Empty(t, checker.disagreements)
 }
@@ -130,15 +128,15 @@ func TestBlockHashChecker_BlockNotInStore(t *testing.T) {
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
+
 	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
 		1: 100,
 	})
 	checker.reset(1, validators)
 
 	// Block 5 is not in the store — should be skipped
-	event := makeTestEvent(1, 5, []hash.Hash{{0xFF}})
+	event := makeTestEvent(1, 5, 1, []hash.Hash{{0xFF}})
 	checker.check(event)
-
 	require.NoError(t, errorLock.Check())
 	require.Empty(t, checker.disagreements)
 }
@@ -162,9 +160,8 @@ func TestBlockHashChecker_DisagreementBelowThreshold(t *testing.T) {
 	})
 	checker.reset(1, validators)
 
-	event := makeTestEvent(1, 1, []hash.Hash{{0xFF}})
+	event := makeTestEvent(1, 1, 1, []hash.Hash{{0xFF}})
 	checker.check(event)
-
 	require.NoError(t, errorLock.Check())
 	require.Len(t, checker.disagreements[1], 1)
 }
@@ -191,16 +188,16 @@ func TestBlockHashChecker_DisagreementExceedsThreshold(t *testing.T) {
 	wrongHash := hash.Hash{0xFF}
 
 	// First disagreement: validator 1 (100/300 = 33%)
-	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(1, 1, 1, []hash.Hash{wrongHash}))
 	require.NoError(t, errorLock.Check())
 
 	// Second disagreement: validator 2 (200/300 = 67%)
-	checker.check(makeTestEvent(2, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(2, 1, 1, []hash.Hash{wrongHash}))
 	require.NoError(t, errorLock.Check())
 
 	// Third disagreement: validator 3 (300/300 = 100% > 67%)
 	require.Panics(t, func() {
-		checker.check(makeTestEvent(3, 1, []hash.Hash{wrongHash}))
+		checker.check(makeTestEvent(3, 1, 1, []hash.Hash{wrongHash}))
 	})
 }
 
@@ -225,16 +222,14 @@ func TestBlockHashChecker_ThresholdExactlyTwoThirds(t *testing.T) {
 	checker.reset(1, validators)
 
 	wrongHash := hash.Hash{0xFF}
-
-	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
-	checker.check(makeTestEvent(2, 1, []hash.Hash{wrongHash}))
-
+	checker.check(makeTestEvent(1, 1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(2, 1, 1, []hash.Hash{wrongHash}))
 	// 2/3 is exactly the threshold — should NOT panic (need strictly greater)
 	require.NoError(t, errorLock.Check())
 
 	// Third validator tips it over: 3 > 2
 	require.Panics(t, func() {
-		checker.check(makeTestEvent(3, 1, []hash.Hash{wrongHash}))
+		checker.check(makeTestEvent(3, 1, 1, []hash.Hash{wrongHash}))
 	})
 }
 
@@ -260,10 +255,9 @@ func TestBlockHashChecker_SameValidatorCountedOnce(t *testing.T) {
 	wrongHash := hash.Hash{0xFF}
 
 	// Same validator sends multiple events — should still only count once
-	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
-	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
-	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
-
+	checker.check(makeTestEvent(1, 1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(1, 1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(1, 1, 1, []hash.Hash{wrongHash}))
 	require.NoError(t, errorLock.Check())
 	require.Len(t, checker.disagreements[1], 1)
 }
@@ -289,12 +283,11 @@ func TestBlockHashChecker_MultipleBlocks(t *testing.T) {
 	checker.reset(1, validators)
 
 	// Disagree on block 1 but agree on block 2
-	event := makeTestEvent(1, 1, []hash.Hash{
+	event := makeTestEvent(1, 1, 1, []hash.Hash{
 		{0xFF},                   // wrong hash for block 1
 		hash.Hash(block2.Hash()), // correct hash for block 2
 	})
 	checker.check(event)
-
 	require.NoError(t, errorLock.Check())
 	require.Len(t, checker.disagreements[1], 1) // block 1 has disagreement
 	require.Empty(t, checker.disagreements[2])  // block 2 has no disagreement
@@ -321,8 +314,8 @@ func TestBlockHashChecker_EpochReset(t *testing.T) {
 	wrongHash := hash.Hash{0xFF}
 
 	// Accumulate disagreements in epoch 1
-	checker.check(makeTestEvent(1, 1, []hash.Hash{wrongHash}))
-	checker.check(makeTestEvent(2, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(1, 1, 1, []hash.Hash{wrongHash}))
+	checker.check(makeTestEvent(2, 1, 1, []hash.Hash{wrongHash}))
 	require.Len(t, checker.disagreements[1], 2)
 
 	// Reset for new epoch — disagreements should be cleared
@@ -340,15 +333,14 @@ func TestBlockHashChecker_NilValidators(t *testing.T) {
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
-	// Don't call reset — validators is nil
 
+	// Don't call reset — validators is nil
 	block := makeTestBlock(1, 1)
 	store.SetBlock(1, block)
 
 	// Should not panic with nil validators
-	event := makeTestEvent(1, 1, []hash.Hash{{0xFF}})
+	event := makeTestEvent(1, 1, 1, []hash.Hash{{0xFF}})
 	checker.check(event)
-
 	require.NoError(t, errorLock.Check())
 }
 
@@ -371,11 +363,10 @@ func TestBlockHashChecker_PartialBlockRange(t *testing.T) {
 	checker.reset(1, validators)
 
 	// Event covers blocks 2 and 3; block 3 is missing so only block 2 is checked
-	event := makeTestEvent(1, 2, []hash.Hash{
+	event := makeTestEvent(1, 2, 1, []hash.Hash{
 		{0xFF}, // wrong hash for block 2
 		{0xEE}, // block 3 doesn't exist, should be skipped
 	})
-
 	require.Panics(t, func() {
 		checker.check(event)
 	})
@@ -402,12 +393,121 @@ func TestBlockHashChecker_IndependentBlockTracking(t *testing.T) {
 	checker.reset(1, validators)
 
 	// Validator 1 disagrees on block 1
-	checker.check(makeTestEvent(1, 1, []hash.Hash{{0xFF}}))
+	checker.check(makeTestEvent(1, 1, 1, []hash.Hash{{0xFF}}))
 	// Validator 2 disagrees on block 2
-	checker.check(makeTestEvent(2, 2, []hash.Hash{{0xEE}}))
-
+	checker.check(makeTestEvent(2, 2, 1, []hash.Hash{{0xEE}}))
 	// Neither block has reached 2/3 threshold
 	require.NoError(t, errorLock.Check())
 	require.Len(t, checker.disagreements[1], 1)
 	require.Len(t, checker.disagreements[2], 1)
+}
+
+func TestBlockHashChecker_WrongEpochSkipped(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Single validator with 100% stake — would trigger halt if processed
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+	})
+	checker.reset(1, validators)
+
+	// Event claims epoch 2 but checker is on epoch 1 — should be ignored entirely
+	event := makeTestEvent(1, 1, 2, []hash.Hash{{0xFF}})
+	checker.check(event)
+	require.NoError(t, errorLock.Check())
+	require.Empty(t, checker.disagreements)
+}
+
+func TestBlockHashChecker_CrossEpochBlockSkipped(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	// Block 1 is stored with epoch 1
+	block := makeTestBlock(1, 1)
+	store.SetBlock(1, block)
+
+	// Single validator with 100% stake
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+	})
+	// Checker is on epoch 2
+	checker.reset(2, validators)
+
+	// Event epoch matches checker (epoch 2), but the local block is from epoch 1
+	// — the per-block guard should skip it
+	event := makeTestEvent(1, 1, 2, []hash.Hash{{0xFF}})
+	checker.check(event)
+	require.NoError(t, errorLock.Check())
+	require.Empty(t, checker.disagreements)
+}
+
+func TestBlockHashChecker_CorrectEpochStillWorks(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	// Block stored in epoch 2
+	block := makeTestBlock(5, 2)
+	store.SetBlock(5, block)
+
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(2, validators)
+
+	// Event with matching epoch 2 and wrong hash — disagreement should be recorded
+	event := makeTestEvent(1, 5, 2, []hash.Hash{{0xFF}})
+	checker.check(event)
+	require.NoError(t, errorLock.Check())
+	require.Len(t, checker.disagreements[5], 1)
+}
+
+func TestBlockHashChecker_MixedEpochBlocks(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	errorLock := errlock.New(t.TempDir())
+	checker := newBlockHashChecker(store, errorLock)
+
+	// Block 10 is from epoch 1, block 11 is from epoch 2
+	block10 := makeTestBlock(10, 1)
+	block11 := makeTestBlock(11, 2)
+	store.SetBlock(10, block10)
+	store.SetBlock(11, block11)
+
+	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
+		1: 100,
+		2: 100,
+		3: 100,
+	})
+	checker.reset(2, validators)
+
+	// Event with epoch 2 covering blocks 10-11; block 10 is epoch 1 in
+	// the store so only block 11 should be tracked
+	event := makeTestEvent(1, 10, 2, []hash.Hash{
+		{0xFF}, // wrong hash for block 10 (epoch 1 — should be skipped)
+		{0xEE}, // wrong hash for block 11 (epoch 2 — should be tracked)
+	})
+	checker.check(event)
+	require.NoError(t, errorLock.Check())
+	require.Empty(t, checker.disagreements[10])  // skipped: wrong epoch in store
+	require.Len(t, checker.disagreements[11], 1) // tracked: correct epoch
 }

--- a/gossip/block_hash_check_test.go
+++ b/gossip/block_hash_check_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
 package gossip
 
 import (

--- a/gossip/block_hash_check_test.go
+++ b/gossip/block_hash_check_test.go
@@ -47,7 +47,7 @@ func makeValidators(stakes map[idx.ValidatorID]pos.Weight) *pos.Validators {
 func TestBlockHashChecker_NilErrorLock(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	checker := newBlockHashChecker(store, nil)
 	validators := makeValidators(map[idx.ValidatorID]pos.Weight{
@@ -66,7 +66,7 @@ func TestBlockHashChecker_NilErrorLock(t *testing.T) {
 func TestBlockHashChecker_NoBlockHashes(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -86,7 +86,7 @@ func TestBlockHashChecker_NoBlockHashes(t *testing.T) {
 func TestBlockHashChecker_MatchingHashes(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -110,7 +110,7 @@ func TestBlockHashChecker_MatchingHashes(t *testing.T) {
 func TestBlockHashChecker_BlockNotInStore(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -130,7 +130,7 @@ func TestBlockHashChecker_BlockNotInStore(t *testing.T) {
 func TestBlockHashChecker_DisagreementBelowThreshold(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -156,7 +156,7 @@ func TestBlockHashChecker_DisagreementBelowThreshold(t *testing.T) {
 func TestBlockHashChecker_DisagreementExceedsThreshold(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -191,7 +191,7 @@ func TestBlockHashChecker_DisagreementExceedsThreshold(t *testing.T) {
 func TestBlockHashChecker_ThresholdExactlyTwoThirds(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -225,7 +225,7 @@ func TestBlockHashChecker_ThresholdExactlyTwoThirds(t *testing.T) {
 func TestBlockHashChecker_SameValidatorCountedOnce(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -255,7 +255,7 @@ func TestBlockHashChecker_SameValidatorCountedOnce(t *testing.T) {
 func TestBlockHashChecker_MultipleBlocks(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -287,7 +287,7 @@ func TestBlockHashChecker_MultipleBlocks(t *testing.T) {
 func TestBlockHashChecker_EpochReset(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -320,7 +320,7 @@ func TestBlockHashChecker_EpochReset(t *testing.T) {
 func TestBlockHashChecker_NilValidators(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -339,7 +339,7 @@ func TestBlockHashChecker_NilValidators(t *testing.T) {
 func TestBlockHashChecker_PartialBlockRange(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)
@@ -368,7 +368,7 @@ func TestBlockHashChecker_PartialBlockRange(t *testing.T) {
 func TestBlockHashChecker_IndependentBlockTracking(t *testing.T) {
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
-	t.Cleanup(func() { store.Close() })
+	t.Cleanup(func() { _ = store.Close() })
 
 	errorLock := errlock.New(t.TempDir())
 	checker := newBlockHashChecker(store, errorLock)

--- a/gossip/c_event_callbacks.go
+++ b/gossip/c_event_callbacks.go
@@ -151,6 +151,9 @@ func (s *Service) switchEpochTo(newEpoch idx.Epoch) {
 	// notify event checkers about new validation data
 	s.gasPowerCheckReader.Ctx.Store(NewGasPowerContext(s.store, s.store.GetValidators(), newEpoch, s.store.GetRules().Economy)) // read gaspower check data from disk
 	s.heavyCheckReader.Pubkeys.Store(readEpochPubKeys(s.store, newEpoch))
+	// reset block hash checker for new epoch
+	s.blockHashChecker.reset(newEpoch, s.store.GetValidators())
+
 	// notify about new epoch
 	for _, em := range s.emitters {
 		em.OnNewEpoch(s.store.GetValidators(), newEpoch)
@@ -247,6 +250,9 @@ func (s *Service) processEvent(e *inter.EventPayload) error {
 	if err != nil {
 		return err
 	}
+
+	// check block hashes against local state
+	s.blockHashChecker.check(e)
 
 	newEpoch := s.store.GetEpoch()
 

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -181,7 +181,7 @@ func newTestEnvWithUpgrades(
 	var err error
 	env.Service, err = newService(DefaultConfig(cachescale.Identity), store, blockProc, engine, vecClock, func(_ evmcore.StateReader) TxPool {
 		return txPool
-	}, enode.ID{})
+	}, enode.ID{}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/gossip/emitter/block_hashes.go
+++ b/gossip/emitter/block_hashes.go
@@ -1,0 +1,110 @@
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package emitter
+
+import (
+	"io"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/0xsoniclabs/sonic/inter"
+)
+
+const (
+	// maxBlockHashesPerEvent is the maximum number of block hashes
+	// that can be included in a single event.
+	maxBlockHashesPerEvent = 64
+)
+
+// addBlockHashes collects block hashes from recently processed blocks and
+// adds them to the event. It follows the emission pattern from go-opera's
+// addLlrBlockVotes but without voting and misbehaviour proof semantics.
+//
+// The function tracks which blocks have already been included in previous
+// events using a persistent file (emittedBvsFile), and collects up to
+// maxBlockHashesPerEvent consecutive block hashes within the current epoch.
+func (em *Emitter) addBlockHashes(e *inter.MutableEventPayload) {
+	// Determine the starting block
+	prevEmittedBlock := em.readLastBlockHashesTip()
+	start := prevEmittedBlock + 1
+
+	latestBlock := em.world.GetLatestBlockIndex()
+	if start > latestBlock {
+		return // nothing new to report
+	}
+
+	// Collect block hashes for consecutive blocks within the same epoch
+	hashes := make([]hash.Hash, 0, maxBlockHashesPerEvent)
+	var epoch idx.Epoch
+	for b := start; b <= latestBlock && len(hashes) < maxBlockHashesPerEvent; b++ {
+		block := em.world.GetBlock(b)
+		if block == nil {
+			break
+		}
+		blockEpoch := block.Epoch
+		if epoch == 0 {
+			epoch = blockEpoch
+		}
+		if blockEpoch != epoch {
+			break // stop at epoch boundaries
+		}
+		blockHash := block.Hash()
+		hashes = append(hashes, hash.Hash(blockHash))
+	}
+	if len(hashes) == 0 {
+		return
+	}
+
+	e.SetBlockHashes(inter.BlockHashes{
+		Start:  start,
+		Epoch:  epoch,
+		Hashes: hashes,
+	})
+
+	// Persist the last emitted block hash tip
+	em.writeLastBlockHashesTip(start + idx.Block(len(hashes)) - 1)
+}
+
+// readLastBlockHashesTip reads the last block number for which block hashes
+// have been emitted from the persistent file (reuses emittedBvsFile).
+func (em *Emitter) readLastBlockHashesTip() idx.Block {
+	if em.emittedBvsFile == nil {
+		return 0
+	}
+	buf := make([]byte, 8)
+	_, err := em.emittedBvsFile.ReadAt(buf, 0)
+	if err != nil {
+		if err == io.EOF {
+			return 0
+		}
+		log.Crit("Failed to read block hashes file",
+			"file", em.config.PrevBlockVotesFile.Path, "err", err)
+	}
+	return idx.BytesToBlock(buf)
+}
+
+// writeLastBlockHashesTip writes the last block number for which block
+// hashes have been emitted to the persistent file (reuses emittedBvsFile).
+func (em *Emitter) writeLastBlockHashesTip(block idx.Block) {
+	if em.emittedBvsFile == nil {
+		return
+	}
+	_, err := em.emittedBvsFile.WriteAt(block.Bytes(), 0)
+	if err != nil {
+		log.Crit("Failed to write block hashes file",
+			"file", em.config.PrevBlockVotesFile.Path, "err", err)
+	}
+}

--- a/gossip/emitter/block_hashes.go
+++ b/gossip/emitter/block_hashes.go
@@ -14,19 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-// Sonic is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Sonic is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
-
 package emitter
 
 import (

--- a/gossip/emitter/block_hashes.go
+++ b/gossip/emitter/block_hashes.go
@@ -1,3 +1,19 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
 // Sonic is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/gossip/emitter/block_hashes_test.go
+++ b/gossip/emitter/block_hashes_test.go
@@ -191,7 +191,7 @@ func TestAddBlockHashes_PersistsAndReadsTip(t *testing.T) {
 		world: World{External: world},
 	}
 	em.emittedBvsFile = openPrevActionFile(filePath, false)
-	defer em.emittedBvsFile.Close()
+	defer func() { _ = em.emittedBvsFile.Close() }()
 
 	// First call: collect blocks 1-2
 	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(2))
@@ -245,7 +245,7 @@ func TestReadWriteLastBlockHashesTip_RoundTrip(t *testing.T) {
 
 	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0600)
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	em := &Emitter{emittedBvsFile: f}
 

--- a/gossip/emitter/block_hashes_test.go
+++ b/gossip/emitter/block_hashes_test.go
@@ -1,5 +1,5 @@
-// Copyright 2024 The Sonic Authors
-// This file is part of the Sonic library.
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
 //
 // Sonic is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by

--- a/gossip/emitter/block_hashes_test.go
+++ b/gossip/emitter/block_hashes_test.go
@@ -1,0 +1,257 @@
+// Copyright 2024 The Sonic Authors
+// This file is part of the Sonic library.
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package emitter
+
+import (
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/0xsoniclabs/sonic/gossip/emitter/config"
+	"github.com/0xsoniclabs/sonic/inter"
+)
+
+func TestAddBlockHashes_NothingNewToReport(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	world := NewMockExternal(ctrl)
+
+	em := &Emitter{
+		config: config.Config{},
+		world:  World{External: world},
+	}
+
+	// latestBlock == 0, start == 1, so start > latestBlock
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(0))
+
+	event := &inter.MutableEventPayload{}
+	em.addBlockHashes(event)
+
+	// No block hashes should be set
+	require.Empty(t, event.BlockHashes().Hashes)
+}
+
+func TestAddBlockHashes_CollectsConsecutiveBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	world := NewMockExternal(ctrl)
+
+	em := &Emitter{
+		config: config.Config{},
+		world:  World{External: world},
+	}
+
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(3))
+
+	block1 := inter.NewBlockBuilder().
+		WithNumber(1).
+		WithEpoch(idx.Epoch(1)).
+		WithBaseFee(big.NewInt(0)).
+		Build()
+	block2 := inter.NewBlockBuilder().
+		WithNumber(2).
+		WithEpoch(idx.Epoch(1)).
+		WithBaseFee(big.NewInt(0)).
+		Build()
+	block3 := inter.NewBlockBuilder().
+		WithNumber(3).
+		WithEpoch(idx.Epoch(1)).
+		WithBaseFee(big.NewInt(0)).
+		Build()
+
+	world.EXPECT().GetBlock(idx.Block(1)).Return(block1)
+	world.EXPECT().GetBlock(idx.Block(2)).Return(block2)
+	world.EXPECT().GetBlock(idx.Block(3)).Return(block3)
+
+	event := &inter.MutableEventPayload{}
+	em.addBlockHashes(event)
+
+	bh := event.BlockHashes()
+	require.Equal(t, idx.Block(1), bh.Start)
+	require.Equal(t, idx.Epoch(1), bh.Epoch)
+	require.Len(t, bh.Hashes, 3)
+	require.Equal(t, hash.Hash(block1.Hash()), bh.Hashes[0])
+	require.Equal(t, hash.Hash(block2.Hash()), bh.Hashes[1])
+	require.Equal(t, hash.Hash(block3.Hash()), bh.Hashes[2])
+}
+
+func TestAddBlockHashes_StopsAtEpochBoundary(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	world := NewMockExternal(ctrl)
+
+	em := &Emitter{
+		config: config.Config{},
+		world:  World{External: world},
+	}
+
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(3))
+
+	block1 := inter.NewBlockBuilder().
+		WithNumber(1).
+		WithEpoch(idx.Epoch(1)).
+		WithBaseFee(big.NewInt(0)).
+		Build()
+	block2 := inter.NewBlockBuilder().
+		WithNumber(2).
+		WithEpoch(idx.Epoch(2)). // different epoch
+		WithBaseFee(big.NewInt(0)).
+		Build()
+
+	world.EXPECT().GetBlock(idx.Block(1)).Return(block1)
+	world.EXPECT().GetBlock(idx.Block(2)).Return(block2)
+	// block 3 should not be requested since we stopped at epoch boundary
+
+	event := &inter.MutableEventPayload{}
+	em.addBlockHashes(event)
+
+	bh := event.BlockHashes()
+	require.Equal(t, idx.Block(1), bh.Start)
+	require.Equal(t, idx.Epoch(1), bh.Epoch)
+	require.Len(t, bh.Hashes, 1)
+}
+
+func TestAddBlockHashes_StopsAtNilBlock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	world := NewMockExternal(ctrl)
+
+	em := &Emitter{
+		config: config.Config{},
+		world:  World{External: world},
+	}
+
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(3))
+	world.EXPECT().GetBlock(idx.Block(1)).Return((*inter.Block)(nil))
+
+	event := &inter.MutableEventPayload{}
+	em.addBlockHashes(event)
+
+	require.Empty(t, event.BlockHashes().Hashes)
+}
+
+func TestAddBlockHashes_RespectsMaxBlockHashesPerEvent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	world := NewMockExternal(ctrl)
+
+	em := &Emitter{
+		config: config.Config{},
+		world:  World{External: world},
+	}
+
+	// Make more blocks available than the maximum
+	numBlocks := maxBlockHashesPerEvent + 10
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(numBlocks))
+
+	for i := idx.Block(1); i <= idx.Block(maxBlockHashesPerEvent); i++ {
+		block := inter.NewBlockBuilder().
+			WithNumber(uint64(i)).
+			WithEpoch(idx.Epoch(1)).
+			WithBaseFee(big.NewInt(0)).
+			Build()
+		world.EXPECT().GetBlock(i).Return(block)
+	}
+
+	event := &inter.MutableEventPayload{}
+	em.addBlockHashes(event)
+
+	bh := event.BlockHashes()
+	require.Len(t, bh.Hashes, maxBlockHashesPerEvent)
+}
+
+func TestAddBlockHashes_PersistsAndReadsTip(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	world := NewMockExternal(ctrl)
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bvs")
+
+	em := &Emitter{
+		config: config.Config{
+			PrevBlockVotesFile: config.FileConfig{
+				Path: filePath,
+			},
+		},
+		world: World{External: world},
+	}
+	em.emittedBvsFile = openPrevActionFile(filePath, false)
+	defer em.emittedBvsFile.Close()
+
+	// First call: collect blocks 1-2
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(2))
+	block1 := inter.NewBlockBuilder().
+		WithNumber(1).
+		WithEpoch(idx.Epoch(1)).
+		WithBaseFee(big.NewInt(0)).
+		Build()
+	block2 := inter.NewBlockBuilder().
+		WithNumber(2).
+		WithEpoch(idx.Epoch(1)).
+		WithBaseFee(big.NewInt(0)).
+		Build()
+	world.EXPECT().GetBlock(idx.Block(1)).Return(block1)
+	world.EXPECT().GetBlock(idx.Block(2)).Return(block2)
+
+	event1 := &inter.MutableEventPayload{}
+	em.addBlockHashes(event1)
+	require.Len(t, event1.BlockHashes().Hashes, 2)
+
+	// Second call: only block 3 should be collected (tip was persisted at 2)
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(3))
+	block3 := inter.NewBlockBuilder().
+		WithNumber(3).
+		WithEpoch(idx.Epoch(1)).
+		WithBaseFee(big.NewInt(0)).
+		Build()
+	world.EXPECT().GetBlock(idx.Block(3)).Return(block3)
+
+	event2 := &inter.MutableEventPayload{}
+	em.addBlockHashes(event2)
+	bh := event2.BlockHashes()
+	require.Equal(t, idx.Block(3), bh.Start)
+	require.Len(t, bh.Hashes, 1)
+}
+
+func TestReadLastBlockHashesTip_ReturnsZeroWithNilFile(t *testing.T) {
+	em := &Emitter{}
+	require.Equal(t, idx.Block(0), em.readLastBlockHashesTip())
+}
+
+func TestWriteLastBlockHashesTip_NoOpWithNilFile(t *testing.T) {
+	em := &Emitter{}
+	// Should not panic
+	em.writeLastBlockHashesTip(42)
+}
+
+func TestReadWriteLastBlockHashesTip_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "bvs")
+
+	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0600)
+	require.NoError(t, err)
+	defer f.Close()
+
+	em := &Emitter{emittedBvsFile: f}
+
+	em.writeLastBlockHashesTip(123)
+	require.Equal(t, idx.Block(123), em.readLastBlockHashesTip())
+
+	em.writeLastBlockHashesTip(456)
+	require.Equal(t, idx.Block(456), em.readLastBlockHashesTip())
+}

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -518,7 +518,9 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 	}
 
 	version := uint8(0)
-	if em.world.GetRules().Upgrades.SingleProposerBlockFormation {
+	if em.world.GetRules().Upgrades.BlockHashesOnEvents {
+		version = 4
+	} else if em.world.GetRules().Upgrades.SingleProposerBlockFormation {
 		version = 3
 	} else if em.world.GetRules().Upgrades.Sonic {
 		version = 2
@@ -557,7 +559,7 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 		return nil, nil
 	}
 
-	if version == 3 {
+	if version == 3 || version == 4 {
 		// add proposal sync state and an optional proposal
 		payload, err := em.createPayload(mutEvent, sortedTxs)
 		if err != nil {
@@ -565,6 +567,12 @@ func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.E
 			return nil, err
 		}
 		mutEvent.SetPayload(payload)
+		if version == 4 {
+			// add block hashes from recently processed blocks
+			em.addBlockHashes(mutEvent)
+			// recalculate payload hash to include block hashes
+			mutEvent.SetPayloadHash(inter.CalcPayloadHash(mutEvent))
+		}
 	} else {
 		// Add txs
 		em.addTxs(mutEvent, sortedTxs)

--- a/gossip/emitter/world.go
+++ b/gossip/emitter/world.go
@@ -80,6 +80,7 @@ type (
 type Reader interface {
 	GetLatestBlockIndex() idx.Block
 	GetLatestBlock() *inter.Block
+	GetBlock(idx.Block) *inter.Block
 	GetEpochValidators() (*pos.Validators, idx.Epoch)
 	GetEvent(hash.Event) *inter.Event
 	GetEventPayload(hash.Event) *inter.EventPayload

--- a/gossip/emitter/world_mock.go
+++ b/gossip/emitter/world_mock.go
@@ -189,6 +189,20 @@ func (mr *MockExternalMockRecorder) GetLastEvent(epoch, from any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastEvent", reflect.TypeOf((*MockExternal)(nil).GetLastEvent), epoch, from)
 }
 
+// GetBlock mocks base method.
+func (m *MockExternal) GetBlock(arg0 idx.Block) *inter.Block {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlock", arg0)
+	ret0, _ := ret[0].(*inter.Block)
+	return ret0
+}
+
+// GetBlock indicates an expected call of GetBlock.
+func (mr *MockExternalMockRecorder) GetBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlock", reflect.TypeOf((*MockExternal)(nil).GetBlock), arg0)
+}
+
 // GetLatestBlock mocks base method.
 func (m *MockExternal) GetLatestBlock() *inter.Block {
 	m.ctrl.T.Helper()
@@ -558,6 +572,20 @@ func (m *MockReader) GetLastEvent(epoch idx.Epoch, from idx.ValidatorID) *hash.E
 func (mr *MockReaderMockRecorder) GetLastEvent(epoch, from any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastEvent", reflect.TypeOf((*MockReader)(nil).GetLastEvent), epoch, from)
+}
+
+// GetBlock mocks base method.
+func (m *MockReader) GetBlock(arg0 idx.Block) *inter.Block {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlock", arg0)
+	ret0, _ := ret[0].(*inter.Block)
+	return ret0
+}
+
+// GetBlock indicates an expected call of GetBlock.
+func (mr *MockReaderMockRecorder) GetBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlock", reflect.TypeOf((*MockReader)(nil).GetBlock), arg0)
 }
 
 // GetLatestBlock mocks base method.

--- a/gossip/emitter_world.go
+++ b/gossip/emitter_world.go
@@ -111,6 +111,10 @@ func (ew *emitterWorldRead) GetLastEvent(epoch idx.Epoch, from idx.ValidatorID) 
 	return ew.Store.GetLastEvent(epoch, from)
 }
 
+func (ew *emitterWorldRead) GetBlock(n idx.Block) *inter.Block {
+	return ew.Store.GetBlock(n)
+}
+
 func (ew *emitterWorldRead) GetBlockEpoch(block idx.Block) idx.Epoch {
 	return ew.FindBlockEpoch(block)
 }

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -66,6 +66,7 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/logger"
 	scc_node "github.com/0xsoniclabs/sonic/scc/node"
+	"github.com/0xsoniclabs/sonic/utils/errlock"
 	"github.com/0xsoniclabs/sonic/utils/txtime"
 	"github.com/0xsoniclabs/sonic/utils/wgmutex"
 	"github.com/0xsoniclabs/sonic/valkeystore"
@@ -269,18 +270,21 @@ type Service struct {
 
 	bootstrapping bool
 
+	blockHashChecker *blockHashChecker
+
 	logger.Instance
 }
 
 func NewService(stack *node.Node, config Config, store *Store, blockProc BlockProc,
 	engine lachesis.Consensus, dagIndexer *vecmt.Index, newTxPool func(evmcore.StateReader) TxPool,
-	haltCheck func(oldEpoch, newEpoch idx.Epoch, age time.Time) bool) (*Service, error) {
+	haltCheck func(oldEpoch, newEpoch idx.Epoch, age time.Time) bool,
+	errorLock *errlock.ErrorLock) (*Service, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 
 	localNodeId := enode.PubkeyToIDV4(&stack.Server().PrivateKey.PublicKey)
-	svc, err := newService(config, store, blockProc, engine, dagIndexer, newTxPool, localNodeId)
+	svc, err := newService(config, store, blockProc, engine, dagIndexer, newTxPool, localNodeId, errorLock)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +299,7 @@ func NewService(stack *node.Node, config Config, store *Store, blockProc BlockPr
 	return svc, nil
 }
 
-func newService(config Config, store *Store, blockProc BlockProc, engine lachesis.Consensus, dagIndexer *vecmt.Index, newTxPool func(evmcore.StateReader) TxPool, localId enode.ID) (*Service, error) {
+func newService(config Config, store *Store, blockProc BlockProc, engine lachesis.Consensus, dagIndexer *vecmt.Index, newTxPool func(evmcore.StateReader) TxPool, localId enode.ID, errorLock *errlock.ErrorLock) (*Service, error) {
 	svc := &Service{
 		config:             config,
 		blockProcTasksDone: make(chan struct{}),
@@ -318,6 +322,10 @@ func newService(config Config, store *Store, blockProc BlockProc, engine lachesi
 	svc.dagIndexer.Reset(svc.store.GetValidators(), es.table.DagIndex, func(id hash.Event) dag.Event {
 		return svc.store.GetEvent(id)
 	})
+
+	// initialize block hash checker
+	svc.blockHashChecker = newBlockHashChecker(store, errorLock)
+	svc.blockHashChecker.reset(svc.store.GetEpoch(), svc.store.GetValidators())
 
 	// load caches for mutable values to avoid race condition
 	svc.store.GetBlockEpochState()

--- a/inter/block_hashes.go
+++ b/inter/block_hashes.go
@@ -37,6 +37,9 @@ type BlockHashes struct {
 
 // LastBlock returns the block number of the last block in the range.
 func (bh BlockHashes) LastBlock() idx.Block {
+	if len(bh.Hashes) == 0 {
+		return bh.Start
+	}
 	return bh.Start + idx.Block(len(bh.Hashes)) - 1
 }
 

--- a/inter/block_hashes.go
+++ b/inter/block_hashes.go
@@ -1,3 +1,19 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
 // Sonic is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/inter/block_hashes.go
+++ b/inter/block_hashes.go
@@ -1,0 +1,79 @@
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package inter
+
+import (
+	"crypto/sha256"
+
+	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+
+	"github.com/0xsoniclabs/sonic/utils/cser"
+)
+
+// BlockHashes contains hashes of recently processed blocks to be included
+// in version 4 events. Each entry is the Ethereum block hash for a
+// consecutive range of blocks within a single epoch.
+type BlockHashes struct {
+	Start  idx.Block
+	Epoch  idx.Epoch
+	Hashes []hash.Hash
+}
+
+// LastBlock returns the block number of the last block in the range.
+func (bh BlockHashes) LastBlock() idx.Block {
+	return bh.Start + idx.Block(len(bh.Hashes)) - 1
+}
+
+// Hash computes a deterministic hash over all block hashes fields.
+func (bh BlockHashes) Hash() hash.Hash {
+	hasher := sha256.New()
+	hasher.Write(bh.Start.Bytes())
+	hasher.Write(bh.Epoch.Bytes())
+	hasher.Write(bigendian.Uint32ToBytes(uint32(len(bh.Hashes))))
+	for _, h := range bh.Hashes {
+		hasher.Write(h.Bytes())
+	}
+	return hash.BytesToHash(hasher.Sum(nil))
+}
+
+// MarshalCSER serializes block hashes in CSER format.
+func (bh BlockHashes) MarshalCSER(w *cser.Writer) error {
+	w.U64(uint64(bh.Start))
+	w.U32(uint32(bh.Epoch))
+	w.U32(uint32(len(bh.Hashes)))
+	for _, h := range bh.Hashes {
+		w.FixedBytes(h[:])
+	}
+	return nil
+}
+
+// UnmarshalCSER deserializes block hashes from CSER format.
+func (bh *BlockHashes) UnmarshalCSER(r *cser.Reader) error {
+	start := r.U64()
+	epoch := r.U32()
+	num := r.U32()
+	if num > ProtocolMaxMsgSize/32 {
+		return cser.ErrTooLargeAlloc
+	}
+	hashes := make([]hash.Hash, num)
+	for i := range hashes {
+		r.FixedBytes(hashes[i][:])
+	}
+	bh.Start = idx.Block(start)
+	bh.Epoch = idx.Epoch(epoch)
+	bh.Hashes = hashes
+	return nil
+}

--- a/inter/block_hashes.go
+++ b/inter/block_hashes.go
@@ -14,19 +14,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-// Sonic is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// Sonic is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
-
 package inter
 
 import (

--- a/inter/block_hashes_test.go
+++ b/inter/block_hashes_test.go
@@ -1,5 +1,5 @@
-// Copyright 2024 The Sonic Authors
-// This file is part of the Sonic library.
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
 //
 // Sonic is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by

--- a/inter/block_hashes_test.go
+++ b/inter/block_hashes_test.go
@@ -1,0 +1,137 @@
+// Copyright 2024 The Sonic Authors
+// This file is part of the Sonic library.
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package inter
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xsoniclabs/sonic/utils/cser"
+)
+
+func TestBlockHashes_LastBlock(t *testing.T) {
+	bh := BlockHashes{
+		Start:  idx.Block(5),
+		Hashes: make([]hash.Hash, 3),
+	}
+	require.Equal(t, idx.Block(7), bh.LastBlock())
+}
+
+func TestBlockHashes_Hash_IsDeterministic(t *testing.T) {
+	bh := BlockHashes{
+		Start:  idx.Block(1),
+		Epoch:  idx.Epoch(10),
+		Hashes: []hash.Hash{{1}, {2}, {3}},
+	}
+	h1 := bh.Hash()
+	h2 := bh.Hash()
+	require.Equal(t, h1, h2)
+}
+
+func TestBlockHashes_Hash_DiffersForDifferentInputs(t *testing.T) {
+	base := BlockHashes{
+		Start:  idx.Block(1),
+		Epoch:  idx.Epoch(10),
+		Hashes: []hash.Hash{{1}, {2}},
+	}
+	tests := map[string]BlockHashes{
+		"different start": {
+			Start:  idx.Block(2),
+			Epoch:  idx.Epoch(10),
+			Hashes: []hash.Hash{{1}, {2}},
+		},
+		"different epoch": {
+			Start:  idx.Block(1),
+			Epoch:  idx.Epoch(11),
+			Hashes: []hash.Hash{{1}, {2}},
+		},
+		"different hashes": {
+			Start:  idx.Block(1),
+			Epoch:  idx.Epoch(10),
+			Hashes: []hash.Hash{{1}, {3}},
+		},
+		"different length": {
+			Start:  idx.Block(1),
+			Epoch:  idx.Epoch(10),
+			Hashes: []hash.Hash{{1}},
+		},
+	}
+	baseHash := base.Hash()
+	for name, other := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotEqual(t, baseHash, other.Hash())
+		})
+	}
+}
+
+func TestBlockHashes_MarshalUnmarshalCSER_RoundTrip(t *testing.T) {
+	tests := map[string]BlockHashes{
+		"empty": {
+			Start:  idx.Block(0),
+			Epoch:  idx.Epoch(0),
+			Hashes: []hash.Hash{},
+		},
+		"single hash": {
+			Start:  idx.Block(100),
+			Epoch:  idx.Epoch(5),
+			Hashes: []hash.Hash{{1, 2, 3}},
+		},
+		"multiple hashes": {
+			Start:  idx.Block(500),
+			Epoch:  idx.Epoch(42),
+			Hashes: []hash.Hash{{1}, {2}, {3}, {4}, {5}},
+		},
+	}
+
+	for name, original := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := cser.MarshalBinaryAdapter(original.MarshalCSER)
+			require.NoError(t, err)
+
+			var restored BlockHashes
+			err = cser.UnmarshalBinaryAdapter(data, restored.UnmarshalCSER)
+			require.NoError(t, err)
+
+			require.Equal(t, original.Start, restored.Start)
+			require.Equal(t, original.Epoch, restored.Epoch)
+			require.Equal(t, len(original.Hashes), len(restored.Hashes))
+			for i := range original.Hashes {
+				require.Equal(t, original.Hashes[i], restored.Hashes[i])
+			}
+		})
+	}
+}
+
+func TestBlockHashes_UnmarshalCSER_RejectsTooLargeAlloc(t *testing.T) {
+	// Craft a CSER payload with an impossibly large hash count using
+	// MarshalBinaryAdapter with a custom writer function.
+	tooLargeNum := uint32(ProtocolMaxMsgSize/32 + 1)
+	craftedData, err := cser.MarshalBinaryAdapter(func(w *cser.Writer) error {
+		w.U64(1)           // start
+		w.U32(1)           // epoch
+		w.U32(tooLargeNum) // num (too large)
+		return nil
+	})
+	require.NoError(t, err)
+
+	var restored BlockHashes
+	err = cser.UnmarshalBinaryAdapter(craftedData, restored.UnmarshalCSER)
+	require.ErrorIs(t, err, cser.ErrTooLargeAlloc)
+}

--- a/inter/event.go
+++ b/inter/event.go
@@ -51,6 +51,7 @@ type EventI interface {
 	AnyEpochVote() bool
 	AnyMisbehaviourProofs() bool
 	HasProposal() bool
+	AnyBlockHashes() bool
 	PayloadHash() hash.Hash
 }
 
@@ -89,11 +90,13 @@ type EventPayloadI interface {
 	EpochVote() LlrEpochVote
 	BlockVotes() LlrBlockVotes
 	MisbehaviourProofs() []MisbehaviourProof
+	BlockHashes() BlockHashes
 	Payload() *Payload
 }
 
 var emptyPayloadHash1 = CalcPayloadHash(&MutableEventPayload{extEventData: extEventData{version: 1}})
 var emptyPayloadHash3 = CalcPayloadHash(&MutableEventPayload{extEventData: extEventData{version: 3}})
+var emptyPayloadHash4 = CalcPayloadHash(&MutableEventPayload{extEventData: extEventData{version: 4}})
 
 func EmptyPayloadHash(version uint8) hash.Hash {
 	switch version {
@@ -101,6 +104,8 @@ func EmptyPayloadHash(version uint8) hash.Hash {
 		return emptyPayloadHash1
 	case 3:
 		return emptyPayloadHash3
+	case 4:
+		return emptyPayloadHash4
 	default:
 		return hash.Hash(types.EmptyRootHash)
 	}
@@ -129,6 +134,7 @@ type extEventData struct {
 	anyEpochVote          bool
 	anyMisbehaviourProofs bool
 	hasProposal           bool
+	anyBlockHashes        bool
 	payloadHash           hash.Hash
 }
 
@@ -142,6 +148,8 @@ type payloadData struct {
 
 	epochVote  LlrEpochVote
 	blockVotes LlrBlockVotes
+
+	blockHashes BlockHashes
 
 	payload Payload
 }
@@ -221,7 +229,8 @@ func (e *extEventData) AnyEpochVote() bool { return e.anyEpochVote }
 
 func (e *extEventData) AnyBlockVotes() bool { return e.anyBlockVotes }
 
-func (e *extEventData) HasProposal() bool { return e.hasProposal }
+func (e *extEventData) HasProposal() bool    { return e.hasProposal }
+func (e *extEventData) AnyBlockHashes() bool { return e.anyBlockHashes }
 
 func (e *extEventData) GasPowerLeft() GasPowerLeft { return e.gasPowerLeft }
 
@@ -243,6 +252,7 @@ func (e *payloadData) TransactionsToMeter() types.Transactions {
 func (e *payloadData) MisbehaviourProofs() []MisbehaviourProof { return e.misbehaviourProofs }
 
 func (e *payloadData) BlockVotes() LlrBlockVotes { return e.blockVotes }
+func (e *payloadData) BlockHashes() BlockHashes  { return e.blockHashes }
 
 func (e *payloadData) EpochVote() LlrEpochVote { return e.epochVote }
 
@@ -263,6 +273,9 @@ func CalcMisbehaviourProofsHash(mps []MisbehaviourProof) hash.Hash {
 func CalcPayloadHash(e EventPayloadI) hash.Hash {
 	if e.Version() == 1 {
 		return hash.Of(hash.Of(CalcTxHash(e.Transactions()).Bytes(), CalcMisbehaviourProofsHash(e.MisbehaviourProofs()).Bytes()).Bytes(), hash.Of(e.EpochVote().Hash().Bytes(), e.BlockVotes().Hash().Bytes()).Bytes())
+	}
+	if e.Version() == 4 {
+		return hash.Of(e.Payload().Hash().Bytes(), e.BlockHashes().Hash().Bytes())
 	}
 	if e.Version() == 3 {
 		return e.Payload().Hash()
@@ -303,6 +316,11 @@ func (e *MutableEventPayload) SetMisbehaviourProofs(v []MisbehaviourProof) {
 func (e *MutableEventPayload) SetBlockVotes(v LlrBlockVotes) {
 	e.blockVotes = v
 	e.anyBlockVotes = len(v.Votes) != 0
+}
+
+func (e *MutableEventPayload) SetBlockHashes(v BlockHashes) {
+	e.blockHashes = v
+	e.anyBlockHashes = len(v.Hashes) != 0
 }
 
 func (e *MutableEventPayload) SetEpochVote(v LlrEpochVote) {

--- a/inter/event_mock.go
+++ b/inter/event_mock.go
@@ -226,6 +226,20 @@ func (mr *MockEventIMockRecorder) HasProposal() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProposal", reflect.TypeOf((*MockEventI)(nil).HasProposal))
 }
 
+// AnyBlockHashes mocks base method.
+func (m *MockEventI) AnyBlockHashes() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AnyBlockHashes")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AnyBlockHashes indicates an expected call of AnyBlockHashes.
+func (mr *MockEventIMockRecorder) AnyBlockHashes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnyBlockHashes", reflect.TypeOf((*MockEventI)(nil).AnyBlockHashes))
+}
+
 // HashToSign mocks base method.
 func (m *MockEventI) HashToSign() hash.Hash {
 	m.ctrl.T.Helper()
@@ -654,6 +668,34 @@ func (m *MockEventPayloadI) HasProposal() bool {
 func (mr *MockEventPayloadIMockRecorder) HasProposal() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProposal", reflect.TypeOf((*MockEventPayloadI)(nil).HasProposal))
+}
+
+// AnyBlockHashes mocks base method.
+func (m *MockEventPayloadI) AnyBlockHashes() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AnyBlockHashes")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AnyBlockHashes indicates an expected call of AnyBlockHashes.
+func (mr *MockEventPayloadIMockRecorder) AnyBlockHashes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnyBlockHashes", reflect.TypeOf((*MockEventPayloadI)(nil).AnyBlockHashes))
+}
+
+// BlockHashes mocks base method.
+func (m *MockEventPayloadI) BlockHashes() BlockHashes {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockHashes")
+	ret0, _ := ret[0].(BlockHashes)
+	return ret0
+}
+
+// BlockHashes indicates an expected call of BlockHashes.
+func (mr *MockEventPayloadIMockRecorder) BlockHashes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHashes", reflect.TypeOf((*MockEventPayloadI)(nil).BlockHashes))
 }
 
 // HashToSign mocks base method.

--- a/inter/event_serializer.go
+++ b/inter/event_serializer.go
@@ -36,7 +36,7 @@ var (
 	ErrUnknownVersion    = errors.New("unknown serialization version")
 )
 
-const MaxSerializationVersion = 3
+const MaxSerializationVersion = 4
 
 const ProtocolMaxMsgSize = 10 * 1024 * 1024
 
@@ -92,7 +92,11 @@ func (e *Event) MarshalCSER(w *cser.Writer) error {
 	if e.Version() == 3 {
 		w.Bool(e.HasProposal())
 	}
-	if e.AnyTxs() || e.AnyMisbehaviourProofs() || e.AnyBlockVotes() || e.AnyEpochVote() || e.Version() == 3 {
+	if e.Version() == 4 {
+		w.Bool(e.HasProposal())
+		w.Bool(e.AnyBlockHashes())
+	}
+	if e.AnyTxs() || e.AnyMisbehaviourProofs() || e.AnyBlockVotes() || e.AnyEpochVote() || e.Version() == 3 || e.Version() == 4 {
 		w.FixedBytes(e.PayloadHash().Bytes())
 	}
 	// extra
@@ -167,10 +171,15 @@ func eventUnmarshalCSER(r *cser.Reader, e *MutableEventPayload) (err error) {
 	anyEpochVote := version == 1 && r.Bool()
 	anyBlockVotes := version == 1 && r.Bool()
 	hasProposal := version == 3 && r.Bool()
+	anyBlockHashes := false
+	if version == 4 {
+		hasProposal = r.Bool()
+		anyBlockHashes = r.Bool()
+	}
 	payloadHash := EmptyPayloadHash(version)
-	if anyTxs || anyMisbehaviourProofs || anyEpochVote || anyBlockVotes || version == 3 {
+	if anyTxs || anyMisbehaviourProofs || anyEpochVote || anyBlockVotes || version == 3 || version == 4 {
 		r.FixedBytes(payloadHash[:])
-		if version != 3 && payloadHash == EmptyPayloadHash(version) {
+		if version != 3 && version != 4 && payloadHash == EmptyPayloadHash(version) {
 			return cser.ErrNonCanonicalEncoding
 		}
 	}
@@ -199,6 +208,7 @@ func eventUnmarshalCSER(r *cser.Reader, e *MutableEventPayload) (err error) {
 	e.anyEpochVote = anyEpochVote
 	e.anyMisbehaviourProofs = anyMisbehaviourProofs
 	e.hasProposal = hasProposal
+	e.anyBlockHashes = anyBlockHashes
 	e.SetPayloadHash(payloadHash)
 	e.SetExtra(extra)
 	return nil
@@ -280,6 +290,17 @@ func (e *EventPayload) MarshalCSER(w *cser.Writer) error {
 			return ErrSerMalformedEvent
 		}
 	}
+	if e.Version() == 4 {
+		if e.AnyBlockVotes() || e.AnyEpochVote() || e.AnyMisbehaviourProofs() || e.AnyTxs() {
+			return ErrSerMalformedEvent
+		}
+		if e.HasProposal() != (e.payload.Proposal != nil) {
+			return ErrSerMalformedEvent
+		}
+		if e.AnyBlockHashes() != (len(e.blockHashes.Hashes) != 0) {
+			return ErrSerMalformedEvent
+		}
+	}
 	err := e.Event.MarshalCSER(w)
 	if err != nil {
 		return err
@@ -325,6 +346,19 @@ func (e *EventPayload) MarshalCSER(w *cser.Writer) error {
 			return err
 		}
 		w.SliceBytes(b)
+	}
+	if e.Version() == 4 {
+		b, err := e.Payload().Serialize()
+		if err != nil {
+			return err
+		}
+		w.SliceBytes(b)
+		if e.AnyBlockHashes() {
+			err = e.BlockHashes().MarshalCSER(w)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -398,12 +432,24 @@ func (e *MutableEventPayload) UnmarshalCSER(r *cser.Reader) error {
 	}
 	e.blockVotes = bvs
 	// generic payload
-	if e.Version() == 3 {
+	if e.Version() == 3 || e.Version() == 4 {
 		b := r.SliceBytes(ProtocolMaxMsgSize)
 		if err := e.payload.Deserialize(b); err != nil {
 			return err
 		}
 	}
+	// block hashes (version 4 only)
+	bhs := BlockHashes{Hashes: make([]hash.Hash, 0)}
+	if e.AnyBlockHashes() {
+		err := bhs.UnmarshalCSER(r)
+		if err != nil {
+			return err
+		}
+		if len(bhs.Hashes) == 0 || bhs.Start == 0 || bhs.Epoch == 0 {
+			return cser.ErrNonCanonicalEncoding
+		}
+	}
+	e.blockHashes = bhs
 	return nil
 }
 

--- a/inter/event_serializer_test.go
+++ b/inter/event_serializer_test.go
@@ -76,10 +76,12 @@ func TestEventPayloadSerialization(t *testing.T) {
 		"empty1":  emptyEvent(1),
 		"empty2":  emptyEvent(2),
 		"empty3":  emptyEvent(3),
+		"empty4":  emptyEvent(4),
 		"event":   *event.Build(),
 		"random1": *FakeEvent(1, 12, 1, 1, true),
 		"random2": *FakeEvent(2, 12, 0, 0, false),
 		"random3": *FakeEvent(3, 12, 0, 0, false),
+		"random4": *FakeEvent(4, 12, 0, 0, false),
 	}
 
 	t.Run("ok", func(t *testing.T) {
@@ -240,6 +242,152 @@ func TestEventUnmarshalCSER_Version3DetectsUnsupportedPayload(t *testing.T) {
 			require.ErrorIs(err, ErrSerMalformedEvent)
 		})
 	}
+}
+
+func TestEventUnmarshalCSER_Version4AcceptsIfHashOfAnEmptyPayloadIsIncluded(t *testing.T) {
+	require := require.New(t)
+
+	builder := MutableEventPayload{}
+	builder.SetVersion(4)
+	builder.SetPayload(Payload{})
+	// For version 4, the payload hash includes both the payload and block
+	// hashes. SetPayload only sets payload.Hash(), so we must recalculate.
+	builder.SetPayloadHash(CalcPayloadHash(&builder))
+	event := builder.Build()
+
+	require.Equal(event.payloadHash, EmptyPayloadHash(4))
+
+	data, err := rlp.EncodeToBytes(&event)
+	require.NoError(err)
+
+	var recovered EventPayload
+	err = rlp.DecodeBytes(data, &recovered)
+	require.NoError(err)
+}
+
+func TestEventUnmarshalCSER_Version4DetectsUnsupportedPayload(t *testing.T) {
+	require := require.New(t)
+
+	tests := map[string]*EventPayload{
+		"with transactions": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.SetTxs([]*types.Transaction{
+				types.NewTx(&types.LegacyTx{Nonce: 12}),
+			})
+			return builder.Build()
+		}(),
+		"with epoch vote": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.SetEpochVote(LlrEpochVote{
+				Epoch: 1,
+			})
+			return builder.Build()
+		}(),
+		"with block votes": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.SetBlockVotes(LlrBlockVotes{
+				Start: 1,
+				Votes: []hash.Hash{{}, {}},
+			})
+			return builder.Build()
+		}(),
+		"with misbehavior proofs": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.SetMisbehaviourProofs([]MisbehaviourProof{
+				{
+					EventsDoublesign: &EventsDoublesign{
+						Pair: [2]SignedEventLocator{{}, {}},
+					},
+				},
+			})
+			return builder.Build()
+		}(),
+		"with proposal but missing has-proposal flag": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.SetPayload(Payload{
+				Proposal: &Proposal{
+					Number: 1,
+				},
+			})
+			builder.hasProposal = false
+			return builder.Build()
+		}(),
+		"without proposal but with has-proposal flag": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.hasProposal = true
+			return builder.Build()
+		}(),
+		"with block hashes but missing any-block-hashes flag": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.blockHashes = BlockHashes{
+				Start:  1,
+				Epoch:  1,
+				Hashes: []hash.Hash{{1}},
+			}
+			builder.anyBlockHashes = false
+			return builder.Build()
+		}(),
+		"without block hashes but with any-block-hashes flag": func() *EventPayload {
+			builder := MutableEventPayload{}
+			builder.SetVersion(4)
+			builder.anyBlockHashes = true
+			return builder.Build()
+		}(),
+	}
+
+	for name, event := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := rlp.EncodeToBytes(event)
+			require.ErrorIs(err, ErrSerMalformedEvent)
+		})
+	}
+}
+
+func TestEventPayloadSerialization_Version4WithBlockHashes(t *testing.T) {
+	require := require.New(t)
+
+	builder := MutableEventPayload{}
+	builder.SetVersion(4)
+	builder.SetEpoch(1234)
+	builder.SetParents(hash.Events{})
+	builder.SetExtra([]byte{})
+	builder.SetPayload(Payload{
+		ProposalSyncState: ProposalSyncState{
+			LastSeenProposalTurn:  5,
+			LastSeenProposalFrame: 10,
+		},
+	})
+	builder.SetBlockHashes(BlockHashes{
+		Start: 100,
+		Epoch: 1234,
+		Hashes: []hash.Hash{
+			{1, 2, 3},
+			{4, 5, 6},
+		},
+	})
+	builder.SetPayloadHash(CalcPayloadHash(&builder))
+	event := builder.Build()
+
+	buf, err := rlp.EncodeToBytes(event)
+	require.NoError(err)
+
+	var decoded EventPayload
+	err = rlp.DecodeBytes(buf, &decoded)
+	require.NoError(err)
+
+	require.Equal(event.Version(), decoded.Version())
+	require.True(decoded.AnyBlockHashes())
+	require.Equal(idx.Block(100), decoded.BlockHashes().Start)
+	require.Equal(idx.Epoch(1234), decoded.BlockHashes().Epoch)
+	require.Len(decoded.BlockHashes().Hashes, 2)
+	require.Equal(event.PayloadHash(), decoded.PayloadHash())
 }
 
 func TestEventPayloadMarshalCSER_DetectsInvalidTransactionEncoding(t *testing.T) {
@@ -662,7 +810,7 @@ func FakeEvent(version uint8, txsNum, mpsNum, bvsNum int, ersNum bool) *EventPay
 		random.SetEpochVote(ers)
 	}
 
-	if version == 3 {
+	if version == 3 || version == 4 {
 		random.SetTxs(nil)
 		random.SetPayload(Payload{
 			ProposalSyncState: ProposalSyncState{
@@ -674,6 +822,18 @@ func FakeEvent(version uint8, txsNum, mpsNum, bvsNum int, ersNum bool) *EventPay
 				ParentHash:   common.Hash(randHash(r)),
 				RandaoReveal: randao.RandaoReveal(randBytes(r, 64)),
 				Transactions: txs,
+			},
+		})
+	}
+
+	if version == 4 {
+		random.SetBlockHashes(BlockHashes{
+			Start: 1 + idx.Block(rand.IntN(1000)),
+			Epoch: 1 + idx.Epoch(rand.IntN(1000)),
+			Hashes: []hash.Hash{
+				randHash(r),
+				randHash(r),
+				randHash(r),
 			},
 		})
 	}
@@ -695,9 +855,11 @@ func FuzzEventDeserialization(f *testing.F) {
 		emptyEvent(1),
 		emptyEvent(2),
 		emptyEvent(3),
+		emptyEvent(4),
 		*FakeEvent(1, 12, 1, 1, true),
 		*FakeEvent(2, 12, 0, 0, false),
 		*FakeEvent(3, 12, 0, 0, false),
+		*FakeEvent(4, 12, 0, 0, false),
 	}
 
 	for _, example := range examples {

--- a/opera/legacy_serialization.go
+++ b/opera/legacy_serialization.go
@@ -127,6 +127,9 @@ func (u Upgrades) EncodeRLP(w io.Writer) error {
 	if u.TransactionBundles {
 		bitmap.V |= transactionBundlesBit
 	}
+	if u.BlockHashesOnEvents {
+		bitmap.V |= blockHashesOnEventsBit
+	}
 	return rlp.Encode(w, &bitmap)
 }
 
@@ -149,6 +152,7 @@ func (u *Upgrades) DecodeRLP(s *rlp.Stream) error {
 	u.SingleProposerBlockFormation = (bitmap.V & singleProposerBlockFormationBit) != 0
 	u.GasSubsidies = (bitmap.V & gasSubsidiesBit) != 0
 	u.TransactionBundles = (bitmap.V & transactionBundlesBit) != 0
+	u.BlockHashesOnEvents = (bitmap.V & blockHashesOnEventsBit) != 0
 	return nil
 }
 

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -147,6 +147,7 @@ func TestUpgradesRLP_CanBeEncodedAndDecoded(t *testing.T) {
 		func(u *Upgrades) { u.Brio = true },
 		func(u *Upgrades) { u.GasSubsidies = true },
 		func(u *Upgrades) { u.TransactionBundles = true },
+		func(u *Upgrades) { u.BlockHashesOnEvents = true },
 	}
 
 	for mask := range 1 << len(setUpgrade) {

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -49,6 +49,7 @@ const (
 	singleProposerBlockFormationBit = 1 << 63
 	gasSubsidiesBit                 = 1 << 62
 	transactionBundlesBit           = 1 << 61
+	blockHashesOnEventsBit          = 1 << 60
 
 	MinimumMaxBlockGas          = 5_000_000_000 // < must be large enough to allow internal transactions to seal blocks
 	MaximumMaxBlockGas          = math.MaxInt64 // < should fit into 64-bit signed integers to avoid parsing errors in third-party libraries
@@ -264,6 +265,18 @@ type Upgrades struct {
 	// It can be enabled or disabled at any time. Changes in the feature state
 	// become effective at the start of the next epoch.
 	TransactionBundles bool
+
+	// BlockHashesOnEvents enables the inclusion of block hashes from
+	// recently processed blocks in events. When enabled, the event format
+	// is extended to version 4 (building on version 3 single-proposer
+	// format) with an additional block hashes section.
+	//
+	// This feature requires SingleProposerBlockFormation to be enabled.
+	//
+	// Given the conditions stated above, the feature is considered optional.
+	// It can be enabled or disabled at any time. Changes in the feature state
+	// become effective at the start of the next epoch.
+	BlockHashesOnEvents bool
 }
 
 // UpgradeHeight contains the information about the block height at which

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -289,5 +289,12 @@ func validateUpgrades(old, new Upgrades) error {
 
 	// The GasSubsidies feature can be freely modified.
 
+	// The BlockHashesOnEvents feature can be freely modified, but requires
+	// SingleProposerBlockFormation since it extends the version 3 event format.
+	if new.BlockHashesOnEvents && !new.SingleProposerBlockFormation {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
+		issues = append(issues, errors.New("BlockHashesOnEvents requires SingleProposerBlockFormation"))
+	}
+
 	return errors.Join(issues...)
 }

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -528,6 +528,10 @@ func TestUpgradesValidation_DetectsIssues(t *testing.T) {
 			upgrade: Upgrades{Brio: false},
 			issue:   "Brio upgrade cannot be disabled",
 		},
+		"BlockHashesOnEvents requires SingleProposerBlockFormation": {
+			upgrade: Upgrades{BlockHashesOnEvents: true},
+			issue:   "BlockHashesOnEvents requires SingleProposerBlockFormation",
+		},
 	}
 
 	for name, test := range issues {
@@ -547,6 +551,13 @@ func TestUpgradesValidation_AcceptsValidRules(t *testing.T) {
 		London:  true,
 		Sonic:   true,
 		Allegro: true,
+	}, {
+		Berlin:                       true,
+		London:                       true,
+		Sonic:                        true,
+		Allegro:                      true,
+		SingleProposerBlockFormation: true,
+		BlockHashesOnEvents:          true,
 	}}
 
 	for _, test := range upgrades {

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -126,7 +126,7 @@ func getNodeService(t *testing.T) *gossip.Service {
 	defaultConfig := gossip.DefaultConfig(cacheRatio)
 	s, err := gossip.NewService(node, defaultConfig, store, gossip.BlockProc{}, engine, vecClock, func(_ evmcore.StateReader) gossip.TxPool {
 		return txPoolMock
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 	return s
 }


### PR DESCRIPTION
# Add Block Hashes to Events (Event Version 4)

## Overview

Introduces **event version 4** that extends the existing version 3 (single-proposer) format by including block hashes from recently processed blocks. Every validator's emitted event now carries the latest observed block hashes, providing on-chain attestation of block processing. If validators representing more than 2/3 of total stake report block hashes that disagree with the local node's hashes, the node permanently stops to prevent operating on a fork.

## Motivation

Block hashes in events enable the network to detect nodes operating on divergent chains. By having each validator attest to the block hashes they observe, nodes can cross-check their local state against the network majority and shut down if they fall out of consensus.

## Architecture

### Component Overview

```
+--------------------------------------------------------------------+
|                          Sonic Node                                 |
|                                                                     |
|  +------------------+       +------------------------------------+  |
|  |   opera/rules    |       |          gossip/emitter            |  |
|  |                  |       |                                    |  |
|  | BlockHashesOn    |       |  createEvent()                    |  |
|  | Events = true  --+------>|    version = 4                    |  |
|  |                  |       |    addBlockHashes()               |  |
|  +------------------+       |      |                            |  |
|                             |      v                            |  |
|                             |  store.GetBlock(n) ----+          |  |
|                             |  for n = tip+1..latest |          |  |
|                             |    collect hashes       |          |  |
|                             |    stop at epoch boundary|         |  |
|                             |    max 64 per event     |          |  |
|                             |      |                  |          |  |
|                             |      v                  |          |  |
|                             |  Event v4 {             |          |  |
|                             |    Proposal             |          |  |
|                             |    BlockHashes [        |          |  |
|                             |      Start: 100         |          |  |
|                             |      Epoch: 5           |          |  |
|                             |      Hashes: [H100,     |          |  |
|                             |        H101, H102, ...] |          |  |
|                             |    ]                    |          |  |
|                             |  }                      |          |  |
|                             +----+-------------------+           |  |
|                                  |                               |  |
|                                  | broadcast via p2p             |  |
|                                  v                               |  |
|  +-----------------------------------------------------------+  |  |
|  |                    gossip/handler                          |  |  |
|  |                                                            |  |  |
|  |  dagProcessor.Enqueue(event, peer)                         |  |  |
|  |    |                                                       |  |  |
|  |    +--> lightCheck (basiccheck, epochcheck)                |  |  |
|  |    +--> bufferedCheck (parentscheck, proposalcheck)        |  |  |
|  |    +--> Process callback                                   |  |  |
|  |           |                                                |  |  |
|  |           v                                                |  |  |
|  +-----------------------------------------------------------+  |  |
|              |                                                   |  |
|              v                                                   |  |
|  +-----------------------------------------------------------+  |  |
|  |              gossip/c_event_callbacks                      |  |  |
|  |                                                            |  |  |
|  |  processEvent(e)                                           |  |  |
|  |    |                                                       |  |  |
|  |    +--> epochcheck.Validate(e)                             |  |  |
|  |    +--> saveAndProcessEvent(e)                             |  |  |
|  |    |                                                       |  |  |
|  |    +--> blockHashChecker.check(e)  <--- NEW                |  |  |
|  |    |                                                       |  |  |
|  |    +--> processEventEpochIndex(e)                          |  |  |
|  |    +--> if epoch changed: switchEpochTo()                  |  |  |
|  |              +--> blockHashChecker.reset()  <--- NEW       |  |  |
|  |                                                            |  |  |
|  +-----------------------------------------------------------+  |  |
|                                                                  |  |
+------------------------------------------------------------------+  |
```

### Disagreement Detection Flow

```
  blockHashChecker.check(event)
  ================================

  For each block hash in event:

     Event says block 100 = 0xABCD
     Local store has block 100 = 0x1234
                         |
                         v
                    Match? ----YES----> skip, no action
                         |
                         NO
                         |
                         v
            Record disagreement:
            disagreements[block 100] += validator X
                         |
                         v
            Sum stake of all disagreeing
            validators for block 100
                         |
                         v
       +----------------------------------+
       | disagreeingStake > totalStake*2/3 |
       +----------------------------------+
                |                |
               YES               NO
                |                |
                v                v
      errlock.Permanent()   continue processing
      (node halts)          next block hash
```

### Stake-Weighted Threshold Example

```
  Validators:  V1 (stake=100)  V2 (stake=100)  V3 (stake=100)
  Total stake: 300
  Threshold:   (300 * 2) / 3 = 200 (need strictly greater)

  Block 42: local hash = 0xAAAA

  1. V1 event arrives: block 42 = 0xBBBB (disagrees)
     disagreeing stake = 100   (100 <= 200, continue)

  2. V2 event arrives: block 42 = 0xCCCC (disagrees)
     disagreeing stake = 200   (200 <= 200, continue)

  3. V3 event arrives: block 42 = 0xDDDD (disagrees)
     disagreeing stake = 300   (300 > 200, HALT)
     --> errlock.Permanent("block hash disagreement...")
     --> node stops, requires manual intervention
```

### Epoch Lifecycle

```
  Epoch N                          Epoch N+1
  ==============================   ==============================
  blockHashChecker tracks          blockHashChecker.reset()
  disagreements for blocks         clears all disagreements
  in epoch N                       starts fresh with new
                                   validator set
  switchEpochTo(N+1) ------------> reset(N+1, newValidators)
```

## Changes

### New Event Format (Version 4)

Version 4 extends version 3 with a `BlockHashes` section. The serialization format adds two flags (`hasProposal`, `anyBlockHashes`) and serializes block hashes using the same CSER wire format as `LlrBlockVotes`: `[8B start][4B epoch][4B count][32B x N]`.

The payload hash for v4 is computed as `Hash(Payload.Hash(), BlockHashes.Hash())`.

**Activation:** Gated behind a new `Upgrades.BlockHashesOnEvents` flag (bit 60), which requires `SingleProposerBlockFormation` to be enabled. Takes effect at the next epoch boundary.

### Block Hash Emission

The emitter collects up to 64 consecutive block hashes per event, starting from the last emitted tip. Collection stops at epoch boundaries. The emission tip is persisted to disk (reusing the `emittedBvsFile` storage) so it survives restarts.

### Disagreement Detection

A `blockHashChecker` in the gossip service compares incoming event block hashes against local block hashes during `processEvent()`. It tracks per-block disagreements keyed by validator ID, weighted by stake. When disagreeing stake exceeds 2/3 of total weight for any block, the node calls `errlock.Permanent()` to halt permanently. The tracker resets on epoch transitions.

## Files Changed

### New Files

| File | Description |
|------|-------------|
| `inter/block_hashes.go` | `BlockHashes` type with `Start`, `Epoch`, `Hashes` fields, CSER serialization, and deterministic hashing |
| `gossip/emitter/block_hashes.go` | Emission logic: collects consecutive block hashes within an epoch, persists emission tip |
| `gossip/block_hash_check.go` | Stake-weighted disagreement tracker that triggers `errlock.Permanent()` on >2/3 disagreement |
| `gossip/block_hash_check_test.go` | 13 unit tests covering all checker scenarios |

### Network Rules and Upgrades

| File | Change |
|------|--------|
| `opera/rules.go` | Added `blockHashesOnEventsBit = 1 << 60` and `BlockHashesOnEvents bool` field to `Upgrades` |
| `opera/legacy_serialization.go` | RLP encode/decode for the new upgrade bit |
| `opera/validate.go` | `BlockHashesOnEvents` requires `SingleProposerBlockFormation` |
| `opera/marshal_test.go` | Added `BlockHashesOnEvents` to round-trip test |

### Event Data and Serialization

| File | Change |
|------|--------|
| `inter/event.go` | Added `AnyBlockHashes()` / `BlockHashes()` to interfaces, `anyBlockHashes` / `blockHashes` fields, `emptyPayloadHash4`, updated `CalcPayloadHash` for v4 |
| `inter/event_serializer.go` | Bumped `MaxSerializationVersion` to 4, added v4 marshal/unmarshal paths with proposal + block hashes flags |
| `inter/event_mock.go` | Added `AnyBlockHashes` and `BlockHashes` mock methods |

### Emitter

| File | Change |
|------|--------|
| `gossip/emitter/emitter.go` | Version 4 selection when `BlockHashesOnEvents` is enabled, calls `addBlockHashes()`, recalculates payload hash |
| `gossip/emitter/world.go` | Added `GetBlock(idx.Block)` to `Reader` interface |
| `gossip/emitter/world_mock.go` | Added `GetBlock` mock methods |
| `gossip/emitter_world.go` | Implemented `GetBlock` on `emitterWorldRead` |

### Event Validation

| File | Change |
|------|--------|
| `eventcheck/basiccheck/basic_check.go` | Added `MaxBlockHashesPerEvent = 64` validation |
| `eventcheck/epochcheck/epoch_check.go` | Version 4 in version determination, block hashes gas accounting using `BlockVotesBaseGas` / `BlockVoteGas` |
| `eventcheck/proposalcheck/proposal_check.go` | Accept version 4 alongside version 3 for proposal validation |
| `eventcheck/proposalcheck/proposal_check_test.go` | Updated tests to skip version 4 |
| `eventcheck/epochcheck/epoch_check_test.go` | Added `BlockHashes()` mock expectation |

### Gossip Service and Wiring

| File | Change |
|------|--------|
| `gossip/service.go` | Added `blockHashChecker` field, `errorLock` parameter to `NewService`/`newService`, initialized checker on startup |
| `gossip/c_event_callbacks.go` | Calls `blockHashChecker.check()` in `processEvent()`, calls `blockHashChecker.reset()` in `switchEpochTo()` |
| `config/make_node.go` | Passes `errorLock` to `gossip.NewService()` |
| `gossip/common_test.go` | Updated test constructor call |
| `tests/eth_rpc_api_functions_test.go` | Updated test constructor call |

## Testing

- 13 unit tests in `gossip/block_hash_check_test.go` covering:
  - Nil errorLock / nil validators (graceful no-op)
  - Events without block hashes (skipped)
  - Matching hashes (no disagreement recorded)
  - Blocks not in local store (skipped)
  - Disagreement below 2/3 threshold (no halt)
  - Disagreement exceeding 2/3 threshold (permanent halt)
  - Exact 2/3 boundary (strictly greater than required)
  - Same validator counted only once per block
  - Multiple blocks tracked independently
  - Epoch reset clears all disagreements
  - Partial block ranges (missing blocks skipped)
- All existing tests in `gossip/...`, `inter/...`, `opera/...`, `eventcheck/...`, and `config/...` pass
