### PR TITLE
Add submitBundle RPC function

### DIFF
--- a/api/rpc_test/backend.go
+++ b/api/rpc_test/backend.go
@@ -374,6 +374,11 @@ func (b *fakeBackend) ChainConfig(blockHeight idx.Block) *params.ChainConfig {
 	return opera.CreateTransientEvmChainConfig(b.chainID, heights, blockHeight)
 }
 
+// UnprotectedAllowed returns false — only EIP-155 protected transactions allowed.
+func (b *fakeBackend) UnprotectedAllowed() bool {
+	return false
+}
+
 // GetBundleExecutionInfo returns nil — not used in fake backend tests.
 func (b *fakeBackend) GetBundleExecutionInfo(_ common.Hash) *bundle.ExecutionInfo {
 	panic("not implemented")

--- a/api/sonicapi/bundle_api.go
+++ b/api/sonicapi/bundle_api.go
@@ -41,7 +41,20 @@ type RPCExecutionPlan struct {
 }
 
 // NewRPCExecutionPlan converts a bundle.ExecutionPlan to an RPCExecutionPlan for JSON-RPC responses.
+// This produces a flat representation of the plan's transaction references.
+// Note: hierarchical execution plans with nested groups cannot be fully represented
+// in this flat format. Only plans with a single level of transaction references are
+// fully supported.
 func NewRPCExecutionPlan(plan bundle.ExecutionPlan) RPCExecutionPlan {
-	// TODO: This needs to be re-implemented reflecting the new execution plan structure.
-	panic("not implemented yet")
+	refs := plan.Root.GetTransactionReferencesInReferencedOrder()
+	steps := make([]RPCExecutionStep, len(refs))
+	for i, ref := range refs {
+		steps[i] = RPCExecutionStep{From: ref.From, Hash: ref.Hash}
+	}
+	return RPCExecutionPlan{
+		Flags:    plan.Root.Flags(),
+		Steps:    steps,
+		Earliest: rpc.BlockNumber(plan.Range.Earliest),
+		Latest:   rpc.BlockNumber(plan.Range.Latest),
+	}
 }

--- a/api/sonicapi/bundle_api_test.go
+++ b/api/sonicapi/bundle_api_test.go
@@ -20,11 +20,160 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewRPCExecutionPlan(t *testing.T) {
-	require.PanicsWithValue(t, "not implemented yet", func() {
-		_ = NewRPCExecutionPlan(bundle.ExecutionPlan{})
-	})
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+	addr3 := common.Address{3}
+	hash1 := common.Hash{0x01}
+	hash2 := common.Hash{0x02}
+	hash3 := common.Hash{0x03}
+
+	ref1 := bundle.TxReference{From: addr1, Hash: hash1}
+	ref2 := bundle.TxReference{From: addr2, Hash: hash2}
+	ref3 := bundle.TxReference{From: addr3, Hash: hash3}
+
+	tests := []struct {
+		name         string
+		plan         bundle.ExecutionPlan
+		wantSteps    []RPCExecutionStep
+		wantFlags    bundle.ExecutionFlags
+		wantEarliest rpc.BlockNumber
+		wantLatest   rpc.BlockNumber
+	}{
+		{
+			name: "single tx step, default flags",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 1, Latest: 100},
+				Root:  bundle.NewTxStep(ref1),
+			},
+			wantSteps:    []RPCExecutionStep{{From: addr1, Hash: hash1}},
+			wantFlags:    bundle.EF_Default,
+			wantEarliest: 1,
+			wantLatest:   100,
+		},
+		{
+			name: "two tx steps in AllOf group",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 5, Latest: 50},
+				Root:  bundle.NewAllOfStep(bundle.NewTxStep(ref1), bundle.NewTxStep(ref2)),
+			},
+			wantSteps: []RPCExecutionStep{
+				{From: addr1, Hash: hash1},
+				{From: addr2, Hash: hash2},
+			},
+			wantFlags:    bundle.EF_Default,
+			wantEarliest: 5,
+			wantLatest:   50,
+		},
+		{
+			name: "three tx steps in AllOf group",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 0, Latest: 1000},
+				Root: bundle.NewAllOfStep(
+					bundle.NewTxStep(ref1),
+					bundle.NewTxStep(ref2),
+					bundle.NewTxStep(ref3),
+				),
+			},
+			wantSteps: []RPCExecutionStep{
+				{From: addr1, Hash: hash1},
+				{From: addr2, Hash: hash2},
+				{From: addr3, Hash: hash3},
+			},
+			wantFlags:    bundle.EF_Default,
+			wantEarliest: 0,
+			wantLatest:   1000,
+		},
+		{
+			name: "TolerateFailed flag preserved",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 10, Latest: 20},
+				Root:  bundle.NewTxStep(ref1).WithFlags(bundle.EF_TolerateFailed),
+			},
+			wantSteps:    []RPCExecutionStep{{From: addr1, Hash: hash1}},
+			wantFlags:    bundle.EF_TolerateFailed,
+			wantEarliest: 10,
+			wantLatest:   20,
+		},
+		{
+			name: "TolerateInvalid flag preserved",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 10, Latest: 20},
+				Root:  bundle.NewTxStep(ref1).WithFlags(bundle.EF_TolerateInvalid),
+			},
+			wantSteps:    []RPCExecutionStep{{From: addr1, Hash: hash1}},
+			wantFlags:    bundle.EF_TolerateInvalid,
+			wantEarliest: 10,
+			wantLatest:   20,
+		},
+		{
+			name: "both tolerate flags preserved",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 1, Latest: 5},
+				Root:  bundle.NewTxStep(ref1).WithFlags(bundle.EF_TolerateFailed | bundle.EF_TolerateInvalid),
+			},
+			wantSteps:    []RPCExecutionStep{{From: addr1, Hash: hash1}},
+			wantFlags:    bundle.EF_TolerateFailed | bundle.EF_TolerateInvalid,
+			wantEarliest: 1,
+			wantLatest:   5,
+		},
+		{
+			name: "block range boundaries preserved",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 42, Latest: 99},
+				Root:  bundle.NewTxStep(ref1),
+			},
+			wantSteps:    []RPCExecutionStep{{From: addr1, Hash: hash1}},
+			wantFlags:    bundle.EF_Default,
+			wantEarliest: 42,
+			wantLatest:   99,
+		},
+		{
+			name: "nested groups return steps in referenced order",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 1, Latest: 10},
+				Root: bundle.NewAllOfStep(
+					bundle.NewAllOfStep(
+						bundle.NewTxStep(ref1),
+						bundle.NewTxStep(ref2),
+					),
+					bundle.NewTxStep(ref3),
+				),
+			},
+			wantSteps: []RPCExecutionStep{
+				{From: addr1, Hash: hash1},
+				{From: addr2, Hash: hash2},
+				{From: addr3, Hash: hash3},
+			},
+			wantFlags:    bundle.EF_Default,
+			wantEarliest: 1,
+			wantLatest:   10,
+		},
+		{
+			name: "step From and Hash fields correctly mapped",
+			plan: bundle.ExecutionPlan{
+				Range: bundle.BlockRange{Earliest: 0, Latest: 0},
+				Root:  bundle.NewTxStep(ref2),
+			},
+			wantSteps:    []RPCExecutionStep{{From: addr2, Hash: hash2}},
+			wantFlags:    bundle.EF_Default,
+			wantEarliest: 0,
+			wantLatest:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewRPCExecutionPlan(tt.plan)
+			require.Equal(t, tt.wantSteps, got.Steps)
+			require.Equal(t, tt.wantFlags, got.Flags)
+			require.Equal(t, tt.wantEarliest, got.Earliest)
+			require.Equal(t, tt.wantLatest, got.Latest)
+		})
+	}
 }

--- a/api/sonicapi/submit_bundle.go
+++ b/api/sonicapi/submit_bundle.go
@@ -44,6 +44,7 @@ type SubmitBundleArgs struct {
 }
 
 // SubmitBundle implements the `sonic_submitBundle` RPC method, which submits a prepared bundle for execution.
+// Returns the hash of the execution plan and an error if any.
 func (a *PublicBundleAPI) SubmitBundle(
 	ctx context.Context,
 	args SubmitBundleArgs,
@@ -53,12 +54,12 @@ func (a *PublicBundleAPI) SubmitBundle(
 		return common.Hash{}, fmt.Errorf("signedTransactions must not be empty")
 	}
 
-	earliest, err := parseRPCBlockNumber(args.ExecutionPlan.Earliest, a.b)
+	earliest, err := parseRPCBlockNumber(a.b, args.ExecutionPlan.Earliest)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("invalid earliest block number: %w", err)
 	}
 
-	latest, err := parseRPCBlockNumber(args.ExecutionPlan.Latest, a.b)
+	latest, err := parseRPCBlockNumber(a.b, args.ExecutionPlan.Latest)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("invalid latest block number: %w", err)
 	}
@@ -105,7 +106,7 @@ func (a *PublicBundleAPI) SubmitBundle(
 	// Make a one use key to sign the bundle
 	key, err := crypto.GenerateKey()
 	if err != nil {
-		return common.Hash{}, fmt.Errorf("failed to generate signing key: %w", err)
+		return common.Hash{}, fmt.Errorf("failed to generate single use signing key: %w", err)
 	}
 
 	// Sign the bundle transaction with the one-use key and send it to the network
@@ -129,12 +130,16 @@ func (a *PublicBundleAPI) SubmitBundle(
 
 	// Submit the transaction to the network
 	_, err = ethapi.SubmitTransaction(ctx, a.b, tx)
-	return plan.Hash(), err
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to submit bundle transaction: %w", err)
+	}
+
+	return plan.Hash(), nil
 }
 
 // parseRPCBlockNumber converts an RPC block number (which can be a specific block number
 // or a tag like "latest") into a uint64 block number.
-func parseRPCBlockNumber(num rpc.BlockNumber, b BundleApiBackend) (uint64, error) {
+func parseRPCBlockNumber(b BundleApiBackend, num rpc.BlockNumber) (uint64, error) {
 
 	if num == rpc.PendingBlockNumber ||
 		num == rpc.LatestBlockNumber ||

--- a/api/sonicapi/submit_bundle.go
+++ b/api/sonicapi/submit_bundle.go
@@ -17,7 +17,7 @@
 package sonicapi
 
 import (
-	context "context"
+	"context"
 	"fmt"
 
 	"github.com/0xsoniclabs/sonic/api/ethapi"
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // SubmitBundleArgs represents the arguments for the `sonic_submitBundle` RPC method.
@@ -48,12 +49,30 @@ func (a *PublicBundleAPI) SubmitBundle(
 	args SubmitBundleArgs,
 ) (common.Hash, error) {
 
+	if len(args.SignedTransactions) == 0 {
+		return common.Hash{}, fmt.Errorf("signedTransactions must not be empty")
+	}
+
+	earliest, err := parseRPCBlockNumber(args.ExecutionPlan.Earliest, a.b)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("invalid earliest block number: %w", err)
+	}
+
+	latest, err := parseRPCBlockNumber(args.ExecutionPlan.Latest, a.b)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("invalid latest block number: %w", err)
+	}
+
+	if latest < earliest {
+		return common.Hash{}, fmt.Errorf("latest block number cannot be smaller than earliest block number")
+	}
+
 	txBundle := bundle.TransactionBundle{
 		Transactions: make(types.Transactions, len(args.SignedTransactions)),
 		Flags:        args.ExecutionPlan.Flags,
 		Range: bundle.BlockRange{
-			Earliest: uint64(args.ExecutionPlan.Earliest),
-			Latest:   uint64(args.ExecutionPlan.Latest),
+			Earliest: earliest,
+			Latest:   latest,
 		},
 	}
 
@@ -111,4 +130,28 @@ func (a *PublicBundleAPI) SubmitBundle(
 	// Submit the transaction to the network
 	_, err = ethapi.SubmitTransaction(ctx, a.b, tx)
 	return plan.Hash(), err
+}
+
+// parseRPCBlockNumber converts an RPC block number (which can be a specific block number
+// or a tag like "latest") into a uint64 block number.
+func parseRPCBlockNumber(num rpc.BlockNumber, b BundleApiBackend) (uint64, error) {
+
+	if num == rpc.PendingBlockNumber ||
+		num == rpc.LatestBlockNumber ||
+		num == rpc.FinalizedBlockNumber ||
+		num == rpc.SafeBlockNumber {
+
+		if current := b.CurrentBlock(); current != nil {
+			return current.NumberU64(), nil
+		}
+
+		return 0, fmt.Errorf("block number %s is not available: no current block", num)
+	}
+	if num == rpc.EarliestBlockNumber {
+		return 0, nil
+	}
+	if num < 0 {
+		return 0, fmt.Errorf("block number cannot be negative")
+	}
+	return uint64(num), nil
 }

--- a/api/sonicapi/submit_bundle.go
+++ b/api/sonicapi/submit_bundle.go
@@ -68,31 +68,53 @@ func (a *PublicBundleAPI) SubmitBundle(
 		return common.Hash{}, fmt.Errorf("latest block number cannot be smaller than earliest block number")
 	}
 
-	txBundle := bundle.TransactionBundle{
-		Transactions: make(types.Transactions, len(args.SignedTransactions)),
-		Flags:        args.ExecutionPlan.Flags,
-		Range: bundle.BlockRange{
-			Earliest: earliest,
-			Latest:   latest,
-		},
+	if len(args.ExecutionPlan.Steps) != len(args.SignedTransactions) {
+		return common.Hash{}, fmt.Errorf("executionPlan steps count (%d) must match signedTransactions count (%d)",
+			len(args.ExecutionPlan.Steps), len(args.SignedTransactions))
 	}
 
-	// Decode bundled transactions and compute total gas requirement
+	// Decode bundled transactions and build TxReference map and execution steps.
+	transactions := make(map[bundle.TxReference]*types.Transaction, len(args.SignedTransactions))
+	steps := make([]bundle.ExecutionStep, len(args.SignedTransactions))
 	var totalGas uint64
 	for i, encodedTx := range args.SignedTransactions {
-
 		tx := new(types.Transaction)
 		if err := tx.UnmarshalBinary(encodedTx); err != nil {
 			return common.Hash{}, fmt.Errorf("failed to decode bundled transaction %d: %w", i, err)
 		}
-
-		txBundle.Transactions[i] = tx
+		txRef := bundle.TxReference{
+			From: args.ExecutionPlan.Steps[i].From,
+			Hash: args.ExecutionPlan.Steps[i].Hash,
+		}
+		transactions[txRef] = tx
+		steps[i] = bundle.NewTxStep(txRef).WithFlags(args.ExecutionPlan.Flags)
 		totalGas += tx.Gas()
+	}
+
+	var root bundle.ExecutionStep
+	if len(steps) == 1 {
+		root = steps[0]
+	} else {
+		root = bundle.NewAllOfStep(steps...)
+	}
+
+	txBundle := bundle.TransactionBundle{
+		Transactions: transactions,
+		Plan: bundle.ExecutionPlan{
+			Range: bundle.BlockRange{
+				Earliest: earliest,
+				Latest:   latest,
+			},
+			Root: root,
+		},
 	}
 
 	// Encode the bundle and compute if gas limits are sufficient to cover
 	// both the payload and the data-related gas costs.
-	data := txBundle.Encode()
+	data, err := txBundle.Encode()
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to encode bundle: %w", err)
+	}
 	minGas, err := core.IntrinsicGas(data, nil, nil, false, true, true, true)
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to finalize bundle: could not calculate intrinsic gas: %w", err)

--- a/api/sonicapi/submit_bundle.go
+++ b/api/sonicapi/submit_bundle.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package sonicapi
+
+import (
+	context "context"
+	"fmt"
+
+	"github.com/0xsoniclabs/sonic/api/ethapi"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// SubmitBundleArgs represents the arguments for the `sonic_submitBundle` RPC method.
+type SubmitBundleArgs struct {
+	// SignedTransactions is the list of transactions that have been signed using
+	// the transaction arguments returned by the `sonic_prepareBundle` method.
+	// These transactions must be included in the bundle exactly as they were prepared;
+	// any modification will invalidate the execution plan and result in an ill-formed bundle.
+	SignedTransactions []hexutil.Bytes `json:"signedTransactions"`
+	// ExecutionPlan contains the execution plan that each bundled transaction references.
+	// This value must be provided as returned by the `sonic_prepareBundle` method;
+	// any modification will invalidate the execution plan and result in an ill-formed bundle.
+	ExecutionPlan RPCExecutionPlan `json:"executionPlan,omitempty"`
+}
+
+// SubmitBundle implements the `sonic_submitBundle` RPC method, which submits a prepared bundle for execution.
+func (a *PublicBundleAPI) SubmitBundle(
+	ctx context.Context,
+	args SubmitBundleArgs,
+) (common.Hash, error) {
+
+	txBundle := bundle.TransactionBundle{
+		Transactions: make(types.Transactions, len(args.SignedTransactions)),
+		Flags:        args.ExecutionPlan.Flags,
+		Range: bundle.BlockRange{
+			Earliest: uint64(args.ExecutionPlan.Earliest),
+			Latest:   uint64(args.ExecutionPlan.Latest),
+		},
+	}
+
+	// Decode bundled transactions and compute total gas requirement
+	var totalGas uint64
+	for i, encodedTx := range args.SignedTransactions {
+
+		tx := new(types.Transaction)
+		if err := tx.UnmarshalBinary(encodedTx); err != nil {
+			return common.Hash{}, fmt.Errorf("failed to decode bundled transaction %d: %w", i, err)
+		}
+
+		txBundle.Transactions[i] = tx
+		totalGas += tx.Gas()
+	}
+
+	// Encode the bundle and compute if gas limits are sufficient to cover
+	// both the payload and the data-related gas costs.
+	data := txBundle.Encode()
+	minGas, err := core.IntrinsicGas(data, nil, nil, false, true, true, true)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to finalize bundle: could not calculate intrinsic gas: %w", err)
+	}
+	floorDataGas, err := core.FloorDataGas(data)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to finalize bundle: could not calculate floor data gas: %w", err)
+	}
+	totalGas = max(totalGas, minGas, floorDataGas)
+
+	// Make a one use key to sign the bundle
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to generate signing key: %w", err)
+	}
+
+	// Sign the bundle transaction with the one-use key and send it to the network
+	signer := types.LatestSignerForChainID(a.b.ChainID())
+	tx, err := types.SignNewTx(key, signer,
+		&types.DynamicFeeTx{
+			To:    &bundle.BundleProcessor,
+			Nonce: 0,
+			Data:  data,
+			Gas:   totalGas,
+		})
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to sign bundle transaction: %w", err)
+	}
+
+	// Validate generated transaction
+	_, plan, err := bundle.ValidateEnvelope(signer, tx)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to validate bundle transaction: %w", err)
+	}
+
+	// Submit the transaction to the network
+	_, err = ethapi.SubmitTransaction(ctx, a.b, tx)
+	return plan.Hash(), err
+}

--- a/api/sonicapi/submit_bundle_test.go
+++ b/api/sonicapi/submit_bundle_test.go
@@ -1,0 +1,369 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package sonicapi
+
+import (
+	"errors"
+	"testing"
+
+	rpctest "github.com/0xsoniclabs/sonic/api/rpc_test"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_SubmitBundle_ValidBundle_ReturnsExecutionPlanHash(t *testing.T) {
+	addr := common.Address{2}
+
+	tests := []struct {
+		name     string
+		flags    bundle.ExecutionFlags
+		numSteps int
+	}{
+		{"single tx, AllOf", bundle.EF_AllOf, 1},
+		{"two txs, AllOf", bundle.EF_AllOf, 2},
+		{"three txs, AllOf", bundle.EF_AllOf, 3},
+		{"single tx, OneOf", bundle.EF_OneOf, 1},
+		{"two txs, OneOf", bundle.EF_OneOf, 2},
+		{"single tx, TolerateFailed", bundle.EF_TolerateFailed, 1},
+		{"two txs, TolerateFailed", bundle.EF_TolerateFailed, 2},
+		{"single tx, TolerateInvalid", bundle.EF_TolerateInvalid, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			pool := rpctest.NewMockTxPool(ctrl)
+			pool.EXPECT().AddLocal(gomock.Any()).Return(nil)
+
+			be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
+			signer := types.LatestSignerForChainID(be.ChainID())
+
+			steps := make([]bundle.BundleStep, tt.numSteps)
+			for i := range steps {
+				key, err := crypto.GenerateKey()
+				require.NoError(t, err)
+				steps[i] = bundle.Step(key, &types.DynamicFeeTx{
+					To:  &addr,
+					Gas: params.TxGas,
+				})
+			}
+
+			args := buildSubmitBundleArgs(signer, tt.flags, 1, 100, steps...)
+
+			hash, err := NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+			require.NoError(t, err)
+
+			// Returned hash must match the execution plan hash derived from the args.
+			plan := args.ExecutionPlan
+			execPlan := bundle.ExecutionPlan{
+				Flags: plan.Flags,
+				Range: bundle.BlockRange{
+					Earliest: uint64(plan.Earliest),
+					Latest:   uint64(plan.Latest),
+				},
+				Steps: make([]bundle.ExecutionStep, len(plan.Steps)),
+			}
+			for i, s := range plan.Steps {
+				execPlan.Steps[i] = bundle.ExecutionStep{From: s.From, Hash: s.Hash}
+			}
+			require.Equal(t, execPlan.Hash(), hash)
+		})
+	}
+}
+
+func Test_SubmitBundle_InvalidTxEncoding_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name   string
+		txData hexutil.Bytes
+	}{
+		{"empty bytes", hexutil.Bytes{}},
+		{"garbage bytes", hexutil.Bytes{0xde, 0xad, 0xbe, 0xef}},
+		{"truncated rlp", hexutil.Bytes{0x01, 0x80}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			// AddLocal must not be called, decoding fails before submission.
+			pool := rpctest.NewMockTxPool(ctrl)
+
+			be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
+			signer := types.LatestSignerForChainID(be.ChainID())
+
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			addr := common.Address{2}
+
+			validArgs := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 100,
+				bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
+			)
+
+			args := SubmitBundleArgs{
+				SignedTransactions: []hexutil.Bytes{tt.txData},
+				ExecutionPlan:      validArgs.ExecutionPlan,
+			}
+
+			_, err = NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+			require.ErrorContains(t, err, "failed to decode bundled transaction 0")
+		})
+	}
+}
+
+func Test_SubmitBundle_PoolError_ReturnsError(t *testing.T) {
+	poolErr := errors.New("pool is full")
+
+	ctrl := gomock.NewController(t)
+	pool := rpctest.NewMockTxPool(ctrl)
+	pool.EXPECT().AddLocal(gomock.Any()).Return(poolErr)
+
+	be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
+	signer := types.LatestSignerForChainID(be.ChainID())
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	addr := common.Address{2}
+
+	args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 100,
+		bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
+	)
+
+	_, err = NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+	require.ErrorIs(t, err, poolErr)
+}
+
+func Test_SubmitBundle_SubmittedEnvelopeMatchesBundleContents(t *testing.T) {
+	var submitted *types.Transaction
+
+	ctrl := gomock.NewController(t)
+	pool := rpctest.NewMockTxPool(ctrl)
+	pool.EXPECT().AddLocal(gomock.Any()).DoAndReturn(func(tx *types.Transaction) error {
+		submitted = tx
+		return nil
+	})
+
+	be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
+	signer := types.LatestSignerForChainID(be.ChainID())
+
+	key1, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	key2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	addr := common.Address{2}
+	args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 10, 20,
+		bundle.Step(key1, &types.DynamicFeeTx{To: &addr, Nonce: 0, Gas: params.TxGas}),
+		bundle.Step(key2, &types.DynamicFeeTx{To: &addr, Nonce: 0, Gas: params.TxGas}),
+	)
+
+	_, err = NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+	require.NoError(t, err)
+	require.NotNil(t, submitted)
+
+	require.True(t, bundle.IsEnvelope(submitted))
+	decoded, err := bundle.OpenEnvelope(submitted)
+	require.NoError(t, err)
+	require.Len(t, decoded.Transactions, 2)
+	require.Equal(t, bundle.EF_AllOf, decoded.Flags)
+	require.EqualValues(t, 10, decoded.Range.Earliest)
+	require.EqualValues(t, 20, decoded.Range.Latest)
+}
+
+func Test_SubmitBundle_EnvelopeGasCoversAllBundledTxs(t *testing.T) {
+	var submitted *types.Transaction
+
+	ctrl := gomock.NewController(t)
+	pool := rpctest.NewMockTxPool(ctrl)
+	pool.EXPECT().AddLocal(gomock.Any()).DoAndReturn(func(tx *types.Transaction) error {
+		submitted = tx
+		return nil
+	})
+
+	be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
+	signer := types.LatestSignerForChainID(be.ChainID())
+
+	addr := common.Address{2}
+	highGas := uint64(200_000)
+
+	steps := make([]bundle.BundleStep, 3)
+	for i := range steps {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		steps[i] = bundle.Step(key, &types.DynamicFeeTx{
+			To:    &addr,
+			Nonce: uint64(i),
+			Gas:   highGas,
+		})
+	}
+
+	args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 50, steps...)
+
+	expectedMinGas := uint64(0)
+	for _, b := range args.SignedTransactions {
+		tx := new(types.Transaction)
+		require.NoError(t, tx.UnmarshalBinary(b))
+		expectedMinGas += tx.Gas()
+	}
+
+	_, err := NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+	require.NoError(t, err)
+	require.NotNil(t, submitted)
+	require.GreaterOrEqual(t, submitted.Gas(), expectedMinGas)
+}
+
+func Test_SubmitBundle_BlockRangeIsPreservedInPool(t *testing.T) {
+	tests := []struct {
+		name     string
+		earliest uint64
+		latest   uint64
+	}{
+		{"range [1,1]", 1, 1},
+		{"range [1,100]", 1, 100},
+		{"range [50,50]", 50, 50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var submitted *types.Transaction
+
+			ctrl := gomock.NewController(t)
+			pool := rpctest.NewMockTxPool(ctrl)
+			pool.EXPECT().AddLocal(gomock.Any()).DoAndReturn(func(tx *types.Transaction) error {
+				submitted = tx
+				return nil
+			})
+
+			be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
+			signer := types.LatestSignerForChainID(be.ChainID())
+
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			addr := common.Address{2}
+
+			args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, tt.earliest, tt.latest,
+				bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
+			)
+
+			_, err = NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+			require.NoError(t, err)
+			require.NotNil(t, submitted)
+
+			decoded, err := bundle.OpenEnvelope(submitted)
+			require.NoError(t, err)
+			require.Equal(t, tt.earliest, decoded.Range.Earliest)
+			require.Equal(t, tt.latest, decoded.Range.Latest)
+		})
+	}
+}
+
+func Test_SubmitBundle_InvalidBlockRange_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		earliest uint64
+		latest   uint64
+		errMsg   string
+	}{
+		{
+			name:     "empty range (earliest > latest)",
+			earliest: 10,
+			latest:   5,
+			errMsg:   "invalid empty block range",
+		},
+		{
+			name:     "range too large",
+			earliest: 0,
+			latest:   bundle.MaxBlockRange + 1,
+			errMsg:   "invalid block range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			// AddLocal must not be called, validation fails before submission.
+			pool := rpctest.NewMockTxPool(ctrl)
+
+			be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
+			signer := types.LatestSignerForChainID(be.ChainID())
+
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			addr := common.Address{2}
+
+			// Build args with a valid range, then override to invalid.
+			tb, plan := bundle.NewBuilder(signer).
+				SetEarliest(1).
+				SetLatest(10).
+				With(bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas})).
+				BuildBundleAndPlan()
+
+			signedTxs := make([]hexutil.Bytes, len(tb.Transactions))
+			for i, tx := range tb.Transactions {
+				data, err := tx.MarshalBinary()
+				require.NoError(t, err)
+				signedTxs[i] = data
+			}
+
+			rpcPlan := NewRPCExecutionPlan(plan)
+			rpcPlan.Earliest = rpc.BlockNumber(tt.earliest)
+			rpcPlan.Latest = rpc.BlockNumber(tt.latest)
+
+			args := SubmitBundleArgs{
+				SignedTransactions: signedTxs,
+				ExecutionPlan:      rpcPlan,
+			}
+
+			_, err = NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+			require.ErrorContains(t, err, tt.errMsg)
+		})
+	}
+}
+
+// buildSubmitBundleArgs creates a valid SubmitBundleArgs using the bundle builder.
+func buildSubmitBundleArgs(
+	signer types.Signer,
+	flags bundle.ExecutionFlags,
+	earliest, latest uint64,
+	steps ...bundle.BundleStep,
+) SubmitBundleArgs {
+	tb, plan := bundle.NewBuilder(signer).
+		SetFlags(flags).
+		SetEarliest(earliest).
+		SetLatest(latest).
+		With(steps...).
+		BuildBundleAndPlan()
+
+	signedTxs := make([]hexutil.Bytes, len(tb.Transactions))
+	for i, tx := range tb.Transactions {
+		data, err := tx.MarshalBinary()
+		if err != nil {
+			panic(err)
+		}
+		signedTxs[i] = data
+	}
+
+	return SubmitBundleArgs{
+		SignedTransactions: signedTxs,
+		ExecutionPlan:      NewRPCExecutionPlan(plan),
+	}
+}

--- a/api/sonicapi/submit_bundle_test.go
+++ b/api/sonicapi/submit_bundle_test.go
@@ -42,11 +42,9 @@ func Test_SubmitBundle_ValidBundle_ReturnsExecutionPlanHash(t *testing.T) {
 		flags    bundle.ExecutionFlags
 		numSteps int
 	}{
-		{"single tx, AllOf", bundle.EF_AllOf, 1},
-		{"two txs, AllOf", bundle.EF_AllOf, 2},
-		{"three txs, AllOf", bundle.EF_AllOf, 3},
-		{"single tx, OneOf", bundle.EF_OneOf, 1},
-		{"two txs, OneOf", bundle.EF_OneOf, 2},
+		{"single tx, default flags", bundle.EF_Default, 1},
+		{"two txs, default flags", bundle.EF_Default, 2},
+		{"three txs, default flags", bundle.EF_Default, 3},
 		{"single tx, TolerateFailed", bundle.EF_TolerateFailed, 1},
 		{"two txs, TolerateFailed", bundle.EF_TolerateFailed, 2},
 		{"single tx, TolerateInvalid", bundle.EF_TolerateInvalid, 1},
@@ -65,7 +63,7 @@ func Test_SubmitBundle_ValidBundle_ReturnsExecutionPlanHash(t *testing.T) {
 			be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
 			signer := types.LatestSignerForChainID(be.ChainID())
 
-			steps := make([]bundle.BundleStep, tt.numSteps)
+			steps := make([]bundle.BuilderStep, tt.numSteps)
 			for i := range steps {
 				key, err := crypto.GenerateKey()
 				require.NoError(t, err)
@@ -80,33 +78,18 @@ func Test_SubmitBundle_ValidBundle_ReturnsExecutionPlanHash(t *testing.T) {
 			hash, err := NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
 			require.NoError(t, err)
 
-			// Returned hash must match the execution plan hash derived from the args.
-			plan := args.ExecutionPlan
-			execPlan := bundle.ExecutionPlan{
-				Flags: plan.Flags,
-				Range: bundle.BlockRange{
-					Earliest: uint64(plan.Earliest),
-					Latest:   uint64(plan.Latest),
-				},
-				Steps: make([]bundle.ExecutionStep, len(plan.Steps)),
-			}
-			for i, s := range plan.Steps {
-				execPlan.Steps[i] = bundle.ExecutionStep{From: s.From, Hash: s.Hash}
-			}
-			require.Equal(t, execPlan.Hash(), hash)
-
-			// Submitted transaction must be a valid bundle envelope corresponding to the same execution plan.
+			// Submitted transaction must be a valid bundle envelope.
 			require.NotNil(t, submitted)
 			require.True(t, bundle.IsEnvelope(submitted))
-			decoded, err := bundle.OpenEnvelope(submitted)
-			require.NoError(t, err)
-			require.Equal(t, execPlan.Flags, decoded.Flags)
-			require.EqualValues(t, execPlan.Range.Earliest, decoded.Range.Earliest)
-			require.EqualValues(t, execPlan.Range.Latest, decoded.Range.Latest)
-			poolPlan, err := bundle.ExtractExecutionPlan(signer, submitted)
-			require.NoError(t, err)
-			require.Equal(t, execPlan.Hash(), poolPlan.Hash())
 
+			// Returned hash must match the execution plan extracted from the submitted envelope.
+			_, submittedPlan, err := bundle.ValidateEnvelope(signer, submitted)
+			require.NoError(t, err)
+			require.Equal(t, submittedPlan.Hash(), hash)
+
+			// Block range must be preserved.
+			require.EqualValues(t, 1, submittedPlan.Range.Earliest)
+			require.EqualValues(t, 100, submittedPlan.Range.Latest)
 		})
 	}
 }
@@ -134,7 +117,7 @@ func Test_SubmitBundle_InvalidTxEncoding_ReturnsError(t *testing.T) {
 			require.NoError(t, err)
 			addr := common.Address{2}
 
-			validArgs := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 100,
+			validArgs := buildSubmitBundleArgs(signer, bundle.EF_Default, 1, 100,
 				bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
 			)
 
@@ -163,7 +146,7 @@ func Test_SubmitBundle_PoolError_ReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	addr := common.Address{2}
 
-	args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 100,
+	args := buildSubmitBundleArgs(signer, bundle.EF_Default, 1, 100,
 		bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
 	)
 
@@ -190,7 +173,7 @@ func Test_SubmitBundle_SubmittedEnvelopeMatchesBundleContents(t *testing.T) {
 	require.NoError(t, err)
 
 	addr := common.Address{2}
-	args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 10, 20,
+	args := buildSubmitBundleArgs(signer, bundle.EF_Default, 10, 20,
 		bundle.Step(key1, &types.DynamicFeeTx{To: &addr, Nonce: 0, Gas: params.TxGas}),
 		bundle.Step(key2, &types.DynamicFeeTx{To: &addr, Nonce: 0, Gas: params.TxGas}),
 	)
@@ -200,12 +183,11 @@ func Test_SubmitBundle_SubmittedEnvelopeMatchesBundleContents(t *testing.T) {
 	require.NotNil(t, submitted)
 
 	require.True(t, bundle.IsEnvelope(submitted))
-	decoded, err := bundle.OpenEnvelope(submitted)
+	decoded, err := bundle.OpenEnvelope(signer, submitted)
 	require.NoError(t, err)
 	require.Len(t, decoded.Transactions, 2)
-	require.Equal(t, bundle.EF_AllOf, decoded.Flags)
-	require.EqualValues(t, 10, decoded.Range.Earliest)
-	require.EqualValues(t, 20, decoded.Range.Latest)
+	require.EqualValues(t, 10, decoded.Plan.Range.Earliest)
+	require.EqualValues(t, 20, decoded.Plan.Range.Latest)
 }
 
 func Test_SubmitBundle_EnvelopeGasCoversAllBundledTxs(t *testing.T) {
@@ -224,7 +206,7 @@ func Test_SubmitBundle_EnvelopeGasCoversAllBundledTxs(t *testing.T) {
 	addr := common.Address{2}
 	highGas := uint64(200_000)
 
-	steps := make([]bundle.BundleStep, 3)
+	steps := make([]bundle.BuilderStep, 3)
 	for i := range steps {
 		key, err := crypto.GenerateKey()
 		require.NoError(t, err)
@@ -235,7 +217,7 @@ func Test_SubmitBundle_EnvelopeGasCoversAllBundledTxs(t *testing.T) {
 		})
 	}
 
-	args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 50, steps...)
+	args := buildSubmitBundleArgs(signer, bundle.EF_Default, 1, 50, steps...)
 
 	expectedMinGas := uint64(0)
 	for _, b := range args.SignedTransactions {
@@ -279,7 +261,7 @@ func Test_SubmitBundle_BlockRangeIsPreservedInPool(t *testing.T) {
 			require.NoError(t, err)
 			addr := common.Address{2}
 
-			args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, tt.earliest, tt.latest,
+			args := buildSubmitBundleArgs(signer, bundle.EF_Default, tt.earliest, tt.latest,
 				bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
 			)
 
@@ -287,10 +269,10 @@ func Test_SubmitBundle_BlockRangeIsPreservedInPool(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, submitted)
 
-			decoded, err := bundle.OpenEnvelope(submitted)
+			decoded, err := bundle.OpenEnvelope(signer, submitted)
 			require.NoError(t, err)
-			require.Equal(t, tt.earliest, decoded.Range.Earliest)
-			require.Equal(t, tt.latest, decoded.Range.Latest)
+			require.Equal(t, tt.earliest, decoded.Plan.Range.Earliest)
+			require.Equal(t, tt.latest, decoded.Plan.Range.Latest)
 		})
 	}
 }
@@ -330,14 +312,16 @@ func Test_SubmitBundle_InvalidBlockRange_ReturnsError(t *testing.T) {
 			addr := common.Address{2}
 
 			// Build args with a valid range, then override to invalid.
-			tb, plan := bundle.NewBuilder(signer).
+			tb, plan := bundle.NewBuilder().
+				WithSigner(signer).
 				SetEarliest(1).
 				SetLatest(10).
 				With(bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas})).
 				BuildBundleAndPlan()
 
-			signedTxs := make([]hexutil.Bytes, len(tb.Transactions))
-			for i, tx := range tb.Transactions {
+			txsInOrder := tb.GetTransactionsInReferencedOrder()
+			signedTxs := make([]hexutil.Bytes, len(txsInOrder))
+			for i, tx := range txsInOrder {
 				data, err := tx.MarshalBinary()
 				require.NoError(t, err)
 				signedTxs[i] = data
@@ -399,7 +383,7 @@ func Test_SubmitBundle_InvalidExecutionPlanBlockNumbers_ReturnsError(t *testing.
 			key, err := crypto.GenerateKey()
 			require.NoError(t, err)
 			addr := common.Address{2}
-			args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 100,
+			args := buildSubmitBundleArgs(signer, bundle.EF_Default, 1, 100,
 				bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
 			)
 			args.ExecutionPlan.Earliest = tt.earliest
@@ -529,21 +513,35 @@ func makeEvmBlock(number uint64) *evmcore.EvmBlock {
 }
 
 // buildSubmitBundleArgs creates a valid SubmitBundleArgs using the bundle builder.
+// The flags are applied to each transaction step individually.
 func buildSubmitBundleArgs(
 	signer types.Signer,
 	flags bundle.ExecutionFlags,
 	earliest, latest uint64,
-	steps ...bundle.BundleStep,
+	steps ...bundle.BuilderStep,
 ) SubmitBundleArgs {
-	tb, plan := bundle.NewBuilder(signer).
-		SetFlags(flags).
+	stepsWithFlags := make([]bundle.BuilderStep, len(steps))
+	for i, s := range steps {
+		stepsWithFlags[i] = s.WithFlags(flags)
+	}
+
+	var root bundle.BuilderStep
+	if len(stepsWithFlags) == 1 {
+		root = stepsWithFlags[0]
+	} else {
+		root = bundle.AllOf(stepsWithFlags...)
+	}
+
+	tb, plan := bundle.NewBuilder().
+		WithSigner(signer).
 		SetEarliest(earliest).
 		SetLatest(latest).
-		With(steps...).
+		With(root).
 		BuildBundleAndPlan()
 
-	signedTxs := make([]hexutil.Bytes, len(tb.Transactions))
-	for i, tx := range tb.Transactions {
+	txsInOrder := tb.GetTransactionsInReferencedOrder()
+	signedTxs := make([]hexutil.Bytes, len(txsInOrder))
+	for i, tx := range txsInOrder {
 		data, err := tx.MarshalBinary()
 		if err != nil {
 			panic(err)

--- a/api/sonicapi/submit_bundle_test.go
+++ b/api/sonicapi/submit_bundle_test.go
@@ -18,9 +18,11 @@ package sonicapi
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	rpctest "github.com/0xsoniclabs/sonic/api/rpc_test"
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -52,9 +54,13 @@ func Test_SubmitBundle_ValidBundle_ReturnsExecutionPlanHash(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var submitted *types.Transaction
 			ctrl := gomock.NewController(t)
 			pool := rpctest.NewMockTxPool(ctrl)
-			pool.EXPECT().AddLocal(gomock.Any()).Return(nil)
+			pool.EXPECT().AddLocal(gomock.Any()).DoAndReturn(func(tx *types.Transaction) error {
+				submitted = tx
+				return nil
+			})
 
 			be := rpctest.NewBackendBuilder(t).WithPool(pool).Build()
 			signer := types.LatestSignerForChainID(be.ChainID())
@@ -88,6 +94,19 @@ func Test_SubmitBundle_ValidBundle_ReturnsExecutionPlanHash(t *testing.T) {
 				execPlan.Steps[i] = bundle.ExecutionStep{From: s.From, Hash: s.Hash}
 			}
 			require.Equal(t, execPlan.Hash(), hash)
+
+			// Submitted transaction must be a valid bundle envelope corresponding to the same execution plan.
+			require.NotNil(t, submitted)
+			require.True(t, bundle.IsEnvelope(submitted))
+			decoded, err := bundle.OpenEnvelope(submitted)
+			require.NoError(t, err)
+			require.Equal(t, execPlan.Flags, decoded.Flags)
+			require.EqualValues(t, execPlan.Range.Earliest, decoded.Range.Earliest)
+			require.EqualValues(t, execPlan.Range.Latest, decoded.Range.Latest)
+			poolPlan, err := bundle.ExtractExecutionPlan(signer, submitted)
+			require.NoError(t, err)
+			require.Equal(t, execPlan.Hash(), poolPlan.Hash())
+
 		})
 	}
 }
@@ -284,10 +303,10 @@ func Test_SubmitBundle_InvalidBlockRange_ReturnsError(t *testing.T) {
 		errMsg   string
 	}{
 		{
-			name:     "empty range (earliest > latest)",
+			name:     "earliest > latest",
 			earliest: 10,
 			latest:   5,
-			errMsg:   "invalid empty block range",
+			errMsg:   "latest block number cannot be smaller than earliest block number",
 		},
 		{
 			name:     "range too large",
@@ -337,6 +356,176 @@ func Test_SubmitBundle_InvalidBlockRange_ReturnsError(t *testing.T) {
 			require.ErrorContains(t, err, tt.errMsg)
 		})
 	}
+}
+
+func Test_SubmitBundle_InvalidExecutionPlanBlockNumbers_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		earliest rpc.BlockNumber
+	}{
+		{
+			name:     "latest as earliest",
+			earliest: rpc.LatestBlockNumber,
+		},
+		{
+			name:     "pending as earliest",
+			earliest: rpc.PendingBlockNumber,
+		},
+		{
+			name:     "finalized as earliest",
+			earliest: rpc.FinalizedBlockNumber,
+		},
+		{
+			name:     "safe as earliest",
+			earliest: rpc.SafeBlockNumber,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			// AddLocal must not be called, request validation fails before submission.
+			pool := rpctest.NewMockTxPool(ctrl)
+			be := rpctest.NewBackendBuilder(t).
+				WithPool(pool).
+				WithBlockHistory(
+					[]rpctest.Block{
+						{Number: 1},
+						{Number: 5},
+						{Number: 10},
+					},
+				).
+				Build()
+			signer := types.LatestSignerForChainID(be.ChainID())
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			addr := common.Address{2}
+			args := buildSubmitBundleArgs(signer, bundle.EF_AllOf, 1, 100,
+				bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
+			)
+			args.ExecutionPlan.Earliest = tt.earliest
+			args.ExecutionPlan.Latest = rpc.BlockNumber(1)
+			_, err = NewPublicBundleAPI(be).SubmitBundle(t.Context(), args)
+			require.ErrorContains(t, err, "latest block number cannot be smaller than earliest block number")
+		})
+	}
+}
+
+func Test_parseRPCBlockNumber(t *testing.T) {
+	tests := []struct {
+		name          string
+		num           rpc.BlockNumber
+		currentBlock  *evmcore.EvmBlock
+		wantNum       uint64
+		wantErrSubstr string
+	}{
+		{
+			name:    "explicit block number",
+			num:     rpc.BlockNumber(42),
+			wantNum: 42,
+		},
+		{
+			name:    "block number zero",
+			num:     rpc.BlockNumber(0),
+			wantNum: 0,
+		},
+		{
+			name:    "large block number",
+			num:     rpc.BlockNumber(1_000_000),
+			wantNum: 1_000_000,
+		},
+		{
+			name:    "earliest block number returns zero",
+			num:     rpc.EarliestBlockNumber,
+			wantNum: 0,
+		},
+		{
+			name:         "latest with current block",
+			num:          rpc.LatestBlockNumber,
+			currentBlock: makeEvmBlock(99),
+			wantNum:      99,
+		},
+		{
+			name:         "pending with current block",
+			num:          rpc.PendingBlockNumber,
+			currentBlock: makeEvmBlock(5),
+			wantNum:      5,
+		},
+		{
+			name:         "finalized with current block",
+			num:          rpc.FinalizedBlockNumber,
+			currentBlock: makeEvmBlock(77),
+			wantNum:      77,
+		},
+		{
+			name:         "safe with current block",
+			num:          rpc.SafeBlockNumber,
+			currentBlock: makeEvmBlock(33),
+			wantNum:      33,
+		},
+		{
+			name:          "latest without current block returns error",
+			num:           rpc.LatestBlockNumber,
+			currentBlock:  nil,
+			wantErrSubstr: "no current block",
+		},
+		{
+			name:          "pending without current block returns error",
+			num:           rpc.PendingBlockNumber,
+			currentBlock:  nil,
+			wantErrSubstr: "no current block",
+		},
+		{
+			name:          "finalized without current block returns error",
+			num:           rpc.FinalizedBlockNumber,
+			currentBlock:  nil,
+			wantErrSubstr: "no current block",
+		},
+		{
+			name:          "safe without current block returns error",
+			num:           rpc.SafeBlockNumber,
+			currentBlock:  nil,
+			wantErrSubstr: "no current block",
+		},
+		{
+			name:          "arbitrary negative number returns error",
+			num:           rpc.BlockNumber(-100),
+			wantErrSubstr: "block number cannot be negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mock := NewMockBundleApiBackend(ctrl)
+
+			needsCurrentBlock := tt.num == rpc.PendingBlockNumber ||
+				tt.num == rpc.LatestBlockNumber ||
+				tt.num == rpc.FinalizedBlockNumber ||
+				tt.num == rpc.SafeBlockNumber
+			if needsCurrentBlock {
+				// parseRPCBlockNumber calls CurrentBlock() twice: once for the nil
+				// guard and once to read the block number (only when block != nil).
+				if tt.currentBlock != nil {
+					mock.EXPECT().CurrentBlock().Return(tt.currentBlock).Times(1)
+				} else {
+					mock.EXPECT().CurrentBlock().Return(nil).Times(1)
+				}
+			}
+
+			got, err := parseRPCBlockNumber(tt.num, mock)
+			if tt.wantErrSubstr != "" {
+				require.ErrorContains(t, err, tt.wantErrSubstr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantNum, got)
+			}
+		})
+	}
+}
+
+func makeEvmBlock(number uint64) *evmcore.EvmBlock {
+	n := big.NewInt(int64(number))
+	return &evmcore.EvmBlock{EvmHeader: evmcore.EvmHeader{Number: n}}
 }
 
 // buildSubmitBundleArgs creates a valid SubmitBundleArgs using the bundle builder.

--- a/api/sonicapi/submit_bundle_test.go
+++ b/api/sonicapi/submit_bundle_test.go
@@ -512,7 +512,7 @@ func Test_parseRPCBlockNumber(t *testing.T) {
 				}
 			}
 
-			got, err := parseRPCBlockNumber(tt.num, mock)
+			got, err := parseRPCBlockNumber(mock, tt.num)
 			if tt.wantErrSubstr != "" {
 				require.ErrorContains(t, err, tt.wantErrSubstr)
 			} else {

--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -443,7 +443,7 @@ func newEnvelope(
 	bundle *TransactionBundle,
 ) *types.Transaction {
 
-	payload, err := bundle.encode()
+	payload, err := bundle.Encode()
 	if err != nil {
 		panic(fmt.Sprintf("failed to encode bundle: %v", err))
 	}

--- a/gossip/blockproc/bundle/bundle.go
+++ b/gossip/blockproc/bundle/bundle.go
@@ -94,7 +94,9 @@ func (tb *TransactionBundle) GetTransactionsInReferencedOrder() []*types.Transac
 	return txs
 }
 
-func (tb *TransactionBundle) encode() ([]byte, error) {
+// Encode encodes the transaction bundle into a byte slice for use in an
+// envelope transaction's data field.
+func (tb *TransactionBundle) Encode() ([]byte, error) {
 	return encodeInternal(bundleEncodingVersion, tb)
 }
 

--- a/gossip/blockproc/bundle/bundle_test.go
+++ b/gossip/blockproc/bundle/bundle_test.go
@@ -100,7 +100,7 @@ func TestOpenEnvelope_SuccessfullyDecodesEnvelopes(t *testing.T) {
 
 	for name, bundle := range tests {
 		t.Run(name, func(t *testing.T) {
-			payload, err := bundle.encode()
+			payload, err := bundle.Encode()
 			require.NoError(t, err)
 			envelope := types.NewTx(&types.LegacyTx{
 				To:   &BundleProcessor,
@@ -604,7 +604,7 @@ func TestDecode_SuccessfullyUnpacksValidBundle(t *testing.T) {
 	for name, bundle := range tests {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			encoded, err := bundle.encode()
+			encoded, err := bundle.Encode()
 			require.NoError(err)
 			restored, err := decode(signer, encoded)
 			require.NoError(err)
@@ -666,7 +666,7 @@ func TestEncode_NonEncodableTransactions_ReturnsError(t *testing.T) {
 		},
 	}
 
-	_, err := bundle.encode()
+	_, err := bundle.Encode()
 	require.ErrorIs(err, issue)
 	require.ErrorContains(err, "failed to encode transaction bundle")
 }
@@ -699,7 +699,7 @@ func TestDecode_LegacyTxDataInBundle_FailsDecodingSinceBundleOnlyMarkCanNotBeRem
 		},
 	}
 
-	encoded, err := bundle.encode()
+	encoded, err := bundle.Encode()
 	require.NoError(t, err)
 
 	_, err = decode(signer, encoded)
@@ -713,7 +713,7 @@ func TestDecode_CorruptedExecutionPlanEncoding_DetectedDuringDecoding(t *testing
 		},
 	}
 
-	encoded, err := bundle.encode()
+	encoded, err := bundle.Encode()
 	require.NoError(t, err)
 
 	_, err = decode(nil, encoded)

--- a/gossip/blockproc/bundle/execution_plan.go
+++ b/gossip/blockproc/bundle/execution_plan.go
@@ -148,6 +148,20 @@ func (s ExecutionStep) WithFlags(flags ExecutionFlags) ExecutionStep {
 	return res
 }
 
+// Flags returns the execution flags for this step. For single transaction
+// steps it returns the step's own flags. For group steps it recurses into the
+// first child step, which enables callers to retrieve the common flags for a
+// flat plan where all transaction steps carry the same flags.
+func (s *ExecutionStep) Flags() ExecutionFlags {
+	if s.single != nil {
+		return s.single.flags
+	}
+	if s.group != nil && len(s.group.steps) > 0 {
+		return s.group.steps[0].Flags()
+	}
+	return EF_Default
+}
+
 // valid returns true if the step is valid, meaning that it is either a single
 // step or a group step, but not both or neither. This is a basic validation to
 // ensure the integrity of the execution plan structure.

--- a/gossip/blockproc/bundle/validate_test.go
+++ b/gossip/blockproc/bundle/validate_test.go
@@ -96,7 +96,7 @@ func TestValidateEnvelope_DetectsErrorInIntrinsicGasCalculation(t *testing.T) {
 	signer := types.LatestSignerForChainID(testChainID)
 
 	bundle := NewBuilder().AllOf().BuildBundle()
-	encoded, err := bundle.encode()
+	encoded, err := bundle.Encode()
 	require.NoError(t, err)
 
 	envelope := types.NewTx(&types.LegacyTx{
@@ -121,7 +121,7 @@ func TestValidateEnvelope_DetectsErrorInFloorDataGasCalculation(t *testing.T) {
 	signer := types.LatestSignerForChainID(testChainID)
 
 	bundle := NewBuilder().AllOf().BuildBundle()
-	encoded, err := bundle.encode()
+	encoded, err := bundle.Encode()
 	require.NoError(t, err)
 
 	envelope := types.NewTx(&types.LegacyTx{
@@ -210,7 +210,7 @@ func TestValidateEnvelope_AcceptsValidBlockRanges(t *testing.T) {
 						Latest:   test.To,
 					}},
 			}
-			encoded, err := bundle.encode()
+			encoded, err := bundle.Encode()
 			require.NoError(t, err)
 			tx := types.NewTx(&types.LegacyTx{
 				To:   &BundleProcessor,
@@ -253,7 +253,7 @@ func TestValidateEnvelope_IdentifiesInvalidBlockRanges(t *testing.T) {
 						Latest:   test.To,
 					}},
 			}
-			encoded, err := bundle.encode()
+			encoded, err := bundle.Encode()
 			require.NoError(t, err)
 			tx := types.NewTx(&types.LegacyTx{
 				To:   &BundleProcessor,
@@ -349,7 +349,7 @@ func (gen testBundleGenerator) makeUnsoundBundleTx(t testing.TB) *types.Transact
 		},
 	}
 
-	data, err := bundle.encode()
+	data, err := bundle.Encode()
 	require.NoError(t, err)
 	floorGas, err := core.FloorDataGas(data)
 	require.NoError(t, err)
@@ -394,7 +394,7 @@ func (gen testBundleGenerator) makeBundleTxWithWronglySignedTx(t testing.TB) *ty
 		},
 	}
 
-	encoded, err := bundle.encode()
+	encoded, err := bundle.Encode()
 	require.NoError(t, err)
 
 	return types.NewTx(&types.LegacyTx{
@@ -428,7 +428,7 @@ func (gen testBundleGenerator) makeBundleTxWithoutEnoughFloorGas(t testing.TB) *
 		},
 	}
 
-	data, err := bundle.encode()
+	data, err := bundle.Encode()
 	require.NoError(t, err)
 	floorGas, err := core.FloorDataGas(data)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR introduces new RPC function `sonic_submitBundle`. Final step in the bundle workflow. Takes the signed transactions and execution plan produced by `sonic_prepareBundle` and wraps them into a single envelope transaction that is submitted to the network.