### PR TITLE
Add bundle store utilities for genesis

### DIFF
--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -250,6 +250,22 @@ func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
 	return blockNum, hash
 }
 
+// SetProcessedBundlesHistoryHash sets the block number and hash of the
+// processed bundles history. This should be used only during genesis initialization.
+func (s *Store) SetProcessedBundlesHistoryHash(blockNum uint64, hash common.Hash) {
+	// Make sure there is only one update at any time.
+	s.processedBundleMutex.Lock()
+	defer s.processedBundleMutex.Unlock()
+
+	err := s.table.ProcessedBundles.Put(nil, append(
+		bigendian.Uint64ToBytes(blockNum),
+		hash.Bytes()...,
+	))
+	if err != nil {
+		s.Log.Crit("failed to set hash of processed bundles", "error", err)
+	}
+}
+
 // --- utility functions for processed bundles management ---
 
 // getEntryKey returns the key used to store the presence of a processed bundle

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -129,6 +129,7 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) common.
 		// enough blocks have passed to start cleaning up the store
 		highestOutdatedBlockNumber := blockNum - bundle.MaxBlockRange + 1
 		it := s.table.ProcessedBundles.NewIterator([]byte{'i'}, nil)
+		defer it.Release()
 		for it.Next() {
 			key := it.Key()
 			// size of the key used to index processed bundle is:

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -79,7 +80,7 @@ func (s *Store) AddProcessedBundles(
 	newHash := computeNewBundleStateHash(oldHash, addedHash, deletedHash, blockNum)
 
 	err := batch.Put(nil, append(
-		binary.BigEndian.AppendUint64(nil, blockNum),
+		bigendian.Uint64ToBytes(blockNum),
 		newHash.Bytes()...,
 	))
 	if err != nil {
@@ -314,7 +315,9 @@ func getEntryKey(hash common.Hash) []byte {
 // getIndexKey returns the key used to index a processed bundle hash at a
 // specific block number, to handle cleanups.
 func getIndexKey(blockNum uint64, hash common.Hash) []byte {
-	return append(append([]byte{'i'}, binary.BigEndian.AppendUint64(nil, blockNum)...), hash.Bytes()...)
+	return append(
+		append([]byte{'i'}, bigendian.Uint64ToBytes(blockNum)...),
+		hash.Bytes()...)
 }
 
 // xorHash returns the XOR of two hashes.

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -266,6 +266,43 @@ func (s *Store) SetProcessedBundlesHistoryHash(blockNum uint64, hash common.Hash
 	}
 }
 
+// EnumerateProcessedBundles returns a list of all recently processed bundle
+// execution infos currently tracked by the store.
+func (s *Store) EnumerateProcessedBundles() []bundle.ExecutionInfo {
+	// Make sure there is only one update at any time.
+	s.processedBundleMutex.Lock()
+	defer s.processedBundleMutex.Unlock()
+
+	result := make([]bundle.ExecutionInfo, 0)
+
+	// get all recently processed bundles
+	it := s.table.ProcessedBundles.NewIterator([]byte{'e'}, nil)
+	defer it.Release()
+	for it.Next() {
+		key := it.Key()
+		value := it.Value()
+		if len(key) != 1+32 || len(value) != 16 {
+			s.Log.Crit(
+				"invalid key or value length for processed bundle entry during export",
+				"keyLength", len(key),
+				"valueLength", len(value))
+		}
+
+		result = append(result, bundle.ExecutionInfo{
+			ExecutionPlanHash: common.BytesToHash(key[1:]),
+			BlockNumber:       binary.BigEndian.Uint64(value[:8]),
+			Position: bundle.PositionInBlock{
+				Offset: binary.BigEndian.Uint32(value[8:12]),
+				Count:  binary.BigEndian.Uint32(value[12:]),
+			},
+		})
+	}
+	if it.Error() != nil {
+		s.Log.Crit("failed to export processed bundles", "error", it.Error())
+	}
+	return result
+}
+
 // --- utility functions for processed bundles management ---
 
 // getEntryKey returns the key used to store the presence of a processed bundle

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/logger"
+	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -254,7 +255,7 @@ func TestStore_GetProcessedBundleHistoryHash_CorrectlyParsesHash(t *testing.T) {
 		hash := crypto.Keccak256Hash([]byte(fmt.Sprintf("hash for block %d", block)))
 
 		encoded := append(
-			binary.BigEndian.AppendUint64(nil, block),
+			bigendian.Uint64ToBytes(block),
 			hash.Bytes()...,
 		)
 

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -158,9 +158,8 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 		bundle.MaxBlockRange + 1,
 	} {
 		t.Run(fmt.Sprintf("BlockNumber=%d", block), func(t *testing.T) {
-			store, table, _, _, _ := storeTableLogMocks(t)
+			store, table, _, batch, it := storeTableLogMocks(t)
 
-			batch := NewMockstoreBatch(gomock.NewController(t))
 			table.EXPECT().NewBatch().Return(batch)
 			table.EXPECT().Get(gomock.Any())
 
@@ -183,7 +182,6 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 			if block >= bundle.MaxBlockRange-1 {
 				toDelete := block - bundle.MaxBlockRange + 1
 
-				it := NewMockdbIterator(gomock.NewController(t))
 				table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
 				next := it.EXPECT().Next().Return(true)
 				it.EXPECT().Next().Return(false).After(next).AnyTimes()
@@ -508,6 +506,7 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 			batch := NewMockstoreBatch(ctrl)
 			table := NewMockstoreTable(ctrl)
 			it := NewMockdbIterator(ctrl)
+			it.EXPECT().Release().AnyTimes()
 			store := &Store{}
 			store.table.ProcessedBundles = table
 
@@ -551,6 +550,7 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 	store.table.ProcessedBundles = table
 
 	it := NewMockdbIterator(ctrl)
+	it.EXPECT().Release().AnyTimes()
 	table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
 
 	for i := range 10 {
@@ -1109,6 +1109,7 @@ func storeTableLogMocks(t *testing.T) (
 
 	batch := NewMockstoreBatch(ctrl)
 	it := NewMockdbIterator(ctrl)
+	it.EXPECT().Release().AnyTimes()
 
 	return store, table, log, batch, it
 }

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -508,7 +508,7 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 			table := NewMockstoreTable(ctrl)
 			it := NewMockdbIterator(ctrl)
 			if c.finishingBlock >= bundle.MaxBlockRange-1 {
-				it.EXPECT().Release().AnyTimes()
+				it.EXPECT().Release()
 			}
 			store := &Store{}
 			store.table.ProcessedBundles = table

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -934,6 +934,36 @@ func TestStore_ProcessedBundles_RetainsAllBundlesRequiredToCoverTheMaximumBlockR
 	}
 }
 
+func TestStore_SetProcessedBundlesHistoryHash_WritesBundlesHistoryHash(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	blockNum := uint64(10)
+	hash := common.Hash{1, 2, 3}
+
+	store.SetProcessedBundlesHistoryHash(blockNum, hash)
+
+	resBlockNum, resHash := store.GetProcessedBundleHistoryHash()
+	require.Equal(blockNum, resBlockNum)
+	require.Equal(hash, resHash)
+}
+
+func TestStore_SetProcessedBundlesHistoryHash_LogsOnPutError(t *testing.T) {
+	store, table, log, _, _ := storeTableLogMocks(t)
+
+	injectedErr := errors.New("put error")
+	table.EXPECT().Put(gomock.Any(), gomock.Any()).Return(injectedErr)
+
+	expectCrit(log, "failed to set hash of processed bundles", "error", injectedErr)
+	// In production, a Crit log call causes the logger to exit the process.
+	// To prevent the test from exiting, the mock logger is configured to panic instead.
+	require.PanicsWithValue(t,
+		fmt.Sprintf("failed to set hash of processed bundles: %v", []any{"error", injectedErr}),
+		func() { store.SetProcessedBundlesHistoryHash(1, common.Hash{1, 2, 3}) })
+}
+
+
 // --- helper functions ---
 
 // referenceComputeStateHash is a reference implementation of the hash

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -963,6 +963,113 @@ func TestStore_SetProcessedBundlesHistoryHash_LogsOnPutError(t *testing.T) {
 		func() { store.SetProcessedBundlesHistoryHash(1, common.Hash{1, 2, 3}) })
 }
 
+func TestStore_EnumerateProcessedBundles_ReturnsEmptySliceWhenNoEntries(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	exportedEntries := store.EnumerateProcessedBundles()
+	require.NotNil(exportedEntries)
+	require.Empty(exportedEntries, "expected no exported entries when store is empty")
+}
+
+func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
+
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	expected := map[common.Hash]bundle.ExecutionInfo{}
+	// fill the store with the maximum number of bundles
+	for i := range bundle.MaxBlockRange + 1 {
+		hash := common.BytesToHash(bigendian.Uint32ToBytes(uint32(i)))
+		position := bundle.PositionInBlock{Offset: uint32(i), Count: 1}
+		executedBundles := map[common.Hash]bundle.PositionInBlock{
+			hash: position,
+		}
+		store.AddProcessedBundles(uint64(i), executedBundles)
+		if i > 1 {
+			expected[hash] = bundle.ExecutionInfo{
+				ExecutionPlanHash: hash,
+				BlockNumber:       uint64(i),
+				Position:          position,
+			}
+		}
+	}
+	block, historyHash := store.GetProcessedBundleHistoryHash()
+	require.Equal(uint64(bundle.MaxBlockRange), block)
+	require.NotNil(historyHash)
+	require.NotZero(historyHash)
+
+	entries := store.EnumerateProcessedBundles()
+	// MaxBlockRange-1 entries (oldest was pruned)
+	require.Len(entries, int(bundle.MaxBlockRange-1))
+	require.Len(entries, len(expected),
+		"expected number of exported entries does not match expected")
+
+	// Verify each returned entry matches the expected info
+	for _, entry := range expected {
+		require.Contains(entries, entry, "expected entry not found: %+v", entry)
+	}
+}
+
+func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) {
+	store, table, log, _, it := storeTableLogMocks(t)
+
+	injectedErr := errors.New("iterator error")
+	gomock.InOrder(
+		table.EXPECT().NewIterator([]byte{'e'}, nil).Return(it),
+		it.EXPECT().Next().Return(false),
+		it.EXPECT().Error().Return(injectedErr).AnyTimes(),
+	)
+	expectCrit(log, "failed to export processed bundles", "error", injectedErr)
+
+	require.PanicsWithValue(t,
+		fmt.Sprintf("failed to export processed bundles: %v", []any{"error", injectedErr}),
+		func() { store.EnumerateProcessedBundles() })
+}
+
+func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorWrongSize(t *testing.T) {
+
+	tests := map[string]struct {
+		key   []byte
+		value []byte
+	}{
+		"short key": {
+			key:   []byte{1, 2}, // should be 33 bytes for 'e' + hash
+			value: make([]byte, 16),
+		},
+		"short value": {
+			key:   append([]byte{'e'}, common.Hash{1, 2, 3}.Bytes()...),
+			value: make([]byte, 15), // should be 16 bytes
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store, table, log, _, it := storeTableLogMocks(t)
+
+			gomock.InOrder(
+				table.EXPECT().NewIterator([]byte{'e'}, nil).Return(it),
+				it.EXPECT().Next().Return(true),
+				it.EXPECT().Key().Return(tc.key),
+				it.EXPECT().Value().Return(tc.value),
+			)
+			expectCrit(
+				log,
+				"invalid key or value length for processed bundle entry during export",
+				"keyLength", len(tc.key),
+				"valueLength", len(tc.value))
+
+			require.PanicsWithValue(t,
+				fmt.Sprintf("invalid key or value length for processed bundle entry during export: %v",
+					[]any{"keyLength", fmt.Sprintf("%d", len(tc.key)),
+						"valueLength", fmt.Sprintf("%d", len(tc.value))}),
+				func() { store.EnumerateProcessedBundles() })
+
+		})
+	}
+}
 
 // --- helper functions ---
 

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -191,6 +191,7 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 				hash := uint64ToHash(toDelete)
 				batch.EXPECT().Delete(getEntryKey(hash)).Return(nil)
 				batch.EXPECT().Delete(getIndexKey(toDelete, hash)).Return(nil)
+				it.EXPECT().Release()
 			}
 
 			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
@@ -506,7 +507,9 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 			batch := NewMockstoreBatch(ctrl)
 			table := NewMockstoreTable(ctrl)
 			it := NewMockdbIterator(ctrl)
-			it.EXPECT().Release().AnyTimes()
+			if c.finishingBlock >= bundle.MaxBlockRange-1 {
+				it.EXPECT().Release().AnyTimes()
+			}
 			store := &Store{}
 			store.table.ProcessedBundles = table
 
@@ -550,7 +553,7 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 	store.table.ProcessedBundles = table
 
 	it := NewMockdbIterator(ctrl)
-	it.EXPECT().Release().AnyTimes()
+	it.EXPECT().Release()
 	table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
 
 	for i := range 10 {
@@ -613,6 +616,7 @@ func TestStore_deleteOutdatedBundles_ReturnsXorHashOfDeletedEntries(t *testing.T
 			}
 
 			it.EXPECT().Next().Return(false)
+			it.EXPECT().Release()
 
 			deletedHash := store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch)
 
@@ -634,6 +638,7 @@ func TestStore_deleteOutdatedBundles_IgnoresKeysOfWrongLength(t *testing.T) {
 		// This is the key that will be ignored, since it does not have the correct length.
 		it.EXPECT().Key().Return([]byte{1, 2}),
 		it.EXPECT().Next().Return(false),
+		it.EXPECT().Release(),
 	)
 	table.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(it)
 
@@ -651,6 +656,7 @@ func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
 	gomock.InOrder(
 		it.EXPECT().Next().Return(true),
 		it.EXPECT().Key().Return(getIndexKey(1, common.Hash{1, 2, 3})),
+		it.EXPECT().Release(),
 	)
 	table.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(it)
 
@@ -981,7 +987,7 @@ func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 	require.NoError(err)
 
 	expected := map[common.Hash]bundle.ExecutionInfo{}
-	// fill the store with the maximum number of bundles
+	// fill the store with the maximum number of block
 	for i := range bundle.MaxBlockRange + 1 {
 		hash := common.BytesToHash(bigendian.Uint32ToBytes(uint32(i)))
 		position := bundle.PositionInBlock{Offset: uint32(i), Count: 1}
@@ -1021,7 +1027,8 @@ func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorError(t *testing.T) 
 	gomock.InOrder(
 		table.EXPECT().NewIterator([]byte{'e'}, nil).Return(it),
 		it.EXPECT().Next().Return(false),
-		it.EXPECT().Error().Return(injectedErr).AnyTimes(),
+		it.EXPECT().Error().Return(injectedErr).Times(2),
+		it.EXPECT().Release(),
 	)
 	expectCrit(log, "failed to export processed bundles", "error", injectedErr)
 
@@ -1055,6 +1062,7 @@ func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorWrongSize(t *testing
 				it.EXPECT().Next().Return(true),
 				it.EXPECT().Key().Return(tc.key),
 				it.EXPECT().Value().Return(tc.value),
+				it.EXPECT().Release(),
 			)
 			expectCrit(
 				log,
@@ -1109,7 +1117,6 @@ func storeTableLogMocks(t *testing.T) (
 
 	batch := NewMockstoreBatch(ctrl)
 	it := NewMockdbIterator(ctrl)
-	it.EXPECT().Release().AnyTimes()
 
 	return store, table, log, batch, it
 }


### PR DESCRIPTION
This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/622

**Main Contributions**
- `SetProcessedBundlesHistoryHash` an exported method to enable the genesis import to write the processed bundle history hash. 2d12a9f9f0969045474e188c977e7a221aeced22
- `EnumerateProcessedBundles` an exported method which returns a slice containing the `bundle.ExecutionInfo` corresponding to all the entries in the `ProcessedBundles` table. bc1c8762022a90c56e8d3663acedefd24edb13bc

**Minor Contributions**
- Utilisation of existing tooling. 6907c592ba4b23eee14ae19f9b59df6379356ba8
- Missing iterator release and mock ussage. d0aa253034f7286f50e1a2dd672141c3ca333172