### PR TITLE
Add bundles to genesis export/import.

### DIFF
--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -472,7 +472,7 @@ func (f dropableFile) Drop() error {
 func MustRlpEncodeToByte(value any) []byte {
 	res, err := rlp.EncodeToBytes(value)
 	if err != nil {
-		panic("insert your favorite message here")
+		panic("failed to encode value to bytes: " + err.Error())
 	}
 	return res
 }

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -118,6 +118,15 @@ func ExportGenesis(ctx context.Context, gdb *gossip.Store, includeArchive bool, 
 		return err
 	}
 
+	// bundles hash
+	writer = newUnitWriter(out)
+	if err := writer.Start(header, "bh", tmpPath); err != nil {
+		return err
+	}
+	if err := exportBundlesHash(ctx, gdb, writer, lastBlock); err != nil {
+		return err
+	}
+
 	// bundles
 	writer = newUnitWriter(out)
 	if err := writer.Start(header, "bundles", tmpPath); err != nil {
@@ -285,8 +294,8 @@ func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter
 	return nil
 }
 
-func exportBundles(ctx context.Context, gdb *gossip.Store, writer *unitWriter, lastBlock idx.Block) error {
-	log.Info("Exporting processed bundles")
+func exportBundlesHash(ctx context.Context, gdb *gossip.Store, writer *unitWriter, lastBlock idx.Block) error {
+	log.Info("Exporting processed bundles history hash")
 
 	// write the history hash as the first item.
 	blockNum, histHash := gdb.GetProcessedBundleHistoryHash()
@@ -297,6 +306,17 @@ func exportBundles(ctx context.Context, gdb *gossip.Store, writer *unitWriter, l
 	if _, err := writer.Write(b); err != nil {
 		return err
 	}
+	hash, err := writer.Flush()
+	if err != nil {
+		return err
+	}
+	log.Info("Exported processed bundles history hash", "blockNum", blockNum, "hash", histHash)
+	fmt.Printf("- Processed bundles history hash: %v \n", hash.String())
+	return nil
+}
+
+func exportBundles(ctx context.Context, gdb *gossip.Store, writer *unitWriter, lastBlock idx.Block) error {
+	log.Info("Exporting processed bundles")
 
 	// write all the execution info from the store.
 	count := 0

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -24,6 +24,7 @@ import (
 	"path"
 
 	"github.com/0xsoniclabs/sonic/gossip"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/ibr"
 	"github.com/0xsoniclabs/sonic/inter/ier"
 	"github.com/0xsoniclabs/sonic/opera/genesis"
@@ -114,6 +115,15 @@ func ExportGenesis(ctx context.Context, gdb *gossip.Store, includeArchive bool, 
 		return err
 	}
 	if err := exportBlockCertificates(ctx, gdb, writer, lastBlock); err != nil {
+		return err
+	}
+
+	// bundles
+	writer = newUnitWriter(out)
+	if err := writer.Start(header, "bundles", tmpPath); err != nil {
+		return err
+	}
+	if err := exportBundles(ctx, gdb, writer, lastBlock); err != nil {
 		return err
 	}
 
@@ -272,6 +282,41 @@ func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter
 	}
 	log.Info("Exported Sonic World State Archive data")
 	fmt.Printf("- FWA hash: %v \n", fwaHash.String())
+	return nil
+}
+
+func exportBundles(ctx context.Context, gdb *gossip.Store, writer *unitWriter, lastBlock idx.Block) error {
+	log.Info("Exporting processed bundles")
+
+	// write the history hash as the first item.
+	blockNum, histHash := gdb.GetProcessedBundleHistoryHash()
+	b, _ := rlp.EncodeToBytes(bundle.HistoryHash{
+		BlockNumber: blockNum,
+		Hash:        histHash,
+	})
+	if _, err := writer.Write(b); err != nil {
+		return err
+	}
+
+	// write all the execution info from the store.
+	count := 0
+	for _, info := range gdb.EnumerateProcessedBundles() {
+		b, _ := rlp.EncodeToBytes(info)
+		if _, err := writer.Write(b); err != nil {
+			return err
+		}
+		count++
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	hash, err := writer.Flush()
+	if err != nil {
+		return err
+	}
+	log.Info("Exported processed bundles", "count", count)
+	fmt.Printf("- Processed bundles hash: %v \n", hash.String())
 	return nil
 }
 

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -290,7 +290,7 @@ func exportBundles(ctx context.Context, gdb *gossip.Store, writer *unitWriter, l
 
 	// write the history hash as the first item.
 	blockNum, histHash := gdb.GetProcessedBundleHistoryHash()
-	b, _ := rlp.EncodeToBytes(bundle.HistoryHash{
+	b := MustRlpEncodeToByte(bundle.HistoryHash{
 		BlockNumber: blockNum,
 		Hash:        histHash,
 	})
@@ -301,7 +301,7 @@ func exportBundles(ctx context.Context, gdb *gossip.Store, writer *unitWriter, l
 	// write all the execution info from the store.
 	count := 0
 	for _, info := range gdb.EnumerateProcessedBundles() {
-		b, _ := rlp.EncodeToBytes(info)
+		b := MustRlpEncodeToByte(info)
 		if _, err := writer.Write(b); err != nil {
 			return err
 		}
@@ -447,4 +447,12 @@ type dropableFile struct {
 
 func (f dropableFile) Drop() error {
 	return os.Remove(f.path)
+}
+
+func MustRlpEncodeToByte(value any) []byte {
+	res, err := rlp.EncodeToBytes(value)
+	if err != nil {
+		panic("insert your favorite message here")
+	}
+	return res
 }

--- a/cmd/sonictool/genesis/export_test.go
+++ b/cmd/sonictool/genesis/export_test.go
@@ -32,107 +32,26 @@ import (
 	"github.com/0xsoniclabs/sonic/opera/genesis"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore/fileshash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 )
 
 func TestExportBundles_WritesIntoWriter(t *testing.T) {
-
-	tests := map[string]struct {
-		storeSetup func(*gossip.Store)
-	}{
-		"empty store": {
-			storeSetup: func(store *gossip.Store) {},
-		},
-		"store with history hash but no bundles": {
-			storeSetup: func(store *gossip.Store) {
-				store.SetProcessedBundlesHistoryHash(1, common.Hash{0x42})
-			},
-		},
-		"store with bundles": {
-			storeSetup: func(store *gossip.Store) {
-				store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
-					{1}: {Offset: 0, Count: 2},
-					{2}: {Offset: 2, Count: 1},
-				})
-				store.AddProcessedBundles(2, map[common.Hash]bundle.PositionInBlock{
-					{3}: {Offset: 0, Count: 1},
-				})
-			},
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			store := setupBundleStore(t)
-			writer := newDryRunWriter(t)
-
-			tc.storeSetup(store)
-
-			err := exportBundles(context.Background(), store, writer, 10)
-			require.NoError(t, err)
-			// Even with no bundles, the history hash is always written.
-			require.Greater(t, writer.uncompressedSize, uint64(0),
-				"history hash should always be written")
-
-		})
-	}
-}
-
-func TestExportBundles_DataIntegrity(t *testing.T) {
 	store := setupBundleStore(t)
-
 	store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
-		{0x10}: {Offset: 0, Count: 1},
+		{1}: {Offset: 0, Count: 2},
 	})
-	store.SetProcessedBundlesHistoryHash(5, common.Hash{0xde, 0xad})
-
-	// Manually compute expected size.
-	blockNum, histHash := store.GetProcessedBundleHistoryHash()
-	histBytes, err := rlp.EncodeToBytes(bundle.HistoryHash{
-		BlockNumber: blockNum,
-		Hash:        histHash,
-	})
-	require.NoError(t, err)
-	expectedSize := uint64(len(histBytes))
-
-	for _, info := range store.EnumerateProcessedBundles() {
-		b, err := rlp.EncodeToBytes(info)
-		require.NoError(t, err)
-		expectedSize += uint64(len(b))
-	}
 
 	writer := newDryRunWriter(t)
-	err = exportBundles(context.Background(), store, writer, 100)
-	require.NoError(t, err)
-	require.Equal(t, expectedSize, writer.uncompressedSize,
-		"written bytes should match manually encoded data")
-}
 
-func TestExportBundles_MoreBundlesProducesMoreData(t *testing.T) {
-	// Store with 1 bundle
-	store1 := setupBundleStore(t)
-	store1.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
-		{1}: {Offset: 0, Count: 1},
-	})
-	writer1 := newDryRunWriter(t)
-	err := exportBundles(context.Background(), store1, writer1, 10)
+	err := exportBundles(context.Background(), store, writer, 10)
 	require.NoError(t, err)
+	// Even with no bundles, the history hash is always written.
+	require.Greater(t, writer.uncompressedSize, uint64(0),
+		"history hash should always be written")
 
-	// Store with 3 bundles
-	store3 := setupBundleStore(t)
-	store3.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
-		{1}: {Offset: 0, Count: 1},
-		{2}: {Offset: 1, Count: 1},
-		{3}: {Offset: 2, Count: 1},
-	})
-	writer3 := newDryRunWriter(t)
-	err = exportBundles(context.Background(), store3, writer3, 10)
-	require.NoError(t, err)
-
-	require.Greater(t, writer3.uncompressedSize, writer1.uncompressedSize,
-		"3 bundles should produce more data than 1 bundle")
 }
 
 func TestExportBundles_ContextCancelledImmediately(t *testing.T) {
@@ -170,8 +89,11 @@ func TestExportBundles_ContextCancelledAfterFirstBundle(t *testing.T) {
 		"some data should have been written before cancellation")
 }
 
-func TestExportBundles_HistoryHash_WriteError(t *testing.T) {
+func TestBundles_WriteError(t *testing.T) {
 	store := setupBundleStore(t)
+	store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{1}: {Offset: 0, Count: 1},
+	})
 
 	writer := &unitWriter{}
 	writer.fileshasher = fileshash.WrapWriter(nil, genesisstore.FilesHashPieceSize,
@@ -179,72 +101,95 @@ func TestExportBundles_HistoryHash_WriteError(t *testing.T) {
 			return &failingTmpWriter{}
 		},
 	)
+	err := exportBundlesHash(context.Background(), store, writer, 10)
+	require.Error(t, err)
 
-	err := exportBundles(context.Background(), store, writer, 10)
+	err = exportBundles(context.Background(), store, writer, 10)
 	require.Error(t, err)
 }
 
-func TestExportBundles_WrittenWithRealFile(t *testing.T) {
+func TestBundles_RoundTrip(t *testing.T) {
 	store := setupBundleStore(t)
-	store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
-		{0xaa}: {Offset: 0, Count: 2},
-	})
-	store.SetProcessedBundlesHistoryHash(1, common.Hash{0xff})
 
+	wantBundles := map[common.Hash]bundle.PositionInBlock{
+		{0xaa}: {Offset: 0, Count: 2},
+		{0xbb}: {Offset: 2, Count: 1},
+	}
+	store.AddProcessedBundles(1, wantBundles)
+	wantHistoryHash := common.Hash{0xff}
+	store.SetProcessedBundlesHistoryHash(1, wantHistoryHash)
+
+	// Export to a real file.
 	tmpDir := t.TempDir()
-	outFile, err := os.CreateTemp(tmpDir, "export-bundles-*")
+	outFile, err := os.CreateTemp(tmpDir, "export-bundles-*.g")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, outFile.Close()) }()
 
+	header := genesis.Header{}
 	writer := newUnitWriter(outFile)
-	err = writer.Start(genesis.Header{}, "bundles", tmpDir)
+
+	err = writer.Start(header, "bh", tmpDir)
+	require.NoError(t, err)
+	err = exportBundlesHash(context.Background(), store, writer, 10)
 	require.NoError(t, err)
 
+	err = writer.Start(header, "bundles", tmpDir)
+	require.NoError(t, err)
 	err = exportBundles(context.Background(), store, writer, 10)
 	require.NoError(t, err)
-	require.Greater(t, writer.uncompressedSize, uint64(0))
+
+	// Re-open the file and read back through genesisstore.
+	_, err = outFile.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	gs, _, err := genesisstore.OpenGenesisStore(outFile)
+	require.NoError(t, err)
+
+	// Verify history hash roundtrips correctly.
+	gotHist, ok := gs.ProcessedBundles().GetHistoryHash()
+	require.True(t, ok, "history hash should be present")
+	require.Equal(t, uint64(1), gotHist.BlockNumber)
+	require.Equal(t, wantHistoryHash, gotHist.Hash)
+
+	// Verify bundle execution infos roundtrip correctly.
+	wantInfos := store.EnumerateProcessedBundles()
+	var gotInfos []bundle.ExecutionInfo
+	gs.ProcessedBundles().ForEach(func(info bundle.ExecutionInfo) bool {
+		gotInfos = append(gotInfos, info)
+		return true
+	})
+	require.Equal(t, wantInfos, gotInfos,
+		"exported and re-imported bundle execution infos should match")
 }
 
-func TestExportBundles_DeterministicOutput(t *testing.T) {
+func TestBundles_DeterministicOutput(t *testing.T) {
 	// Running export twice with the same data should produce the same hash.
-	makeStore := func() *gossip.Store {
-		s := setupBundleStore(t)
-		s.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
-			{0x01}: {Offset: 0, Count: 1},
-		})
-		s.SetProcessedBundlesHistoryHash(1, common.Hash{0x42})
-		return s
+
+	exporter := []func(context.Context, *gossip.Store, *unitWriter, idx.Block) error{
+		exportBundlesHash,
+		exportBundles,
 	}
 
-	writer1 := newDryRunWriter(t)
-	err := exportBundles(context.Background(), makeStore(), writer1, 10)
-	require.NoError(t, err)
+	for _, exp := range exporter {
+		t.Run("exporter", func(t *testing.T) {
+			s := setupBundleStore(t)
+			s.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+				{0x01}: {Offset: 0, Count: 1},
+			})
+			s.SetProcessedBundlesHistoryHash(1, common.Hash{0x42})
 
-	writer2 := newDryRunWriter(t)
-	err = exportBundles(context.Background(), makeStore(), writer2, 10)
-	require.NoError(t, err)
+			hashWriter1 := newDryRunWriter(t)
+			err := exp(context.Background(), s, hashWriter1, 10)
+			require.NoError(t, err)
 
-	require.Equal(t, writer1.fileshasher.Root(), writer2.fileshasher.Root(),
-		"same input should produce same output hash")
-}
+			hashWriter2 := newDryRunWriter(t)
+			err = exp(context.Background(), s, hashWriter2, 10)
+			require.NoError(t, err)
 
-func TestExportBundles_HistoryHashAlwaysWrittenFirst(t *testing.T) {
-	storeEmpty := setupBundleStore(t)
-	writerEmpty := newDryRunWriter(t)
-	err := exportBundles(context.Background(), storeEmpty, writerEmpty, 10)
-	require.NoError(t, err)
-	histOnlySize := writerEmpty.uncompressedSize
-
-	storeWithBundles := setupBundleStore(t)
-	storeWithBundles.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
-		{1}: {Offset: 0, Count: 1},
-	})
-	writerWithBundles := newDryRunWriter(t)
-	err = exportBundles(context.Background(), storeWithBundles, writerWithBundles, 10)
-	require.NoError(t, err)
-
-	require.Greater(t, writerWithBundles.uncompressedSize, histOnlySize,
-		"bundles should add data beyond just the history hash")
+			require.Equal(t, hashWriter1.fileshasher.Root(), hashWriter2.fileshasher.Root(),
+				"same input should produce same output hash")
+		})
+	}
 }
 
 func TestMustRlpEncodeToByte_PanicsOnError(t *testing.T) {

--- a/cmd/sonictool/genesis/export_test.go
+++ b/cmd/sonictool/genesis/export_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math/big"
 	"os"
 	"sync"
 	"testing"
@@ -244,6 +245,37 @@ func TestExportBundles_HistoryHashAlwaysWrittenFirst(t *testing.T) {
 
 	require.Greater(t, writerWithBundles.uncompressedSize, histOnlySize,
 		"bundles should add data beyond just the history hash")
+}
+
+func TestMustRlpEncodeToByte_PanicsOnError(t *testing.T) {
+	require.Panics(t, func() {
+		MustRlpEncodeToByte(new(big.Int).Sub(big.NewInt(0), big.NewInt(1)))
+	}, "MustRlpEncodeToByte should panic on encoding error")
+}
+
+func TestMustRlpEncodeToByte_CanEncodeHistoryHashAndExecutionInfo(t *testing.T) {
+
+	tests := map[string]any{
+		"history hash": bundle.HistoryHash{
+			BlockNumber: 123,
+			Hash:        common.HexToHash("0xdeadbeef"),
+		},
+		"execution info": bundle.ExecutionInfo{
+			BlockNumber:       123,
+			ExecutionPlanHash: common.Hash{0x42},
+			Position:          bundle.PositionInBlock{Offset: 1, Count: 2},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			expected, err := rlp.EncodeToBytes(test)
+			require.NoError(t, err)
+
+			result := MustRlpEncodeToByte(test)
+			require.Equal(t, expected, result, "MustRlpEncodeToByte should return correct encoded bytes")
+		})
+	}
 }
 
 // ------------- tooling for tests -------------

--- a/cmd/sonictool/genesis/export_test.go
+++ b/cmd/sonictool/genesis/export_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package genesis
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/inter/iblockproc"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/opera/genesis"
+	"github.com/0xsoniclabs/sonic/opera/genesisstore"
+	"github.com/0xsoniclabs/sonic/opera/genesisstore/fileshash"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportBundles_WritesIntoWriter(t *testing.T) {
+
+	tests := map[string]struct {
+		storeSetup func(*gossip.Store)
+	}{
+		"empty store": {
+			storeSetup: func(store *gossip.Store) {},
+		},
+		"store with history hash but no bundles": {
+			storeSetup: func(store *gossip.Store) {
+				store.SetProcessedBundlesHistoryHash(1, common.Hash{0x42})
+			},
+		},
+		"store with bundles": {
+			storeSetup: func(store *gossip.Store) {
+				store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+					{1}: {Offset: 0, Count: 2},
+					{2}: {Offset: 2, Count: 1},
+				})
+				store.AddProcessedBundles(2, map[common.Hash]bundle.PositionInBlock{
+					{3}: {Offset: 0, Count: 1},
+				})
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := setupBundleStore(t)
+			writer := newDryRunWriter(t)
+
+			tc.storeSetup(store)
+
+			err := exportBundles(context.Background(), store, writer, 10)
+			require.NoError(t, err)
+			// Even with no bundles, the history hash is always written.
+			require.Greater(t, writer.uncompressedSize, uint64(0),
+				"history hash should always be written")
+
+		})
+	}
+}
+
+func TestExportBundles_DataIntegrity(t *testing.T) {
+	store := setupBundleStore(t)
+
+	store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{0x10}: {Offset: 0, Count: 1},
+	})
+	store.SetProcessedBundlesHistoryHash(5, common.Hash{0xde, 0xad})
+
+	// Manually compute expected size.
+	blockNum, histHash := store.GetProcessedBundleHistoryHash()
+	histBytes, err := rlp.EncodeToBytes(bundle.HistoryHash{
+		BlockNumber: blockNum,
+		Hash:        histHash,
+	})
+	require.NoError(t, err)
+	expectedSize := uint64(len(histBytes))
+
+	for _, info := range store.EnumerateProcessedBundles() {
+		b, err := rlp.EncodeToBytes(info)
+		require.NoError(t, err)
+		expectedSize += uint64(len(b))
+	}
+
+	writer := newDryRunWriter(t)
+	err = exportBundles(context.Background(), store, writer, 100)
+	require.NoError(t, err)
+	require.Equal(t, expectedSize, writer.uncompressedSize,
+		"written bytes should match manually encoded data")
+}
+
+func TestExportBundles_MoreBundlesProducesMoreData(t *testing.T) {
+	// Store with 1 bundle
+	store1 := setupBundleStore(t)
+	store1.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{1}: {Offset: 0, Count: 1},
+	})
+	writer1 := newDryRunWriter(t)
+	err := exportBundles(context.Background(), store1, writer1, 10)
+	require.NoError(t, err)
+
+	// Store with 3 bundles
+	store3 := setupBundleStore(t)
+	store3.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{1}: {Offset: 0, Count: 1},
+		{2}: {Offset: 1, Count: 1},
+		{3}: {Offset: 2, Count: 1},
+	})
+	writer3 := newDryRunWriter(t)
+	err = exportBundles(context.Background(), store3, writer3, 10)
+	require.NoError(t, err)
+
+	require.Greater(t, writer3.uncompressedSize, writer1.uncompressedSize,
+		"3 bundles should produce more data than 1 bundle")
+}
+
+func TestExportBundles_ContextCancelledImmediately(t *testing.T) {
+	store := setupBundleStore(t)
+	store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{1}: {Offset: 0, Count: 1},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	writer := newDryRunWriter(t)
+	err := exportBundles(ctx, store, writer, 10)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestExportBundles_ContextCancelledAfterFirstBundle(t *testing.T) {
+	store := setupBundleStore(t)
+	store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{1}: {Offset: 0, Count: 1},
+		{2}: {Offset: 1, Count: 1},
+		{3}: {Offset: 2, Count: 1},
+	})
+
+	// Allow 1 ctx.Err() check to pass (after first bundle write), then cancel.
+	ctx := &cancelAfterNChecks{
+		Context:      context.Background(),
+		allowedCalls: 1,
+	}
+
+	writer := newDryRunWriter(t)
+	err := exportBundles(ctx, store, writer, 10)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Greater(t, writer.uncompressedSize, uint64(0),
+		"some data should have been written before cancellation")
+}
+
+func TestExportBundles_HistoryHash_WriteError(t *testing.T) {
+	store := setupBundleStore(t)
+
+	writer := &unitWriter{}
+	writer.fileshasher = fileshash.WrapWriter(nil, genesisstore.FilesHashPieceSize,
+		func(int) fileshash.TmpWriter {
+			return &failingTmpWriter{}
+		},
+	)
+
+	err := exportBundles(context.Background(), store, writer, 10)
+	require.Error(t, err)
+}
+
+func TestExportBundles_WrittenWithRealFile(t *testing.T) {
+	store := setupBundleStore(t)
+	store.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{0xaa}: {Offset: 0, Count: 2},
+	})
+	store.SetProcessedBundlesHistoryHash(1, common.Hash{0xff})
+
+	tmpDir := t.TempDir()
+	outFile, err := os.CreateTemp(tmpDir, "export-bundles-*")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, outFile.Close()) }()
+
+	writer := newUnitWriter(outFile)
+	err = writer.Start(genesis.Header{}, "bundles", tmpDir)
+	require.NoError(t, err)
+
+	err = exportBundles(context.Background(), store, writer, 10)
+	require.NoError(t, err)
+	require.Greater(t, writer.uncompressedSize, uint64(0))
+}
+
+func TestExportBundles_DeterministicOutput(t *testing.T) {
+	// Running export twice with the same data should produce the same hash.
+	makeStore := func() *gossip.Store {
+		s := setupBundleStore(t)
+		s.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+			{0x01}: {Offset: 0, Count: 1},
+		})
+		s.SetProcessedBundlesHistoryHash(1, common.Hash{0x42})
+		return s
+	}
+
+	writer1 := newDryRunWriter(t)
+	err := exportBundles(context.Background(), makeStore(), writer1, 10)
+	require.NoError(t, err)
+
+	writer2 := newDryRunWriter(t)
+	err = exportBundles(context.Background(), makeStore(), writer2, 10)
+	require.NoError(t, err)
+
+	require.Equal(t, writer1.fileshasher.Root(), writer2.fileshasher.Root(),
+		"same input should produce same output hash")
+}
+
+func TestExportBundles_HistoryHashAlwaysWrittenFirst(t *testing.T) {
+	storeEmpty := setupBundleStore(t)
+	writerEmpty := newDryRunWriter(t)
+	err := exportBundles(context.Background(), storeEmpty, writerEmpty, 10)
+	require.NoError(t, err)
+	histOnlySize := writerEmpty.uncompressedSize
+
+	storeWithBundles := setupBundleStore(t)
+	storeWithBundles.AddProcessedBundles(1, map[common.Hash]bundle.PositionInBlock{
+		{1}: {Offset: 0, Count: 1},
+	})
+	writerWithBundles := newDryRunWriter(t)
+	err = exportBundles(context.Background(), storeWithBundles, writerWithBundles, 10)
+	require.NoError(t, err)
+
+	require.Greater(t, writerWithBundles.uncompressedSize, histOnlySize,
+		"bundles should add data beyond just the history hash")
+}
+
+// ------------- tooling for tests -------------
+
+// failingTmpWriter implements fileshash.TmpWriter but always fails on Write.
+type failingTmpWriter struct{}
+
+func (f *failingTmpWriter) Read(p []byte) (int, error)                   { return 0, errors.New("read error") }
+func (f *failingTmpWriter) Write(p []byte) (int, error)                  { return 0, errors.New("write error") }
+func (f *failingTmpWriter) Seek(offset int64, whence int) (int64, error) { return 0, nil }
+func (f *failingTmpWriter) Close() error                                 { return nil }
+func (f *failingTmpWriter) Drop() error                                  { return nil }
+
+// Ensure failingTmpWriter satisfies the interface.
+var _ fileshash.TmpWriter = (*failingTmpWriter)(nil)
+var _ io.ReadWriteSeeker = (*failingTmpWriter)(nil)
+
+// cancelAfterNChecks is a context.Context wrapper that returns
+// context.Canceled after allowedCalls calls to Err().
+type cancelAfterNChecks struct {
+	context.Context
+	mu           sync.Mutex
+	allowedCalls int
+	calls        int
+}
+
+func (c *cancelAfterNChecks) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	if c.calls > c.allowedCalls {
+		return context.Canceled
+	}
+	return nil
+}
+
+// newDryRunWriter creates a unitWriter in dry-run mode (nil plain)
+// which writes data to DevNull-backed tmp files. Useful for testing
+// export logic without writing real files.
+func newDryRunWriter(t *testing.T) *unitWriter {
+	t.Helper()
+	w := newUnitWriter(nil)
+	err := w.Start(genesis.Header{}, "test", "")
+	require.NoError(t, err)
+	return w
+}
+
+// setupBundleStore creates a gossip.Store with a current epoch state set
+// and optionally populated with processed bundles and a history hash.
+func setupBundleStore(t *testing.T) *gossip.Store {
+	t.Helper()
+	store, err := gossip.NewMemStore(t)
+	require.NoError(t, err)
+
+	rules := opera.FakeNetRules(opera.Upgrades{})
+	store.SetBlockEpochState(
+		iblockproc.BlockState{},
+		iblockproc.EpochState{Epoch: 1, Rules: rules},
+	)
+	return store
+}

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -19,7 +19,10 @@ package gossip
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/ibr"
 	"github.com/0xsoniclabs/sonic/inter/ier"
@@ -147,6 +150,40 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 		}
 		return true
 	})
+
+	if g.ProcessedBundles != nil {
+
+		// accumulate all execution infos based on the block where they were processed
+		bundlesByBlock := make(map[uint64][]bundle.ExecutionInfo)
+		g.ProcessedBundles.ForEach(func(info bundle.ExecutionInfo) bool {
+			bundlesByBlock[info.BlockNumber] = append(bundlesByBlock[info.BlockNumber], info)
+			return true
+		})
+
+		// Import bundles grouped by block number in ascending order.
+		for _, bn := range slices.Sorted(maps.Keys(bundlesByBlock)) {
+			bundlesPerBlock := map[common.Hash]bundle.PositionInBlock{}
+			for _, info := range bundlesByBlock[bn] {
+				if _, exists := bundlesPerBlock[info.ExecutionPlanHash]; exists {
+					s.Log.Crit("Duplicate execution plan hash in genesis",
+						"blockNumber", bn,
+						"hash", info.ExecutionPlanHash)
+					return fmt.Errorf(
+						"duplicate execution plan hash in genesis: block %d, hash %s",
+						bn, info.ExecutionPlanHash)
+				}
+				bundlesPerBlock[info.ExecutionPlanHash] = info.Position
+			}
+			s.AddProcessedBundles(bn, bundlesPerBlock)
+		}
+
+		// last overwrite of the history hash, to ensure it is consistent with
+		// the exported hash. This is needed because the history hash is affected
+		// by bundles that could have been deleted from the store out of old age.
+		if h, found := g.ProcessedBundles.GetHistoryHash(); found {
+			s.SetProcessedBundlesHistoryHash(h.BlockNumber, h.Hash)
+		}
+	}
 
 	return nil
 }

--- a/gossip/blockproc/bundle/execution_info.go
+++ b/gossip/blockproc/bundle/execution_info.go
@@ -33,3 +33,10 @@ type PositionInBlock struct {
 	Offset uint32
 	Count  uint32
 }
+
+// HistoryHash represents the block number and cumulative hash of the processed
+// bundles history. It is used for genesis export/import serialization.
+type HistoryHash struct {
+	BlockNumber uint64
+	Hash        common.Hash
+}

--- a/opera/genesis/types.go
+++ b/opera/genesis/types.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/ibr"
 	"github.com/0xsoniclabs/sonic/inter/ier"
 	"github.com/0xsoniclabs/sonic/scc/cert"
@@ -48,6 +49,10 @@ type (
 	SccBlockCertificates interface {
 		ForEach(fn func(cert.Certificate[cert.BlockStatement]) bool)
 	}
+	ProcessedBundles interface {
+		ForEach(fn func(bundle.ExecutionInfo) bool)
+		GetHistoryHash() (bundle.HistoryHash, bool)
+	}
 	FwsLiveSection interface {
 		GetReader() (io.Reader, error)
 	}
@@ -69,6 +74,7 @@ type (
 		RawEvmItems           EvmItems
 		CommitteeCertificates SccCommitteeCertificates
 		BlockCertificates     SccBlockCertificates
+		ProcessedBundles      ProcessedBundles
 		FwsLiveSection
 		FwsArchiveSection
 		SignatureSection

--- a/opera/genesisstore/store.go
+++ b/opera/genesisstore/store.go
@@ -51,6 +51,10 @@ func SccBlockSection(i int) string {
 	return getSectionName("scc_bc", i)
 }
 
+func BundlesSection(i int) string {
+	return getSectionName("bundles", i)
+}
+
 type FilesMap func(string) (io.Reader, error)
 
 // Store is a node persistent storage working over a physical zip archive.

--- a/opera/genesisstore/store.go
+++ b/opera/genesisstore/store.go
@@ -51,6 +51,10 @@ func SccBlockSection(i int) string {
 	return getSectionName("scc_bc", i)
 }
 
+func BundleHashSection(i int) string {
+	return getSectionName("bh", i)
+}
+
 func BundlesSection(i int) string {
 	return getSectionName("bundles", i)
 }

--- a/opera/genesisstore/store_genesis.go
+++ b/opera/genesisstore/store_genesis.go
@@ -227,7 +227,7 @@ func (s *Store) ProcessedBundles() genesis.ProcessedBundles {
 
 func (s RawProcessedBundles) GetHistoryHash() (bundle.HistoryHash, bool) {
 	for i := range 1000 {
-		f, err := s.fMap(BundlesSection(i))
+		f, err := s.fMap(BundleHashSection(i))
 		if err != nil {
 			continue
 		}
@@ -252,11 +252,6 @@ func (s RawProcessedBundles) ForEach(fn func(bundle.ExecutionInfo) bool) {
 			continue
 		}
 		stream := rlp.NewStream(f, 0)
-		// Skip the history hash (first item in the stream).
-		var h bundle.HistoryHash
-		if err := stream.Decode(&h); err != nil {
-			return
-		}
 		for {
 			var info bundle.ExecutionInfo
 			err := stream.Decode(&info)

--- a/opera/genesisstore/store_genesis.go
+++ b/opera/genesisstore/store_genesis.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/ibr"
 	"github.com/0xsoniclabs/sonic/inter/ier"
 	"github.com/0xsoniclabs/sonic/opera/genesis"
@@ -56,6 +57,9 @@ type (
 	SignatureSection struct {
 		fMap FilesMap
 	}
+	RawProcessedBundles struct {
+		fMap FilesMap
+	}
 )
 
 func (s *Store) Genesis() genesis.Genesis {
@@ -69,6 +73,7 @@ func (s *Store) Genesis() genesis.Genesis {
 		FwsLiveSection:        s.FwsLiveSection(),
 		FwsArchiveSection:     s.FwsArchiveSection(),
 		SignatureSection:      s.SignatureSection(),
+		ProcessedBundles:      s.ProcessedBundles(),
 	}
 }
 
@@ -210,6 +215,58 @@ func (s RawBlockCertificates) ForEach(fn func(cert.Certificate[cert.BlockStateme
 				log.Crit("Failed to decode block certificate genesis section", "err", err)
 			}
 			if !fn(cur) {
+				break
+			}
+		}
+	}
+}
+
+func (s *Store) ProcessedBundles() genesis.ProcessedBundles {
+	return RawProcessedBundles{s.fMap}
+}
+
+func (s RawProcessedBundles) GetHistoryHash() (bundle.HistoryHash, bool) {
+	for i := range 1000 {
+		f, err := s.fMap(BundlesSection(i))
+		if err != nil {
+			continue
+		}
+		stream := rlp.NewStream(f, 0)
+		var h bundle.HistoryHash
+		err = stream.Decode(&h)
+		if err == io.EOF {
+			return bundle.HistoryHash{}, false
+		}
+		if err != nil {
+			log.Crit("Failed to decode Processed Bundles history hash", "err", err)
+		}
+		return h, true
+	}
+	return bundle.HistoryHash{}, false
+}
+
+func (s RawProcessedBundles) ForEach(fn func(bundle.ExecutionInfo) bool) {
+	for i := range 1000 {
+		f, err := s.fMap(BundlesSection(i))
+		if err != nil {
+			continue
+		}
+		stream := rlp.NewStream(f, 0)
+		// Skip the history hash (first item in the stream).
+		var h bundle.HistoryHash
+		if err := stream.Decode(&h); err != nil {
+			return
+		}
+		for {
+			var info bundle.ExecutionInfo
+			err := stream.Decode(&info)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				log.Crit("Failed to decode ProcessedBundles genesis section", "err", err)
+			}
+			if !fn(info) {
 				break
 			}
 		}


### PR DESCRIPTION
This PR implements the necessary mechanisms for adding bundles into genesis export/import mechanisms via the sonictool.

- For the `ProcessedBundlesHistoryHash` a new `HistoryHash` struct is added. This makes the encoding of the special entry possible via `rlp.EncodeToBytes`.
- Since both the historical hash and the list of execution infos need to be encoded into the same section, special measures are taken considering that the historical will be the first encoded info in the `bundles` section of the genesis. 

This PR contributes to https://github.com/0xsoniclabs/sonic-admin/issues/622

Note: most testing of this mechanisms are done via integration tests. That will come in a follow-up. In this PR there is only unit testing for `exportBundles`.