### PR TITLE
Have bundle builder adjust gas limits for markers automatically

### DIFF
--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // This file offers utilities to build bundles from transaction data. The most
@@ -197,8 +198,44 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 		b.signer = types.LatestSignerForChainID(big.NewInt(1))
 	}
 
-	// Create an Execution Plan for the bundle.
+	// Add the costs for the additional marker to the gas limit.
+	markerCosts := params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas
+	for _, step := range b.steps {
+		// Fix the gas limit for nested envelops to be accurate.
+		tx := types.NewTx(step.tx)
+		newGasLimit := tx.Gas() + markerCosts
 
+		// For nested envelopes, the gas price needs to be accurately adjusted
+		// to pass the bundle validation test.
+		if IsEnvelope(tx) {
+			innerBundle, _, err := ValidateEnvelope(b.signer, tx)
+			if err == nil {
+				marker := types.AccessTuple{
+					Address:     BundleOnly,
+					StorageKeys: []common.Hash{{1, 2, 3}}, // < value not relevant
+				}
+				newGasLimit = getGasLimitForEnvelope(
+					innerBundle, tx.Data(), []types.AccessTuple{marker},
+				)
+			}
+		}
+
+		switch data := step.tx.(type) {
+		case *types.DynamicFeeTx:
+			data.Gas = newGasLimit
+		case *types.AccessListTx:
+			data.Gas = newGasLimit
+		case *types.BlobTx:
+			data.Gas = newGasLimit
+		case *types.SetCodeTx:
+			data.Gas = newGasLimit
+		default:
+			panic("unsupported TxData type for gas adjustment")
+		}
+
+	}
+
+	// Create an Execution Plan for the bundle.
 	plan := ExecutionPlan{
 		Steps: make([]ExecutionStep, len(b.steps)),
 		Flags: flags,
@@ -305,10 +342,25 @@ func newEnvelope(
 ) *types.Transaction {
 
 	payload := bundle.Encode()
+	gasLimit := getGasLimitForEnvelope(bundle, payload, nil)
 
+	return types.MustSignNewTx(key, signer, &types.AccessListTx{
+		To:       &BundleProcessor,
+		Nonce:    nonce,
+		Data:     payload,
+		Gas:      gasLimit,
+		GasPrice: gasPrice,
+	})
+}
+
+func getGasLimitForEnvelope(
+	bundle *TransactionBundle,
+	payload []byte,
+	accessList []types.AccessTuple,
+) uint64 {
 	intrinsic, err := core.IntrinsicGas(
 		payload,
-		nil,   // access list is not used in the envelope transaction
+		accessList,
 		nil,   // code auth is not used in the bundle transaction
 		false, // bundle transaction is not a contract creation
 		true,  // is homestead
@@ -329,13 +381,5 @@ func newEnvelope(
 		txGasSum += tx.Gas()
 	}
 
-	gasLimit := max(intrinsic, floorDataGas, txGasSum)
-
-	return types.MustSignNewTx(key, signer, &types.AccessListTx{
-		To:       &BundleProcessor,
-		Nonce:    nonce,
-		Data:     payload,
-		Gas:      gasLimit,
-		GasPrice: gasPrice,
-	})
+	return max(intrinsic, floorDataGas, txGasSum)
 }

--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -205,7 +205,7 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 		tx := types.NewTx(step.tx)
 		newGasLimit := tx.Gas() + markerCosts
 
-		// For nested envelopes, the gas price needs to be accurately adjusted
+		// For nested envelopes, the gas limit needs to be accurately adjusted
 		// to pass the bundle validation test.
 		if IsEnvelope(tx) {
 			innerBundle, _, err := ValidateEnvelope(b.signer, tx)

--- a/gossip/blockproc/bundle/builder_test.go
+++ b/gossip/blockproc/bundle/builder_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
 )
 
@@ -228,6 +229,70 @@ func TestBundleBuilder_Builder_NewNestedBundle(t *testing.T) {
 	)
 
 	_, _, err = ValidateEnvelope(signer, combined)
+	require.NoError(t, err)
+}
+
+func TestBundleBuilder_AutomaticallyAddsGasCostsForMarkers(t *testing.T) {
+	require := require.New(t)
+	signer := types.LatestSignerForChainID(testChainID)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	txData := []types.TxData{
+		&types.AccessListTx{},
+		&types.AccessListTx{Gas: 1000},
+		&types.DynamicFeeTx{},
+		&types.DynamicFeeTx{Gas: 1000},
+		&types.BlobTx{},
+		&types.BlobTx{Gas: 1000},
+		&types.SetCodeTx{},
+		&types.SetCodeTx{Gas: 1000},
+	}
+
+	// The transaction data gets modified by the builder. So we keep a backup
+	// of the gas limits before passing them to the builder.
+	gasLimits := make([]uint64, len(txData))
+	for i, data := range txData {
+		gasLimits[i] = types.NewTx(data).Gas()
+	}
+
+	steps := make([]BundleStep, len(txData))
+	for i, data := range txData {
+		steps[i] = Step(key, data)
+	}
+
+	bundle, _ := NewBuilder(signer).With(steps...).BuildBundleAndPlan()
+
+	require.Len(bundle.Transactions, len(txData))
+
+	markerCosts := params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas
+	for i, tx := range bundle.Transactions {
+		require.True(IsBundleOnly(tx))
+		cur := types.NewTx(txData[i])
+		require.Equal(tx.Type(), cur.Type())
+		require.Equal(gasLimits[i]+markerCosts, cur.Gas())
+	}
+}
+
+func TestBundleBuilder_AdjustsNestedEnvelopeGasToPassValidation(t *testing.T) {
+	signer := types.LatestSignerForChainID(testChainID)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	inner := OneOf(signer,
+		Step(key, &types.AccessListTx{}),
+	)
+
+	outer := AllOf(signer,
+		Step(key, inner),
+	)
+
+	bundle, _, err := ValidateEnvelope(signer, outer)
+	require.NoError(t, err)
+
+	_, _, err = ValidateEnvelope(signer, bundle.Transactions[0])
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This PR extends the build-process of the bundle builder to automatically add the extra gas cost for the bundle-only marker to the provided transactions. This frees the user writing tests from making the necessary adjustments. 

In particular, RPC functions like `estimate_gas` can be used on transactions to get the needed gas limit before using the result to build a bundle. Users do not need to account for the added marker themselfs.