### PR TITLE
Update block formation to handle bundles

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -260,11 +260,6 @@ func consensusCallbackBeginBlockFn(
 					proposal.Transactions, &es.Rules, log.Root(), invalidTxsMeter,
 				)
 
-				// Filter obsolete bundles from the proposal.
-				proposal.Transactions = filterObsoleteBundles(
-					proposal.Transactions, uint64(proposal.Number), &es.Rules, signer, log.Root(), skippedTxsMeter,
-				)
-
 				// Make sure the new block time is after the last block time.
 				if blockTime <= bs.LastBlock.Time {
 					blockTime = bs.LastBlock.Time + 1
@@ -883,7 +878,14 @@ func isPermissible(
 	tx *types.Transaction,
 	rules *opera.Rules,
 ) error {
+	return isPermissibleInternal(tx, rules, false)
+}
 
+func isPermissibleInternal(
+	tx *types.Transaction,
+	rules *opera.Rules,
+	isInBundle bool,
+) error {
 	if tx == nil {
 		return fmt.Errorf("nil transaction")
 	}
@@ -917,113 +919,34 @@ func isPermissible(
 		}
 	}
 
-	return nil
-}
+	// Starting with Brio, rules for bundled transactions are introduced.
+	if rules.Upgrades.Brio {
+		// Bundle-only transactions must not be included in blocks stand-alone.
+		if !isInBundle && bundle.IsBundleOnly(tx) {
+			return fmt.Errorf("bundle-only transactions are not supported")
+		}
 
-// filterObsoleteBundles filters bundles that were already included in the
-// chain, are outdated or invalid. This makes sure that bundles are processed
-// at most once. This is to defend against validators proposing the same bundle
-// multiple times for inclusion.
-func filterObsoleteBundles(
-	transactions []*types.Transaction,
-	blockNumber uint64,
-	rules *opera.Rules,
-	signer types.Signer,
-	log log.Logger,
-	skippedBundleCounter metricCounter,
-) []*types.Transaction {
-
-	// How bundles are handled by this filter:
-	//
-	// Before Brio: there is no special treatment of bundles. They are
-	//  interpreted as regular transactions in order to be backward compatible
-	//  during the roll-out phase.
-	//
-	// After Brio: bundles are filtered out if the `TransactionBundles` feature
-	//  is disabled. In this case, bundles are filtered out (=skipped). If the
-	//  `TransactionBundles` feature is enabled, bundles are checked for
-	//  validity and obsolescence. Invalid or obsolete bundles are filtered out
-	//  (=skipped), while valid and non-obsolete bundles are kept for inclusion.
-
-	// This filter is only enabled with the Brio upgrade. This is for backward
-	// compatibility during the roll-out phase.
-	if !rules.Upgrades.Brio {
-		return transactions
-	}
-
-	// TODO: check for duplicates of execution plans
-	// TODO: check for non-permissible transaction payloads in bundles
-
-	res := make([]*types.Transaction, 0, len(transactions))
-	for _, tx := range transactions {
-		if isObsoleteBundle(tx, blockNumber, rules, signer, log) {
-			if skippedBundleCounter != nil {
-				skippedBundleCounter.Mark(1)
+		// Deal with envelopes.
+		if bundle.IsEnvelope(tx) {
+			// Envelopes delivering bundles are ignored if feature is disabled.
+			if !rules.Upgrades.TransactionBundles {
+				return fmt.Errorf("bundle transactions are disabled")
 			}
-		} else {
-			res = append(res, tx)
-		}
-	}
-	return res
-}
 
-func isObsoleteBundle(
-	tx *types.Transaction,
-	blockNumber uint64,
-	rules *opera.Rules,
-	signer types.Signer,
-	log log.Logger,
-) bool {
-	if !bundle.IsEnvelope(tx) {
-		return false
-	}
-
-	// If bundles are disabled, all bundles are to be removed.
-	if !rules.Upgrades.TransactionBundles {
-		if log != nil {
-			log.Warn("Bundles are not enabled but a bundle transaction needed to be skipped", "tx", tx.Hash())
-		}
-		return true
-	}
-
-	// Check static properties of the bundle, to make sure it is not malformed.
-	bundle, execPlan, err := bundle.ValidateEnvelope(signer, tx)
-	if err != nil {
-		if log != nil {
-			log.Warn("Invalid bundle transaction in the proposal", "tx", tx.Hash(), "issue", err)
-		}
-		return true
-	}
-
-	// Check that the block this bundle is to be included is within its
-	// valid range.
-	if !execPlan.Range.IsInRange(blockNumber) {
-		if log != nil {
-			log.Warn(
-				"Bundle transaction in the proposal is out of range for execution",
-				"tx", tx.Hash(),
-				"block", blockNumber,
-				"earliest", execPlan.Range.Earliest,
-				"latest", execPlan.Range.Latest,
-			)
-		}
-		return true
-	}
-
-	if len(bundle.Transactions) == 0 {
-		if log != nil {
-			log.Warn("Bundle transaction in the proposal contains no transactions", "tx", tx.Hash())
-		}
-		return true
-	}
-
-	for _, tx := range bundle.Transactions {
-		if isObsoleteBundle(tx, blockNumber, rules, signer, log) {
-			return true
+			// Make sure the envelope does not contain non-permissible transactions.
+			txBundle, err := bundle.OpenEnvelope(tx)
+			if err != nil {
+				return fmt.Errorf("invalid bundle envelope: %w", err)
+			}
+			for _, tx := range txBundle.Transactions {
+				if err := isPermissibleInternal(tx, rules, true); err != nil {
+					return fmt.Errorf("bundle contains non-permissible transaction: %w", err)
+				}
+			}
 		}
 	}
 
-	return false
+	return nil
 }
 
 // metricCounter is an abstraction of the *metrics.Meter type to facilitate

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -938,8 +938,8 @@ func isPermissibleInternal(
 			if err != nil {
 				return fmt.Errorf("invalid bundle envelope: %w", err)
 			}
-			for _, tx := range txBundle.Transactions {
-				if err := isPermissibleInternal(tx, rules, true); err != nil {
+			for _, inner := range txBundle.Transactions {
+				if err := isPermissibleInternal(inner, rules, true); err != nil {
 					return fmt.Errorf("bundle contains non-permissible transaction: %w", err)
 				}
 			}

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
@@ -731,6 +730,10 @@ func TestFilterNonPermissibleTransactions_ReportsNonPermissibleTransactionsToMon
 }
 
 func TestIsPermissible_AcceptsPermissibleTransactions(t *testing.T) {
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
 	tests := map[string]*types.Transaction{
 		"legacy":      types.NewTx(&types.LegacyTx{}),
 		"access list": types.NewTx(&types.AccessListTx{}),
@@ -739,11 +742,24 @@ func TestIsPermissible_AcceptsPermissibleTransactions(t *testing.T) {
 		"set code": types.NewTx(&types.SetCodeTx{
 			AuthList: []types.SetCodeAuthorization{{}},
 		}),
+		"empty all-of bundle": bundle.AllOf(signer),
+		"empty one-of bundle": bundle.OneOf(signer),
+		"non-empty bundle": bundle.AllOf(signer,
+			bundle.Step(key, &types.AccessListTx{}),
+			bundle.Step(key, &types.AccessListTx{}),
+		),
+		"nested bundle": bundle.AllOf(signer,
+			bundle.Step(key, bundle.AllOf(signer,
+				bundle.Step(key, &types.AccessListTx{}),
+			)),
+		),
 	}
 
 	rules := opera.Rules{
 		Upgrades: opera.Upgrades{
-			Allegro: true,
+			Allegro:            true,
+			Brio:               true,
+			TransactionBundles: true,
 		},
 	}
 	for name, tx := range tests {
@@ -753,19 +769,21 @@ func TestIsPermissible_AcceptsPermissibleTransactions(t *testing.T) {
 	}
 }
 
-func TestIsPermissible_AcceptsSetCodeTransactionsOnlyInAllegro(t *testing.T) {
+func TestIsPermissible_AcceptsSetCodeTransactionsInAllegroAndBeyond(t *testing.T) {
 	tx := types.NewTx(&types.SetCodeTx{
 		AuthList: []types.SetCodeAuthorization{{}},
 	})
 
-	for _, enabled := range []bool{false, true} {
-		t.Run(fmt.Sprintf("allegro=%t", enabled), func(t *testing.T) {
-			rules := opera.Rules{
-				Upgrades: opera.Upgrades{
-					Allegro: enabled,
-				},
-			}
-			if enabled {
+	tests := map[string]opera.Upgrades{
+		"Sonic":   {},
+		"Allegro": {Allegro: true},
+		"Brio":    {Allegro: true, Brio: true},
+	}
+
+	for name, updates := range tests {
+		t.Run(name, func(t *testing.T) {
+			rules := opera.Rules{Upgrades: updates}
+			if updates.Allegro {
 				require.NoError(t, isPermissible(tx, &rules))
 			} else {
 				require.ErrorContains(t,
@@ -775,6 +793,133 @@ func TestIsPermissible_AcceptsSetCodeTransactionsOnlyInAllegro(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsPermissible_WithBrio_RejectsBundleOnlyTransactions(t *testing.T) {
+	require := require.New(t)
+	tx := types.NewTx(&types.AccessListTx{
+		AccessList: []types.AccessTuple{{
+			Address: bundle.BundleOnly,
+		}},
+	})
+
+	require.True(bundle.IsBundleOnly(tx))
+
+	// Before Brio, this transaction should be permissible.
+	rules := opera.Rules{Upgrades: opera.Upgrades{Brio: false}}
+	require.NoError(isPermissible(tx, &rules))
+
+	// With Brio, this transaction should not be permissible.
+	rules.Upgrades.Brio = true
+	require.ErrorContains(isPermissible(tx, &rules), "bundle-only transactions are not supported")
+}
+
+func TestIsPermissible_WithBrio_BundlesDisabled_RejectsBundleEnvelopes(t *testing.T) {
+	require := require.New(t)
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	tx := bundle.AllOf(signer)
+
+	require.True(bundle.IsEnvelope(tx))
+
+	// Before Brio, envelopes are accepted, but not interpreted as such.
+	rules := opera.Rules{Upgrades: opera.Upgrades{Brio: false}}
+	require.NoError(isPermissible(tx, &rules))
+
+	// With Brio, envelopes are rejected if bundles are disabled.
+	rules.Upgrades.Brio = true
+	rules.Upgrades.TransactionBundles = false
+	require.ErrorContains(isPermissible(tx, &rules), "bundle transactions are disabled")
+
+	// If bundles are enabled, envelopes should be accepted.
+	rules.Upgrades.TransactionBundles = true
+	require.NoError(isPermissible(tx, &rules))
+}
+
+func TestIsPermissible_NonOpenableEnvelope_IsRejectedWithBrio(t *testing.T) {
+	require := require.New(t)
+	tx := types.NewTx(&types.LegacyTx{
+		To:   &bundle.BundleProcessor,
+		Data: []byte("not a valid encoding"),
+	})
+
+	require.True(bundle.IsEnvelope(tx))
+
+	// Before Brio, this is accepted.
+	rules := opera.Rules{Upgrades: opera.Upgrades{Brio: false}}
+	require.NoError(isPermissible(tx, &rules))
+
+	// With Brio, and bundles disabled, this is rejected for being an envelope.
+	rules.Upgrades.Brio = true
+	rules.Upgrades.TransactionBundles = false
+	require.ErrorContains(isPermissible(tx, &rules), "bundle transactions are disabled")
+
+	// With Brio and bundles enabled, this should be rejected as it's an invalid envelope.
+	rules.Upgrades.Brio = true
+	rules.Upgrades.TransactionBundles = true
+	require.ErrorContains(isPermissible(tx, &rules), "invalid bundle envelope")
+}
+
+func TestIsPermissible_BundlesWithInvalidContent_Rejected(t *testing.T) {
+	require := require.New(t)
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	tx, txBundle, _ := bundle.NewBuilder(signer).
+		With(bundle.Step(key, &types.SetCodeTx{
+			// Invalid, since there are no authorizations.
+		})).
+		BuildEnvelopeBundleAndPlan()
+
+	rules := opera.Rules{Upgrades: opera.Upgrades{
+		Allegro:            true,
+		Brio:               true,
+		TransactionBundles: true,
+	}}
+
+	// The first transaction in the bundle is not permissible.
+	issue := isPermissible(txBundle.Transactions[0], &rules)
+	require.Error(issue)
+
+	// Thus, the bundle should be rejected.
+	got := isPermissible(tx, &rules)
+	require.ErrorContains(got, "bundle contains non-permissible transaction")
+	require.ErrorContains(got, issue.Error())
+}
+
+func TestIsPermissible_BundlesWithInvalidNestedContent_Rejected(t *testing.T) {
+	require := require.New(t)
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	// Issues in nested bundles are also detected.
+	inner, txBundle, _ := bundle.NewBuilder(signer).
+		With(bundle.Step(key, &types.SetCodeTx{
+			// Invalid, since there are no authorizations.
+		})).
+		BuildEnvelopeBundleAndPlan()
+
+	outer := bundle.NewBuilder(signer).
+		With(bundle.Step(key, inner)).
+		Build()
+
+	rules := opera.Rules{Upgrades: opera.Upgrades{
+		Allegro:            true,
+		Brio:               true,
+		TransactionBundles: true,
+	}}
+
+	// The first transaction in the bundle is not permissible.
+	issue := isPermissible(txBundle.Transactions[0], &rules)
+	require.Error(issue)
+
+	// Thus, the bundle should be rejected.
+	got := isPermissible(outer, &rules)
+	require.ErrorContains(got, "bundle contains non-permissible transaction")
+	require.ErrorContains(got, issue.Error())
 }
 
 func TestMergeCheaters_CanMergeLists(t *testing.T) {
@@ -1337,159 +1482,6 @@ func TestSpillBlockEvents(t *testing.T) {
 			require.Equal(t, test.expectedSignatures, foundSignatures)
 		})
 	}
-}
-
-func TestFilterObsoleteBundles_RemovesInvalidBundles(t *testing.T) {
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	tests := map[string]struct {
-		tx             *types.Transaction
-		blockNumber    uint64
-		expectFiltered bool
-	}{
-		"normal tx": {
-			tx:             types.NewTx(&types.LegacyTx{GasPrice: big.NewInt(1)}),
-			expectFiltered: false,
-		},
-		"sponsored tx": {
-			tx:             types.NewTx(&types.LegacyTx{GasPrice: big.NewInt(0)}),
-			expectFiltered: false,
-		},
-		"bundle valid": {
-			tx:             bundle.AllOf(signer, bundle.Step(key, &types.AccessListTx{})),
-			expectFiltered: false,
-		},
-		"bundle invalid": {
-			tx:             types.NewTx(&types.AccessListTx{To: &bundle.BundleProcessor}),
-			expectFiltered: true,
-		},
-		"bundle out of range": {
-			tx:             bundle.NewBuilder(signer).With(bundle.Step(key, &types.AccessListTx{})).SetLatest(1).Build(),
-			blockNumber:    2,
-			expectFiltered: true,
-		},
-		"bundle empty": {
-			tx:             bundle.AllOf(signer /* empty */),
-			expectFiltered: true,
-		},
-		"bundle with invalid nested bundle": {
-			tx:             bundle.AllOf(signer, bundle.Step(key, types.NewTx(&types.AccessListTx{To: &bundle.BundleProcessor}))),
-			expectFiltered: true,
-		},
-		"bundle with out of range nested bundle": {
-			tx: bundle.AllOf(signer, bundle.Step(key,
-				bundle.NewBuilder(signer).With(bundle.Step(key, &types.AccessListTx{})).SetLatest(1).Build(),
-			)),
-			blockNumber:    2,
-			expectFiltered: true,
-		},
-		"bundle with empty nested bundle": {
-			tx:             bundle.AllOf(signer, bundle.Step(key, bundle.AllOf(signer /* empty */))),
-			expectFiltered: true,
-		},
-	}
-
-	positions := map[string]uint64{
-		"first": 0,
-		"mid":   1,
-		"last":  2,
-	}
-
-	for pos_name, pos := range positions {
-		for name, test := range tests {
-			t.Run(fmt.Sprintf("%s/%s", pos_name, name), func(t *testing.T) {
-				ctrl := gomock.NewController(t)
-
-				skippedBundleCounter := NewMockmetricCounter(ctrl)
-
-				if test.expectFiltered {
-					skippedBundleCounter.EXPECT().Mark(int64(1)).AnyTimes()
-				}
-
-				rules := opera.Rules{Upgrades: opera.GetBrioUpgrades()}
-				rules.Upgrades.TransactionBundles = true
-
-				txs := []*types.Transaction{
-					types.NewTx(&types.LegacyTx{Nonce: 0}),
-					types.NewTx(&types.LegacyTx{Nonce: 1}),
-					types.NewTx(&types.LegacyTx{Nonce: 2}),
-				}
-				txs[pos] = test.tx
-
-				filteredTxs := filterObsoleteBundles(txs, test.blockNumber, &rules, signer, log.Root(), skippedBundleCounter)
-				if test.expectFiltered {
-					expected := txs[:pos]
-					expected = append(expected, txs[pos+1:]...)
-					require.Equal(t, expected, filteredTxs)
-				} else {
-					require.Equal(t, txs, filteredTxs)
-				}
-			})
-		}
-	}
-}
-
-func TestFilterObsoleteBundles_RemovesBundlesIfFeatureNotEnabled(t *testing.T) {
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	ctrl := gomock.NewController(t)
-
-	skippedBundleCounter := NewMockmetricCounter(ctrl)
-	skippedBundleCounter.EXPECT().Mark(int64(1)).AnyTimes()
-
-	rules := opera.Rules{Upgrades: opera.GetBrioUpgrades()}
-	rules.Upgrades.TransactionBundles = false
-
-	txs := []*types.Transaction{bundle.AllOf(signer, bundle.Step(key, &types.AccessListTx{}))}
-
-	filteredTxs := filterObsoleteBundles(txs, 0, &rules, signer, log.Root(), skippedBundleCounter)
-	require.Empty(t, filteredTxs)
-}
-
-func TestFilterObsoleteBundles_DoesNotFilterIfBrioNotEnabled(t *testing.T) {
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	ctrl := gomock.NewController(t)
-
-	skippedBundleCounter := NewMockmetricCounter(ctrl)
-	skippedBundleCounter.EXPECT().Mark(int64(1)).AnyTimes()
-
-	rules := opera.Rules{Upgrades: opera.GetAllegroUpgrades()}
-
-	txs := []*types.Transaction{
-		bundle.AllOf(signer /* empty */), // empty bundle (invalid)
-		bundle.AllOf(signer, bundle.Step(key, &types.AccessListTx{})), // valid bundle
-	}
-
-	filteredTxs := filterObsoleteBundles(txs, 0, &rules, signer, log.Root(), skippedBundleCounter)
-	require.Equal(t, txs, filteredTxs)
-}
-
-func TestFilterObsoleteBundles_RemovesInvalidBundles_FromSequencesWithMultipleBundles(t *testing.T) {
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-
-	txs := []*types.Transaction{
-		types.NewTx(&types.LegacyTx{Nonce: 0}),
-		bundle.AllOf(signer /* empty */),
-		bundle.AllOf(signer /* empty */),
-	}
-
-	ctrl := gomock.NewController(t)
-
-	skippedBundleCounter := NewMockmetricCounter(ctrl)
-	skippedBundleCounter.EXPECT().Mark(int64(1)).Times(2)
-
-	rules := opera.Rules{Upgrades: opera.GetBrioUpgrades()}
-	rules.Upgrades.TransactionBundles = true
-
-	filteredTxs := filterObsoleteBundles(txs, 0, &rules, signer, log.Root(), skippedBundleCounter)
-	require.Equal(t, txs[:1], filteredTxs)
 }
 
 type fakePayload struct {


### PR DESCRIPTION
This PR updates the integration of bundles in `c_block_callbacks` by
- removing the `filterObsoleteBundles`, since filtering of obsolete bundles is covered by the state processor and the StateDB, analog to nonces
- integrate the enforcing accepting/rejecting bundle related transactions into the `IsPermissible` filter
- apply the `IsPermissible` filter recursively on transactions included in bundles