### PR TITLE
WIP: make waiting for epoch faster.

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -859,9 +859,17 @@ func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSessio
 // For this reason, it is not exposed via the Session object to avoid side effects in parallel tests.
 func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 	t.Helper()
+
 	client, err := n.GetClient()
 	require.NoError(t, err, "failed to connect to the Ethereum client")
 	defer client.Close()
+
+	//send a noop transaction to trigger a block
+	sendNoop := func() {
+		noopTx := CreateTransaction(t, n, &types.LegacyTx{}, n.GetSessionSponsor())
+		err := client.SendTransaction(t.Context(), noopTx)
+		require.NoError(t, err, "failed to send noop transaction to trigger block sealing")
+	}
 
 	var currentEpoch hexutil.Uint64
 	err = client.Client().Call(&currentEpoch, "eth_currentEpoch")
@@ -882,7 +890,11 @@ func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 		if err := client.Client().Call(&newEpoch, "eth_currentEpoch"); err != nil {
 			return false, fmt.Errorf("failed to get current epoch: %w", err)
 		}
-		return newEpoch >= currentEpoch+hexutil.Uint64(epochs), nil
+		hasEpochAdvanced := newEpoch >= currentEpoch+hexutil.Uint64(epochs)
+		if !hasEpochAdvanced {
+			sendNoop()
+		}
+		return hasEpochAdvanced, nil
 	})
 	require.NoError(t, err, "failed to wait for epoch to advance")
 
@@ -895,12 +907,19 @@ func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 	// block is completed.
 	currentBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(t, err)
+
+	sendNoop()
 	err = WaitFor(t.Context(), func(ctx context.Context) (bool, error) {
 		newBlock, err := client.BlockByNumber(t.Context(), nil)
 		if err != nil {
 			return false, err
 		}
-		return newBlock.Number().Int64() > currentBlock.Number().Int64()+1, nil
+		advancedEnough := newBlock.Number().Int64() > currentBlock.Number().Int64()+1
+		if !advancedEnough {
+			sendNoop()
+			return false, nil
+		}
+		return true, nil
 	})
 	require.NoError(t, err, "failed to wait seling block to be completed epoch change")
 }

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -56,7 +56,7 @@ import (
 //     minimum gas required to execute the transaction
 //     Filled gas is a static minimum value, it does not account for the gas
 //     costs of the contract opcodes.
-func CreateTransaction(t *testing.T, session IntegrationTestNetSession, tx types.TxData, account *Account) *types.Transaction {
+func CreateTransaction(t testing.TB, session IntegrationTestNetSession, tx types.TxData, account *Account) *types.Transaction {
 	t.Helper()
 	signedTx := SignTransaction(
 		t,
@@ -70,7 +70,7 @@ func CreateTransaction(t *testing.T, session IntegrationTestNetSession, tx types
 // SignTransaction is a testing helper that signs a transaction with the
 // key from the provided account
 func SignTransaction(
-	t *testing.T,
+	t testing.TB,
 	chainId *big.Int,
 	payload types.TxData,
 	from *Account,
@@ -98,7 +98,7 @@ func SignTransaction(
 // Notice that this function is generic, returning the same type as the input, this
 // allows further manual configuration of the transaction fields after the defaults are set.
 func SetTransactionDefaults[T types.TxData](
-	t *testing.T,
+	t testing.TB,
 	net IntegrationTestNetSession,
 	txPayload T,
 	sender *Account,


### PR DESCRIPTION
**The problem:**
Many integration tests need to advance epoch (to change rules or simply for the sake of advancing epochs) and the new imeplementation of `AdvanceEpoch` (https://github.com/0xsoniclabs/sonic/commit/7b266ec9ea3ad5d961863d9ded661c1d73f2327b) also introduces a necessary wait for the following blocks. That means at least 3 blocks need to be produced, one for the new rule to be processed and 2 more for the rules to take effect. That means if no transactions is sent, this could delay any test by 8 seconds. 

**The Solution**
This PR proposes to send a noop transaction while waiting for the epoch to have advanced and the blocks to be produced. As the presence of a transaction, even if it does not transfer any value or trigger any contracts, will trigger a block, hence reducing the time needed for each advance epoch from more than 8 seconds, to 4. 

**The Impact**
Observing CI times before/after https://github.com/0xsoniclabs/sonic/commit/7b266ec9ea3ad5d961863d9ded661c1d73f2327b, showed that PR introduced a 6 minute delay. This PR reduces the CI time back to ~11 minutes

Note: This PR depends on a pending https://github.com/0xsoniclabs/sonic/pull/840