### PR TITLE
Refactor validator flags to use brio boolean

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -711,8 +711,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		eip7623:  pool.eip7623,
 		eip7702:  pool.eip7702,
 
-		gasSubsidies:            pool.chain.CurrentRules().Upgrades.GasSubsidies,
-		customInitCodeSizeLimit: pool.chain.CurrentRules().Upgrades.Brio,
+		gasSubsidies: pool.chain.CurrentRules().Upgrades.GasSubsidies,
+		brio:         pool.chain.CurrentRules().Upgrades.Brio,
 	}
 
 	subsidiesChecker := pool.createSubsidiesChecker()

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -59,8 +59,8 @@ type NetworkRules struct {
 	eip7623 bool // Fork indicator whether we are using EIP-7623 floor gas validation.
 	eip7702 bool // Fork indicator whether we are using EIP-7702 set code transactions.
 
-	gasSubsidies            bool // Indicator whether gas subsidies are active.
-	customInitCodeSizeLimit bool // Indicator whether a custom init code size limit is active.
+	gasSubsidies bool // Indicator whether gas subsidies are active.
+	brio         bool // Indicator whether Brio revision is active
 }
 
 // Signer wraps types.Signer to allow mocking it in tests.
@@ -154,7 +154,7 @@ func ValidateTxForNetwork(tx *types.Transaction, rules NetworkRules, chain State
 	// Check whether the init code size has been exceeded, introduced in EIP-3860
 	if tx.To() == nil && rules.shanghai {
 		limit := params.MaxInitCodeSize
-		if rules.customInitCodeSizeLimit {
+		if rules.brio {
 			limit = opera.SonicPostAllegroMaxInitCodeSize
 		}
 		if len(tx.Data()) > limit {

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -531,69 +531,6 @@ func TestValidateTxForNetwork_AcceptsTransactions(t *testing.T) {
 	}
 }
 
-func TestValidateTxForNetwork_SetCodeTx_ValidatesInitCodeSizesAfterBrioHardfork(t *testing.T) {
-	tests := map[string]struct {
-		dataSize      int
-		rules         NetworkRules
-		expectedError error
-	}{
-		"accept tx with code size equal to limit before brio hardfork": {
-			dataSize: params.MaxInitCodeSize,
-		},
-		"reject tx with code size overflow before brio hardfork": {
-			dataSize:      params.MaxInitCodeSize + 1,
-			expectedError: ErrMaxInitCodeSizeExceeded,
-		},
-		"accept tx with previously overflowing code size after brio hardfork": {
-			dataSize: params.MaxInitCodeSize + 1,
-			rules: NetworkRules{
-				brio: true,
-			},
-		},
-		"accept tx with code size equal to limit after brio hardfork": {
-			dataSize: opera.SonicPostAllegroMaxInitCodeSize,
-			rules: NetworkRules{
-				brio: true,
-			},
-		},
-		"reject tx with code size overflow after brio hardfork": {
-			dataSize: opera.SonicPostAllegroMaxInitCodeSize + 1,
-			rules: NetworkRules{
-				brio: true,
-			},
-			expectedError: ErrMaxInitCodeSizeExceeded,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			chain := NewMockStateReader(ctrl)
-			signer := NewMockSigner(ctrl)
-			signer.EXPECT().Sender(gomock.Any()).Return(common.Address{42}, nil).AnyTimes()
-
-			data := make([]byte, test.dataSize)
-			gas, err := core.IntrinsicGas(data, nil, nil, true, true, true, true)
-			require.NoError(t, err)
-
-			tx := types.NewTx(&types.LegacyTx{
-				To:   nil, // contract creation
-				Gas:  gas,
-				Data: data,
-			})
-
-			// this test requires at least shanghai
-			test.rules.shanghai = true
-			err = ValidateTxForNetwork(tx, test.rules, chain, signer)
-			if test.expectedError == nil {
-				require.NoError(t, err)
-			} else {
-				require.ErrorIs(t, err, ErrMaxInitCodeSizeExceeded)
-			}
-		})
-	}
-}
-
 func TestValidateTxForNetwork_CustomSonicCodeSizeLimitIsEnforced(t *testing.T) {
 	tests := map[string]struct {
 		customSize   bool

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -531,6 +531,69 @@ func TestValidateTxForNetwork_AcceptsTransactions(t *testing.T) {
 	}
 }
 
+func TestValidateTxForNetwork_SetCodeTx_ValidatesInitCodeSizesAfterBrioHardfork(t *testing.T) {
+	tests := map[string]struct {
+		dataSize      int
+		rules         NetworkRules
+		expectedError error
+	}{
+		"accept tx with code size equal to limit before brio hardfork": {
+			dataSize: params.MaxInitCodeSize,
+		},
+		"reject tx with code size overflow before brio hardfork": {
+			dataSize:      params.MaxInitCodeSize + 1,
+			expectedError: ErrMaxInitCodeSizeExceeded,
+		},
+		"accept tx with previously overflowing code size after brio hardfork": {
+			dataSize: params.MaxInitCodeSize + 1,
+			rules: NetworkRules{
+				brio: true,
+			},
+		},
+		"accept tx with code size equal to limit after brio hardfork": {
+			dataSize: opera.SonicPostAllegroMaxInitCodeSize,
+			rules: NetworkRules{
+				brio: true,
+			},
+		},
+		"reject tx with code size overflow after brio hardfork": {
+			dataSize: opera.SonicPostAllegroMaxInitCodeSize + 1,
+			rules: NetworkRules{
+				brio: true,
+			},
+			expectedError: ErrMaxInitCodeSizeExceeded,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			chain := NewMockStateReader(ctrl)
+			signer := NewMockSigner(ctrl)
+			signer.EXPECT().Sender(gomock.Any()).Return(common.Address{42}, nil).AnyTimes()
+
+			data := make([]byte, test.dataSize)
+			gas, err := core.IntrinsicGas(data, nil, nil, true, true, true, true)
+			require.NoError(t, err)
+
+			tx := types.NewTx(&types.LegacyTx{
+				To:   nil, // contract creation
+				Gas:  gas,
+				Data: data,
+			})
+
+			// this test requires at least shanghai
+			test.rules.shanghai = true
+			err = ValidateTxForNetwork(tx, test.rules, chain, signer)
+			if test.expectedError == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, ErrMaxInitCodeSizeExceeded)
+			}
+		})
+	}
+}
+
 func TestValidateTxForNetwork_CustomSonicCodeSizeLimitIsEnforced(t *testing.T) {
 	tests := map[string]struct {
 		customSize   bool
@@ -563,12 +626,12 @@ func TestValidateTxForNetwork_CustomSonicCodeSizeLimitIsEnforced(t *testing.T) {
 			signer := NewMockSigner(ctrl)
 			signer.EXPECT().Sender(gomock.Any()).Return(common.Address{42}, nil).AnyTimes()
 			rules := NetworkRules{
-				eip2718:                 true,
-				eip1559:                 true,
-				eip4844:                 true,
-				eip7702:                 true,
-				shanghai:                true,
-				customInitCodeSizeLimit: test.customSize,
+				eip2718:  true,
+				eip1559:  true,
+				eip4844:  true,
+				eip7702:  true,
+				shanghai: true,
+				brio:     test.customSize,
 			}
 
 			data := make([]byte, test.initCodeSize)


### PR DESCRIPTION
The reason behind this change is that code sizes can never be enabled or disabled as a feature, once they are used once (contract overflowing will remain deployed). 

The brio flag can be reused to validate bundles (before brio they behave as normal txs). 

