### PR TITLE
Add Store utilities for bundles import/export.

### DIFF
--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -339,7 +339,15 @@ func (s *Store) DumpProcessedBundles() [][]byte {
 	it := s.table.ProcessedBundles.NewIterator([]byte{'e'}, nil)
 	defer it.Release()
 	for it.Next() {
-		entry := BundleKV{Key: it.Key(), Value: it.Value()}
+		key := it.Key()
+		value := it.Value()
+		if len(key) != 1+32 || len(value) != 16 {
+			s.Log.Crit(
+				"invalid key or value length for processed bundle entry during dump",
+				"keyLength", len(key),
+				"valueLength", len(value))
+		}
+		entry := BundleKV{Key: key, Value: value}
 		dump = append(dump, entry.Encode())
 	}
 	if it.Error() != nil {

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -19,9 +19,9 @@ package gossip
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -80,7 +80,7 @@ func (s *Store) AddProcessedBundles(
 	newHash := computeNewBundleStateHash(oldHash, addedHash, deletedHash, blockNum)
 
 	err := batch.Put(nil, append(
-		uint64ToBytes(blockNum),
+		bigendian.Uint64ToBytes(blockNum),
 		newHash.Bytes()...,
 	))
 	if err != nil {
@@ -233,7 +233,7 @@ func (s *Store) GetBundleExecutionInfo(execPlanHash common.Hash) *bundle.Executi
 // GetProcessedBundleHistoryHash returns the block number of the last update
 // and the current hash of the processed bundles history.
 func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
-	state := s.processedBundleHistoryEntry()
+	state := s.readProcessedBundleHistoryEntry()
 	if state == nil {
 		return 0, common.Hash{}
 	}
@@ -242,12 +242,12 @@ func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
 	return blockNum, hash
 }
 
-// processedBundleHistoryEntry returns the raw value of the entry that stores the
+// readProcessedBundleHistoryEntry returns the raw value of the entry that stores the
 // block number and hash of the processed bundles history, or nil if it is not
 // set. The returned value is expected to be 40 bytes long, with the first 8
 // bytes representing the block number in big-endian format, and the next 32
 // bytes representing the hash of the processed bundles history.
-func (s *Store) processedBundleHistoryEntry() []byte {
+func (s *Store) readProcessedBundleHistoryEntry() []byte {
 	state, err := s.table.ProcessedBundles.Get(nil)
 	if err != nil {
 		s.Log.Crit("failed to get hash of processed bundles", "error", err)
@@ -265,125 +265,30 @@ func (s *Store) processedBundleHistoryEntry() []byte {
 	return state
 }
 
-// ImportProcessedBundles imports a batch of processed bundle entries from a
-// single byte slice.
-// The format is a repeated sequence of:
-//
-//	[4 bytes key length][key][4 bytes value length][value]
-//
-// This is used for genesis import.
-func (s *Store) ImportProcessedBundles(data []byte) error {
+// SetProcessedBundlesHistoryHash sets the block number and hash of the
+// processed bundles history. This should be used only during genesis initialization.
+func (s *Store) SetProcessedBundlesHistoryHash(blockNum uint64, hash common.Hash) {
 	// Make sure there is only one update at any time.
 	s.processedBundleMutex.Lock()
 	defer s.processedBundleMutex.Unlock()
 
-	for offset := 0; offset < len(data); {
-
-		key, value, newOffset, err := decodeEntry(offset, data)
-		if err != nil {
-			return err
-		}
-		offset = newOffset
-
-		if len(key) == 0 {
-			// This is the entry for the history hash and block number, which is
-			// expected to have an empty key. We validate the value length and content,
-			// but we don't require the hash to be non-zero since a genesis may start
-			// with no bundles having been processed.
-			if len(value) != 8+32 {
-				return fmt.Errorf("invalid value length for bundle history hash (should be 40, got %d)", len(value))
-			}
-			blockNum := binary.BigEndian.Uint64(value[:8])
-			hash := common.BytesToHash(value[8:])
-			s.Log.Info("Importing processed bundle history hash from genesis",
-				"blockNum", blockNum,
-				"hash", hash)
-			if err := s.table.ProcessedBundles.Put(nil, value); err != nil {
-				return err
-			}
-			continue
-		}
-
-		// key := e + plan.Hash
-		// value := blockNum + position + count
-		if len(key) != 1+32 || len(value) != 16 {
-			return fmt.Errorf(
-				"invalid key or value for processed bundle entry (key length: %d, value length: %d)",
-				len(key),
-				len(value),
-			)
-		}
-
-		if key[0] != 'e' {
-			return fmt.Errorf("invalid key prefix for processed bundle entry: expected 'e', got '%c'", key[0])
-		}
-
-		var execPlanHash common.Hash
-		copy(execPlanHash[:], key[1:])
-		if execPlanHash == (common.Hash{}) {
-			return errors.New("invalid execution plan hash in processed bundle entry")
-		}
-
-		batch := s.table.ProcessedBundles.NewBatch()
-
-		// write entry key
-		if err := batch.Put(key, value); err != nil {
-			return err
-		}
-		// write index key
-		blockNumber := binary.BigEndian.Uint64(value[:8])
-		indexKey := getIndexKey(blockNumber, execPlanHash)
-		if err := batch.Put(indexKey, []byte{0}); err != nil {
-			return err
-		}
-		if err := batch.Write(); err != nil {
-			return err
-		}
+	err := s.table.ProcessedBundles.Put(nil, append(
+		bigendian.Uint64ToBytes(blockNum),
+		hash.Bytes()...,
+	))
+	if err != nil {
+		s.Log.Crit("failed to set hash of processed bundles", "error", err)
 	}
-
-	return nil
 }
 
-func decodeEntry(offset int, data []byte) ([]byte, []byte, int, error) {
-	if offset+4 > len(data) {
-		return nil, nil, 0, fmt.Errorf("invalid data: incomplete key length at offset %d", offset)
-	}
-	keyLen := int(binary.BigEndian.Uint32(data[offset : offset+4]))
-	offset += 4
-	if offset+keyLen > len(data) {
-		return nil, nil, 0, fmt.Errorf("invalid data: incomplete key at offset %d", offset)
-	}
-	key := data[offset : offset+keyLen]
-	offset += keyLen
-	if offset+4 > len(data) {
-		return nil, nil, 0, fmt.Errorf("invalid data: incomplete value length at offset %d", offset)
-	}
-	valueLen := int(binary.BigEndian.Uint32(data[offset : offset+4]))
-	offset += 4
-	if offset+valueLen > len(data) {
-		return nil, nil, 0, fmt.Errorf("invalid data: incomplete value at offset %d", offset)
-	}
-	value := data[offset : offset+valueLen]
-	offset += valueLen
-	return key, value, offset, nil
-}
-
-// ExportProcessedBundles exports all the entries in the processed
-// bundles table in bytes. The export includes both the history entry and the
-// entries for recently processed bundles.
-func (s *Store) ExportProcessedBundles() [][]byte {
+// EnumerateProcessedBundles returns a list of all recently processed bundle
+// execution infos currently tracked by the store.
+func (s *Store) EnumerateProcessedBundles() []bundle.ExecutionInfo {
 	// Make sure there is only one update at any time.
 	s.processedBundleMutex.Lock()
 	defer s.processedBundleMutex.Unlock()
 
-	result := make([][]byte, 0)
-
-	// get history entry
-	currentHistoryHash := s.processedBundleHistoryEntry()
-	if currentHistoryHash == nil {
-		return [][]byte{}
-	}
-	result = append(result, Encode(nil, currentHistoryHash))
+	result := make([]bundle.ExecutionInfo, 0)
 
 	// get all recently processed bundles
 	it := s.table.ProcessedBundles.NewIterator([]byte{'e'}, nil)
@@ -398,25 +303,19 @@ func (s *Store) ExportProcessedBundles() [][]byte {
 				"valueLength", len(value))
 		}
 
-		result = append(result, Encode(key, value))
+		result = append(result, bundle.ExecutionInfo{
+			ExecutionPlanHash: common.BytesToHash(key[1:]),
+			BlockNumber:       binary.BigEndian.Uint64(value[:8]),
+			Position: bundle.PositionInBlock{
+				Offset: binary.BigEndian.Uint32(value[8:12]),
+				Count:  binary.BigEndian.Uint32(value[12:]),
+			},
+		})
 	}
 	if it.Error() != nil {
 		s.Log.Crit("failed to export processed bundles", "error", it.Error())
 	}
 	return result
-}
-
-// Encode encodes a key-value pair into a byte slice for storage or export.
-// The format is: [uint32 key length][key][uint32 value length][value]
-func Encode(key, value []byte) []byte {
-	data := make([]byte, 0, 8+len(key)+len(value))
-	keyLen := uint32ToBytes(uint32(len(key)))
-	data = append(data, keyLen...)
-	data = append(data, key...)
-	valueLen := uint32ToBytes(uint32(len(value)))
-	data = append(data, valueLen...)
-	data = append(data, value...)
-	return data
 }
 
 // --- utility functions for processed bundles management ---
@@ -430,7 +329,9 @@ func getEntryKey(hash common.Hash) []byte {
 // getIndexKey returns the key used to index a processed bundle hash at a
 // specific block number, to handle cleanups.
 func getIndexKey(blockNum uint64, hash common.Hash) []byte {
-	return append(append([]byte{'i'}, uint64ToBytes(blockNum)...), hash.Bytes()...)
+	return append(
+		append([]byte{'i'}, bigendian.Uint64ToBytes(blockNum)...),
+		hash.Bytes()...)
 }
 
 // xorHash returns the XOR of two hashes.
@@ -440,14 +341,4 @@ func xorHash(a, b common.Hash) common.Hash {
 		res[i] = a[i] ^ b[i]
 	}
 	return res
-}
-
-// uint64ToBytes converts a uint64 to a byte slice in big-endian order.
-func uint64ToBytes(v uint64) []byte {
-	return binary.BigEndian.AppendUint64(nil, v)
-}
-
-// uint32ToBytes converts a uint32 to a byte slice in big-endian order.
-func uint32ToBytes(v uint32) []byte {
-	return binary.BigEndian.AppendUint32(nil, v)
 }

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -129,6 +129,7 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) common.
 		// enough blocks have passed to start cleaning up the store
 		highestOutdatedBlockNumber := blockNum - bundle.MaxBlockRange + 1
 		it := s.table.ProcessedBundles.NewIterator([]byte{'i'}, nil)
+		defer it.Release()
 		for it.Next() {
 			key := it.Key()
 			// size of the key used to index processed bundle is:
@@ -330,6 +331,10 @@ func (s *Store) SetRawProcessedBundle(kv BundleKV) error {
 // bundles table in bytes. The dump includes both the history entry and the
 // entries for recently processed bundles.
 func (s *Store) DumpProcessedBundles() [][]byte {
+	// Make sure there is only one update at any time.
+	s.processedBundleMutex.Lock()
+	defer s.processedBundleMutex.Unlock()
+
 	dump := make([][]byte, 0)
 
 	// get history entry
@@ -341,6 +346,7 @@ func (s *Store) DumpProcessedBundles() [][]byte {
 
 	// get all recently processed bundles
 	it := s.table.ProcessedBundles.NewIterator([]byte{'e'}, nil)
+	defer it.Release()
 	for it.Next() {
 		entry := BundleKV{Key: it.Key(), Value: it.Value()}
 		dump = append(dump, entry.Encode())

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -265,14 +265,14 @@ func (s *Store) processedBundleHistoryEntry() []byte {
 	return state
 }
 
-// SetRawProcessedBundles imports a batch of processed bundle entries from a
+// ImportProcessedBundles imports a batch of processed bundle entries from a
 // single byte slice.
 // The format is a repeated sequence of:
 //
 //	[4 bytes key length][key][4 bytes value length][value]
 //
 // This is used for genesis import.
-func (s *Store) SetRawProcessedBundles(data []byte) error {
+func (s *Store) ImportProcessedBundles(data []byte) error {
 	// Make sure there is only one update at any time.
 	s.processedBundleMutex.Lock()
 	defer s.processedBundleMutex.Unlock()
@@ -368,22 +368,22 @@ func decodeEntry(offset int, data []byte) ([]byte, []byte, int, error) {
 	return key, value, offset, nil
 }
 
-// DumpProcessedBundles returns a dump of all the entries in the processed
-// bundles table in bytes. The dump includes both the history entry and the
+// ExportProcessedBundles exports all the entries in the processed
+// bundles table in bytes. The export includes both the history entry and the
 // entries for recently processed bundles.
-func (s *Store) DumpProcessedBundles() [][]byte {
+func (s *Store) ExportProcessedBundles() [][]byte {
 	// Make sure there is only one update at any time.
 	s.processedBundleMutex.Lock()
 	defer s.processedBundleMutex.Unlock()
 
-	dump := make([][]byte, 0)
+	result := make([][]byte, 0)
 
 	// get history entry
 	currentHistoryHash := BundleKV{Key: nil, Value: s.processedBundleHistoryEntry()}
 	if currentHistoryHash.Value == nil {
 		return [][]byte{}
 	}
-	dump = append(dump, currentHistoryHash.Encode())
+	result = append(result, currentHistoryHash.Encode())
 
 	// get all recently processed bundles
 	it := s.table.ProcessedBundles.NewIterator([]byte{'e'}, nil)
@@ -393,17 +393,17 @@ func (s *Store) DumpProcessedBundles() [][]byte {
 		value := it.Value()
 		if len(key) != 1+32 || len(value) != 16 {
 			s.Log.Crit(
-				"invalid key or value length for processed bundle entry during dump",
+				"invalid key or value length for processed bundle entry during export",
 				"keyLength", len(key),
 				"valueLength", len(value))
 		}
 		entry := BundleKV{Key: key, Value: value}
-		dump = append(dump, entry.Encode())
+		result = append(result, entry.Encode())
 	}
 	if it.Error() != nil {
-		s.Log.Crit("failed to dump processed bundles", "error", it.Error())
+		s.Log.Crit("failed to export processed bundles", "error", it.Error())
 	}
-	return dump
+	return result
 }
 
 // BundleKV represents a key-value pair for a processed bundle entry, used for

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -80,7 +80,7 @@ func (s *Store) AddProcessedBundles(
 	newHash := computeNewBundleStateHash(oldHash, addedHash, deletedHash, blockNum)
 
 	err := batch.Put(nil, append(
-		binary.BigEndian.AppendUint64(nil, blockNum),
+		uint64ToBytes(blockNum),
 		newHash.Bytes()...,
 	))
 	if err != nil {
@@ -367,9 +367,11 @@ type BundleKV struct {
 // The format is: [uint32 key length][key][uint32 value length][value]
 func (k *BundleKV) Encode() []byte {
 	data := make([]byte, 0, 8+len(k.Key)+len(k.Value))
-	data = append(data, uint32ToBytes(uint32(len(k.Key)))...)
+	keyLen := uint32ToBytes(uint32(len(k.Key)))
+	data = append(data, keyLen...)
 	data = append(data, k.Key...)
-	data = append(data, uint32ToBytes(uint32(len(k.Value)))...)
+	valueLen := uint32ToBytes(uint32(len(k.Value)))
+	data = append(data, valueLen...)
 	data = append(data, k.Value...)
 	return data
 }
@@ -385,7 +387,7 @@ func getEntryKey(hash common.Hash) []byte {
 // getIndexKey returns the key used to index a processed bundle hash at a
 // specific block number, to handle cleanups.
 func getIndexKey(blockNum uint64, hash common.Hash) []byte {
-	return append(append([]byte{'i'}, binary.BigEndian.AppendUint64(nil, blockNum)...), hash.Bytes()...)
+	return append(append([]byte{'i'}, uint64ToBytes(blockNum)...), hash.Bytes()...)
 }
 
 // xorHash returns the XOR of two hashes.
@@ -397,9 +399,12 @@ func xorHash(a, b common.Hash) common.Hash {
 	return res
 }
 
+// uint64ToBytes converts a uint64 to a byte slice in big-endian order.
+func uint64ToBytes(v uint64) []byte {
+	return binary.BigEndian.AppendUint64(nil, v)
+}
+
 // uint32ToBytes converts a uint32 to a byte slice in big-endian order.
 func uint32ToBytes(v uint32) []byte {
-	b := make([]byte, 4)
-	binary.BigEndian.PutUint32(b, v)
-	return b
+	return binary.BigEndian.AppendUint32(nil, v)
 }

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -19,6 +19,7 @@ package gossip
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
@@ -231,12 +232,27 @@ func (s *Store) GetBundleExecutionInfo(execPlanHash common.Hash) *bundle.Executi
 // GetProcessedBundleHistoryHash returns the block number of the last update
 // and the current hash of the processed bundles history.
 func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
+	state := s.processedBundleHistoryEntry()
+	if state == nil {
+		return 0, common.Hash{}
+	}
+	blockNum := binary.BigEndian.Uint64(state[:8])
+	hash := common.BytesToHash(state[8:])
+	return blockNum, hash
+}
+
+// processedBundleHistoryEntry returns the raw value of the entry that stores the
+// block number and hash of the processed bundles history, or nil if it is not
+// set. The returned value is expected to be 40 bytes long, with the first 8
+// bytes representing the block number in big-endian format, and the next 32
+// bytes representing the hash of the processed bundles history.
+func (s *Store) processedBundleHistoryEntry() []byte {
 	state, err := s.table.ProcessedBundles.Get(nil)
 	if err != nil {
 		s.Log.Crit("failed to get hash of processed bundles", "error", err)
 	}
 	if state == nil {
-		return 0, common.Hash{}
+		return nil
 	}
 
 	// size of the value used stored in the processed bundles history:
@@ -245,9 +261,112 @@ func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
 	if len(state) != 8+32 {
 		s.Log.Crit("invalid state length for processed bundles", "length", len(state))
 	}
-	blockNum := binary.BigEndian.Uint64(state[:8])
-	hash := common.BytesToHash(state[8:])
-	return blockNum, hash
+	return state
+}
+
+// SetRawProcessedBundle writes a raw key-value pair to the ProcessedBundles
+// table, if key and value are of valid sizes. The main use case is to import
+// the processed bundles history hash and block number from the genesis file.
+func (s *Store) SetRawProcessedBundle(kv BundleKV) error {
+	// Make sure there is only one update at any time.
+	s.processedBundleMutex.Lock()
+	defer s.processedBundleMutex.Unlock()
+
+	if len(kv.Key) == 0 {
+		// This is the entry for the history hash and block number, which is
+		// expected to have an empty key. We validate the value length and content,
+		// but we don't require the hash to be non-zero since a genesis may start
+		// with no bundles having been processed.
+		if len(kv.Value) != 8+32 {
+			return fmt.Errorf(
+				"invalid value length for bundle history hash (should be 40, got %d)",
+				len(kv.Value),
+			)
+		}
+		blockNum := binary.BigEndian.Uint64(kv.Value[:8])
+		hash := common.BytesToHash(kv.Value[8:])
+		s.Log.Info("Importing processed bundle history hash from genesis",
+			"blockNum", blockNum,
+			"hash", hash)
+		return s.table.ProcessedBundles.Put(nil, kv.Value)
+	}
+
+	// key := e + plan.Hash
+	// value := blockNum + position + count
+	if len(kv.Key) != 1+32 || len(kv.Value) != 16 {
+		return fmt.Errorf(
+			"invalid key or value for processed bundle entry (key length: %d, value length: %d)",
+			len(kv.Key),
+			len(kv.Value),
+		)
+	}
+
+	if kv.Key[0] != 'e' {
+		return fmt.Errorf("invalid key prefix for processed bundle entry: expected 'e', got '%c'", kv.Key[0])
+	}
+
+	var execPlanHash common.Hash
+	copy(execPlanHash[:], kv.Key[1:])
+	if execPlanHash == (common.Hash{}) {
+		return errors.New("invalid execution plan hash in processed bundle entry")
+	}
+
+	batch := s.table.ProcessedBundles.NewBatch()
+
+	// write entry key
+	if err := batch.Put(kv.Key, kv.Value); err != nil {
+		return err
+	}
+	// write index key
+	indexKey := getIndexKey(binary.BigEndian.Uint64(kv.Value[:8]), execPlanHash)
+	if err := batch.Put(indexKey, []byte{0}); err != nil {
+		return err
+	}
+
+	return batch.Write()
+}
+
+// DumpProcessedBundles returns a dump of all the entries in the processed
+// bundles table in bytes. The dump includes both the history entry and the
+// entries for recently processed bundles.
+func (s *Store) DumpProcessedBundles() [][]byte {
+	dump := make([][]byte, 0)
+
+	// get history entry
+	currentHistoryHash := BundleKV{Key: nil, Value: s.processedBundleHistoryEntry()}
+	if currentHistoryHash.Value == nil {
+		return [][]byte{}
+	}
+	dump = append(dump, currentHistoryHash.Encode())
+
+	// get all recently processed bundles
+	it := s.table.ProcessedBundles.NewIterator([]byte{'e'}, nil)
+	for it.Next() {
+		entry := BundleKV{Key: it.Key(), Value: it.Value()}
+		dump = append(dump, entry.Encode())
+	}
+	if it.Error() != nil {
+		s.Log.Crit("failed to dump processed bundles", "error", it.Error())
+	}
+	return dump
+}
+
+// BundleKV represents a key-value pair for a processed bundle entry, used for
+// exporting and importing processed bundles in the genesis file.
+type BundleKV struct {
+	Key   []byte
+	Value []byte
+}
+
+// Encode encodes the BundleKV into a byte slice for storage or export.
+// The format is: [uint32 key length][key][uint32 value length][value]
+func (k *BundleKV) Encode() []byte {
+	data := make([]byte, 0, 8+len(k.Key)+len(k.Value))
+	data = append(data, uint32ToBytes(uint32(len(k.Key)))...)
+	data = append(data, k.Key...)
+	data = append(data, uint32ToBytes(uint32(len(k.Value)))...)
+	data = append(data, k.Value...)
+	return data
 }
 
 // --- utility functions for processed bundles management ---
@@ -271,4 +390,11 @@ func xorHash(a, b common.Hash) common.Hash {
 		res[i] = a[i] ^ b[i]
 	}
 	return res
+}
+
+// uint32ToBytes converts a uint32 to a byte slice in big-endian order.
+func uint32ToBytes(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return b
 }

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -314,17 +314,8 @@ func (s *Store) SetRawProcessedBundle(kv BundleKV) error {
 
 	batch := s.table.ProcessedBundles.NewBatch()
 
-	// write entry key
-	if err := batch.Put(kv.Key, kv.Value); err != nil {
-		return err
-	}
-	// write index key
-	indexKey := getIndexKey(binary.BigEndian.Uint64(kv.Value[:8]), execPlanHash)
-	if err := batch.Put(indexKey, []byte{0}); err != nil {
-		return err
-	}
-
-	return batch.Write()
+		blockNumber := binary.BigEndian.Uint64(value[:8])
+		indexKey := getIndexKey(blockNumber, execPlanHash)
 }
 
 // DumpProcessedBundles returns a dump of all the entries in the processed

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -265,57 +265,107 @@ func (s *Store) processedBundleHistoryEntry() []byte {
 	return state
 }
 
-// SetRawProcessedBundle writes a raw key-value pair to the ProcessedBundles
-// table, if key and value are of valid sizes. The main use case is to import
-// the processed bundles history hash and block number from the genesis file.
-func (s *Store) SetRawProcessedBundle(kv BundleKV) error {
+// SetRawProcessedBundles imports a batch of processed bundle entries from a
+// single byte slice.
+// The format is a repeated sequence of:
+//
+//	[4 bytes key length][key][4 bytes value length][value]
+//
+// This is used for genesis import.
+func (s *Store) SetRawProcessedBundles(data []byte) error {
 	// Make sure there is only one update at any time.
 	s.processedBundleMutex.Lock()
 	defer s.processedBundleMutex.Unlock()
 
-	if len(kv.Key) == 0 {
-		// This is the entry for the history hash and block number, which is
-		// expected to have an empty key. We validate the value length and content,
-		// but we don't require the hash to be non-zero since a genesis may start
-		// with no bundles having been processed.
-		if len(kv.Value) != 8+32 {
+	for offset := 0; offset < len(data); {
+
+		key, value, newOffset, err := decodeEntry(offset, data)
+		if err != nil {
+			return err
+		}
+		offset = newOffset
+
+		if len(key) == 0 {
+			// This is the entry for the history hash and block number, which is
+			// expected to have an empty key. We validate the value length and content,
+			// but we don't require the hash to be non-zero since a genesis may start
+			// with no bundles having been processed.
+			if len(value) != 8+32 {
+				return fmt.Errorf("invalid value length for bundle history hash (should be 40, got %d)", len(value))
+			}
+			blockNum := binary.BigEndian.Uint64(value[:8])
+			hash := common.BytesToHash(value[8:])
+			s.Log.Info("Importing processed bundle history hash from genesis",
+				"blockNum", blockNum,
+				"hash", hash)
+			if err := s.table.ProcessedBundles.Put(nil, value); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// key := e + plan.Hash
+		// value := blockNum + position + count
+		if len(key) != 1+32 || len(value) != 16 {
 			return fmt.Errorf(
-				"invalid value length for bundle history hash (should be 40, got %d)",
-				len(kv.Value),
+				"invalid key or value for processed bundle entry (key length: %d, value length: %d)",
+				len(key),
+				len(value),
 			)
 		}
-		blockNum := binary.BigEndian.Uint64(kv.Value[:8])
-		hash := common.BytesToHash(kv.Value[8:])
-		s.Log.Info("Importing processed bundle history hash from genesis",
-			"blockNum", blockNum,
-			"hash", hash)
-		return s.table.ProcessedBundles.Put(nil, kv.Value)
-	}
 
-	// key := e + plan.Hash
-	// value := blockNum + position + count
-	if len(kv.Key) != 1+32 || len(kv.Value) != 16 {
-		return fmt.Errorf(
-			"invalid key or value for processed bundle entry (key length: %d, value length: %d)",
-			len(kv.Key),
-			len(kv.Value),
-		)
-	}
+		if key[0] != 'e' {
+			return fmt.Errorf("invalid key prefix for processed bundle entry: expected 'e', got '%c'", key[0])
+		}
 
-	if kv.Key[0] != 'e' {
-		return fmt.Errorf("invalid key prefix for processed bundle entry: expected 'e', got '%c'", kv.Key[0])
-	}
+		var execPlanHash common.Hash
+		copy(execPlanHash[:], key[1:])
+		if execPlanHash == (common.Hash{}) {
+			return errors.New("invalid execution plan hash in processed bundle entry")
+		}
 
-	var execPlanHash common.Hash
-	copy(execPlanHash[:], kv.Key[1:])
-	if execPlanHash == (common.Hash{}) {
-		return errors.New("invalid execution plan hash in processed bundle entry")
-	}
+		batch := s.table.ProcessedBundles.NewBatch()
 
-	batch := s.table.ProcessedBundles.NewBatch()
-
+		// write entry key
+		if err := batch.Put(key, value); err != nil {
+			return err
+		}
+		// write index key
 		blockNumber := binary.BigEndian.Uint64(value[:8])
 		indexKey := getIndexKey(blockNumber, execPlanHash)
+		if err := batch.Put(indexKey, []byte{0}); err != nil {
+			return err
+		}
+		if err := batch.Write(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodeEntry(offset int, data []byte) ([]byte, []byte, int, error) {
+	if offset+4 > len(data) {
+		return nil, nil, 0, fmt.Errorf("invalid data: incomplete key length at offset %d", offset)
+	}
+	keyLen := int(binary.BigEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	if offset+keyLen > len(data) {
+		return nil, nil, 0, fmt.Errorf("invalid data: incomplete key at offset %d", offset)
+	}
+	key := data[offset : offset+keyLen]
+	offset += keyLen
+	if offset+4 > len(data) {
+		return nil, nil, 0, fmt.Errorf("invalid data: incomplete value length at offset %d", offset)
+	}
+	valueLen := int(binary.BigEndian.Uint32(data[offset : offset+4]))
+	offset += 4
+	if offset+valueLen > len(data) {
+		return nil, nil, 0, fmt.Errorf("invalid data: incomplete value at offset %d", offset)
+	}
+	value := data[offset : offset+valueLen]
+	offset += valueLen
+	return key, value, offset, nil
 }
 
 // DumpProcessedBundles returns a dump of all the entries in the processed

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -379,11 +379,11 @@ func (s *Store) ExportProcessedBundles() [][]byte {
 	result := make([][]byte, 0)
 
 	// get history entry
-	currentHistoryHash := BundleKV{Key: nil, Value: s.processedBundleHistoryEntry()}
-	if currentHistoryHash.Value == nil {
+	currentHistoryHash := s.processedBundleHistoryEntry()
+	if currentHistoryHash == nil {
 		return [][]byte{}
 	}
-	result = append(result, currentHistoryHash.Encode())
+	result = append(result, Encode(nil, currentHistoryHash))
 
 	// get all recently processed bundles
 	it := s.table.ProcessedBundles.NewIterator([]byte{'e'}, nil)
@@ -397,8 +397,8 @@ func (s *Store) ExportProcessedBundles() [][]byte {
 				"keyLength", len(key),
 				"valueLength", len(value))
 		}
-		entry := BundleKV{Key: key, Value: value}
-		result = append(result, entry.Encode())
+
+		result = append(result, Encode(key, value))
 	}
 	if it.Error() != nil {
 		s.Log.Crit("failed to export processed bundles", "error", it.Error())
@@ -406,23 +406,16 @@ func (s *Store) ExportProcessedBundles() [][]byte {
 	return result
 }
 
-// BundleKV represents a key-value pair for a processed bundle entry, used for
-// exporting and importing processed bundles in the genesis file.
-type BundleKV struct {
-	Key   []byte
-	Value []byte
-}
-
-// Encode encodes the BundleKV into a byte slice for storage or export.
+// Encode encodes a key-value pair into a byte slice for storage or export.
 // The format is: [uint32 key length][key][uint32 value length][value]
-func (k *BundleKV) Encode() []byte {
-	data := make([]byte, 0, 8+len(k.Key)+len(k.Value))
-	keyLen := uint32ToBytes(uint32(len(k.Key)))
+func Encode(key, value []byte) []byte {
+	data := make([]byte, 0, 8+len(key)+len(value))
+	keyLen := uint32ToBytes(uint32(len(key)))
 	data = append(data, keyLen...)
-	data = append(data, k.Key...)
-	valueLen := uint32ToBytes(uint32(len(k.Value)))
+	data = append(data, key...)
+	valueLen := uint32ToBytes(uint32(len(value)))
 	data = append(data, valueLen...)
-	data = append(data, k.Value...)
+	data = append(data, value...)
 	return data
 }
 

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -988,10 +988,12 @@ func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 			hash: position,
 		}
 		store.AddProcessedBundles(uint64(i), executedBundles)
-		expected[hash] = bundle.ExecutionInfo{
-			ExecutionPlanHash: hash,
-			BlockNumber:       uint64(i),
-			Position:          position,
+		if i > 1 {
+			expected[hash] = bundle.ExecutionInfo{
+				ExecutionPlanHash: hash,
+				BlockNumber:       uint64(i),
+				Position:          position,
+			}
 		}
 	}
 	block, historyHash := store.GetProcessedBundleHistoryHash()
@@ -1002,12 +1004,12 @@ func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 	entries := store.EnumerateProcessedBundles()
 	// MaxBlockRange-1 entries (oldest was pruned)
 	require.Len(entries, int(bundle.MaxBlockRange-1))
+	require.Len(entries, len(expected),
+		"expected number of exported entries does not match expected")
 
 	// Verify each returned entry matches the expected info
-	for _, entry := range entries {
-		exp, ok := expected[entry.ExecutionPlanHash]
-		require.True(ok, "unexpected hash %x", entry.ExecutionPlanHash)
-		require.Equal(exp, entry)
+	for _, entry := range expected {
+		require.Contains(entries, entry, "expected entry not found: %+v", entry)
 	}
 }
 
@@ -1027,7 +1029,7 @@ func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) 
 		func() { store.EnumerateProcessedBundles() })
 }
 
-func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t *testing.T) {
+func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorWrongSize(t *testing.T) {
 
 	tests := map[string]struct {
 		key   []byte

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -935,8 +935,6 @@ func TestStore_ProcessedBundles_RetainsAllBundlesRequiredToCoverTheMaximumBlockR
 }
 
 func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidHashLength(t *testing.T) {
-	require := require.New(t)
-
 	tests := map[string]struct {
 		key, value []byte
 		errorMsg   string
@@ -956,10 +954,10 @@ func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidHashLength(t *testing
 			value:    []byte{0, 1, 2},                          // short value
 			errorMsg: "invalid key or value for processed bundle entry",
 		},
-		"empty execution plan": {
+		"zero execution plan": {
 			key:      append([]byte{'e'}, make([]byte, 32)...), // valid length key
 			value:    make([]byte, 16),                         // valid length but empty value
-			errorMsg: "invalid execution plan hash",            // we require the hash to be non-zero to avoid confusion with empty entries, but the error message is the same as for invalid lengths since we check length first
+			errorMsg: "invalid execution plan hash",
 		},
 		"entry does not start with 'e'": {
 			key:      append([]byte{'x'}, make([]byte, 32)...), // valid length but wrong prefix
@@ -970,14 +968,29 @@ func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidHashLength(t *testing
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
 			store, err := NewMemStore(t)
 			require.NoError(err)
 
-			err = store.SetRawProcessedBundle(BundleKV{Key: tc.key, Value: tc.value})
+			// Encode as batch
+			entry := BundleKV{Key: tc.key, Value: tc.value}
+			batch := entry.Encode()
+			err = store.SetRawProcessedBundles(batch)
 			require.Error(err)
 			require.Contains(err.Error(), tc.errorMsg)
 		})
 	}
+}
+
+func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidBatchData(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	invalidData := []byte{0, 1, 2} // not a valid batch encoding
+	err = store.SetRawProcessedBundles(invalidData)
+	require.Error(err)
+	require.Contains(err.Error(), "invalid data")
 }
 
 func TestStore_SetRawProcessedBundle_RecognizesBundleHistoryHash(t *testing.T) {
@@ -992,13 +1005,68 @@ func TestStore_SetRawProcessedBundle_RecognizesBundleHistoryHash(t *testing.T) {
 	binary.BigEndian.PutUint64(value[:8], blockNum)
 	copy(value[8:], hash[:])
 
-	// nil key for history hash
-	err = store.SetRawProcessedBundle(BundleKV{Key: nil, Value: value})
+	entry := BundleKV{Key: nil, Value: value}
+	batch := entry.Encode()
+	err = store.SetRawProcessedBundles(batch)
 	require.NoError(err)
 
 	resBlockNum, resHash := store.GetProcessedBundleHistoryHash()
 	require.Equal(blockNum, resBlockNum)
 	require.Equal(hash, resHash)
+}
+
+func TestStore_SetRawProcessedBundle_ReportsHistoryHashPutErrors(t *testing.T) {
+	store, table, log, _, _ := storeTableLogMocks(t)
+
+	log.EXPECT().Info(gomock.Any(), gomock.Any())
+
+	historyEntry := BundleKV{
+		Key:   nil,
+		Value: append(uint64ToBytes(10), common.Hash{1, 2, 3}.Bytes()...),
+	}
+	data := historyEntry.Encode()
+
+	injectedErr := errors.New("put error")
+	table.EXPECT().Put(nil, historyEntry.Value).Return(injectedErr)
+
+	err := store.SetRawProcessedBundles(data)
+	require.ErrorIs(t, err, injectedErr)
+}
+
+func TestStore_SetRawProcessedBundle_ReportsEntryPutErrors(t *testing.T) {
+	hash := common.Hash{1, 2, 3}
+	entry := BundleKV{
+		Key:   append([]byte{'e'}, hash.Bytes()...),
+		Value: make([]byte, 16),
+	}
+	data := entry.Encode()
+	injectedError := errors.New("put entry error")
+
+	cases := map[string]func(batch *MockstoreBatch){
+		"entry put error": func(batch *MockstoreBatch) {
+			batch.EXPECT().Put(getEntryKey(hash), entry.Value).Return(injectedError)
+		},
+		"index put error": func(batch *MockstoreBatch) {
+			batch.EXPECT().Put(getEntryKey(hash), entry.Value).Return(nil)
+			batch.EXPECT().Put(getIndexKey(uint64(0), hash), []byte{0}).Return(injectedError)
+		},
+		"batch write error": func(batch *MockstoreBatch) {
+			batch.EXPECT().Put(getEntryKey(hash), entry.Value).Return(nil)
+			batch.EXPECT().Put(getIndexKey(uint64(0), hash), []byte{0}).Return(nil)
+			batch.EXPECT().Write().Return(injectedError)
+		},
+	}
+
+	for name, setupMocks := range cases {
+		t.Run(name, func(t *testing.T) {
+			store, table, _, batch, _ := storeTableLogMocks(t)
+			table.EXPECT().NewBatch().Return(batch)
+			setupMocks(batch)
+
+			err := store.SetRawProcessedBundles(data)
+			require.ErrorIs(t, err, injectedError)
+		})
+	}
 }
 
 func TestStore_SetRawProcessedBundle_AddsEntryToStore(t *testing.T) {
@@ -1026,7 +1094,8 @@ func TestStore_SetRawProcessedBundle_AddsEntryToStore(t *testing.T) {
 		Value: data,
 	}
 
-	err = store.SetRawProcessedBundle(entry)
+	batch := entry.Encode()
+	err = store.SetRawProcessedBundles(batch)
 	require.NoError(err)
 
 	resInfo := store.GetBundleExecutionInfo(hash)
@@ -1059,7 +1128,8 @@ func TestStore_SetRawProcessedBundle_AddsIndexEntry(t *testing.T) {
 		Key:   append([]byte{'e'}, hash.Bytes()...),
 		Value: data,
 	}
-	err = store.SetRawProcessedBundle(entry)
+	batch := entry.Encode()
+	err = store.SetRawProcessedBundles(batch)
 	require.NoError(err)
 
 	// check that the index entry was added (the value doesn't matter, just that it exists)
@@ -1069,35 +1139,89 @@ func TestStore_SetRawProcessedBundle_AddsIndexEntry(t *testing.T) {
 	require.True(hasIndexEntry, "expected index entry for processed bundle was not found")
 }
 
-func TestStore_SetRawProcessedBundle_ReturnsErrorForBatchErrors(t *testing.T) {
-	store, table, _, batch, _ := storeTableLogMocks(t)
-
-	bundleEntry := BundleKV{
-		Key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
-		Value: make([]byte, 16),
+func TestStore_DecodeEntry_ReturnsErrorForInvalidData(t *testing.T) {
+	tests := map[string]struct {
+		data     []byte
+		errorMsg string
+	}{
+		"empty data": {
+			data:     []byte{},
+			errorMsg: "incomplete key length",
+		},
+		"incomplete key length": {
+			data:     append(uint32ToBytes(4), []byte{1, 2}...),
+			errorMsg: "incomplete key at",
+		},
+		"incomplete value length": {
+			data:     append(uint32ToBytes(4), uint32ToBytes(5)...),
+			errorMsg: "incomplete value length",
+		},
+		"incomplete value": {
+			data: append(
+				append(uint32ToBytes(4),
+					[]byte{1, 2, 3, 4}...),
+				uint32ToBytes(5)...),
+			errorMsg: "incomplete value at ",
+		},
 	}
 
-	entryError := errors.New("batch put error entry")
-	entryKey := getEntryKey(common.BytesToHash(bundleEntry.Key[1:]))
-	batch.EXPECT().Put(entryKey, bundleEntry.Value).Return(entryError)
-	table.EXPECT().NewBatch().Return(batch)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			key, value, bytesRead, err := decodeEntry(0, tc.data)
+			require.Error(err)
+			require.Contains(err.Error(), tc.errorMsg)
+			require.Nil(key)
+			require.Nil(value)
+			require.Zero(bytesRead)
+		})
+	}
+}
 
-	err := store.SetRawProcessedBundle(bundleEntry)
-	require.ErrorIs(t, err, entryError)
+func TestStore_DecodeEntry_ReturnsKeyAndValue(t *testing.T) {
 
-	indexKey := getIndexKey(
-		binary.BigEndian.Uint64(bundleEntry.Value[:8]),
-		common.BytesToHash(bundleEntry.Key[1:]))
-	indexError := errors.New("batch put error index")
-	batch.EXPECT().Put(entryKey, gomock.Any()).Return(nil)
-	batch.EXPECT().Put(indexKey, gomock.Any()).Return(indexError)
-	table.EXPECT().NewBatch().Return(batch)
+	bundleHistoryValue := append(uint64ToBytes(10), common.Hash{1, 2, 3}.Bytes()...)
+	bundleHistoryEntry := BundleKV{
+		Key:   nil,
+		Value: bundleHistoryValue,
+	}
+	entryValue := append(
+		append(
+			uint64ToBytes(20),
+			uint32ToBytes(1)...),
+		uint32ToBytes(2)...)
+	entryData := BundleKV{
+		Key:   append([]byte{'e'}, common.Hash{4, 5, 6}.Bytes()...),
+		Value: entryValue,
+	}
 
-	err = store.SetRawProcessedBundle(BundleKV{
-		Key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
-		Value: make([]byte, 16),
-	})
-	require.ErrorIs(t, err, indexError)
+	tests := map[string]struct {
+		data          []byte
+		expectedKey   []byte
+		expectedValue []byte
+	}{
+		"bundle history hash": {
+			data:          bundleHistoryEntry.Encode(),
+			expectedKey:   []byte{},
+			expectedValue: bundleHistoryValue,
+		},
+		"bundle entry": {
+			data:          entryData.Encode(),
+			expectedKey:   append([]byte{'e'}, common.Hash{4, 5, 6}.Bytes()...),
+			expectedValue: entryValue,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			key, value, bytesRead, err := decodeEntry(0, tc.data)
+			require.NoError(err)
+			require.Equal(tc.expectedKey, key)
+			require.Equal(tc.expectedValue, value)
+			require.Equal(len(tc.data), bytesRead)
+		})
+	}
 }
 
 func TestStore_DumpProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -1069,6 +1069,37 @@ func TestStore_SetRawProcessedBundle_AddsIndexEntry(t *testing.T) {
 	require.True(hasIndexEntry, "expected index entry for processed bundle was not found")
 }
 
+func TestStore_SetRawProcessedBundle_ReturnsErrorForBatchErrors(t *testing.T) {
+	store, table, _, batch, _ := storeTableLogMocks(t)
+
+	bundleEntry := BundleKV{
+		Key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
+		Value: make([]byte, 16),
+	}
+
+	entryError := errors.New("batch put error entry")
+	entryKey := getEntryKey(common.BytesToHash(bundleEntry.Key[1:]))
+	batch.EXPECT().Put(entryKey, bundleEntry.Value).Return(entryError)
+	table.EXPECT().NewBatch().Return(batch)
+
+	err := store.SetRawProcessedBundle(bundleEntry)
+	require.ErrorIs(t, err, entryError)
+
+	indexKey := getIndexKey(
+		binary.BigEndian.Uint64(bundleEntry.Value[:8]),
+		common.BytesToHash(bundleEntry.Key[1:]))
+	indexError := errors.New("batch put error index")
+	batch.EXPECT().Put(entryKey, gomock.Any()).Return(nil)
+	batch.EXPECT().Put(indexKey, gomock.Any()).Return(indexError)
+	table.EXPECT().NewBatch().Return(batch)
+
+	err = store.SetRawProcessedBundle(BundleKV{
+		Key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
+		Value: make([]byte, 16),
+	})
+	require.ErrorIs(t, err, indexError)
+}
+
 func TestStore_DumpProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -157,9 +157,8 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 		bundle.MaxBlockRange + 1,
 	} {
 		t.Run(fmt.Sprintf("BlockNumber=%d", block), func(t *testing.T) {
-			store, table, _, _, _ := storeTableLogMocks(t)
+			store, table, _, batch, it := storeTableLogMocks(t)
 
-			batch := NewMockstoreBatch(gomock.NewController(t))
 			table.EXPECT().NewBatch().Return(batch)
 			table.EXPECT().Get(gomock.Any())
 
@@ -182,7 +181,6 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 			if block >= bundle.MaxBlockRange-1 {
 				toDelete := block - bundle.MaxBlockRange + 1
 
-				it := NewMockdbIterator(gomock.NewController(t))
 				table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
 				next := it.EXPECT().Next().Return(true)
 				it.EXPECT().Next().Return(false).After(next).AnyTimes()
@@ -507,6 +505,7 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 			batch := NewMockstoreBatch(ctrl)
 			table := NewMockstoreTable(ctrl)
 			it := NewMockdbIterator(ctrl)
+			it.EXPECT().Release().AnyTimes()
 			store := &Store{}
 			store.table.ProcessedBundles = table
 
@@ -550,6 +549,7 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 	store.table.ProcessedBundles = table
 
 	it := NewMockdbIterator(ctrl)
+	it.EXPECT().Release().AnyTimes()
 	table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
 
 	for i := range 10 {
@@ -1253,6 +1253,7 @@ func storeTableLogMocks(t *testing.T) (
 
 	batch := NewMockstoreBatch(ctrl)
 	it := NewMockdbIterator(ctrl)
+	it.EXPECT().Release().AnyTimes()
 
 	return store, table, log, batch, it
 }

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -1192,7 +1192,7 @@ func TestStore_DumpProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
 	require.Contains(dumpedEntries, expectedEntry.Encode())
 }
 
-func TestStore_DumpProcessedBundles_LogsOnCrit(t *testing.T) {
+func TestStore_DumpProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
 	store, table, log, _, it := storeTableLogMocks(t)
 
 	injectedErr := errors.New("iterator error")
@@ -1207,6 +1207,49 @@ func TestStore_DumpProcessedBundles_LogsOnCrit(t *testing.T) {
 	require.PanicsWithValue(t,
 		fmt.Sprintf("failed to dump processed bundles: %v", []any{"error", injectedErr}),
 		func() { store.DumpProcessedBundles() })
+}
+
+func TestStore_DumpProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t *testing.T) {
+
+	tests := map[string]struct {
+		key   []byte
+		value []byte
+	}{
+		"short key": {
+			key:   []byte{1, 2}, // should be 33 bytes for 'e' + hash
+			value: make([]byte, 16),
+		},
+		"short value": {
+			key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
+			value: make([]byte, 15), // should be 16 bytes
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store, table, log, _, it := storeTableLogMocks(t)
+
+			gomock.InOrder(
+				table.EXPECT().Get(nil).Return(make([]byte, 40), nil),
+				table.EXPECT().NewIterator([]byte{'e'}, nil).Return(it),
+				it.EXPECT().Next().Return(true),
+				it.EXPECT().Key().Return(tc.key),
+				it.EXPECT().Value().Return(tc.value),
+			)
+			expectCrit(
+				log,
+				"invalid key or value length for processed bundle entry during dump",
+				"keyLength", len(tc.key),
+				"valueLength", len(tc.value))
+
+			require.PanicsWithValue(t,
+				fmt.Sprintf("invalid key or value length for processed bundle entry during dump: %v",
+					[]any{"keyLength", fmt.Sprintf("%d", len(tc.key)),
+						"valueLength", fmt.Sprintf("%d", len(tc.value))}),
+				func() { store.DumpProcessedBundles() })
+
+		})
+	}
 }
 
 func TestStore_BundleKV_Encode_FollowsExpectedFormat(t *testing.T) {

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -252,7 +252,7 @@ func TestStore_GetProcessedBundleHistoryHash_CorrectlyParsesHash(t *testing.T) {
 		hash := crypto.Keccak256Hash([]byte(fmt.Sprintf("hash for block %d", block)))
 
 		encoded := append(
-			binary.BigEndian.AppendUint64(nil, block),
+			uint64ToBytes(block),
 			hash.Bytes()...,
 		)
 

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/logger"
+	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -252,7 +253,7 @@ func TestStore_GetProcessedBundleHistoryHash_CorrectlyParsesHash(t *testing.T) {
 		hash := crypto.Keccak256Hash([]byte(fmt.Sprintf("hash for block %d", block)))
 
 		encoded := append(
-			uint64ToBytes(block),
+			bigendian.Uint64ToBytes(block),
 			hash.Bytes()...,
 		)
 
@@ -933,375 +934,88 @@ func TestStore_ProcessedBundles_RetainsAllBundlesRequiredToCoverTheMaximumBlockR
 		})
 	}
 }
-
-func TestStore_ImportProcessedBundles_ReturnsErrorForInvalidHashLength(t *testing.T) {
-	tests := map[string]struct {
-		key, value []byte
-		errorMsg   string
-	}{
-		"history hash invalid value": {
-			key:      nil,
-			value:    []byte{0, 1, 2}, // should be 40 bytes for blockNum + hash
-			errorMsg: "invalid value length for bundle history hash",
-		},
-		"entry invalid key length": {
-			key:      []byte{0, 1, 2},  // should be 33 bytes for 'e' + hash
-			value:    make([]byte, 16), // correct length for value
-			errorMsg: "invalid key or value for processed bundle entry",
-		},
-		"entry invalid value length": {
-			key:      append([]byte{'e'}, make([]byte, 32)...), // valid length key
-			value:    []byte{0, 1, 2},                          // short value
-			errorMsg: "invalid key or value for processed bundle entry",
-		},
-		"zero execution plan": {
-			key:      append([]byte{'e'}, make([]byte, 32)...), // valid length key
-			value:    make([]byte, 16),                         // valid length but empty value
-			errorMsg: "invalid execution plan hash",
-		},
-		"entry does not start with 'e'": {
-			key:      append([]byte{'x'}, make([]byte, 32)...), // valid length but wrong prefix
-			value:    make([]byte, 16),                         // correct length for value
-			errorMsg: "invalid key prefix for processed bundle entry: expected 'e'",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
-			store, err := NewMemStore(t)
-			require.NoError(err)
-
-			// Encode as batch
-			batch := Encode(tc.key, tc.value)
-			err = store.ImportProcessedBundles(batch)
-			require.Error(err)
-			require.Contains(err.Error(), tc.errorMsg)
-		})
-	}
-}
-
-func TestStore_ImportProcessedBundles_ReturnsErrorForInvalidBatchData(t *testing.T) {
-	require := require.New(t)
-	store, err := NewMemStore(t)
-	require.NoError(err)
-
-	invalidData := []byte{0, 1, 2} // not a valid batch encoding
-	err = store.ImportProcessedBundles(invalidData)
-	require.Error(err)
-	require.Contains(err.Error(), "invalid data")
-}
-
-func TestStore_ImportProcessedBundles_RecognizesBundleHistoryHash(t *testing.T) {
+func TestStore_SetProcessedBundlesHistoryHash_WritesBundlesHistoryHash(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
 	blockNum := uint64(10)
 	hash := common.Hash{1, 2, 3}
-	// build the value for the history hash entry
-	value := make([]byte, 8+32)
-	binary.BigEndian.PutUint64(value[:8], blockNum)
-	copy(value[8:], hash[:])
 
-	batch := Encode(nil, value)
-	err = store.ImportProcessedBundles(batch)
-	require.NoError(err)
+	store.SetProcessedBundlesHistoryHash(blockNum, hash)
 
 	resBlockNum, resHash := store.GetProcessedBundleHistoryHash()
 	require.Equal(blockNum, resBlockNum)
 	require.Equal(hash, resHash)
 }
 
-func TestStore_ImportProcessedBundles_ReportsHistoryHashPutErrors(t *testing.T) {
+func TestStore_SetProcessedBundlesHistoryHash_LogsOnPutError(t *testing.T) {
 	store, table, log, _, _ := storeTableLogMocks(t)
 
-	log.EXPECT().Info(gomock.Any(), gomock.Any())
-
-	historyEntry := append(uint64ToBytes(10), common.Hash{1, 2, 3}.Bytes()...)
-	data := Encode(nil, historyEntry)
-
 	injectedErr := errors.New("put error")
-	table.EXPECT().Put(nil, historyEntry).Return(injectedErr)
+	table.EXPECT().Put(gomock.Any(), gomock.Any()).Return(injectedErr)
 
-	err := store.ImportProcessedBundles(data)
-	require.ErrorIs(t, err, injectedErr)
+	expectCrit(log, "failed to set hash of processed bundles", "error", injectedErr)
+	// In production, a Crit log call causes the logger to exit the process.
+	// To prevent the test from exiting, the mock logger is configured to panic instead.
+	require.PanicsWithValue(t,
+		fmt.Sprintf("failed to set hash of processed bundles: %v", []any{"error", injectedErr}),
+		func() { store.SetProcessedBundlesHistoryHash(1, common.Hash{1, 2, 3}) })
 }
 
-func TestStore_ImportProcessedBundles_ReportsEntryPutErrors(t *testing.T) {
-	hash := common.Hash{1, 2, 3}
-	key := append([]byte{'e'}, hash.Bytes()...)
-	value := make([]byte, 16)
-	data := Encode(key, value)
-	injectedError := errors.New("put entry error")
-
-	cases := map[string]func(batch *MockstoreBatch){
-		"entry put error": func(batch *MockstoreBatch) {
-			batch.EXPECT().Put(getEntryKey(hash), value).Return(injectedError)
-		},
-		"index put error": func(batch *MockstoreBatch) {
-			batch.EXPECT().Put(getEntryKey(hash), value).Return(nil)
-			batch.EXPECT().Put(getIndexKey(uint64(0), hash), []byte{0}).Return(injectedError)
-		},
-		"batch write error": func(batch *MockstoreBatch) {
-			batch.EXPECT().Put(getEntryKey(hash), value).Return(nil)
-			batch.EXPECT().Put(getIndexKey(uint64(0), hash), []byte{0}).Return(nil)
-			batch.EXPECT().Write().Return(injectedError)
-		},
-	}
-
-	for name, setupMocks := range cases {
-		t.Run(name, func(t *testing.T) {
-			store, table, _, batch, _ := storeTableLogMocks(t)
-			table.EXPECT().NewBatch().Return(batch)
-			setupMocks(batch)
-
-			err := store.ImportProcessedBundles(data)
-			require.ErrorIs(t, err, injectedError)
-		})
-	}
-}
-
-func TestStore_ImportProcessedBundles_AddsEntryToStore(t *testing.T) {
+func TestStore_EnumerateProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
-	// build execution info
-	hash := common.Hash{1, 2, 3}
-	blockNum := uint64(10)
-	info := bundle.ExecutionInfo{
-		ExecutionPlanHash: hash,
-		BlockNumber:       blockNum,
-		Position:          bundle.PositionInBlock{Offset: 0, Count: 1},
-	}
-
-	// encode entry value.
-	data := make([]byte, 16)
-	binary.BigEndian.PutUint64(data[:8], info.BlockNumber)
-	binary.BigEndian.PutUint32(data[8:12], info.Position.Offset)
-	binary.BigEndian.PutUint32(data[12:], info.Position.Count)
-
-	key := append([]byte{'e'}, hash.Bytes()...)
-	value := data
-
-	batch := Encode(key, value)
-	err = store.ImportProcessedBundles(batch)
-	require.NoError(err)
-
-	resInfo := store.GetBundleExecutionInfo(hash)
-	require.NotNil(resInfo)
-	require.Equal(info.ExecutionPlanHash, resInfo.ExecutionPlanHash)
-	require.Equal(info.BlockNumber, resInfo.BlockNumber)
-	require.Equal(info.Position, resInfo.Position)
-}
-
-func TestStore_ImportProcessedBundles_AddsIndexEntry(t *testing.T) {
-	require := require.New(t)
-	store, err := NewMemStore(t)
-	require.NoError(err)
-
-	hash := common.Hash{1, 2, 3}
-	blockNum := uint64(10)
-	info := bundle.ExecutionInfo{
-		ExecutionPlanHash: hash,
-		BlockNumber:       blockNum,
-		Position:          bundle.PositionInBlock{Offset: 0, Count: 1},
-	}
-
-	// encode entry value.
-	data := make([]byte, 16)
-	binary.BigEndian.PutUint64(data[:8], info.BlockNumber)
-	binary.BigEndian.PutUint32(data[8:12], info.Position.Offset)
-	binary.BigEndian.PutUint32(data[12:], info.Position.Count)
-
-	key := append([]byte{'e'}, hash.Bytes()...)
-	value := data
-	batch := Encode(key, value)
-	err = store.ImportProcessedBundles(batch)
-	require.NoError(err)
-
-	// check that the index entry was added (the value doesn't matter, just that it exists)
-	indexKey := getIndexKey(blockNum, hash)
-	hasIndexEntry, err := store.table.ProcessedBundles.Has(indexKey)
-	require.NoError(err)
-	require.True(hasIndexEntry, "expected index entry for processed bundle was not found")
-}
-
-func TestStore_DecodeEntry_ReturnsErrorForInvalidData(t *testing.T) {
-	tests := map[string]struct {
-		data     []byte
-		errorMsg string
-	}{
-		"empty data": {
-			data:     []byte{},
-			errorMsg: "incomplete key length",
-		},
-		"incomplete key length": {
-			data:     append(uint32ToBytes(4), []byte{1, 2}...),
-			errorMsg: "incomplete key at",
-		},
-		"incomplete value length": {
-			data:     append(uint32ToBytes(4), uint32ToBytes(5)...),
-			errorMsg: "incomplete value length",
-		},
-		"incomplete value": {
-			data: append(
-				append(uint32ToBytes(4),
-					[]byte{1, 2, 3, 4}...),
-				uint32ToBytes(5)...),
-			errorMsg: "incomplete value at ",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
-			key, value, bytesRead, err := decodeEntry(0, tc.data)
-			require.Error(err)
-			require.Contains(err.Error(), tc.errorMsg)
-			require.Nil(key)
-			require.Nil(value)
-			require.Zero(bytesRead)
-		})
-	}
-}
-
-func TestStore_DecodeEntry_ReturnsKeyAndValue(t *testing.T) {
-
-	bundleHistoryValue := append(uint64ToBytes(10), common.Hash{1, 2, 3}.Bytes()...)
-	entryValue := append(
-		append(
-			uint64ToBytes(20),
-			uint32ToBytes(1)...),
-		uint32ToBytes(2)...)
-	key := append([]byte{'e'}, common.Hash{4, 5, 6}.Bytes()...)
-
-	tests := map[string]struct {
-		data          []byte
-		expectedKey   []byte
-		expectedValue []byte
-	}{
-		"bundle history hash": {
-			data:          Encode(nil, bundleHistoryValue),
-			expectedKey:   []byte{},
-			expectedValue: bundleHistoryValue,
-		},
-		"bundle entry": {
-			data:          Encode(key, entryValue),
-			expectedKey:   append([]byte{'e'}, common.Hash{4, 5, 6}.Bytes()...),
-			expectedValue: entryValue,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
-			key, value, bytesRead, err := decodeEntry(0, tc.data)
-			require.NoError(err)
-			require.Equal(tc.expectedKey, key)
-			require.Equal(tc.expectedValue, value)
-			require.Equal(len(tc.data), bytesRead)
-		})
-	}
-}
-
-func TestStore_ExportProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {
-	require := require.New(t)
-	store, err := NewMemStore(t)
-	require.NoError(err)
-
-	exportedEntries := store.ExportProcessedBundles()
+	exportedEntries := store.EnumerateProcessedBundles()
 	require.NotNil(exportedEntries)
 	require.Empty(exportedEntries, "expected no exported entries when store is empty")
 }
 
-func TestStore_ExportProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
+func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
+	expected := map[common.Hash]bundle.ExecutionInfo{}
 	// fill the store with the maximum number of bundles
 	for i := range bundle.MaxBlockRange + 1 {
-		hash := uint32ToBytes(uint32(i))
+		hash := common.BytesToHash(bigendian.Uint32ToBytes(uint32(i)))
+		position := bundle.PositionInBlock{Offset: uint32(i), Count: 1}
 		executedBundles := map[common.Hash]bundle.PositionInBlock{
-			common.BytesToHash(hash): {Offset: 0, Count: 1},
+			hash: position,
 		}
 		store.AddProcessedBundles(uint64(i), executedBundles)
+		expected[hash] = bundle.ExecutionInfo{
+			ExecutionPlanHash: hash,
+			BlockNumber:       uint64(i),
+			Position:          position,
+		}
 	}
 	block, historyHash := store.GetProcessedBundleHistoryHash()
 	require.Equal(uint64(bundle.MaxBlockRange), block)
 	require.NotNil(historyHash)
 	require.NotZero(historyHash)
 
-	// blockNum (8 bytes) + hash (32 bytes)
-	bundleHistoryHashSize := 8 + 32
-	// key size: 'e' prefix + hash
-	// value size: blockNum (8 bytes) + position (4 bytes) + count (4 bytes)
-	entrySize := 1 + 32 + 16
+	entries := store.EnumerateProcessedBundles()
+	// MaxBlockRange-1 entries (oldest was pruned)
+	require.Len(entries, int(bundle.MaxBlockRange-1))
 
-	expectedSize :=
-		bundleHistoryHashSize +
-			int(bundle.MaxBlockRange-1)*entrySize +
-			8*int(bundle.MaxBlockRange) // key/value size per entry.
-
-	entries := store.ExportProcessedBundles()
-	// 1 history hash + MaxBlockRange-1 entries
-	require.Len(entries, int(bundle.MaxBlockRange),
-		fmt.Sprintf("expected %d exported entries, got %d",
-			bundle.MaxBlockRange, len(entries)))
-
-	actualSize := 0
+	// Verify each returned entry matches the expected info
 	for _, entry := range entries {
-		actualSize += len(entry)
+		exp, ok := expected[entry.ExecutionPlanHash]
+		require.True(ok, "unexpected hash %x", entry.ExecutionPlanHash)
+		require.Equal(exp, entry)
 	}
-
-	require.Equal(expectedSize, actualSize,
-		fmt.Sprintf("expected %d exported entries, got %d",
-			expectedSize, actualSize))
 }
 
-func TestStore_ExportProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
-	require := require.New(t)
-	store, err := NewMemStore(t)
-	require.NoError(err)
-
-	// make an execution info
-	hash := common.Hash{1, 2, 3}
-	blockNum := uint64(10)
-	info := bundle.ExecutionInfo{
-		ExecutionPlanHash: hash,
-		BlockNumber:       blockNum,
-		Position:          bundle.PositionInBlock{Offset: 0, Count: 1},
-	}
-	executedBundles := map[common.Hash]bundle.PositionInBlock{
-		hash: {Offset: info.Position.Offset, Count: info.Position.Count},
-	}
-
-	// add execution info to store.
-	store.AddProcessedBundles(blockNum, executedBundles)
-
-	// get the exported entries
-	exportedEntries := store.ExportProcessedBundles()
-	require.Len(exportedEntries, 2) // history hash + 1 entry
-
-	// check that the exported entry matches the expected encoding of the added entry
-	key := append([]byte{'e'}, hash.Bytes()...)
-	value := make([]byte, 16)
-	binary.BigEndian.PutUint64(value[:8], info.BlockNumber)
-	binary.BigEndian.PutUint32(value[8:12], info.Position.Offset)
-	binary.BigEndian.PutUint32(value[12:], info.Position.Count)
-
-	require.Contains(exportedEntries, Encode(key, value))
-}
-
-func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
+func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
 	store, table, log, _, it := storeTableLogMocks(t)
 
 	injectedErr := errors.New("iterator error")
 	gomock.InOrder(
-		table.EXPECT().Get(nil).Return(make([]byte, 40), nil),
 		table.EXPECT().NewIterator([]byte{'e'}, nil).Return(it),
 		it.EXPECT().Next().Return(false),
 		it.EXPECT().Error().Return(injectedErr).AnyTimes(),
@@ -1310,10 +1024,10 @@ func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
 
 	require.PanicsWithValue(t,
 		fmt.Sprintf("failed to export processed bundles: %v", []any{"error", injectedErr}),
-		func() { store.ExportProcessedBundles() })
+		func() { store.EnumerateProcessedBundles() })
 }
 
-func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t *testing.T) {
+func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t *testing.T) {
 
 	tests := map[string]struct {
 		key   []byte
@@ -1334,7 +1048,6 @@ func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t
 			store, table, log, _, it := storeTableLogMocks(t)
 
 			gomock.InOrder(
-				table.EXPECT().Get(nil).Return(make([]byte, 40), nil),
 				table.EXPECT().NewIterator([]byte{'e'}, nil).Return(it),
 				it.EXPECT().Next().Return(true),
 				it.EXPECT().Key().Return(tc.key),
@@ -1350,45 +1063,8 @@ func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t
 				fmt.Sprintf("invalid key or value length for processed bundle entry during export: %v",
 					[]any{"keyLength", fmt.Sprintf("%d", len(tc.key)),
 						"valueLength", fmt.Sprintf("%d", len(tc.value))}),
-				func() { store.ExportProcessedBundles() })
+				func() { store.EnumerateProcessedBundles() })
 
-		})
-	}
-}
-
-func TestStore_Encode_FollowsExpectedFormat(t *testing.T) {
-	tests := map[string]struct {
-		key   []byte
-		value []byte
-	}{
-		"entry key": {
-			key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
-			value: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-		},
-		"nil key (history hash)": {
-			key:   []byte{},
-			value: []byte{1: 40},
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			encoded := Encode(tc.key, tc.value)
-
-			// expected total: 4 (key len) + key + 4 (value len) + value
-			expectedLen := 4 + len(tc.key) + 4 + len(tc.value)
-			require.Len(t, encoded, expectedLen)
-
-			// verify lengths are big-endian encoded at the right offsets
-			gotKeyLen := binary.BigEndian.Uint32(encoded[0:4])
-			require.Equal(t, uint32(len(tc.key)), gotKeyLen)
-
-			gotValLen := binary.BigEndian.Uint32(encoded[4+len(tc.key) : 4+len(tc.key)+4])
-			require.Equal(t, uint32(len(tc.value)), gotValLen)
-
-			// verify key and value payloads
-			require.Equal(t, tc.key, encoded[4:4+len(tc.key)])
-			require.Equal(t, tc.value, encoded[4+len(tc.key)+4:])
 		})
 	}
 }

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -934,6 +934,288 @@ func TestStore_ProcessedBundles_RetainsAllBundlesRequiredToCoverTheMaximumBlockR
 	}
 }
 
+func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidHashLength(t *testing.T) {
+	require := require.New(t)
+
+	tests := map[string]struct {
+		key, value []byte
+		errorMsg   string
+	}{
+		"history hash invalid value": {
+			key:      nil,
+			value:    []byte{0, 1, 2}, // should be 40 bytes for blockNum + hash
+			errorMsg: "invalid value length for bundle history hash",
+		},
+		"entry invalid key length": {
+			key:      []byte{0, 1, 2},  // should be 33 bytes for 'e' + hash
+			value:    make([]byte, 16), // correct length for value
+			errorMsg: "invalid key or value for processed bundle entry",
+		},
+		"entry invalid value length": {
+			key:      append([]byte{'e'}, make([]byte, 32)...), // valid length key
+			value:    []byte{0, 1, 2},                          // short value
+			errorMsg: "invalid key or value for processed bundle entry",
+		},
+		"empty execution plan": {
+			key:      append([]byte{'e'}, make([]byte, 32)...), // valid length key
+			value:    make([]byte, 16),                         // valid length but empty value
+			errorMsg: "invalid execution plan hash",            // we require the hash to be non-zero to avoid confusion with empty entries, but the error message is the same as for invalid lengths since we check length first
+		},
+		"entry does not start with 'e'": {
+			key:      append([]byte{'x'}, make([]byte, 32)...), // valid length but wrong prefix
+			value:    make([]byte, 16),                         // correct length for value
+			errorMsg: "invalid key prefix for processed bundle entry: expected 'e'",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store, err := NewMemStore(t)
+			require.NoError(err)
+
+			err = store.SetRawProcessedBundle(BundleKV{Key: tc.key, Value: tc.value})
+			require.Error(err)
+			require.Contains(err.Error(), tc.errorMsg)
+		})
+	}
+}
+
+func TestStore_SetRawProcessedBundle_RecognizesBundleHistoryHash(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	blockNum := uint64(10)
+	hash := common.Hash{1, 2, 3}
+	// build the value for the history hash entry
+	value := make([]byte, 8+32)
+	binary.BigEndian.PutUint64(value[:8], blockNum)
+	copy(value[8:], hash[:])
+
+	// nil key for history hash
+	err = store.SetRawProcessedBundle(BundleKV{Key: nil, Value: value})
+	require.NoError(err)
+
+	resBlockNum, resHash := store.GetProcessedBundleHistoryHash()
+	require.Equal(blockNum, resBlockNum)
+	require.Equal(hash, resHash)
+}
+
+func TestStore_SetRawProcessedBundle_AddsEntryToStore(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// build execution info
+	hash := common.Hash{1, 2, 3}
+	blockNum := uint64(10)
+	info := bundle.ExecutionInfo{
+		ExecutionPlanHash: hash,
+		BlockNumber:       blockNum,
+		Position:          bundle.PositionInBlock{Offset: 0, Count: 1},
+	}
+
+	// encode entry value.
+	data := make([]byte, 16)
+	binary.BigEndian.PutUint64(data[:8], info.BlockNumber)
+	binary.BigEndian.PutUint32(data[8:12], info.Position.Offset)
+	binary.BigEndian.PutUint32(data[12:], info.Position.Count)
+
+	entry := BundleKV{
+		Key:   append([]byte{'e'}, hash.Bytes()...),
+		Value: data,
+	}
+
+	err = store.SetRawProcessedBundle(entry)
+	require.NoError(err)
+
+	resInfo := store.GetBundleExecutionInfo(hash)
+	require.NotNil(resInfo)
+	require.Equal(info.ExecutionPlanHash, resInfo.ExecutionPlanHash)
+	require.Equal(info.BlockNumber, resInfo.BlockNumber)
+	require.Equal(info.Position, resInfo.Position)
+}
+
+func TestStore_SetRawProcessedBundle_AddsIndexEntry(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	hash := common.Hash{1, 2, 3}
+	blockNum := uint64(10)
+	info := bundle.ExecutionInfo{
+		ExecutionPlanHash: hash,
+		BlockNumber:       blockNum,
+		Position:          bundle.PositionInBlock{Offset: 0, Count: 1},
+	}
+
+	// encode entry value.
+	data := make([]byte, 16)
+	binary.BigEndian.PutUint64(data[:8], info.BlockNumber)
+	binary.BigEndian.PutUint32(data[8:12], info.Position.Offset)
+	binary.BigEndian.PutUint32(data[12:], info.Position.Count)
+
+	entry := BundleKV{
+		Key:   append([]byte{'e'}, hash.Bytes()...),
+		Value: data,
+	}
+	err = store.SetRawProcessedBundle(entry)
+	require.NoError(err)
+
+	// check that the index entry was added (the value doesn't matter, just that it exists)
+	indexKey := getIndexKey(blockNum, hash)
+	hasIndexEntry, err := store.table.ProcessedBundles.Has(indexKey)
+	require.NoError(err)
+	require.True(hasIndexEntry, "expected index entry for processed bundle was not found")
+}
+
+func TestStore_DumpProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	dumpedEntries := store.DumpProcessedBundles()
+	require.NotNil(dumpedEntries)
+	require.Empty(dumpedEntries, "expected no dumped entries when store is empty")
+}
+
+func TestStore_DumpProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
+
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// fill the store with the maximum number of bundles
+	for i := range bundle.MaxBlockRange + 1 {
+		hash := uint32ToBytes(uint32(i))
+		executedBundles := map[common.Hash]bundle.PositionInBlock{
+			common.BytesToHash(hash): {Offset: 0, Count: 1},
+		}
+		store.AddProcessedBundles(uint64(i), executedBundles)
+	}
+	block, historyHash := store.GetProcessedBundleHistoryHash()
+	require.Equal(uint64(bundle.MaxBlockRange), block)
+	require.NotNil(historyHash)
+	require.NotZero(historyHash)
+
+	// blockNum (8 bytes) + hash (32 bytes)
+	bundleHistoryHashSize := 8 + 32
+	// key size: 'e' prefix + hash
+	// value size: blockNum (8 bytes) + position (4 bytes) + count (4 bytes)
+	entrySize := 1 + 32 + 16
+
+	expectedSize :=
+		bundleHistoryHashSize +
+			int(bundle.MaxBlockRange-1)*entrySize +
+			8*int(bundle.MaxBlockRange) // key/value size per entry.
+
+	dumpedEntries := store.DumpProcessedBundles()
+	// 1 history hash + MaxBlockRange-1 entries
+	require.Len(dumpedEntries, int(bundle.MaxBlockRange),
+		fmt.Sprintf("expected %d dumped entries, got %d",
+			bundle.MaxBlockRange, len(dumpedEntries)))
+
+	actualSize := 0
+	for _, entry := range dumpedEntries {
+		actualSize += len(entry)
+	}
+
+	require.Equal(expectedSize, actualSize,
+		fmt.Sprintf("expected %d dumped entries, got %d",
+			expectedSize, actualSize))
+}
+
+func TestStore_DumpProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// make an execution info
+	hash := common.Hash{1, 2, 3}
+	blockNum := uint64(10)
+	info := bundle.ExecutionInfo{
+		ExecutionPlanHash: hash,
+		BlockNumber:       blockNum,
+		Position:          bundle.PositionInBlock{Offset: 0, Count: 1},
+	}
+	executedBundles := map[common.Hash]bundle.PositionInBlock{
+		hash: {Offset: info.Position.Offset, Count: info.Position.Count},
+	}
+
+	// add execution info to store.
+	store.AddProcessedBundles(blockNum, executedBundles)
+
+	// get the dumped entries
+	dumpedEntries := store.DumpProcessedBundles()
+	require.Len(dumpedEntries, 2) // history hash + 1 entry
+
+	// check that the dumped entry matches the expected encoding of the added entry
+	expectedEntry := BundleKV{
+		Key:   append([]byte{'e'}, hash.Bytes()...),
+		Value: make([]byte, 16),
+	}
+	binary.BigEndian.PutUint64(expectedEntry.Value[:8], info.BlockNumber)
+	binary.BigEndian.PutUint32(expectedEntry.Value[8:12], info.Position.Offset)
+	binary.BigEndian.PutUint32(expectedEntry.Value[12:], info.Position.Count)
+
+	require.Contains(dumpedEntries, expectedEntry.Encode())
+}
+
+func TestStore_DumpProcessedBundles_LogsOnCrit(t *testing.T) {
+	store, table, log, _, it := storeTableLogMocks(t)
+
+	injectedErr := errors.New("iterator error")
+	gomock.InOrder(
+		table.EXPECT().Get(nil).Return(make([]byte, 40), nil),
+		table.EXPECT().NewIterator([]byte{'e'}, nil).Return(it),
+		it.EXPECT().Next().Return(false),
+		it.EXPECT().Error().Return(injectedErr).AnyTimes(),
+	)
+	expectCrit(log, "failed to dump processed bundles", "error", injectedErr)
+
+	require.PanicsWithValue(t,
+		fmt.Sprintf("failed to dump processed bundles: %v", []any{"error", injectedErr}),
+		func() { store.DumpProcessedBundles() })
+}
+
+func TestStore_BundleKV_Encode_FollowsExpectedFormat(t *testing.T) {
+	tests := map[string]struct {
+		key   []byte
+		value []byte
+	}{
+		"entry key": {
+			key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
+			value: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		},
+		"nil key (history hash)": {
+			key:   []byte{},
+			value: []byte{1: 40},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			entry := BundleKV{Key: tc.key, Value: tc.value}
+			encoded := entry.Encode()
+
+			// expected total: 4 (key len) + key + 4 (value len) + value
+			expectedLen := 4 + len(tc.key) + 4 + len(tc.value)
+			require.Len(t, encoded, expectedLen)
+
+			// verify lengths are big-endian encoded at the right offsets
+			gotKeyLen := binary.BigEndian.Uint32(encoded[0:4])
+			require.Equal(t, uint32(len(tc.key)), gotKeyLen)
+
+			gotValLen := binary.BigEndian.Uint32(encoded[4+len(tc.key) : 4+len(tc.key)+4])
+			require.Equal(t, uint32(len(tc.value)), gotValLen)
+
+			// verify key and value payloads
+			require.Equal(t, tc.key, encoded[4:4+len(tc.key)])
+			require.Equal(t, tc.value, encoded[4+len(tc.key)+4:])
+		})
+	}
+}
+
 // --- helper functions ---
 
 // referenceComputeStateHash is a reference implementation of the hash

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -934,7 +934,7 @@ func TestStore_ProcessedBundles_RetainsAllBundlesRequiredToCoverTheMaximumBlockR
 	}
 }
 
-func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidHashLength(t *testing.T) {
+func TestStore_ImportProcessedBundles_ReturnsErrorForInvalidHashLength(t *testing.T) {
 	tests := map[string]struct {
 		key, value []byte
 		errorMsg   string
@@ -975,25 +975,25 @@ func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidHashLength(t *testing
 			// Encode as batch
 			entry := BundleKV{Key: tc.key, Value: tc.value}
 			batch := entry.Encode()
-			err = store.SetRawProcessedBundles(batch)
+			err = store.ImportProcessedBundles(batch)
 			require.Error(err)
 			require.Contains(err.Error(), tc.errorMsg)
 		})
 	}
 }
 
-func TestStore_SetRawProcessedBundle_ReturnsErrorForInvalidBatchData(t *testing.T) {
+func TestStore_ImportProcessedBundles_ReturnsErrorForInvalidBatchData(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
 	invalidData := []byte{0, 1, 2} // not a valid batch encoding
-	err = store.SetRawProcessedBundles(invalidData)
+	err = store.ImportProcessedBundles(invalidData)
 	require.Error(err)
 	require.Contains(err.Error(), "invalid data")
 }
 
-func TestStore_SetRawProcessedBundle_RecognizesBundleHistoryHash(t *testing.T) {
+func TestStore_ImportProcessedBundles_RecognizesBundleHistoryHash(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
@@ -1007,7 +1007,7 @@ func TestStore_SetRawProcessedBundle_RecognizesBundleHistoryHash(t *testing.T) {
 
 	entry := BundleKV{Key: nil, Value: value}
 	batch := entry.Encode()
-	err = store.SetRawProcessedBundles(batch)
+	err = store.ImportProcessedBundles(batch)
 	require.NoError(err)
 
 	resBlockNum, resHash := store.GetProcessedBundleHistoryHash()
@@ -1015,7 +1015,7 @@ func TestStore_SetRawProcessedBundle_RecognizesBundleHistoryHash(t *testing.T) {
 	require.Equal(hash, resHash)
 }
 
-func TestStore_SetRawProcessedBundle_ReportsHistoryHashPutErrors(t *testing.T) {
+func TestStore_ImportProcessedBundles_ReportsHistoryHashPutErrors(t *testing.T) {
 	store, table, log, _, _ := storeTableLogMocks(t)
 
 	log.EXPECT().Info(gomock.Any(), gomock.Any())
@@ -1029,11 +1029,11 @@ func TestStore_SetRawProcessedBundle_ReportsHistoryHashPutErrors(t *testing.T) {
 	injectedErr := errors.New("put error")
 	table.EXPECT().Put(nil, historyEntry.Value).Return(injectedErr)
 
-	err := store.SetRawProcessedBundles(data)
+	err := store.ImportProcessedBundles(data)
 	require.ErrorIs(t, err, injectedErr)
 }
 
-func TestStore_SetRawProcessedBundle_ReportsEntryPutErrors(t *testing.T) {
+func TestStore_ImportProcessedBundles_ReportsEntryPutErrors(t *testing.T) {
 	hash := common.Hash{1, 2, 3}
 	entry := BundleKV{
 		Key:   append([]byte{'e'}, hash.Bytes()...),
@@ -1063,13 +1063,13 @@ func TestStore_SetRawProcessedBundle_ReportsEntryPutErrors(t *testing.T) {
 			table.EXPECT().NewBatch().Return(batch)
 			setupMocks(batch)
 
-			err := store.SetRawProcessedBundles(data)
+			err := store.ImportProcessedBundles(data)
 			require.ErrorIs(t, err, injectedError)
 		})
 	}
 }
 
-func TestStore_SetRawProcessedBundle_AddsEntryToStore(t *testing.T) {
+func TestStore_ImportProcessedBundles_AddsEntryToStore(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
@@ -1095,7 +1095,7 @@ func TestStore_SetRawProcessedBundle_AddsEntryToStore(t *testing.T) {
 	}
 
 	batch := entry.Encode()
-	err = store.SetRawProcessedBundles(batch)
+	err = store.ImportProcessedBundles(batch)
 	require.NoError(err)
 
 	resInfo := store.GetBundleExecutionInfo(hash)
@@ -1105,7 +1105,7 @@ func TestStore_SetRawProcessedBundle_AddsEntryToStore(t *testing.T) {
 	require.Equal(info.Position, resInfo.Position)
 }
 
-func TestStore_SetRawProcessedBundle_AddsIndexEntry(t *testing.T) {
+func TestStore_ImportProcessedBundles_AddsIndexEntry(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
@@ -1129,7 +1129,7 @@ func TestStore_SetRawProcessedBundle_AddsIndexEntry(t *testing.T) {
 		Value: data,
 	}
 	batch := entry.Encode()
-	err = store.SetRawProcessedBundles(batch)
+	err = store.ImportProcessedBundles(batch)
 	require.NoError(err)
 
 	// check that the index entry was added (the value doesn't matter, just that it exists)
@@ -1224,17 +1224,17 @@ func TestStore_DecodeEntry_ReturnsKeyAndValue(t *testing.T) {
 	}
 }
 
-func TestStore_DumpProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {
+func TestStore_ExportProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
-	dumpedEntries := store.DumpProcessedBundles()
-	require.NotNil(dumpedEntries)
-	require.Empty(dumpedEntries, "expected no dumped entries when store is empty")
+	exportedEntries := store.ExportProcessedBundles()
+	require.NotNil(exportedEntries)
+	require.Empty(exportedEntries, "expected no exported entries when store is empty")
 }
 
-func TestStore_DumpProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
+func TestStore_ExportProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 
 	require := require.New(t)
 	store, err := NewMemStore(t)
@@ -1264,23 +1264,23 @@ func TestStore_DumpProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 			int(bundle.MaxBlockRange-1)*entrySize +
 			8*int(bundle.MaxBlockRange) // key/value size per entry.
 
-	dumpedEntries := store.DumpProcessedBundles()
+	entries := store.ExportProcessedBundles()
 	// 1 history hash + MaxBlockRange-1 entries
-	require.Len(dumpedEntries, int(bundle.MaxBlockRange),
-		fmt.Sprintf("expected %d dumped entries, got %d",
-			bundle.MaxBlockRange, len(dumpedEntries)))
+	require.Len(entries, int(bundle.MaxBlockRange),
+		fmt.Sprintf("expected %d exported entries, got %d",
+			bundle.MaxBlockRange, len(entries)))
 
 	actualSize := 0
-	for _, entry := range dumpedEntries {
+	for _, entry := range entries {
 		actualSize += len(entry)
 	}
 
 	require.Equal(expectedSize, actualSize,
-		fmt.Sprintf("expected %d dumped entries, got %d",
+		fmt.Sprintf("expected %d exported entries, got %d",
 			expectedSize, actualSize))
 }
 
-func TestStore_DumpProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
+func TestStore_ExportProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
@@ -1300,11 +1300,11 @@ func TestStore_DumpProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
 	// add execution info to store.
 	store.AddProcessedBundles(blockNum, executedBundles)
 
-	// get the dumped entries
-	dumpedEntries := store.DumpProcessedBundles()
-	require.Len(dumpedEntries, 2) // history hash + 1 entry
+	// get the exported entries
+	exportedEntries := store.ExportProcessedBundles()
+	require.Len(exportedEntries, 2) // history hash + 1 entry
 
-	// check that the dumped entry matches the expected encoding of the added entry
+	// check that the exported entry matches the expected encoding of the added entry
 	expectedEntry := BundleKV{
 		Key:   append([]byte{'e'}, hash.Bytes()...),
 		Value: make([]byte, 16),
@@ -1313,10 +1313,10 @@ func TestStore_DumpProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
 	binary.BigEndian.PutUint32(expectedEntry.Value[8:12], info.Position.Offset)
 	binary.BigEndian.PutUint32(expectedEntry.Value[12:], info.Position.Count)
 
-	require.Contains(dumpedEntries, expectedEntry.Encode())
+	require.Contains(exportedEntries, expectedEntry.Encode())
 }
 
-func TestStore_DumpProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
+func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
 	store, table, log, _, it := storeTableLogMocks(t)
 
 	injectedErr := errors.New("iterator error")
@@ -1326,14 +1326,14 @@ func TestStore_DumpProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
 		it.EXPECT().Next().Return(false),
 		it.EXPECT().Error().Return(injectedErr).AnyTimes(),
 	)
-	expectCrit(log, "failed to dump processed bundles", "error", injectedErr)
+	expectCrit(log, "failed to export processed bundles", "error", injectedErr)
 
 	require.PanicsWithValue(t,
-		fmt.Sprintf("failed to dump processed bundles: %v", []any{"error", injectedErr}),
-		func() { store.DumpProcessedBundles() })
+		fmt.Sprintf("failed to export processed bundles: %v", []any{"error", injectedErr}),
+		func() { store.ExportProcessedBundles() })
 }
 
-func TestStore_DumpProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t *testing.T) {
+func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t *testing.T) {
 
 	tests := map[string]struct {
 		key   []byte
@@ -1362,15 +1362,15 @@ func TestStore_DumpProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t *
 			)
 			expectCrit(
 				log,
-				"invalid key or value length for processed bundle entry during dump",
+				"invalid key or value length for processed bundle entry during export",
 				"keyLength", len(tc.key),
 				"valueLength", len(tc.value))
 
 			require.PanicsWithValue(t,
-				fmt.Sprintf("invalid key or value length for processed bundle entry during dump: %v",
+				fmt.Sprintf("invalid key or value length for processed bundle entry during export: %v",
 					[]any{"keyLength", fmt.Sprintf("%d", len(tc.key)),
 						"valueLength", fmt.Sprintf("%d", len(tc.value))}),
-				func() { store.DumpProcessedBundles() })
+				func() { store.ExportProcessedBundles() })
 
 		})
 	}

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -973,8 +973,7 @@ func TestStore_ImportProcessedBundles_ReturnsErrorForInvalidHashLength(t *testin
 			require.NoError(err)
 
 			// Encode as batch
-			entry := BundleKV{Key: tc.key, Value: tc.value}
-			batch := entry.Encode()
+			batch := Encode(tc.key, tc.value)
 			err = store.ImportProcessedBundles(batch)
 			require.Error(err)
 			require.Contains(err.Error(), tc.errorMsg)
@@ -1005,8 +1004,7 @@ func TestStore_ImportProcessedBundles_RecognizesBundleHistoryHash(t *testing.T) 
 	binary.BigEndian.PutUint64(value[:8], blockNum)
 	copy(value[8:], hash[:])
 
-	entry := BundleKV{Key: nil, Value: value}
-	batch := entry.Encode()
+	batch := Encode(nil, value)
 	err = store.ImportProcessedBundles(batch)
 	require.NoError(err)
 
@@ -1020,14 +1018,11 @@ func TestStore_ImportProcessedBundles_ReportsHistoryHashPutErrors(t *testing.T) 
 
 	log.EXPECT().Info(gomock.Any(), gomock.Any())
 
-	historyEntry := BundleKV{
-		Key:   nil,
-		Value: append(uint64ToBytes(10), common.Hash{1, 2, 3}.Bytes()...),
-	}
-	data := historyEntry.Encode()
+	historyEntry := append(uint64ToBytes(10), common.Hash{1, 2, 3}.Bytes()...)
+	data := Encode(nil, historyEntry)
 
 	injectedErr := errors.New("put error")
-	table.EXPECT().Put(nil, historyEntry.Value).Return(injectedErr)
+	table.EXPECT().Put(nil, historyEntry).Return(injectedErr)
 
 	err := store.ImportProcessedBundles(data)
 	require.ErrorIs(t, err, injectedErr)
@@ -1035,23 +1030,21 @@ func TestStore_ImportProcessedBundles_ReportsHistoryHashPutErrors(t *testing.T) 
 
 func TestStore_ImportProcessedBundles_ReportsEntryPutErrors(t *testing.T) {
 	hash := common.Hash{1, 2, 3}
-	entry := BundleKV{
-		Key:   append([]byte{'e'}, hash.Bytes()...),
-		Value: make([]byte, 16),
-	}
-	data := entry.Encode()
+	key := append([]byte{'e'}, hash.Bytes()...)
+	value := make([]byte, 16)
+	data := Encode(key, value)
 	injectedError := errors.New("put entry error")
 
 	cases := map[string]func(batch *MockstoreBatch){
 		"entry put error": func(batch *MockstoreBatch) {
-			batch.EXPECT().Put(getEntryKey(hash), entry.Value).Return(injectedError)
+			batch.EXPECT().Put(getEntryKey(hash), value).Return(injectedError)
 		},
 		"index put error": func(batch *MockstoreBatch) {
-			batch.EXPECT().Put(getEntryKey(hash), entry.Value).Return(nil)
+			batch.EXPECT().Put(getEntryKey(hash), value).Return(nil)
 			batch.EXPECT().Put(getIndexKey(uint64(0), hash), []byte{0}).Return(injectedError)
 		},
 		"batch write error": func(batch *MockstoreBatch) {
-			batch.EXPECT().Put(getEntryKey(hash), entry.Value).Return(nil)
+			batch.EXPECT().Put(getEntryKey(hash), value).Return(nil)
 			batch.EXPECT().Put(getIndexKey(uint64(0), hash), []byte{0}).Return(nil)
 			batch.EXPECT().Write().Return(injectedError)
 		},
@@ -1089,12 +1082,10 @@ func TestStore_ImportProcessedBundles_AddsEntryToStore(t *testing.T) {
 	binary.BigEndian.PutUint32(data[8:12], info.Position.Offset)
 	binary.BigEndian.PutUint32(data[12:], info.Position.Count)
 
-	entry := BundleKV{
-		Key:   append([]byte{'e'}, hash.Bytes()...),
-		Value: data,
-	}
+	key := append([]byte{'e'}, hash.Bytes()...)
+	value := data
 
-	batch := entry.Encode()
+	batch := Encode(key, value)
 	err = store.ImportProcessedBundles(batch)
 	require.NoError(err)
 
@@ -1124,11 +1115,9 @@ func TestStore_ImportProcessedBundles_AddsIndexEntry(t *testing.T) {
 	binary.BigEndian.PutUint32(data[8:12], info.Position.Offset)
 	binary.BigEndian.PutUint32(data[12:], info.Position.Count)
 
-	entry := BundleKV{
-		Key:   append([]byte{'e'}, hash.Bytes()...),
-		Value: data,
-	}
-	batch := entry.Encode()
+	key := append([]byte{'e'}, hash.Bytes()...)
+	value := data
+	batch := Encode(key, value)
 	err = store.ImportProcessedBundles(batch)
 	require.NoError(err)
 
@@ -1181,19 +1170,12 @@ func TestStore_DecodeEntry_ReturnsErrorForInvalidData(t *testing.T) {
 func TestStore_DecodeEntry_ReturnsKeyAndValue(t *testing.T) {
 
 	bundleHistoryValue := append(uint64ToBytes(10), common.Hash{1, 2, 3}.Bytes()...)
-	bundleHistoryEntry := BundleKV{
-		Key:   nil,
-		Value: bundleHistoryValue,
-	}
 	entryValue := append(
 		append(
 			uint64ToBytes(20),
 			uint32ToBytes(1)...),
 		uint32ToBytes(2)...)
-	entryData := BundleKV{
-		Key:   append([]byte{'e'}, common.Hash{4, 5, 6}.Bytes()...),
-		Value: entryValue,
-	}
+	key := append([]byte{'e'}, common.Hash{4, 5, 6}.Bytes()...)
 
 	tests := map[string]struct {
 		data          []byte
@@ -1201,12 +1183,12 @@ func TestStore_DecodeEntry_ReturnsKeyAndValue(t *testing.T) {
 		expectedValue []byte
 	}{
 		"bundle history hash": {
-			data:          bundleHistoryEntry.Encode(),
+			data:          Encode(nil, bundleHistoryValue),
 			expectedKey:   []byte{},
 			expectedValue: bundleHistoryValue,
 		},
 		"bundle entry": {
-			data:          entryData.Encode(),
+			data:          Encode(key, entryValue),
 			expectedKey:   append([]byte{'e'}, common.Hash{4, 5, 6}.Bytes()...),
 			expectedValue: entryValue,
 		},
@@ -1305,15 +1287,13 @@ func TestStore_ExportProcessedBundles_ReturnsEncodedEntry(t *testing.T) {
 	require.Len(exportedEntries, 2) // history hash + 1 entry
 
 	// check that the exported entry matches the expected encoding of the added entry
-	expectedEntry := BundleKV{
-		Key:   append([]byte{'e'}, hash.Bytes()...),
-		Value: make([]byte, 16),
-	}
-	binary.BigEndian.PutUint64(expectedEntry.Value[:8], info.BlockNumber)
-	binary.BigEndian.PutUint32(expectedEntry.Value[8:12], info.Position.Offset)
-	binary.BigEndian.PutUint32(expectedEntry.Value[12:], info.Position.Count)
+	key := append([]byte{'e'}, hash.Bytes()...)
+	value := make([]byte, 16)
+	binary.BigEndian.PutUint64(value[:8], info.BlockNumber)
+	binary.BigEndian.PutUint32(value[8:12], info.Position.Offset)
+	binary.BigEndian.PutUint32(value[12:], info.Position.Count)
 
-	require.Contains(exportedEntries, expectedEntry.Encode())
+	require.Contains(exportedEntries, Encode(key, value))
 }
 
 func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
@@ -1376,7 +1356,7 @@ func TestStore_ExportProcessedBundles_LogsOnCrit_IteratorKeyValueWrongSize_Key(t
 	}
 }
 
-func TestStore_BundleKV_Encode_FollowsExpectedFormat(t *testing.T) {
+func TestStore_Encode_FollowsExpectedFormat(t *testing.T) {
 	tests := map[string]struct {
 		key   []byte
 		value []byte
@@ -1393,8 +1373,7 @@ func TestStore_BundleKV_Encode_FollowsExpectedFormat(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			entry := BundleKV{Key: tc.key, Value: tc.value}
-			encoded := entry.Encode()
+			encoded := Encode(tc.key, tc.value)
 
 			// expected total: 4 (key len) + key + 4 (value len) + value
 			expectedLen := 4 + len(tc.key) + 4 + len(tc.value)


### PR DESCRIPTION
This PR adds 3 methods related to bundles to the `gossip.Store`.

**Main Contributions:**
- `readProcessedBundleHistoryEntry` an internal method which fetches the entry with the empty key.
- `SetProcessedBundlesHistoryHash` an exported method to enable the genesis import to write the processed bundle history hash. 
- `EnumerateProcessedBundles` an exported method which returns a slice containing the `bundle.ExecutionInfo` corresponding to all the entries in the `ProcessedBundles` table.

This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/622

NOTE: This PR has been simplified from its original ideas after an offline talk with @LuisPH3. Encoding/Decoding will be added in follow-up unrelated to the methods in the store. 

