### PR TITLE
Fix node 0 timeout flaky

### DIFF
--- a/tests/connect_p2p_test.go
+++ b/tests/connect_p2p_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/discover/discfilter"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectP2PNetwork_TrustedPeersBypassBan(t *testing.T) {
+	// This test verifies that peers marked as trusted via admin_addTrustedPeer
+	// can reconnect even when their node IDs have been banned by discfilter.
+	//
+	// This test would consistently fail if connectP2PNetwork did not call
+	// admin_addTrustedPeer, because a restart after banning would be unable
+	// to re-establish P2P connections.
+	require := require.New(t)
+
+	net := StartIntegrationTestNet(t, IntegrationTestNetOptions{
+		NumNodes: 2,
+	})
+
+	// Get the enode IDs of all nodes in the running network.
+	nodeIDs := getNodeIDs(t, net)
+
+	// Ban all node IDs in the process-global discfilter.
+	for _, id := range nodeIDs {
+		discfilter.Ban(id)
+	}
+
+	// Verify the bans are in effect.
+	for _, id := range nodeIDs {
+		require.True(discfilter.BannedDynamic(id), "node ID should be banned")
+	}
+
+	// Restart the network. On restart, connectP2PNetwork is called with
+	// fresh enode URLs (same node IDs, new ports). Despite the bans,
+	// this should succeed because connectP2PNetwork adds peers as
+	// trusted, which bypasses the discfilter ban check in the P2P
+	// server's postHandshakeChecks.
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- net.Restart()
+	}()
+
+	select {
+	case err := <-errCh:
+		require.NoError(err, "network restart should succeed")
+	case <-time.After(30 * time.Second):
+		t.Fatal("network restart timed out, likely due to discfilter bans")
+	}
+
+	// Verify both nodes are connected after the restart.
+	for i := range net.NumNodes() {
+		client, err := net.GetClientConnectedToNode(i)
+		require.NoError(err)
+		defer client.Close()
+
+		var peers []map[string]any
+		require.NoError(client.Client().Call(&peers, "admin_peers"))
+		require.NotEmpty(peers, "node %d should have peers after restart", i)
+	}
+}
+
+// getNodeIDs returns the enode.ID for each node in the network.
+func getNodeIDs(t *testing.T, net *IntegrationTestNet) []enode.ID {
+	t.Helper()
+	ids := make([]enode.ID, net.NumNodes())
+	for i := range net.NumNodes() {
+		client, err := net.GetClientConnectedToNode(i)
+		require.NoError(t, err)
+		defer client.Close()
+
+		var info struct {
+			Enode string `json:"enode"`
+		}
+		require.NoError(t, client.Client().Call(&info, "admin_nodeInfo"))
+
+		node, err := enode.ParseV4(info.Enode)
+		require.NoError(t, err)
+		ids[i] = node.ID()
+	}
+	return ids
+}

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -604,26 +604,44 @@ func (n *IntegrationTestNet) connectP2PNetwork(enodes []string) error {
 		return nil
 	}
 
+	// First, register each node's next neighbor in the ring as trusted before
+	// waiting for any connections.
+	//
+	// - Trusted status is important because if a gossip handshake times out),
+	// 	 the gossip layer bans the peer's node ID via discfilter.Ban() and
+	//   subsequent attempts to connect with that peer are rejected in postHandshakeChecks.
+	// 	 Marking the configured ring peers as trusted prevents this rejection.
 	for i := range n.nodes {
 		client, err := n.GetClientConnectedToNode(i)
 		if err != nil {
 			return fmt.Errorf("failed to connect to the Ethereum client: %w", err)
 		}
+
+		enode := enodes[(i+1)%len(n.nodes)]
+		if err := client.Client().Call(nil, "admin_addTrustedPeer", enode); err != nil {
+			client.Close()
+			return fmt.Errorf("failed to add trusted peer on node %d: %v", i, err)
+		}
+		if err := client.Client().Call(nil, "admin_addPeer", enode); err != nil {
+			client.Close()
+			return fmt.Errorf("failed to add peer on node %d: %v", i, err)
+		}
+		client.Close()
+	}
+
+	// Now wait for each node to have the expected number of connections.
+	for i := range n.nodes {
+		client, err := n.GetClientConnectedToNode(i)
+		if err != nil {
+			return fmt.Errorf("failed to connect to the client: %w", err)
+		}
 		defer client.Close()
 
-		// Wait until connection is established
 		err = WaitFor(context.Background(), func(ctx context.Context) (bool, error) {
-
-			// Connect each node to the next one, and the last one to the first.
-			enode := enodes[(i+1)%len(n.nodes)]
-			if err := client.Client().Call(nil, "admin_addPeer", enode); err != nil {
-				return false, fmt.Errorf("failed to connect to node %d: %v", i, err)
-			}
-
 			// Fetch the list of connected peers
 			var res []map[string]any
 			if err := client.Client().Call(&res, "admin_peers"); err != nil {
-				return false, fmt.Errorf("failed to connect to node %d: %v", i, err)
+				return false, fmt.Errorf("failed to query peers on node %d: %v", i, err)
 			}
 
 			// Expect each node to be connected to the previous and next nodes,


### PR DESCRIPTION
Before fully publishing this PR, it needs to run against CI multiple times.

This PR addresses a flakiness issue in Sonic’s P2P integration tests.

**The problem:**
During integration tests when the test net starts and nodes are connected, sporadically node 0 would not connect to other nodes.

**The Cause**
The integration test net start up and connect checks that a node can report its Chain ID via RPC to identify when a node is "ready" or no. Node's P2P handler and RPC service start independently, without any assurance that the P2P handler has finished booting. When a node would fail the [initial handshake](https://github.com/0xsoniclabs/sonic/blob/main/gossip/handler.go#L565), it would be banned and future attempts rejected. 

**The Solution presented here**
Workaround: Add other nodes as `admin_addTrustedPeer` before adding them as normal peers. This will ignore the previous ban of the failed handshake and try again.
