### PR TITLE
Mark also failed bundles as executed

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -375,6 +375,13 @@ func (r *transactionRunner) runTransactionBundleInternal(
 	// Run the bundle and collect the processed transactions.
 	runner := bundleTransactionRunner{ctxt: ctxt, txOffset: txIndex}
 	if success := bundle.RunBundle(txBundle, &runner); !success {
+		// Mark the execution plan as processed in the StateDB to prevent processing
+		// another bundle with the same execution plan in the same block. Also keep
+		// track of the position of the bundle in the block.
+		// Note: it is sufficient to mark the execution plan of a bundle after the
+		// execution of the bundle as used since nested bundles can not contain
+		// copies of themselves without finding a hash-function collision.
+		ctxt.statedb.AddProcessedBundle(planHash, positionInBlock)
 		return []ProcessedTransaction{}, core_types.TransactionResultFailed
 	}
 

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -1924,11 +1924,13 @@ func TestRunTransactionBundle_PreviouslyProcessedBundle_ReturnsEnvelopeAndResult
 	require.Equal(t, core_types.TransactionResultInvalid, result)
 }
 
-func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResultFailed(t *testing.T) {
+func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResultFailed_AndMarksBundleAsProcessed(t *testing.T) {
 	signer := types.LatestSignerForChainID(big.NewInt(1))
 	ctrl := gomock.NewController(t)
 	state := state.NewMockStateDB(ctrl)
 	evm := NewMock_evm(ctrl)
+
+	txOffset := 12
 
 	tx := bundle.OneOf().Build() // an empty bundle with OneOf flag will fail
 	_, plan, err := bundle.ValidateEnvelope(signer, tx)
@@ -1938,6 +1940,10 @@ func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResu
 		state.EXPECT().HasBundleRecentlyBeenProcessed(plan.Hash()),
 		state.EXPECT().InterTxSnapshot().Return(1),
 		state.EXPECT().RevertToInterTxSnapshot(1),
+		state.EXPECT().AddProcessedBundle(plan.Hash(), bundle.PositionInBlock{
+			Offset: uint32(txOffset),
+			Count:  0,
+		}),
 	)
 
 	gasPool := new(core.GasPool).AddGas(1_000_000)
@@ -1952,12 +1958,12 @@ func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResu
 
 	runner := &transactionRunner{evm: evm}
 
-	processedTransactions, result := runner.runTransactionBundle(context, tx, 0)
+	processedTransactions, result := runner.runTransactionBundle(context, tx, txOffset)
 	require.Len(t, processedTransactions, 0)
 	require.Equal(t, core_types.TransactionResultFailed, result)
 }
 
-func TestRunTransactionBundle_RunBundleSuccessful_ReturnsBundleOnlyTransactionAndResultSuccessful(t *testing.T) {
+func TestRunTransactionBundle_RunBundleSuccessful_ReturnsBundleOnlyTransactionAndResultSuccessful_AndMarksBundleAsProcessed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	state := state.NewMockStateDB(ctrl)
 	evm := NewMock_evm(ctrl)


### PR DESCRIPTION
This PR fixes a bug where failed bundles were not marked as executed and were therefore processed over and over again.