### PR TITLE
Ignore flaky error of noopTx

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -867,7 +867,7 @@ func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 	//send a noop transaction to trigger a block
 	sendNoop := func() {
 		noopTx := CreateTransaction(t, n, &types.LegacyTx{Gas: 100_000}, n.GetSessionSponsor())
-		// this transaction can failed because the new epoch has new rules,
+		// This transaction can fail because the new epoch has new rules,
 		// hence invalidating the values assigned during the transaction creation.
 		// Since the transaction is only meant to trigger a block,
 		// the error is safe to ignore and move on with the epoch change.

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -866,9 +866,12 @@ func (n *IntegrationTestNet) AdvanceEpoch(t testing.TB, epochs int) {
 
 	//send a noop transaction to trigger a block
 	sendNoop := func() {
-		noopTx := CreateTransaction(t, n, &types.LegacyTx{}, n.GetSessionSponsor())
-		err := client.SendTransaction(t.Context(), noopTx)
-		require.NoError(t, err, "failed to send noop transaction to trigger block sealing")
+		noopTx := CreateTransaction(t, n, &types.LegacyTx{Gas: 100_000}, n.GetSessionSponsor())
+		// this transaction can failed because the new epoch has new rules,
+		// hence invalidating the values assigned during the transaction creation.
+		// Since the transaction is only meant to trigger a block,
+		// the error is safe to ignore and move on with the epoch change.
+		_ = client.SendTransaction(t.Context(), noopTx)
 	}
 
 	var currentEpoch hexutil.Uint64


### PR DESCRIPTION
**The Issue:** State Latency in Rule Application
In our integration testing suite, `AdvanceEpoch` is frequently used to trigger consensus rule changes (e.g., base fee adjustments). Due to the asynchronous nature of block production and the transaction pool, a race condition exists:
- Epoch Transition: An epoch change is triggered to apply new rules.
- Transaction Generation: To expedite the wait for the new epoch, the test suite generates a "No-Op" transaction (noopTx) with the old rules.
- Stale Rule Validation: If the `noopTx` is assigned enough gas price for the old rules, the rules applied, and then the gas price estimated, the transaction is built with a gas price lower than the new base fee.
- Rejection: The node eventually evaluates the transaction against the new rules, finds a mismatch (usually an underpriced gas fee), and rejects it, causing the test to fail unnecesarily.

**The Solution**
- Static Gas Allocation: By providing fixed, sufficient gas limit for these `noopTx`, there is no need to call `EstimateGas`. If `EstimateGas` is triggered during a rule change, it becomes a secondary failure vector by attempting to simulate transactions against a state that is in flux, leading to inconsistent gas requirements.
- Ignore the error, since the porpuse of this transaction is to trigger a block, if the transaction fails for whatever reason, it should not stop any test.

This PR fixes https://github.com/0xsoniclabs/sonic-admin/issues/724