### PR TITLE
Skip minimum check tip for bundle envelopes

### DIFF
--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -341,7 +341,8 @@ func validateTxForPool(
 
 	// Drop non-local transactions under our own minimal accepted gas price or tip.
 	isSponsorRequest := netRules.gasSubsidies && subsidies.IsSponsorshipRequest(tx)
-	if !isSponsorRequest && tx.GasTipCapIntCmp(opt.minTip) < 0 {
+	isBundle := netRules.brio && bundle.IsEnvelope(tx)
+	if !isSponsorRequest && !isBundle && tx.GasTipCapIntCmp(opt.minTip) < 0 {
 		log.Trace("Rejecting underpriced tx: pool.minTip", "pool.minTip",
 			opt.minTip, "tx.GasTipCap", tx.GasTipCap())
 		return ErrUnderpriced

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
@@ -1083,6 +1084,67 @@ func TestValidateTxForPool_AcceptsNonLocalTxWithTipBiggerThanMin(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestValidateTxForPool_IgnoresBundleAndSponsoredTx_ForTipChecks(t *testing.T) {
+	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		tx           *types.Transaction
+		expecedError error
+	}{
+		"too low tip tx": {
+			tx: types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
+				GasTipCap: big.NewInt(1),
+			}),
+			expecedError: ErrUnderpriced,
+		},
+		"sponsored tx": {
+			tx: types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
+				To: &common.Address{42}, // not a contract creation
+			})},
+		"bundle envelope": {
+			tx: bundle.NewBuilder(signer).
+				With(bundle.Step(key, &types.DynamicFeeTx{})).
+				Build(),
+		},
+		"priced bundle envelope": {
+			tx: bundle.NewBuilder(signer).
+				SetEnvelopeGasPrice(big.NewInt(10)). // not an sponsorship request as it has a gas price
+				With(bundle.Step(key, &types.DynamicFeeTx{})).
+				Build(),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			if test.expecedError == nil {
+				// sanity chech to make sure that inputs are addequate for the test
+				require.True(t, subsidies.IsSponsorshipRequest(test.tx) || bundle.IsEnvelope(test.tx))
+			}
+
+			opts := poolOptions{
+				minTip: big.NewInt(10),
+				locals: newAccountSet(nil),
+			}
+
+			rules := NetworkRules{
+				brio:               true,
+				gasSubsidies:       true,
+				transactionBundles: true,
+			}
+			err := validateTxForPool(test.tx, rules, opts, signer)
+			if test.expecedError != nil {
+				require.ErrorIs(t, err, test.expecedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1092,14 +1092,14 @@ func TestValidateTxForPool_IgnoresBundleAndSponsoredTx_ForTipChecks(t *testing.T
 	require.NoError(t, err)
 
 	tests := map[string]struct {
-		tx           *types.Transaction
-		expecedError error
+		tx            *types.Transaction
+		expectedError error
 	}{
 		"too low tip tx": {
 			tx: types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
 				GasTipCap: big.NewInt(1),
 			}),
-			expecedError: ErrUnderpriced,
+			expectedError: ErrUnderpriced,
 		},
 		"sponsored tx": {
 			tx: types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
@@ -1112,7 +1112,7 @@ func TestValidateTxForPool_IgnoresBundleAndSponsoredTx_ForTipChecks(t *testing.T
 		},
 		"priced bundle envelope": {
 			tx: bundle.NewBuilder(signer).
-				SetEnvelopeGasPrice(big.NewInt(10)). // not an sponsorship request as it has a gas price
+				SetEnvelopeGasPrice(big.NewInt(1)). // not a sponsorship request as it has a gas price; keep it below minTip to exercise the bundle exemption
 				With(bundle.Step(key, &types.DynamicFeeTx{})).
 				Build(),
 		},
@@ -1121,8 +1121,8 @@ func TestValidateTxForPool_IgnoresBundleAndSponsoredTx_ForTipChecks(t *testing.T
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 
-			if test.expecedError == nil {
-				// sanity chech to make sure that inputs are addequate for the test
+			if test.expectedError == nil {
+				// sanity check to make sure that inputs are adequate for the test
 				require.True(t, subsidies.IsSponsorshipRequest(test.tx) || bundle.IsEnvelope(test.tx))
 			}
 
@@ -1137,8 +1137,8 @@ func TestValidateTxForPool_IgnoresBundleAndSponsoredTx_ForTipChecks(t *testing.T
 				transactionBundles: true,
 			}
 			err := validateTxForPool(test.tx, rules, opts, signer)
-			if test.expecedError != nil {
-				require.ErrorIs(t, err, test.expecedError)
+			if test.expectedError != nil {
+				require.ErrorIs(t, err, test.expectedError)
 			} else {
 				require.NoError(t, err)
 			}

--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -128,12 +128,14 @@ func NewBuilder(signer types.Signer) *builder {
 }
 
 type builder struct {
-	signer      types.Signer
-	flags       *ExecutionFlags
-	earliest    *uint64
-	latest      *uint64
-	steps       []BundleStep
-	envelopeKey *ecdsa.PrivateKey
+	signer        types.Signer
+	flags         *ExecutionFlags
+	earliest      *uint64
+	latest        *uint64
+	steps         []BundleStep
+	envelopeKey   *ecdsa.PrivateKey
+	envelopeNonce uint64
+	gasPrice      *big.Int
 }
 
 func (b *builder) SetFlags(flags ExecutionFlags) *builder {
@@ -158,6 +160,19 @@ func (b *builder) With(steps ...BundleStep) *builder {
 
 func (b *builder) SetEnvelopeSenderKey(key *ecdsa.PrivateKey) *builder {
 	b.envelopeKey = key
+	return b
+}
+
+func (b *builder) SetEnvelopeNonce(nonce uint64) *builder {
+	b.envelopeNonce = nonce
+	return b
+}
+
+// SetEnvelopeGasPrice sets the gas price for the envelope transaction.
+// An envelope with gas price is still a valid envelope. This function is
+// added to be able to generate test cases.
+func (b *builder) SetEnvelopeGasPrice(gasPrice *big.Int) *builder {
+	b.gasPrice = gasPrice
 	return b
 }
 
@@ -253,7 +268,7 @@ func (b *builder) BuildEnvelopeBundleAndPlan() (
 		key = newKey
 	}
 	bundle, plan := b.BuildBundleAndPlan()
-	return newEnvelope(b.signer, key, bundle), bundle, plan
+	return newEnvelope(b.signer, key, b.envelopeNonce, b.gasPrice, bundle), bundle, plan
 }
 
 // BuildEnvelope returns an envelope transaction and its execution plan
@@ -284,6 +299,8 @@ func OneOf(signer types.Signer, steps ...BundleStep) *types.Transaction {
 func newEnvelope(
 	signer types.Signer,
 	key *ecdsa.PrivateKey,
+	nonce uint64,
+	gasPrice *big.Int,
 	bundle *TransactionBundle,
 ) *types.Transaction {
 
@@ -315,8 +332,10 @@ func newEnvelope(
 	gasLimit := max(intrinsic, floorDataGas, txGasSum)
 
 	return types.MustSignNewTx(key, signer, &types.AccessListTx{
-		To:   &BundleProcessor,
-		Data: payload,
-		Gas:  gasLimit,
+		To:       &BundleProcessor,
+		Nonce:    nonce,
+		Data:     payload,
+		Gas:      gasLimit,
+		GasPrice: gasPrice,
 	})
 }

--- a/gossip/blockproc/bundle/builder_test.go
+++ b/gossip/blockproc/bundle/builder_test.go
@@ -260,3 +260,52 @@ func TestBundleBuilder_DefaultsSignerIfUnspecified(t *testing.T) {
 	_, _, err = ValidateEnvelope(signer, tx)
 	require.NoError(t, err)
 }
+
+func TestBundleBuilder_CanSetGasPrice(t *testing.T) {
+	signer := types.LatestSignerForChainID(testChainID)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	for _, price := range []*big.Int{nil, big.NewInt(1), big.NewInt(1_000_000)} {
+		t.Run(price.String(), func(t *testing.T) {
+
+			tx := NewBuilder(signer).
+				SetEnvelopeGasPrice(price).
+				With(
+					Step(key, &types.AccessListTx{
+						Nonce: 0,
+					}),
+				).
+				Build()
+
+			_, _, err = ValidateEnvelope(signer, tx)
+			require.NoError(t, err)
+
+			if price != nil {
+				require.Equal(t, 0, tx.GasPrice().Cmp(price))
+			} else {
+				require.Equal(t, 0, tx.GasPrice().Cmp(big.NewInt(0)))
+			}
+		})
+	}
+}
+
+func TestBundleBuilder_DefaultsGasPriceToZero(t *testing.T) {
+	signer := types.LatestSignerForChainID(testChainID)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	tx := NewBuilder(signer).
+		With(
+			Step(key, &types.AccessListTx{
+				Nonce: 0,
+			}),
+		).
+		Build()
+
+	_, _, err = ValidateEnvelope(signer, tx)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, tx.GasPrice().Cmp(big.NewInt(0)))
+}

--- a/gossip/blockproc/bundle/builder_test.go
+++ b/gossip/blockproc/bundle/builder_test.go
@@ -308,3 +308,43 @@ func TestBundleBuilder_DefaultsGasPriceToZero(t *testing.T) {
 
 	require.Equal(t, 0, tx.GasPrice().Cmp(big.NewInt(0)))
 }
+
+func TestBundleBuilder_SetEnvelopeNonce_SetsNonce(t *testing.T) {
+	signer := types.LatestSignerForChainID(testChainID)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	tx := NewBuilder(signer).
+		SetEnvelopeNonce(123).
+		With(
+			Step(key, &types.AccessListTx{
+				Nonce: 0,
+			}),
+		).
+		Build()
+
+	_, _, err = ValidateEnvelope(signer, tx)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(123), tx.Nonce())
+}
+
+func TestBundleBuilder_SetEnvelopeSenderKey_DefaultsNonceWhenUnset(t *testing.T) {
+	signer := types.LatestSignerForChainID(testChainID)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	tx := NewBuilder(signer).
+		SetEnvelopeSenderKey(key).
+		With(
+			Step(key, &types.AccessListTx{
+				Nonce: 0,
+			}),
+		).
+		Build()
+
+	_, _, err = ValidateEnvelope(signer, tx)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(0), tx.Nonce())
+}

--- a/gossip/blockproc/bundle/builder_test.go
+++ b/gossip/blockproc/bundle/builder_test.go
@@ -269,7 +269,6 @@ func TestBundleBuilder_CanSetGasPrice(t *testing.T) {
 
 	for _, price := range []*big.Int{nil, big.NewInt(1), big.NewInt(1_000_000)} {
 		t.Run(price.String(), func(t *testing.T) {
-
 			tx := NewBuilder(signer).
 				SetEnvelopeGasPrice(price).
 				With(


### PR DESCRIPTION
Bypass min tip check during validation for bundles and sponsored txs. 

