### PR TITLE
Bump carmen version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ module github.com/0xsoniclabs/sonic
 go 1.25.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20260327130402-3d65421a9475
+	github.com/0xsoniclabs/carmen/go v0.0.0-20260413073511-38e882c830d4
 	github.com/0xsoniclabs/tosca v0.0.0-20260327130322-2d1aa839a807
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20260327130402-3d65421a9475 h1:kidFE0yeQxmHw6ZvLO9KqLO6xkOsiJy05j8I8HS1Fwk=
-github.com/0xsoniclabs/carmen/go v0.0.0-20260327130402-3d65421a9475/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260413073511-38e882c830d4 h1:dAH39R35l/fkUAGoELaXWip5bPuICJ/AYt50GFJRFEY=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260413073511-38e882c830d4/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260316131102-1779772a79a7 h1:DrmIiQcFnSI4WDmJzgWR1k9kC6U9lzIwlI/HdYVL7vE=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260316131102-1779772a79a7/go.mod h1:n7fKfyeGBq9OJZNciI0MR0fpFQsPCVqbqS/izf3HYzE=
 github.com/0xsoniclabs/tosca v0.0.0-20260327130322-2d1aa839a807 h1:DUmd+g/9XDUPdJvCfnzguwuwKlfK5z02v3fAJGLIKfQ=


### PR DESCRIPTION
This bump is mostly required for https://github.com/0xsoniclabs/carmen/pull/389, which gives issues with the RPC.
Changes included:
- https://github.com/0xsoniclabs/carmen/pull/388
- https://github.com/0xsoniclabs/carmen/pull/389
- https://github.com/0xsoniclabs/carmen/pull/390
- https://github.com/0xsoniclabs/carmen/pull/373