### PR TITLE
Add execution step validation

### DIFF
--- a/gossip/blockproc/bundle/validate.go
+++ b/gossip/blockproc/bundle/validate.go
@@ -26,6 +26,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+const (
+	// MaxNestingDepth defines the maximum allowed nesting depth of execution steps.
+	MaxNestingDepth = 16
+)
+
 var ErrWrongEnvelopeGasLimit = errors.New("gas limit of envelope does not match gas limit of payload")
 
 // ValidateEnvelope validates an envelope and its contents.
@@ -131,6 +136,46 @@ func validateEnvelopeInternal(
 	}
 
 	return &txBundle, &plan, nil
+}
+
+// validateStep checks that the given execution step is valid.
+func validateStep(step ExecutionStep) error {
+	return validateStepInternal(step, 0)
+}
+
+func validateStepInternal(
+	step ExecutionStep,
+	depth int,
+) error {
+
+	// Check limit of maximum nesting.
+	if depth > MaxNestingDepth {
+		return fmt.Errorf("exceeds maximum nesting depth of execution steps")
+	}
+
+	// The step must be either a single or a group, not neither or both.
+	if !step.valid() {
+		return fmt.Errorf("malformed execution step")
+	}
+
+	// Check properties of the single step variant.
+	if single := step.single; single != nil {
+		if !single.flags.Valid() {
+			return fmt.Errorf("invalid execution flags in step")
+		}
+		return nil
+	}
+
+	// Check properties of the group step variant.
+	if group := step.group; group != nil {
+		for _, subStep := range group.steps {
+			if err := validateStepInternal(subStep, depth+1); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // validateRange checks that the given block range is valid, i.e. that it is not

--- a/gossip/blockproc/bundle/validate.go
+++ b/gossip/blockproc/bundle/validate.go
@@ -27,7 +27,20 @@ import (
 )
 
 const (
-	// MaxNestingDepth defines the maximum allowed nesting depth of execution steps.
+	// MaxNestingDepth defines the maximum allowed nesting depth of execution
+	// steps. This constant is critical to consensus, as it influences the
+	// decision of whether a bundle is valid and can be computed or invalid and
+	// must be rejected. It can thus only be altered as part of a hard-fork.
+	//
+	// The main intention of adding a limit to the number of nesting levels is
+	// to provide a guaranteed upper limit for nesting valid execution plans to
+	// implementations, enabling them to reason about implementation trade-offs.
+	// In particular, the resource usage of recursive operations can be
+	// considered bound and effectively tested.
+	//
+	// The chosen value of 16 is somewhat arbitrary, but motivated by providing
+	// generous room for nesting while keeping the number of levels low enough
+	// to be easily testable and to not cause issues for implementations.
 	MaxNestingDepth = 16
 )
 

--- a/gossip/blockproc/bundle/validate_test.go
+++ b/gossip/blockproc/bundle/validate_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -449,6 +450,153 @@ func (gen testBundleGenerator) makeBundleTxWithoutEnoughGasForAllTransactions() 
 		Data: tx.Data(),
 		Gas:  38_000, // not enough gas for all transactions in the bundle
 	})
+}
+
+func TestValidateStep_AcceptsValidSteps(t *testing.T) {
+	validSteps := []ExecutionStep{
+		// -- atomic steps --
+		NewTxStep(TxReference{}),
+		NewTxStep(TxReference{}).WithFlags(EF_Default),
+		NewTxStep(TxReference{}).WithFlags(EF_TolerateFailed),
+		NewTxStep(TxReference{}).WithFlags(EF_TolerateInvalid),
+		NewTxStep(TxReference{}).WithFlags(EF_TolerateFailed | EF_TolerateInvalid),
+
+		// -- all-of steps --
+		NewAllOfStep(),
+		NewAllOfStep(
+			NewTxStep(TxReference{}),
+			NewTxStep(TxReference{}),
+		),
+		NewAllOfStep(
+			NewTxStep(TxReference{}),
+			NewTxStep(TxReference{}),
+		).WithFlags(EF_TolerateFailed),
+
+		// -- one-of steps --
+		NewOneOfStep(),
+		NewOneOfStep(
+			NewTxStep(TxReference{}),
+			NewTxStep(TxReference{}),
+		),
+		NewOneOfStep(
+			NewTxStep(TxReference{}),
+			NewTxStep(TxReference{}),
+		).WithFlags(EF_TolerateFailed),
+
+		// -- combined steps --
+		NewOneOfStep(
+			NewTxStep(TxReference{}),
+			NewAllOfStep(
+				NewTxStep(TxReference{}),
+			),
+		),
+	}
+
+	for _, step := range validSteps {
+		require.NoError(t, validateStep(step))
+	}
+}
+
+func TestValidateStep_DetectsInvalidSteps(t *testing.T) {
+	tests := map[string]struct {
+		step  ExecutionStep
+		issue string
+	}{
+		"empty step": {
+			step:  ExecutionStep{},
+			issue: "malformed execution step",
+		},
+		"step with both single and group set": {
+			step: ExecutionStep{
+				single: &single{},
+				group:  &group{},
+			},
+			issue: "malformed execution step",
+		},
+		"invalid execution flags": {
+			step:  NewTxStep(TxReference{}).WithFlags(0xFF),
+			issue: "invalid execution flags in step",
+		},
+		"malformed nested all-of step": {
+			step: NewAllOfStep(
+				ExecutionStep{}, // invalid step
+			),
+			issue: "malformed execution step",
+		},
+		"malformed nested one-of step": {
+			step: NewOneOfStep(
+				ExecutionStep{}, // invalid step
+			),
+			issue: "malformed execution step",
+		},
+		"invalid nested execution flags": {
+			step: NewAllOfStep(
+				NewTxStep(TxReference{}),
+				NewOneOfStep(
+					NewTxStep(TxReference{}),
+					NewTxStep(TxReference{}).WithFlags(0xFF),
+					NewTxStep(TxReference{}),
+				),
+				NewTxStep(TxReference{}),
+			),
+			issue: "invalid execution flags in step",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorContains(t, validateStep(test.step), test.issue)
+		})
+	}
+}
+
+func TestValidateStep_DetectsExcessiveNesting(t *testing.T) {
+	require.NoError(t, validateStep(NewAllOfStep(
+		wrapInNested(NewTxStep(TxReference{}), MaxNestingDepth-1),
+		wrapInNested(NewTxStep(TxReference{}), MaxNestingDepth-1),
+		wrapInNested(NewTxStep(TxReference{}), MaxNestingDepth-1),
+	)))
+
+	require.ErrorContains(t, validateStep(NewAllOfStep(
+		wrapInNested(NewTxStep(TxReference{}), MaxNestingDepth-1),
+		wrapInNested(NewTxStep(TxReference{}), MaxNestingDepth),
+		wrapInNested(NewTxStep(TxReference{}), MaxNestingDepth-1),
+	)), "exceeds maximum nesting depth")
+
+	for depth := range MaxNestingDepth + 2 {
+		step := wrapInNested(NewTxStep(TxReference{}), depth)
+		if depth <= MaxNestingDepth {
+			require.NoError(t, validateStep(step))
+		} else {
+			require.ErrorContains(t, validateStep(step), "exceeds maximum nesting depth")
+		}
+	}
+}
+
+func TestValidateStep_MaximumNestingDepthMatchesConstant(t *testing.T) {
+	inner := NewTxStep(TxReference{})
+	allowed := wrapInNested(inner, MaxNestingDepth)
+	invalid := wrapInNested(inner, MaxNestingDepth+1)
+
+	// make sure wrapInNested produces the correct number of nested groups
+	count := strings.Count(allowed.String(), "OneOf")
+	require.Equal(t, MaxNestingDepth, count)
+
+	count = strings.Count(invalid.String(), "OneOf")
+	require.Equal(t, MaxNestingDepth+1, count)
+
+	require.NoError(t, validateStep(allowed))
+	require.ErrorContains(t, validateStep(invalid), "exceeds maximum nesting depth")
+
+}
+
+func wrapInNested(inner ExecutionStep, depth int) ExecutionStep {
+	if depth == 0 {
+		return inner
+	}
+	return NewOneOfStep(
+		wrapInNested(inner, depth-1),
+	)
 }
 
 func TestValidateRange_AcceptsValidRanges(t *testing.T) {


### PR DESCRIPTION
This PR introduces validation for composed `ExecutionStep`s of bundles.

The main properties checked include:
- all steps are valid, thus none defines a single and a group step, nor neither
- the execution flags provided for each step are valid
- group steps are composed of valid individual steps
- the maximum nesting depth of groups is limited