### PR TITLE
Add `BlockHeight` to `eth_config` return struct.

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -727,7 +727,9 @@ type configResponse struct {
 // config as described by https://eips.ethereum.org/EIPS/eip-7910
 type config struct {
 	// ActivationTime is the timestamp of the first block where this config is active.
-	ActivationTime uint64 `json:"activationTime"`
+	ActivationTime uint64       `json:"activationTime"`
+	BlockHeight    *hexutil.Big `json:"blockHeight"`
+
 	// BlobSchedule will remain nil because in Sonic this is not relevant
 	BlobSchedule *params.BlobConfig `json:"blobSchedule"`
 

--- a/api/ethapi/config.go
+++ b/api/ethapi/config.go
@@ -69,6 +69,7 @@ func makeConfigFromUpgrade(
 		// block time needs to be converted to unix timestamp as it is done in
 		// evmcore/dummy_block.go in method EvmHeader.EthHeader()
 		ActivationTime:  uint64(block.Time.Unix()),
+		BlockHeight:     (*hexutil.Big)(block.Number),
 		ChainId:         (*hexutil.Big)(chainID),
 		ForkId:          forkId[:],
 		Precompiles:     precompiled,

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -276,11 +276,6 @@ func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 	UpdateNetworkRules(t, net, originalRules)
 	net.AdvanceEpoch(t, 1)
 
-	// get current block to confirm epoch advancement
-	currentBlock, err := client.BlockByNumber(t.Context(), nil)
-	require.NoError(t, err, "could not get current block after epoch advancement")
-	require.Greater(t, currentBlock.NumberU64(), block1.NumberU64(), "block number did not advance after epoch advancement")
-
 	// get new config
 	err = client.Client().Call(&response, "eth_config")
 	require.NoError(t, err, "eth_config failed")
@@ -297,6 +292,12 @@ func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 	heightString := response["current"]["blockHeight"].(string)
 	heightUint, err := hexutil.DecodeUint64(heightString)
 	require.NoError(t, err, "could not decode block height from hex string")
+
+	// get current block to confirm epoch advancement
+	activationBlock, err := client.HeaderByNumber(t.Context(), big.NewInt(int64(heightUint)))
+	require.NoError(t, err)
+	require.Equal(t, activationBlock.Time, uint64(response["current"]["activationTime"].(float64)),
+		"activation block time should be greater than the activation time in config")
 
 	upgradeHeight = opera.UpgradeHeight{
 		Upgrades: originalRules.Upgrades,

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/abft"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -220,7 +221,6 @@ func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 	// and upgrades gets updated in block 1
 	block1, err := client.BlockByNumber(t.Context(), big.NewInt(1))
 	require.NoError(t, err, "could not get block 1 to determine expected ActivationTime")
-	activationTime := block1.Header().Time
 
 	upgradeHeight := opera.UpgradeHeight{
 		Upgrades: opera.GetBrioUpgrades(),
@@ -232,7 +232,8 @@ func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 
 	want := map[string]map[string]any{
 		"current": {
-			"activationTime": activationTime,
+			"activationTime": block1.Time(),
+			"blockHeight":    fmt.Sprintf("0x%x", block1.Number().Uint64()),
 			"blobSchedule":   nil,
 			"chainId":        "0xfa3",
 			"forkId":         fmt.Sprintf("0x%x", expectedForkId),
@@ -261,27 +262,24 @@ func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 		"next": nil,
 		"last": nil,
 	}
-
 	require.Equal(t, want, response, "eth_config returned unexpected result")
 
 	originalForkId := response["current"]["forkId"]
 	require.NotZero(t, originalForkId, "forkId should not be zero")
 
 	// get current rules and change to single proposer mode
-	var rules opera.Rules
-	err = client.Client().Call(&rules, "eth_getRules", "latest")
+	var originalRules opera.Rules
+	err = client.Client().Call(&originalRules, "eth_getRules", "latest")
 	require.NoError(t, err, "eth_getRules failed")
 
-	rules.Upgrades.GasSubsidies = true
-	UpdateNetworkRules(t, net, rules)
+	originalRules.Upgrades.GasSubsidies = true
+	UpdateNetworkRules(t, net, originalRules)
 	net.AdvanceEpoch(t, 1)
 
 	// get current block to confirm epoch advancement
 	currentBlock, err := client.BlockByNumber(t.Context(), nil)
 	require.NoError(t, err, "could not get current block after epoch advancement")
 	require.Greater(t, currentBlock.NumberU64(), block1.NumberU64(), "block number did not advance after epoch advancement")
-
-	WaitForProofOf(t, client, int(currentBlock.NumberU64()))
 
 	// get new config
 	err = client.Client().Call(&response, "eth_config")
@@ -295,28 +293,18 @@ func TestEthConfig_ProducesReadableConfig(t *testing.T) {
 	require.Contains(t, response["current"], "systemContracts")
 	require.Contains(t, response["current"]["systemContracts"], "GAS_SUBSIDY_REGISTRY_ADDRESS")
 
-	foundActivationBlock := false
-	activationBlockNumber := idx.Block(0)
-	for i := currentBlock.NumberU64(); i > 0 || !foundActivationBlock; i-- {
-		// get previous block to determine expected activation time
-		previousBlock, err := client.BlockByNumber(t.Context(), big.NewInt(int64(i)))
-		require.NoError(t, err, "could not get previous block after epoch advancement")
-
-		if previousBlock.Header().Time == uint64(response["current"]["activationTime"].(float64)) {
-			foundActivationBlock = true
-			activationBlockNumber = idx.Block(previousBlock.NumberU64())
-			break
-		}
-	}
+	// reinterpret block height from string to uint64
+	heightString := response["current"]["blockHeight"].(string)
+	heightUint, err := hexutil.DecodeUint64(heightString)
+	require.NoError(t, err, "could not decode block height from hex string")
 
 	upgradeHeight = opera.UpgradeHeight{
-		Upgrades: rules.Upgrades,
-		Height:   activationBlockNumber,
+		Upgrades: originalRules.Upgrades,
+		Height:   idx.Block(heightUint),
 	}
 	expectedForkId, err = ethapi.MakeForkId(upgradeHeight, genesisId)
 	require.NoError(t, err, "could not make expected fork ID after upgrade")
 
 	require.Equal(t, fmt.Sprintf("0x%x", expectedForkId), response["current"]["forkId"],
 		"fork ID after upgrade is incorrect")
-	require.True(t, foundActivationBlock, "should have found block with the same timestamp as the activation time")
 }


### PR DESCRIPTION
**The Problem**
When Sonic generates more than one block within a second, the `ActivationTime` (which as per the [EIP-7910](https://eips.ethereum.org/EIPS/eip-7910) is a Unix epoch seconds) does not have the required granularity to properly identify the first block when the new rules are active.

**The Proposes Solution**
Add an extra field to the `config` struct, namely `BlockHeight` which has the block number of the first block where the new rules are active.  Since the block height was already used to calculate the `ForkId` no further changes are needed.