### PR TITLE
Factor out TxData extraction

### DIFF
--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -93,25 +94,20 @@ func Step(key *ecdsa.PrivateKey, tx any) BundleStep {
 	case types.SetCodeTx:
 		return BundleStep{key: key, tx: &tx}
 	case *types.Transaction:
-
-		if tx.Type() != types.AccessListTxType &&
-			tx.Type() != types.LegacyTxType {
-			// this code path is used to nest bundles, if
-			// you need any other transaction type, please add it
-			//
-			// not doing this check will lead to data loss
-			panic(" unsupported Tx type for Step. Only AccessListTx and LegacyTx are supported")
+		txData := utils.GetTxData(tx)
+		// Legacy transactions are promoted to AccessListTx in the builder,
+		// to enable marking nested transactions with the bundle-only marker.
+		if data, ok := txData.(*types.LegacyTx); ok {
+			txData = &types.AccessListTx{
+				Nonce:    data.Nonce,
+				GasPrice: data.GasPrice,
+				Gas:      data.Gas,
+				To:       data.To,
+				Value:    data.Value,
+				Data:     data.Data,
+			}
 		}
-
-		return Step(key, &types.AccessListTx{
-			Nonce:      tx.Nonce(),
-			GasPrice:   tx.GasPrice(),
-			Gas:        tx.Gas(),
-			To:         tx.To(),
-			Value:      tx.Value(),
-			Data:       tx.Data(),
-			AccessList: tx.AccessList(),
-		})
+		return Step(key, txData)
 	default:
 		panic("unsupported TxData type")
 	}

--- a/gossip/blockproc/bundle/builder_test.go
+++ b/gossip/blockproc/bundle/builder_test.go
@@ -17,7 +17,6 @@
 package bundle
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -93,25 +92,6 @@ func TestBundleBuilder_Step_AcceptsVariousInputTypes(t *testing.T) {
 	for _, input := range inputs {
 		require.NotPanics(t, func() {
 			Step(nil, input)
-		})
-	}
-}
-
-func TestBundleBuilder_Panics_WhenNestingUnsupportedTxTypes(t *testing.T) {
-
-	cases := []types.TxData{
-		&types.DynamicFeeTx{},
-		&types.BlobTx{},
-		&types.SetCodeTx{},
-	}
-
-	for _, txData := range cases {
-		tx := types.NewTx(txData)
-		t.Run(fmt.Sprintf("TxType%d", tx.Type()), func(t *testing.T) {
-
-			require.Panics(t, func() {
-				Step(nil, tx)
-			}, "unsupported Tx type for Step. Only AccessListTx and LegacyTx are supported")
 		})
 	}
 }

--- a/gossip/blockproc/bundle/bundle.go
+++ b/gossip/blockproc/bundle/bundle.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -144,47 +145,29 @@ func (tb *TransactionBundle) extractExecutionPlan(signer types.Signer) (Executio
 // By doing so, the signature of the transaction is erased. Therefore, the sender
 // or the ChainId can no longer be derived from the resulting transaction.
 func removeBundleOnlyMark(tx *types.Transaction) (*types.Transaction, error) {
-	removeBundleOnlyMark := func(tx *types.Transaction) types.AccessList {
-		var accessList types.AccessList
-		for _, entry := range tx.AccessList() {
-			if entry.Address == BundleOnly {
-				continue
-			}
-			accessList = append(accessList, entry)
+	curAccessList := tx.AccessList()
+	newAccessList := make([]types.AccessTuple, 0, len(curAccessList))
+	for _, cur := range curAccessList {
+		if cur.Address != BundleOnly {
+			newAccessList = append(newAccessList, cur)
 		}
-		return accessList
 	}
 
-	var txData types.TxData
-	switch tx.Type() {
-	case types.AccessListTxType:
-		txData = &types.AccessListTx{
-			Nonce:      tx.Nonce(),
-			GasPrice:   tx.GasPrice(),
-			Gas:        tx.Gas(),
-			To:         tx.To(),
-			Value:      tx.Value(),
-			Data:       tx.Data(),
-			AccessList: removeBundleOnlyMark(tx),
-		}
-	case types.DynamicFeeTxType:
-		txData = &types.DynamicFeeTx{
-			Nonce:      tx.Nonce(),
-			GasTipCap:  tx.GasTipCap(),
-			GasFeeCap:  tx.GasFeeCap(),
-			Gas:        tx.Gas(),
-			To:         tx.To(),
-			Value:      tx.Value(),
-			Data:       tx.Data(),
-			AccessList: removeBundleOnlyMark(tx),
-		}
+	// Create a copy of the transaction data with the modified access list.
+	txData := utils.GetTxData(tx)
+	switch data := txData.(type) {
+	case *types.AccessListTx:
+		data.AccessList = newAccessList
+	case *types.DynamicFeeTx:
+		data.AccessList = newAccessList
+	case *types.BlobTx:
+		data.AccessList = newAccessList
+	case *types.SetCodeTx:
+		data.AccessList = newAccessList
 	default:
-		// Note:
-		// - Legacy transactions cannot be bundled, because they lack of access list
-		// - Blob transactions have dubious usefulness in bundles and are not fully supported in Sonic
-		// - SetCodeTransactions have special interactions with other transactions, and they are not supported in bundles
-		return nil, fmt.Errorf("invalid bundle: unsupported transaction type %d", tx.Type())
+		return nil, fmt.Errorf("unsupported transaction type: %d", tx.Type())
 	}
+
 	return types.NewTx(txData), nil
 }
 

--- a/gossip/blockproc/bundle/bundle_test.go
+++ b/gossip/blockproc/bundle/bundle_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -303,8 +304,6 @@ func TestExtractExecutionPlan_ReturnsErrorWithUnsupportedTransactionType(t *test
 
 	tests := []types.TxData{
 		&types.LegacyTx{},
-		&types.BlobTx{},
-		&types.SetCodeTx{},
 	}
 
 	for _, txData := range tests {
@@ -320,7 +319,7 @@ func TestExtractExecutionPlan_ReturnsErrorWithUnsupportedTransactionType(t *test
 
 		_, err := bundle.extractExecutionPlan(mockSigner)
 		require.ErrorContains(t, err,
-			fmt.Sprintf("invalid bundle: unsupported transaction type %d", tx.Type()))
+			fmt.Sprintf("unsupported transaction type: %d", tx.Type()))
 	}
 }
 
@@ -350,15 +349,13 @@ func TestExtractExecutionPlan_ReturnsErrorWithMalformedSignature(t *testing.T) {
 func TestRemoveBundleOnlyMark_ReturnsErrorWithUnsupportedTransactionType(t *testing.T) {
 	tests := []types.TxData{
 		&types.LegacyTx{},
-		&types.BlobTx{},
-		&types.SetCodeTx{},
 	}
 
 	for _, txData := range tests {
 		tx := types.NewTx(txData)
 		_, err := removeBundleOnlyMark(tx)
 		require.ErrorContains(t, err,
-			fmt.Sprintf("invalid bundle: unsupported transaction type %d", tx.Type()))
+			fmt.Sprintf("unsupported transaction type: %d", tx.Type()))
 	}
 }
 
@@ -366,12 +363,16 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 
 	type msg struct {
 		Nonce      uint64
-		GasPrice   *big.Int
+		GasPrice   *uint256.Int
+		GasFeeCap  *uint256.Int
+		GasTipCap  *uint256.Int
 		Gas        uint64
 		To         *common.Address
-		Value      *big.Int
+		Value      *uint256.Int
 		Data       []byte
 		AccessList types.AccessList
+		BlobHashes []common.Hash
+		AuthList   []types.SetCodeAuthorization
 	}
 
 	normalAccessListEntry := types.AccessList{
@@ -388,24 +389,42 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 	}
 
 	tests := make([]msg, 0)
-	for _, gasPrice := range []*big.Int{nil, big.NewInt(0), big.NewInt(200)} {
-		for _, gas := range []uint64{0, 21000} {
-			for _, to := range []*common.Address{nil, {0x01}} {
-				for _, value := range []*big.Int{nil, big.NewInt(0), big.NewInt(100)} {
-					for _, accessList := range []types.AccessList{
-						nil,
-						normalAccessListEntry,
-					} {
-
-						tests = append(tests, msg{
-							Nonce:      1,
-							GasPrice:   gasPrice,
-							Gas:        gas,
-							To:         to,
-							Value:      value,
-							Data:       []byte{0x01, 0x02},
-							AccessList: accessList,
-						})
+	for _, gasPrice := range []*uint256.Int{nil, uint256.NewInt(0), uint256.NewInt(200)} {
+		for _, gasFeeCap := range []*uint256.Int{nil, uint256.NewInt(0), uint256.NewInt(200)} {
+			for _, gasTipCap := range []*uint256.Int{nil, uint256.NewInt(0), uint256.NewInt(200)} {
+				for _, gas := range []uint64{0, 21000} {
+					for _, to := range []*common.Address{nil, {0x01}} {
+						for _, value := range []*uint256.Int{nil, uint256.NewInt(0), uint256.NewInt(100)} {
+							for _, accessList := range []types.AccessList{
+								nil,
+								normalAccessListEntry,
+							} {
+								for _, blobHash := range [][]common.Hash{
+									nil, {{0x01}, {0x02}},
+								} {
+									for _, authList := range [][]types.SetCodeAuthorization{
+										nil, {
+											{Address: common.Address{1}, Nonce: 0x02},
+											{Address: common.Address{3}, Nonce: 0x04},
+										},
+									} {
+										tests = append(tests, msg{
+											Nonce:      1,
+											GasPrice:   gasPrice,
+											GasFeeCap:  gasFeeCap,
+											GasTipCap:  gasTipCap,
+											Gas:        gas,
+											To:         to,
+											Value:      value,
+											Data:       []byte{0x01, 0x02},
+											AccessList: accessList,
+											BlobHashes: blobHash,
+											AuthList:   authList,
+										})
+									}
+								}
+							}
+						}
 					}
 				}
 			}
@@ -418,10 +437,10 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 
 			txData := &types.AccessListTx{
 				Nonce:      test.Nonce,
-				GasPrice:   test.GasPrice,
+				GasPrice:   test.GasPrice.ToBig(),
 				Gas:        test.Gas,
 				To:         test.To,
-				Value:      test.Value,
+				Value:      test.Value.ToBig(),
 				Data:       test.Data,
 				AccessList: test.AccessList,
 			}
@@ -431,20 +450,20 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 			require.NoError(t, err)
 
 			if test.GasPrice == nil {
-				test.GasPrice = big.NewInt(0)
+				test.GasPrice = uint256.NewInt(0)
 			}
 			if test.Value == nil {
-				test.Value = big.NewInt(0)
+				test.Value = uint256.NewInt(0)
 			}
 			if test.AccessList == nil {
 				test.AccessList = types.AccessList{}
 			}
 
 			require.Equal(t, test.Nonce, modified.Nonce())
-			require.Equal(t, test.GasPrice, modified.GasPrice())
+			require.Equal(t, test.GasPrice.Uint64(), modified.GasPrice().Uint64())
 			require.Equal(t, test.Gas, modified.Gas())
 			require.Equal(t, test.To, modified.To())
-			require.Equal(t, test.Value, modified.Value())
+			require.Equal(t, test.Value.Uint64(), modified.Value().Uint64())
 			require.Equal(t, test.Data, modified.Data())
 			require.Equal(t, test.AccessList, modified.AccessList())
 		})
@@ -453,10 +472,10 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 
 			txData := &types.AccessListTx{
 				Nonce:      test.Nonce,
-				GasPrice:   test.GasPrice,
+				GasPrice:   test.GasPrice.ToBig(),
 				Gas:        test.Gas,
 				To:         test.To,
-				Value:      test.Value,
+				Value:      test.Value.ToBig(),
 				Data:       test.Data,
 				AccessList: append(test.AccessList, bundleOnlyMark...),
 			}
@@ -476,11 +495,11 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 
 			txData := &types.DynamicFeeTx{
 				Nonce:      test.Nonce,
-				GasFeeCap:  test.GasPrice,
-				GasTipCap:  test.GasPrice,
+				GasFeeCap:  test.GasFeeCap.ToBig(),
+				GasTipCap:  test.GasTipCap.ToBig(),
 				Gas:        test.Gas,
 				To:         test.To,
-				Value:      test.Value,
+				Value:      test.Value.ToBig(),
 				Data:       test.Data,
 				AccessList: test.AccessList,
 			}
@@ -489,22 +508,25 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 			modified, err := removeBundleOnlyMark(tx)
 			require.NoError(t, err)
 
-			if test.GasPrice == nil {
-				test.GasPrice = big.NewInt(0)
+			if test.GasFeeCap == nil {
+				test.GasFeeCap = uint256.NewInt(0)
+			}
+			if test.GasTipCap == nil {
+				test.GasTipCap = uint256.NewInt(0)
 			}
 			if test.Value == nil {
-				test.Value = big.NewInt(0)
+				test.Value = uint256.NewInt(0)
 			}
 			if test.AccessList == nil {
 				test.AccessList = types.AccessList{}
 			}
 
 			require.Equal(t, test.Nonce, modified.Nonce())
-			require.Equal(t, test.GasPrice, modified.GasFeeCap())
-			require.Equal(t, test.GasPrice, modified.GasTipCap())
+			require.Equal(t, test.GasFeeCap.Uint64(), modified.GasFeeCap().Uint64())
+			require.Equal(t, test.GasTipCap.Uint64(), modified.GasTipCap().Uint64())
 			require.Equal(t, test.Gas, modified.Gas())
 			require.Equal(t, test.To, modified.To())
-			require.Equal(t, test.Value, modified.Value())
+			require.Equal(t, test.Value.Uint64(), modified.Value().Uint64())
 			require.Equal(t, test.Data, modified.Data())
 			require.Equal(t, test.AccessList, modified.AccessList())
 		})
@@ -513,13 +535,168 @@ func TestRemoveBundleOnlyMark_PreservesOriginalData(t *testing.T) {
 
 			txData := &types.DynamicFeeTx{
 				Nonce:      test.Nonce,
+				GasFeeCap:  test.GasFeeCap.ToBig(),
+				GasTipCap:  test.GasTipCap.ToBig(),
+				Gas:        test.Gas,
+				To:         test.To,
+				Value:      test.Value.ToBig(),
+				Data:       test.Data,
+				AccessList: append(test.AccessList, bundleOnlyMark...),
+			}
+
+			tx := types.NewTx(txData)
+			modified, err := removeBundleOnlyMark(tx)
+			require.NoError(t, err)
+
+			if test.AccessList == nil {
+				test.AccessList = types.AccessList{}
+			}
+
+			require.Equal(t, test.AccessList, modified.AccessList())
+		})
+
+		t.Run("preserves original members of a blob transaction", func(t *testing.T) {
+			if test.To == nil {
+				t.Skip("receiver must not be nil for blob transactions")
+			}
+
+			txData := &types.BlobTx{
+				Nonce:      test.Nonce,
+				GasFeeCap:  test.GasFeeCap,
+				GasTipCap:  test.GasTipCap,
+				Gas:        test.Gas,
+				To:         *test.To,
+				Value:      test.Value,
+				Data:       test.Data,
+				AccessList: test.AccessList,
+				BlobFeeCap: test.GasPrice,
+				BlobHashes: test.BlobHashes,
+			}
+
+			tx := types.NewTx(txData)
+			modified, err := removeBundleOnlyMark(tx)
+			require.NoError(t, err)
+
+			if test.GasPrice == nil {
+				test.GasPrice = uint256.NewInt(0)
+			}
+			if test.GasFeeCap == nil {
+				test.GasFeeCap = uint256.NewInt(0)
+			}
+			if test.GasTipCap == nil {
+				test.GasTipCap = uint256.NewInt(0)
+			}
+			if test.Value == nil {
+				test.Value = uint256.NewInt(0)
+			}
+			if test.AccessList == nil {
+				test.AccessList = types.AccessList{}
+			}
+			if test.BlobHashes == nil {
+				test.BlobHashes = []common.Hash{}
+			}
+
+			require.Equal(t, test.Nonce, modified.Nonce())
+			require.Equal(t, test.GasFeeCap.Uint64(), modified.GasFeeCap().Uint64())
+			require.Equal(t, test.GasTipCap.Uint64(), modified.GasTipCap().Uint64())
+			require.Equal(t, test.Gas, modified.Gas())
+			require.Equal(t, test.To, modified.To())
+			require.Equal(t, test.Value.Uint64(), modified.Value().Uint64())
+			require.Equal(t, test.Data, modified.Data())
+			require.Equal(t, test.AccessList, modified.AccessList())
+			require.Equal(t, test.GasPrice.Uint64(), modified.BlobGasFeeCap().Uint64())
+			require.Equal(t, test.BlobHashes, modified.BlobHashes())
+		})
+
+		t.Run("removes bundle marker from the blob transaction", func(t *testing.T) {
+			if test.To == nil {
+				t.Skip("receiver must not be nil for blob transactions")
+			}
+
+			txData := &types.BlobTx{
+				Nonce:      test.Nonce,
 				GasFeeCap:  test.GasPrice,
 				GasTipCap:  test.GasPrice,
 				Gas:        test.Gas,
-				To:         test.To,
+				To:         *test.To,
 				Value:      test.Value,
 				Data:       test.Data,
 				AccessList: append(test.AccessList, bundleOnlyMark...),
+			}
+
+			tx := types.NewTx(txData)
+			modified, err := removeBundleOnlyMark(tx)
+			require.NoError(t, err)
+
+			if test.AccessList == nil {
+				test.AccessList = types.AccessList{}
+			}
+
+			require.Equal(t, test.AccessList, modified.AccessList())
+		})
+
+		t.Run("preserves original members of a set code transaction", func(t *testing.T) {
+			if test.To == nil {
+				t.Skip("receiver must not be nil for set code transactions")
+			}
+
+			txData := &types.SetCodeTx{
+				Nonce:      test.Nonce,
+				GasFeeCap:  test.GasFeeCap,
+				GasTipCap:  test.GasTipCap,
+				Gas:        test.Gas,
+				To:         *test.To,
+				Value:      test.Value,
+				Data:       test.Data,
+				AccessList: test.AccessList,
+				AuthList:   test.AuthList,
+			}
+
+			tx := types.NewTx(txData)
+			modified, err := removeBundleOnlyMark(tx)
+			require.NoError(t, err)
+
+			if test.GasFeeCap == nil {
+				test.GasFeeCap = uint256.NewInt(0)
+			}
+			if test.GasTipCap == nil {
+				test.GasTipCap = uint256.NewInt(0)
+			}
+			if test.Value == nil {
+				test.Value = uint256.NewInt(0)
+			}
+			if test.AccessList == nil {
+				test.AccessList = types.AccessList{}
+			}
+			if test.AuthList == nil {
+				test.AuthList = []types.SetCodeAuthorization{}
+			}
+
+			require.Equal(t, test.Nonce, modified.Nonce())
+			require.Equal(t, test.GasFeeCap.Uint64(), modified.GasFeeCap().Uint64())
+			require.Equal(t, test.GasTipCap.Uint64(), modified.GasTipCap().Uint64())
+			require.Equal(t, test.Gas, modified.Gas())
+			require.Equal(t, test.To, modified.To())
+			require.Equal(t, test.Value.Uint64(), modified.Value().Uint64())
+			require.Equal(t, test.Data, modified.Data())
+			require.Equal(t, test.AccessList, modified.AccessList())
+			require.Equal(t, test.AuthList, modified.SetCodeAuthorizations())
+		})
+
+		t.Run("removes bundle marker from the dynamic fee transaction", func(t *testing.T) {
+			if test.To == nil {
+				t.Skip("receiver must not be nil for set code transactions")
+			}
+			txData := &types.SetCodeTx{
+				Nonce:      test.Nonce,
+				GasFeeCap:  test.GasFeeCap,
+				GasTipCap:  test.GasTipCap,
+				Gas:        test.Gas,
+				To:         *test.To,
+				Value:      test.Value,
+				Data:       test.Data,
+				AccessList: append(test.AccessList, bundleOnlyMark...),
+				AuthList:   test.AuthList,
 			}
 
 			tx := types.NewTx(txData)

--- a/utils/txs.go
+++ b/utils/txs.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+// GetTxData extracts the inner TxData from a given transaction, which is
+// handy for mutating transactions in various contexts.
+func GetTxData(tx *types.Transaction) types.TxData {
+
+	// TODO: consider adding a modification to Sonic's go-ethereum fork to
+	// enable a direct call to tx.inner.copy(), having the same effect.
+
+	// Manually create a copy of the transactions's inner data type.
+	var txData types.TxData
+	v, r, s := tx.RawSignatureValues()
+	switch tx.Type() {
+	case types.LegacyTxType:
+		txData = &types.LegacyTx{
+			Nonce:    tx.Nonce(),
+			GasPrice: tx.GasPrice(),
+			Gas:      tx.Gas(),
+			To:       tx.To(),
+			Value:    tx.Value(),
+			Data:     tx.Data(),
+			V:        v,
+			R:        r,
+			S:        s,
+		}
+	case types.AccessListTxType:
+		txData = &types.AccessListTx{
+			ChainID:    tx.ChainId(),
+			Nonce:      tx.Nonce(),
+			GasPrice:   tx.GasPrice(),
+			Gas:        tx.Gas(),
+			To:         tx.To(),
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+			V:          v,
+			R:          r,
+			S:          s,
+		}
+	case types.DynamicFeeTxType:
+		txData = &types.DynamicFeeTx{
+			ChainID:    tx.ChainId(),
+			Nonce:      tx.Nonce(),
+			GasTipCap:  tx.GasTipCap(),
+			GasFeeCap:  tx.GasFeeCap(),
+			Gas:        tx.Gas(),
+			To:         tx.To(),
+			Value:      tx.Value(),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+			V:          v,
+			R:          r,
+			S:          s,
+		}
+	case types.BlobTxType:
+		txData = &types.BlobTx{
+			ChainID:    mustToUint256(tx.ChainId()),
+			Nonce:      tx.Nonce(),
+			GasTipCap:  mustToUint256(tx.GasTipCap()),
+			GasFeeCap:  mustToUint256(tx.GasFeeCap()),
+			Gas:        tx.Gas(),
+			To:         *tx.To(),
+			Value:      mustToUint256(tx.Value()),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+			BlobFeeCap: mustToUint256(tx.BlobGasFeeCap()),
+			BlobHashes: tx.BlobHashes(),
+			V:          mustToUint256(v),
+			R:          mustToUint256(r),
+			S:          mustToUint256(s),
+		}
+
+	case types.SetCodeTxType:
+		txData = &types.SetCodeTx{
+			ChainID:    mustToUint256(tx.ChainId()),
+			Nonce:      tx.Nonce(),
+			GasTipCap:  mustToUint256(tx.GasTipCap()),
+			GasFeeCap:  mustToUint256(tx.GasFeeCap()),
+			Gas:        tx.Gas(),
+			To:         *tx.To(),
+			Value:      mustToUint256(tx.Value()),
+			Data:       tx.Data(),
+			AccessList: tx.AccessList(),
+			AuthList:   tx.SetCodeAuthorizations(),
+			V:          mustToUint256(v),
+			R:          mustToUint256(r),
+			S:          mustToUint256(s),
+		}
+	}
+	return txData
+}
+
+func mustToUint256(value *big.Int) *uint256.Int {
+	if value == nil {
+		return nil
+	}
+	if value.Sign() < 0 {
+		panic(fmt.Sprintf("out of uint256 domain: %v", value))
+	}
+	res, overflow := uint256.FromBig(value)
+	if overflow {
+		panic(fmt.Sprintf("out of uint256 domain: %v", value))
+	}
+	return res
+}

--- a/utils/txs_test.go
+++ b/utils/txs_test.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTxData_ExtractsAllData(t *testing.T) {
+
+	type msg struct {
+		ChainId    *uint256.Int
+		Nonce      uint64
+		GasPrice   *uint256.Int
+		GasFeeCap  *uint256.Int
+		GasTipCap  *uint256.Int
+		Gas        uint64
+		To         *common.Address
+		Value      *uint256.Int
+		Data       []byte
+		AccessList types.AccessList
+		BlobHashes []common.Hash
+		AuthList   []types.SetCodeAuthorization
+		V          *uint256.Int
+		R          *uint256.Int
+		S          *uint256.Int
+	}
+
+	uint256Options := []*uint256.Int{uint256.NewInt(5), uint256.NewInt(100)}
+
+	tests := make([]msg, 0)
+	for _, chainId := range uint256Options {
+		for _, nonce := range []uint64{0, 1} {
+			for _, gasPrice := range uint256Options {
+				for _, gasFeeCap := range uint256Options {
+					for _, gasTipCap := range uint256Options {
+						for _, gas := range []uint64{0, 21000} {
+							for _, to := range []*common.Address{nil, {0x01}} {
+								for _, value := range uint256Options {
+									for _, accessList := range []types.AccessList{
+										{},
+										{{
+											Address:     common.Address{1},
+											StorageKeys: []common.Hash{{0x02}, {0x03}},
+										}},
+									} {
+										for _, blobHash := range [][]common.Hash{
+											{}, {{0x01}, {0x02}},
+										} {
+											for _, authList := range [][]types.SetCodeAuthorization{
+												{}, {
+													{Address: common.Address{1}, Nonce: 0x02},
+													{Address: common.Address{3}, Nonce: 0x04},
+												},
+											} {
+												for _, v := range uint256Options {
+													for _, r := range uint256Options {
+														for _, s := range uint256Options {
+															tests = append(tests, msg{
+																ChainId:    chainId,
+																Nonce:      nonce,
+																GasPrice:   gasPrice,
+																GasFeeCap:  gasFeeCap,
+																GasTipCap:  gasTipCap,
+																Gas:        gas,
+																To:         to,
+																Value:      value,
+																Data:       []byte{0x01, 0x02},
+																AccessList: accessList,
+																BlobHashes: blobHash,
+																AuthList:   authList,
+																V:          v,
+																R:          r,
+																S:          s,
+															})
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for _, test := range tests {
+
+		t.Run("LegacyTx", func(t *testing.T) {
+			original := &types.LegacyTx{
+				Nonce:    test.Nonce,
+				GasPrice: test.GasPrice.ToBig(),
+				Gas:      test.Gas,
+				To:       test.To,
+				Value:    test.Value.ToBig(),
+				Data:     test.Data,
+				V:        test.V.ToBig(),
+				R:        test.R.ToBig(),
+				S:        test.S.ToBig(),
+			}
+
+			tx := types.NewTx(original)
+
+			txData := GetTxData(tx)
+
+			restored := txData.(*types.LegacyTx)
+			require.Equal(t, original, restored)
+		})
+		t.Run("AccessListTx", func(t *testing.T) {
+			original := &types.AccessListTx{
+				ChainID:    test.ChainId.ToBig(),
+				Nonce:      test.Nonce,
+				GasPrice:   test.GasPrice.ToBig(),
+				Gas:        test.Gas,
+				To:         test.To,
+				Value:      test.Value.ToBig(),
+				Data:       test.Data,
+				AccessList: test.AccessList,
+				V:          test.V.ToBig(),
+				R:          test.R.ToBig(),
+				S:          test.S.ToBig(),
+			}
+
+			tx := types.NewTx(original)
+
+			txData := GetTxData(tx)
+
+			restored := txData.(*types.AccessListTx)
+			require.Equal(t, original, restored)
+		})
+
+		t.Run("DynamicFeeTx", func(t *testing.T) {
+			original := &types.DynamicFeeTx{
+				ChainID:    test.ChainId.ToBig(),
+				Nonce:      test.Nonce,
+				GasFeeCap:  test.GasFeeCap.ToBig(),
+				GasTipCap:  test.GasTipCap.ToBig(),
+				Gas:        test.Gas,
+				To:         test.To,
+				Value:      test.Value.ToBig(),
+				Data:       test.Data,
+				AccessList: test.AccessList,
+				V:          test.V.ToBig(),
+				R:          test.R.ToBig(),
+				S:          test.S.ToBig(),
+			}
+
+			tx := types.NewTx(original)
+
+			txData := GetTxData(tx)
+
+			restored := txData.(*types.DynamicFeeTx)
+			require.Equal(t, original, restored)
+		})
+
+		t.Run("BlobTx", func(t *testing.T) {
+			if test.To == nil {
+				t.Skip("BlobTx requires a non-nil To address")
+			}
+			original := &types.BlobTx{
+				ChainID:    test.ChainId,
+				Nonce:      test.Nonce,
+				GasFeeCap:  test.GasFeeCap,
+				GasTipCap:  test.GasTipCap,
+				Gas:        test.Gas,
+				To:         *test.To,
+				Value:      test.Value,
+				Data:       test.Data,
+				AccessList: test.AccessList,
+				BlobFeeCap: test.GasPrice, // < reuse of deprecated field
+				BlobHashes: test.BlobHashes,
+				V:          test.V,
+				R:          test.R,
+				S:          test.S,
+			}
+
+			tx := types.NewTx(original)
+
+			txData := GetTxData(tx)
+
+			restored := txData.(*types.BlobTx)
+			require.Equal(t, original, restored)
+		})
+
+		t.Run("SetCodeTx", func(t *testing.T) {
+			if test.To == nil {
+				t.Skip("SetCodeTx requires a non-nil To address")
+			}
+			original := &types.SetCodeTx{
+				ChainID:    test.ChainId,
+				Nonce:      test.Nonce,
+				GasFeeCap:  test.GasFeeCap,
+				GasTipCap:  test.GasTipCap,
+				Gas:        test.Gas,
+				To:         *test.To,
+				Value:      test.Value,
+				Data:       test.Data,
+				AccessList: test.AccessList,
+				AuthList:   test.AuthList,
+				V:          test.V,
+				R:          test.R,
+				S:          test.S,
+			}
+
+			tx := types.NewTx(original)
+
+			txData := GetTxData(tx)
+
+			restored := txData.(*types.SetCodeTx)
+			require.Equal(t, original, restored)
+		})
+	}
+}
+
+func Test_mustToUint256_ValidInputs_ProducesSameValueResult(t *testing.T) {
+	tests := map[string]struct {
+		input    *big.Int
+		expected *uint256.Int
+	}{
+		"nil input": {
+			input:    nil,
+			expected: nil,
+		},
+		"zero input": {
+			input:    big.NewInt(0),
+			expected: uint256.NewInt(0),
+		},
+		"positive input": {
+			input:    big.NewInt(123456789),
+			expected: uint256.NewInt(123456789),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := mustToUint256(test.input)
+			require.Equal(t, test.expected, result)
+			if test.input != nil {
+				test.input.SetInt64(0)                  // mutate input to check for copying
+				require.Equal(t, test.expected, result) // result should not change
+			}
+		})
+	}
+}
+
+func Test_mustToUint256_InvalidInputs_Panics(t *testing.T) {
+	tests := map[string]*big.Int{
+		"-1":     new(big.Int).Sub(big.NewInt(0), big.NewInt(1)),
+		"-20":    new(big.Int).Sub(big.NewInt(0), big.NewInt(20)),
+		"-2^256": new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+		"2^256":  new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil),
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.PanicsWithValue(t,
+				fmt.Sprintf("out of uint256 domain: %v", input), func() {
+					mustToUint256(input)
+				},
+			)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a utility to extract TxData from a transaction.

The extraction of TxData is a useful utility in any context where transactions have to be modified. It enabled the modification of otherwise read-only `types.Transaction` instances.

Currently, this is done by inspecting the transaction type and reconstructing the TxData. In the future, Sonic's go-ethereum fork may be modified to provide access to internal go-etherum functions handling the copying of TxData.

The PR is also used to generalize the support of transaction types in bundles.
