### PR TITLE
Add prepareBundle RPC function

### DIFF
--- a/api/sonicapi/prepare_bundle.go
+++ b/api/sonicapi/prepare_bundle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/0xsoniclabs/sonic/api/ethapi"
+	evmcore "github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice/gaspricelimits"
 	"github.com/ethereum/go-ethereum/common"
@@ -52,12 +53,12 @@ type PrepareBundleArgs struct {
 // RPCPreparedBundle is the return type of the `sonic_prepareBundle` RPC method
 type RPCPreparedBundle struct {
 	// Transactions specifies the ordered list of transactions to be included in the bundle.
-	// These must be signed exactly as provided by the bundle_prepare RPC method; any modification
+	// These must be signed exactly as provided by the `sonic_prepareBundle` RPC method; any modification
 	// will invalidate the execution plan and result in an ill-formed bundle.
 	Transactions []ethapi.TransactionArgs `json:"transactions"`
 	// ExecutionPlan contains the execution plan that each bundled transaction references. This is provided
 	// for verification purposes; users may independently compute and validate the execution plan hash.
-	ExecutionPlan RPCExecutionPlan `json:"executionPlan,omitempty"`
+	ExecutionPlan RPCExecutionPlan `json:"executionPlan"`
 }
 
 // PrepareBundle implements the `sonic_prepareBundle` RPC method.
@@ -101,7 +102,14 @@ func (a *PublicBundleAPI) PrepareBundle(
 		}
 	}
 
-	gasPrice := a.suggestGasPrice()
+	var currentBlock *evmcore.EvmBlock
+	if block := a.b.CurrentBlock(); block != nil {
+		currentBlock = block
+	} else {
+		return nil, fmt.Errorf("failed to prepare bundle: unable to retrieve current block number")
+	}
+
+	gasPrice := a.suggestGasPrice(currentBlock)
 	fillTransactionDefaults(args.Transactions, gasLimits, gasPrice)
 
 	chainID := a.b.ChainID()
@@ -110,6 +118,11 @@ func (a *PublicBundleAPI) PrepareBundle(
 	// Build execution steps and TxReference map.
 	steps := make([]bundle.ExecutionStep, len(args.Transactions))
 	for i, txArgs := range args.Transactions {
+
+		if txArgs.Nonce == nil {
+			return nil, fmt.Errorf("failed to prepare bundle: transaction %d is missing nonce", i)
+		}
+
 		msg, err := txArgs.ToMessage(gasCap, basefee, log.Root())
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare bundle: transaction %d conversion error: %w", i, err)
@@ -126,13 +139,10 @@ func (a *PublicBundleAPI) PrepareBundle(
 		})
 	}
 
-	var currentBlockNumber uint64
-	if block := a.b.CurrentBlock(); block != nil {
-		currentBlockNumber = block.NumberU64()
-	} else {
-		return nil, fmt.Errorf("failed to prepare bundle: unable to retrieve current block number")
+	blockRange, err := resolveBlockRange(currentBlock.NumberU64(), args.EarliestBlock, args.LatestBlock)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare bundle: %w", err)
 	}
-	blockRange := resolveBlockRange(currentBlockNumber, args.EarliestBlock, args.LatestBlock)
 
 	var root bundle.ExecutionStep
 	if len(steps) == 1 {
@@ -156,11 +166,11 @@ func (a *PublicBundleAPI) PrepareBundle(
 }
 
 // fillTransactionDefaults fills missing gas limits and gas price fields.
-// Gas limits are set from gasLimits only when tx.Gas is nil. Gas price fields are
+// Gas limits are set from gasLimits only when tx.Gas is nil or zero. Gas price fields are
 // set from gasPrice only when both tx.GasPrice and tx.MaxFeePerGas are unset.
 func fillTransactionDefaults(txs []ethapi.TransactionArgs, gasLimits []hexutil.Uint64, gasPrice *hexutil.Big) {
 	for i := range txs {
-		if i < len(gasLimits) && txs[i].Gas == nil {
+		if i < len(gasLimits) && (txs[i].Gas == nil || *txs[i].Gas == 0) {
 			txs[i].Gas = &gasLimits[i]
 		}
 		if txs[i].GasPrice == nil && txs[i].MaxFeePerGas == nil {
@@ -175,17 +185,29 @@ func fillTransactionDefaults(txs []ethapi.TransactionArgs, gasLimits []hexutil.U
 
 // resolveBlockRange computes the effective block range for a bundle given the current
 // block number and optional earliest/latest overrides from the user.
-func resolveBlockRange(currentBlock uint64, earliest, latest *hexutil.Uint64) bundle.BlockRange {
+func resolveBlockRange(currentBlock uint64, earliest, latest *hexutil.Uint64) (bundle.BlockRange, error) {
 
-	e := currentBlock + 1
+	if latest != nil && earliest != nil {
+		if uint64(*latest) < uint64(*earliest) {
+			return bundle.BlockRange{}, fmt.Errorf("invalid block range: latest block %d is earlier than earliest block %d", *latest, *earliest)
+		}
+		if uint64(*latest)-uint64(*earliest)+1 > bundle.MaxBlockRange {
+			return bundle.BlockRange{}, fmt.Errorf("invalid block range: range %d is too large; must be at most %d blocks", uint64(*latest)-uint64(*earliest)+1, bundle.MaxBlockRange)
+		}
+	}
+
+	var r bundle.BlockRange
 	if earliest != nil {
-		e = uint64(*earliest)
+		r = bundle.MakeMaxRangeStartingAt(uint64(*earliest))
+	} else {
+		r = bundle.MakeMaxRangeStartingAt(currentBlock + 1)
 	}
-	l := e + bundle.MaxBlockRange - 1
+
 	if latest != nil {
-		l = uint64(*latest)
+		r.Latest = uint64(*latest)
 	}
-	return bundle.BlockRange{Earliest: e, Latest: l}
+
+	return r, nil
 }
 
 // injectPlanHashIntoAccessLists appends the bundle-only access list entry carrying
@@ -242,10 +264,10 @@ func asTransaction(msg *core.Message) (*types.Transaction, error) {
 	}
 }
 
-// suggestGasPrice returns the current suggested gas price for new transactions,
+// suggestGasPrice returns the suggested gas price for new transactions,
 // which is used to fill in missing gas price fields in bundled transactions.
-func (a *PublicBundleAPI) suggestGasPrice() *hexutil.Big {
-	price := a.b.CurrentBlock().Header().BaseFee
+func (a *PublicBundleAPI) suggestGasPrice(block *evmcore.EvmBlock) *hexutil.Big {
+	price := block.Header().BaseFee
 	price = gaspricelimits.GetSuggestedGasPriceForNewTransactions(price)
 	return (*hexutil.Big)(price)
 }

--- a/api/sonicapi/prepare_bundle.go
+++ b/api/sonicapi/prepare_bundle.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/0xsoniclabs/sonic/api/ethapi"
-	evmcore "github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice/gaspricelimits"
 	"github.com/ethereum/go-ethereum/common"
@@ -207,6 +207,10 @@ func resolveBlockRange(currentBlock uint64, earliest, latest *hexutil.Uint64) (b
 		r.Latest = uint64(*latest)
 	}
 
+	if r.Latest-r.Earliest+1 > bundle.MaxBlockRange {
+		return bundle.BlockRange{}, fmt.Errorf("invalid block range: range %d is too large; must be at most %d blocks", r.Latest-r.Earliest+1, bundle.MaxBlockRange)
+	}
+
 	return r, nil
 }
 
@@ -230,6 +234,11 @@ func injectPlanHashIntoAccessLists(txs []ethapi.TransactionArgs, planHash common
 // asTransaction converts a Message to a Transaction, ensuring that unsupported
 // transaction types (e.g. blob transactions) are not included in bundles.
 func asTransaction(msg *core.Message) (*types.Transaction, error) {
+
+	// when gasprice and gas fee cap or gas tip cap are both set, return error
+	if msg.GasPrice != nil && msg.GasPrice.Sign() != 0 && (msg.GasFeeCap != nil || msg.GasTipCap != nil) {
+		return nil, fmt.Errorf("cannot set both gas price and gas fee cap or gas tip cap")
+	}
 
 	if len(msg.BlobHashes) != 0 || msg.BlobGasFeeCap != nil {
 		return nil, fmt.Errorf("blob transactions are not supported in bundles")

--- a/api/sonicapi/prepare_bundle.go
+++ b/api/sonicapi/prepare_bundle.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package sonicapi
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/0xsoniclabs/sonic/api/ethapi"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/gasprice/gaspricelimits"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// PrepareBundleArgs represents the arguments for the `sonic_prepareBundle` RPC method.
+type PrepareBundleArgs struct {
+	// Transactions specifies the ordered list of transactions to be included in the bundle.
+	Transactions []ethapi.TransactionArgs `json:"transactions"`
+	// EarliestBlock specifies the earliest block number at which the bundle can be executed. This allows
+	// users to set a lower bound on when their bundle should be considered for execution, ensuring it is
+	// not included in blocks before a certain point in time.
+	//
+	// If left unspecified, the bundle will be eligible for execution starting from the next block after submission.
+	EarliestBlock *hexutil.Uint64 `json:"earliestBlock"`
+	// LatestBlock specifies the latest block number at which the bundle can be executed. This allows users
+	// to set an upper bound on when their bundle should be considered for execution, ensuring it is
+	// not included in blocks after a certain point in time. If the bundle is not executed by this block,
+	// it will be considered expired and will not be executed.
+	//
+	// If left unspecified, the bundle will be eligible for execution until 1024 blocks after EarliestBlock.
+	LatestBlock *hexutil.Uint64 `json:"latestBlock"`
+}
+
+// RPCPreparedBundle is the return type of the `sonic_prepareBundle` RPC method
+type RPCPreparedBundle struct {
+	// Transactions specifies the ordered list of transactions to be included in the bundle.
+	// These must be signed exactly as provided by the bundle_prepare RPC method; any modification
+	// will invalidate the execution plan and result in an ill-formed bundle.
+	Transactions []ethapi.TransactionArgs `json:"transactions"`
+	// ExecutionPlan contains the execution plan that each bundled transaction references. This is provided
+	// for verification purposes; users may independently compute and validate the execution plan hash.
+	ExecutionPlan RPCExecutionPlan `json:"executionPlan,omitempty"`
+}
+
+// PrepareBundle implements the `sonic_prepareBundle` RPC method.
+// This function streamlines the creation of transaction bundles by preparing an execution plan
+// based on the provided transaction order, to be executed within a specified block range.
+//
+// It accepts a list of unsigned transactions, constructs the corresponding execution plan,
+// and updates each transaction to include the bundler-only marker, ensuring they are executed
+// exclusively as part of the specified plan.
+//
+// Bundled transactions with uninitialized gas limits will have their gas estimated by this method, which will take into account
+// potential state changes from previous transactions in the bundle. However, users can also choose to set gas limits on their own;
+// in this case, the provided gas limits will be used without modification.
+//
+// Bundled transactions with uninitialized gas price fields (GasPrice for access list transactions,
+// or both MaxFeePerGas and MaxPriorityFeePerGas for EIP-1559 capable transactions) will have their gas price
+// set to the current suggested gas price by this method.
+// However, users can also choose to set gas price fields on their own; in this case,
+// the provided gas price fields will be used without modification, even if this is zero.
+//
+// The returned transactions must be signed without altering any fields; any modification may
+// invalidate the execution plan and prevent the bundle from being executed.
+func (a *PublicBundleAPI) PrepareBundle(
+	ctx context.Context,
+	args PrepareBundleArgs,
+) (*RPCPreparedBundle, error) {
+
+	gasCap := a.b.RPCGasCap()
+	basefee := a.b.MinGasPrice()
+
+	// Estimate gas for all transactions if any has an uninitialized gas limit.
+	var gasLimits []hexutil.Uint64
+	for _, tx := range args.Transactions {
+		if tx.Gas == nil || *tx.Gas == 0 {
+			estimated, err := a.EstimateGasForTransactions(ctx, args.Transactions, nil, nil, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to prepare bundle: gas estimation failed: %w", err)
+			}
+			gasLimits = estimated.GasLimits
+			break
+		}
+	}
+
+	gasPrice := a.suggestGasPrice()
+	fillTransactionDefaults(args.Transactions, gasLimits, gasPrice)
+
+	chainID := a.b.ChainID()
+	signer := types.LatestSignerForChainID(chainID)
+
+	// Build execution steps and TxReference map.
+	steps := make([]bundle.ExecutionStep, len(args.Transactions))
+	for i, txArgs := range args.Transactions {
+		msg, err := txArgs.ToMessage(gasCap, basefee, log.Root())
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare bundle: transaction %d conversion error: %w", i, err)
+		}
+
+		tx, err := asTransaction(msg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare bundle: transaction %d conversion error: %w", i, err)
+		}
+
+		steps[i] = bundle.NewTxStep(bundle.TxReference{
+			From: msg.From,
+			Hash: signer.Hash(tx),
+		})
+	}
+
+	var currentBlockNumber uint64
+	if block := a.b.CurrentBlock(); block != nil {
+		currentBlockNumber = block.NumberU64()
+	} else {
+		return nil, fmt.Errorf("failed to prepare bundle: unable to retrieve current block number")
+	}
+	blockRange := resolveBlockRange(currentBlockNumber, args.EarliestBlock, args.LatestBlock)
+
+	var root bundle.ExecutionStep
+	if len(steps) == 1 {
+		root = steps[0]
+	} else {
+		root = bundle.NewAllOfStep(steps...)
+	}
+
+	plan := bundle.ExecutionPlan{
+		Root:  root,
+		Range: blockRange,
+	}
+
+	injectPlanHashIntoAccessLists(args.Transactions, plan.Hash())
+
+	result := RPCPreparedBundle{
+		Transactions:  args.Transactions,
+		ExecutionPlan: NewRPCExecutionPlan(plan),
+	}
+	return &result, nil
+}
+
+// fillTransactionDefaults fills missing gas limits and gas price fields.
+// Gas limits are set from gasLimits only when tx.Gas is nil. Gas price fields are
+// set from gasPrice only when both tx.GasPrice and tx.MaxFeePerGas are unset.
+func fillTransactionDefaults(txs []ethapi.TransactionArgs, gasLimits []hexutil.Uint64, gasPrice *hexutil.Big) {
+	for i := range txs {
+		if i < len(gasLimits) && txs[i].Gas == nil {
+			txs[i].Gas = &gasLimits[i]
+		}
+		if txs[i].GasPrice == nil && txs[i].MaxFeePerGas == nil {
+			if txs[i].MaxPriorityFeePerGas == nil {
+				txs[i].GasPrice = gasPrice
+			} else {
+				txs[i].MaxFeePerGas = gasPrice
+			}
+		}
+	}
+}
+
+// resolveBlockRange computes the effective block range for a bundle given the current
+// block number and optional earliest/latest overrides from the user.
+func resolveBlockRange(currentBlock uint64, earliest, latest *hexutil.Uint64) bundle.BlockRange {
+
+	e := currentBlock + 1
+	if earliest != nil {
+		e = uint64(*earliest)
+	}
+	l := e + bundle.MaxBlockRange - 1
+	if latest != nil {
+		l = uint64(*latest)
+	}
+	return bundle.BlockRange{Earliest: e, Latest: l}
+}
+
+// injectPlanHashIntoAccessLists appends the bundle-only access list entry carrying
+// the execution plan hash to every transaction in-place.
+func injectPlanHashIntoAccessLists(txs []ethapi.TransactionArgs, planHash common.Hash) {
+	for i, tx := range txs {
+		var accessList types.AccessList
+		if tx.AccessList != nil {
+			accessList = *tx.AccessList
+		}
+		accessList = append(accessList, types.AccessTuple{
+			Address:     bundle.BundleOnly,
+			StorageKeys: []common.Hash{planHash},
+		})
+		tx.AccessList = &accessList
+		txs[i] = tx
+	}
+}
+
+// asTransaction converts a Message to a Transaction, ensuring that unsupported
+// transaction types (e.g. blob transactions) are not included in bundles.
+func asTransaction(msg *core.Message) (*types.Transaction, error) {
+
+	if len(msg.BlobHashes) != 0 || msg.BlobGasFeeCap != nil {
+		return nil, fmt.Errorf("blob transactions are not supported in bundles")
+	}
+	if len(msg.SetCodeAuthorizations) != 0 {
+		return nil, fmt.Errorf("transactions with set code authorization are not supported in bundles")
+	}
+
+	if msg.GasPrice == nil || msg.GasPrice.Sign() == 0 {
+		// use dynamic fee transaction
+		return types.NewTx(&types.DynamicFeeTx{
+			To:         msg.To,
+			Nonce:      msg.Nonce,
+			Gas:        msg.GasLimit,
+			GasFeeCap:  msg.GasFeeCap,
+			GasTipCap:  msg.GasTipCap,
+			Value:      msg.Value,
+			Data:       msg.Data,
+			AccessList: msg.AccessList,
+		}), nil
+	} else {
+		// use access list transaction
+		return types.NewTx(&types.AccessListTx{
+			To:         msg.To,
+			Nonce:      msg.Nonce,
+			Gas:        msg.GasLimit,
+			GasPrice:   msg.GasPrice,
+			Value:      msg.Value,
+			Data:       msg.Data,
+			AccessList: msg.AccessList,
+		}), nil
+	}
+}
+
+// suggestGasPrice returns the current suggested gas price for new transactions,
+// which is used to fill in missing gas price fields in bundled transactions.
+func (a *PublicBundleAPI) suggestGasPrice() *hexutil.Big {
+	price := a.b.CurrentBlock().Header().BaseFee
+	price = gaspricelimits.GetSuggestedGasPriceForNewTransactions(price)
+	return (*hexutil.Big)(price)
+}

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -1,0 +1,588 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package sonicapi
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/api/ethapi"
+	rpctest "github.com/0xsoniclabs/sonic/api/rpc_test"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_fillTransactionDefaults(t *testing.T) {
+	addr := common.Address{1}
+	gasPrice := rpctest.ToHexBigInt(big.NewInt(1e9))
+
+	existingGasPrice := rpctest.ToHexBigInt(big.NewInt(999))
+	existingMaxFee := rpctest.ToHexBigInt(big.NewInt(888))
+	tip := rpctest.ToHexBigInt(big.NewInt(1))
+	explicit := hexutil.Uint64(50000)
+
+	tests := []struct {
+		name      string
+		txs       []ethapi.TransactionArgs
+		gasLimits []hexutil.Uint64
+		gasPrice  *hexutil.Big
+		check     func(t *testing.T, txs []ethapi.TransactionArgs)
+	}{
+		{
+			name:      "nil gas limits sets gas price",
+			txs:       []ethapi.TransactionArgs{{From: &addr}},
+			gasLimits: nil,
+			gasPrice:  gasPrice,
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.Nil(t, txs[0].Gas, "gas must remain nil when no limits provided")
+				require.Equal(t, gasPrice, txs[0].GasPrice)
+			},
+		},
+		{
+			name:      "gas limits provided fills nil gas",
+			txs:       []ethapi.TransactionArgs{{From: &addr}},
+			gasLimits: []hexutil.Uint64{21000},
+			gasPrice:  rpctest.ToHexBigInt(big.NewInt(1)),
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.NotNil(t, txs[0].Gas)
+				require.EqualValues(t, 21000, *txs[0].Gas)
+			},
+		},
+		{
+			name:      "gas limits provided preserves explicit gas",
+			txs:       []ethapi.TransactionArgs{{From: &addr, Gas: &explicit}},
+			gasLimits: []hexutil.Uint64{21000},
+			gasPrice:  rpctest.ToHexBigInt(big.NewInt(1)),
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.EqualValues(t, 50000, *txs[0].Gas, "explicit gas must not be overwritten")
+			},
+		},
+		{
+			name:      "existing gas price not overwritten",
+			txs:       []ethapi.TransactionArgs{{From: &addr, GasPrice: existingGasPrice}},
+			gasLimits: nil,
+			gasPrice:  rpctest.ToHexBigInt(big.NewInt(1e9)),
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.Equal(t, existingGasPrice, txs[0].GasPrice, "existing GasPrice must not be overwritten")
+			},
+		},
+		{
+			name:     "existing MaxFeePerGas not overwritten",
+			txs:      []ethapi.TransactionArgs{{From: &addr, MaxFeePerGas: existingMaxFee}},
+			gasPrice: rpctest.ToHexBigInt(big.NewInt(1e9)),
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.Equal(t, existingMaxFee, txs[0].MaxFeePerGas, "existing MaxFeePerGas must not be overwritten")
+				require.Nil(t, txs[0].GasPrice)
+			},
+		},
+		{
+			name:     "MaxPriorityFeePerGas set causes MaxFeePerGas to be filled",
+			txs:      []ethapi.TransactionArgs{{From: &addr, MaxPriorityFeePerGas: tip}},
+			gasPrice: gasPrice,
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.Equal(t, gasPrice, txs[0].MaxFeePerGas)
+				require.Nil(t, txs[0].GasPrice)
+			},
+		},
+		{
+			name:      "multiple txs each filled with correct limit and price",
+			txs:       []ethapi.TransactionArgs{{From: &addr}, {From: &addr}, {From: &addr}},
+			gasLimits: []hexutil.Uint64{21000, 42000, 63000},
+			gasPrice:  gasPrice,
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				for i, expected := range []uint64{21000, 42000, 63000} {
+					require.NotNil(t, txs[i].Gas)
+					require.EqualValues(t, expected, *txs[i].Gas)
+					require.Equal(t, gasPrice, txs[i].GasPrice)
+				}
+			},
+		},
+		{
+			name:      "fewer limits than txs only fills available",
+			txs:       []ethapi.TransactionArgs{{From: &addr}, {From: &addr}},
+			gasLimits: []hexutil.Uint64{21000},
+			gasPrice:  rpctest.ToHexBigInt(big.NewInt(1)),
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.NotNil(t, txs[0].Gas)
+				require.EqualValues(t, 21000, *txs[0].Gas)
+				require.Nil(t, txs[1].Gas, "tx without a corresponding limit must remain nil")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fillTransactionDefaults(tc.txs, tc.gasLimits, tc.gasPrice)
+			tc.check(t, tc.txs)
+		})
+	}
+}
+
+func Test_resolveBlockRange(t *testing.T) {
+	hexN := func(n int64) *hexutil.Uint64 { b := hexutil.Uint64(n); return &b }
+
+	tests := []struct {
+		name         string
+		currentBlock uint64
+		earliest     *hexutil.Uint64
+		latest       *hexutil.Uint64
+		wantEarliest uint64
+		wantLatest   uint64
+	}{
+		{
+			name:         "nil both defaults from current block",
+			currentBlock: 10,
+			wantEarliest: 11,
+			wantLatest:   10 + bundle.MaxBlockRange,
+		},
+		{
+			name:         "explicit earliest",
+			currentBlock: 10,
+			earliest:     hexN(50),
+			wantEarliest: 50,
+			wantLatest:   50 + bundle.MaxBlockRange - 1,
+		},
+		{
+			name:         "explicit latest",
+			currentBlock: 10,
+			latest:       hexN(200),
+			wantEarliest: 11,
+			wantLatest:   200,
+		},
+		{
+			name:         "both explicit",
+			currentBlock: 100,
+			earliest:     hexN(5),
+			latest:       hexN(20),
+			wantEarliest: 5,
+			wantLatest:   20,
+		},
+		{
+			name:         "current block zero earliest is one",
+			currentBlock: 0,
+			wantEarliest: 1,
+			wantLatest:   bundle.MaxBlockRange,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := resolveBlockRange(tc.currentBlock, tc.earliest, tc.latest)
+			require.EqualValues(t, tc.wantEarliest, r.Earliest)
+			require.EqualValues(t, tc.wantLatest, r.Latest)
+		})
+	}
+}
+
+func Test_injectPlanHashIntoAccessLists(t *testing.T) {
+	existingAddr := common.Address{0x42}
+
+	tests := []struct {
+		name     string
+		txs      []ethapi.TransactionArgs
+		planHash common.Hash
+		check    func(t *testing.T, txs []ethapi.TransactionArgs)
+	}{
+		{
+			name:     "nil access list creates bundle-only entry",
+			txs:      []ethapi.TransactionArgs{{}},
+			planHash: common.Hash{0xab},
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				require.NotNil(t, txs[0].AccessList)
+				al := *txs[0].AccessList
+				require.Len(t, al, 1)
+				require.Equal(t, bundle.BundleOnly, al[0].Address)
+				require.Equal(t, []common.Hash{{0xab}}, al[0].StorageKeys)
+			},
+		},
+		{
+			name:     "existing entries appended",
+			txs:      []ethapi.TransactionArgs{{AccessList: &types.AccessList{{Address: existingAddr}}}},
+			planHash: common.Hash{0xcd},
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				al := *txs[0].AccessList
+				require.Len(t, al, 2)
+				require.Equal(t, existingAddr, al[0].Address)
+				require.Equal(t, bundle.BundleOnly, al[1].Address)
+				require.Equal(t, []common.Hash{{0xcd}}, al[1].StorageKeys)
+			},
+		},
+		{
+			name:     "multiple txs all injected",
+			txs:      []ethapi.TransactionArgs{{}, {}, {}},
+			planHash: common.Hash{0x01},
+			check: func(t *testing.T, txs []ethapi.TransactionArgs) {
+				for i, tx := range txs {
+					require.NotNil(t, tx.AccessList, "tx %d missing access list", i)
+					al := *tx.AccessList
+					require.Len(t, al, 1, "tx %d should have exactly one entry", i)
+					require.Equal(t, bundle.BundleOnly, al[0].Address)
+				}
+			},
+		},
+		{
+			name:     "nil txs no panic",
+			txs:      nil,
+			planHash: common.Hash{},
+			check:    func(t *testing.T, txs []ethapi.TransactionArgs) {},
+		},
+		{
+			name:     "empty txs no panic",
+			txs:      []ethapi.TransactionArgs{},
+			planHash: common.Hash{},
+			check:    func(t *testing.T, txs []ethapi.TransactionArgs) {},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			injectPlanHashIntoAccessLists(tc.txs, tc.planHash)
+			tc.check(t, tc.txs)
+		})
+	}
+}
+
+func Test_asTransaction_UnsupportedTypes_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     *core.Message
+		wantErr string
+	}{
+		{
+			name:    "blob hashes",
+			msg:     &core.Message{BlobHashes: []common.Hash{{0x01}}},
+			wantErr: "blob transactions are not supported",
+		},
+		{
+			name:    "blob gas fee cap",
+			msg:     &core.Message{BlobGasFeeCap: big.NewInt(1)},
+			wantErr: "blob transactions are not supported",
+		},
+		{
+			name:    "set code authorizations",
+			msg:     &core.Message{SetCodeAuthorizations: []types.SetCodeAuthorization{{}}},
+			wantErr: "transactions with set code authorization are not supported",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := asTransaction(tc.msg)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+func Test_asTransaction_TxType(t *testing.T) {
+	to := common.Address{2}
+
+	tests := []struct {
+		name     string
+		msg      *core.Message
+		wantType int
+	}{
+		{
+			name: "nil gas price returns dynamic fee tx",
+			msg: &core.Message{
+				To:        &to,
+				GasLimit:  params.TxGas,
+				GasFeeCap: big.NewInt(1e9),
+				GasTipCap: big.NewInt(1e6),
+				Value:     big.NewInt(0),
+			},
+			wantType: types.DynamicFeeTxType,
+		},
+		{
+			name: "zero gas price returns dynamic fee tx",
+			msg: &core.Message{
+				To:       &to,
+				GasPrice: big.NewInt(0),
+				GasLimit: params.TxGas,
+				Value:    big.NewInt(0),
+			},
+			wantType: types.DynamicFeeTxType,
+		},
+		{
+			name: "positive gas price returns access list tx",
+			msg: &core.Message{
+				To:       &to,
+				GasPrice: big.NewInt(1e9),
+				GasLimit: params.TxGas,
+				Value:    big.NewInt(0),
+			},
+			wantType: types.AccessListTxType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, err := asTransaction(tc.msg)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantType, int(tx.Type()))
+		})
+	}
+}
+
+func Test_asTransaction_PreservesFields(t *testing.T) {
+	to := common.Address{0xde}
+	accessList := types.AccessList{{Address: common.Address{0xaa}}}
+	msg := &core.Message{
+		To:         &to,
+		Nonce:      7,
+		GasLimit:   100_000,
+		GasFeeCap:  big.NewInt(2e9),
+		GasTipCap:  big.NewInt(1e6),
+		Value:      big.NewInt(42),
+		Data:       []byte{0x01, 0x02},
+		AccessList: accessList,
+	}
+	tx, err := asTransaction(msg)
+	require.NoError(t, err)
+	require.Equal(t, to, *tx.To())
+	require.EqualValues(t, 7, tx.Nonce())
+	require.EqualValues(t, 100_000, tx.Gas())
+	require.Equal(t, big.NewInt(42), tx.Value())
+	require.Equal(t, []byte{0x01, 0x02}, tx.Data())
+}
+
+func Test_PrepareBundle_SingleTx_GasAndPriceEstimated(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{{
+			From: &addr1,
+			To:   &addr2,
+		}},
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+	require.Len(t, result.Transactions, 1)
+
+	tx := result.Transactions[0]
+	require.NotNil(t, tx.Gas, "gas must be estimated when nil")
+	require.GreaterOrEqual(t, uint64(*tx.Gas), uint64(params.TxGas))
+
+	hasPriceField := tx.GasPrice != nil || tx.MaxFeePerGas != nil
+	require.True(t, hasPriceField, "gas price must be set")
+}
+
+func Test_PrepareBundle_SingleTx_AccessListContainsPlanHash(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{{
+			From: &addr1,
+			To:   &addr2,
+		}},
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+
+	tx := result.Transactions[0]
+	require.NotNil(t, tx.AccessList)
+
+	var found bool
+	for _, entry := range *tx.AccessList {
+		if entry.Address == bundle.BundleOnly {
+			found = true
+			require.Len(t, entry.StorageKeys, 1, "plan hash must be in storage keys")
+		}
+	}
+	require.True(t, found, "BundleOnly marker not found in access list")
+}
+
+func Test_PrepareBundle_ExplicitGasLimit_NotOverwritten(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+	explicitGas := hexutil.Uint64(50000)
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{{
+			From: &addr1,
+			To:   &addr2,
+			Gas:  &explicitGas,
+		}},
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+	require.EqualValues(t, explicitGas, *result.Transactions[0].Gas)
+}
+
+func Test_PrepareBundle_DefaultBlockRange_IsCurrentBlockPlusOne(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	currentBlock := be.CurrentBlock().NumberU64()
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{{
+			From: &addr1,
+			To:   &addr2,
+		}},
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+
+	require.EqualValues(t, currentBlock+1, result.ExecutionPlan.Earliest)
+	require.EqualValues(t, currentBlock+bundle.MaxBlockRange, result.ExecutionPlan.Latest)
+}
+
+func Test_PrepareBundle_ExplicitBlockRange_IsRespected(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+	earliest := hexutil.Uint64(10)
+	latest := hexutil.Uint64(20)
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{{
+			From: &addr1,
+			To:   &addr2,
+		}},
+		EarliestBlock: &earliest,
+		LatestBlock:   &latest,
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+
+	require.EqualValues(t, earliest, result.ExecutionPlan.Earliest)
+	require.EqualValues(t, latest, result.ExecutionPlan.Latest)
+}
+
+func Test_PrepareBundle_MultipleTxs_AllOfPlan(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		WithAccount(addr2, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{
+			{From: &addr1, To: &addr2, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+			{From: &addr2, To: &addr1, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+		},
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+	require.Len(t, result.Transactions, 2)
+	require.Len(t, result.ExecutionPlan.Steps, 2)
+
+	// Each tx must have the BundleOnly marker.
+	for i, tx := range result.Transactions {
+		require.NotNil(t, tx.AccessList, "tx %d missing access list", i)
+		var found bool
+		for _, entry := range *tx.AccessList {
+			if entry.Address == bundle.BundleOnly {
+				found = true
+			}
+		}
+		require.True(t, found, "tx %d missing BundleOnly marker", i)
+	}
+}
+
+func Test_PrepareBundle_PlanHashConsistentAcrossTxs(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		WithAccount(addr2, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{
+			{From: &addr1, To: &addr2, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+			{From: &addr2, To: &addr1, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+		},
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+
+	// All txs must carry the same plan hash.
+	var planHash common.Hash
+	for i, tx := range result.Transactions {
+		for _, entry := range *tx.AccessList {
+			if entry.Address == bundle.BundleOnly {
+				require.Len(t, entry.StorageKeys, 1)
+				if i == 0 {
+					planHash = entry.StorageKeys[0]
+				} else {
+					require.Equal(t, planHash, entry.StorageKeys[0], "tx %d has different plan hash", i)
+				}
+			}
+		}
+	}
+}
+
+func Test_PrepareBundle_EmptyTransactions_ReturnsEmptyBundle(t *testing.T) {
+	be := rpctest.NewBackendBuilder(t).Build()
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{Transactions: []ethapi.TransactionArgs{}}
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+	require.Empty(t, result.Transactions)
+}

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -48,7 +48,7 @@ func Test_fillTransactionDefaults(t *testing.T) {
 		check     func(t *testing.T, txs []ethapi.TransactionArgs)
 	}{
 		{
-			name:      "nil gas limits sets gas price",
+			name:      "nil gas limits fixed gas price",
 			txs:       []ethapi.TransactionArgs{{From: &addr}},
 			gasLimits: nil,
 			gasPrice:  gasPrice,
@@ -58,7 +58,7 @@ func Test_fillTransactionDefaults(t *testing.T) {
 			},
 		},
 		{
-			name:      "gas limits provided fills nil gas",
+			name:      "gas limits provided fills gas",
 			txs:       []ethapi.TransactionArgs{{From: &addr}},
 			gasLimits: []hexutil.Uint64{21000},
 			gasPrice:  rpctest.ToHexBigInt(big.NewInt(1)),
@@ -138,15 +138,16 @@ func Test_fillTransactionDefaults(t *testing.T) {
 }
 
 func Test_resolveBlockRange(t *testing.T) {
-	hexN := func(n int64) *hexutil.Uint64 { b := hexutil.Uint64(n); return &b }
+	hexN := func(n uint64) *hexutil.Uint64 { b := hexutil.Uint64(n); return &b }
 
 	tests := []struct {
-		name         string
-		currentBlock uint64
-		earliest     *hexutil.Uint64
-		latest       *hexutil.Uint64
-		wantEarliest uint64
-		wantLatest   uint64
+		name          string
+		currentBlock  uint64
+		earliest      *hexutil.Uint64
+		latest        *hexutil.Uint64
+		wantEarliest  uint64
+		wantLatest    uint64
+		errorContains string
 	}{
 		{
 			name:         "nil both defaults from current block",
@@ -169,6 +170,12 @@ func Test_resolveBlockRange(t *testing.T) {
 			wantLatest:   200,
 		},
 		{
+			name:          "explicit latest greater than MaxBlockRange",
+			currentBlock:  10,
+			latest:        hexN(10 + bundle.MaxBlockRange + 100),
+			errorContains: "invalid block range",
+		},
+		{
 			name:         "both explicit",
 			currentBlock: 100,
 			earliest:     hexN(5),
@@ -182,14 +189,32 @@ func Test_resolveBlockRange(t *testing.T) {
 			wantEarliest: 1,
 			wantLatest:   bundle.MaxBlockRange,
 		},
+		{
+			name:          "latest is less than earliest",
+			currentBlock:  100,
+			earliest:      hexN(50),
+			latest:        hexN(40),
+			errorContains: "invalid block range",
+		},
+		{
+			name:          "greater than Max block range",
+			currentBlock:  100,
+			earliest:      hexN(50),
+			latest:        hexN(50 + bundle.MaxBlockRange + 1),
+			errorContains: "invalid block range",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			r, err := resolveBlockRange(tc.currentBlock, tc.earliest, tc.latest)
-			require.NoError(t, err)
-			require.EqualValues(t, tc.wantEarliest, r.Earliest)
-			require.EqualValues(t, tc.wantLatest, r.Latest)
+			if tc.errorContains != "" {
+				require.ErrorContains(t, err, tc.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.EqualValues(t, tc.wantEarliest, r.Earliest)
+				require.EqualValues(t, tc.wantLatest, r.Latest)
+			}
 		})
 	}
 }
@@ -297,9 +322,10 @@ func Test_asTransaction_TxType(t *testing.T) {
 	to := common.Address{2}
 
 	tests := []struct {
-		name     string
-		msg      *core.Message
-		wantType int
+		name          string
+		msg           *core.Message
+		wantType      int
+		errorContains string
 	}{
 		{
 			name: "nil gas price returns dynamic fee tx",
@@ -344,13 +370,27 @@ func Test_asTransaction_TxType(t *testing.T) {
 			},
 			wantType: types.AccessListTxType,
 		},
+		{
+			name: "positive gas price and gas fee cap returns dynamic fee tx",
+			msg: &core.Message{
+				To:        &to,
+				GasPrice:  big.NewInt(1e9),
+				GasFeeCap: big.NewInt(1e9),
+				Value:     big.NewInt(0),
+			},
+			errorContains: "cannot set both gas price",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tx, err := asTransaction(tc.msg)
-			require.NoError(t, err)
-			require.Equal(t, tc.wantType, int(tx.Type()))
+			if tc.errorContains != "" {
+				require.ErrorContains(t, err, tc.errorContains)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantType, int(tx.Type()))
+			}
 		})
 	}
 }
@@ -407,7 +447,44 @@ func Test_PrepareBundle_SingleTx_GasAndPriceEstimated(t *testing.T) {
 	require.True(t, hasPriceField, "gas price must be set")
 }
 
-func Test_PrepareBundle_SingleTx_AccessListContainsPlanHash(t *testing.T) {
+func Test_PrepareBundle_PlanHashConsistentAcrossTxs(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		WithAccount(addr2, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{
+			{From: &addr1, To: &addr2, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+			{From: &addr2, To: &addr1, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+		},
+	}
+
+	result, err := api.PrepareBundle(t.Context(), args)
+	require.NoError(t, err)
+
+	// All txs must carry the same plan hash.
+	var planHash common.Hash
+	for i, tx := range result.Transactions {
+		for _, entry := range *tx.AccessList {
+			if entry.Address == bundle.BundleOnly {
+				require.Len(t, entry.StorageKeys, 1)
+				if i == 0 {
+					planHash = entry.StorageKeys[0]
+				} else {
+					require.Equal(t, planHash, entry.StorageKeys[0], "tx %d has different plan hash", i)
+				}
+			}
+		}
+	}
+}
+
+func Test_PrepareBundle_AccessListContainsConsistentPlanHash(t *testing.T) {
 	addr1 := common.Address{1}
 	addr2 := common.Address{2}
 
@@ -418,27 +495,32 @@ func Test_PrepareBundle_SingleTx_AccessListContainsPlanHash(t *testing.T) {
 	api := NewPublicBundleAPI(be)
 
 	args := PrepareBundleArgs{
-		Transactions: []ethapi.TransactionArgs{{
-			From:  &addr1,
-			To:    &addr2,
-			Nonce: rpctest.ToHexUint64(0),
-		}},
+		Transactions: []ethapi.TransactionArgs{
+			{From: &addr1, To: &addr2, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+			{From: &addr2, To: &addr1, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
+		},
 	}
 
 	result, err := api.PrepareBundle(t.Context(), args)
 	require.NoError(t, err)
+	require.Len(t, result.Transactions, 2)
 
-	tx := result.Transactions[0]
-	require.NotNil(t, tx.AccessList)
-
-	var found bool
-	for _, entry := range *tx.AccessList {
-		if entry.Address == bundle.BundleOnly {
-			found = true
-			require.Len(t, entry.StorageKeys, 1, "plan hash must be in storage keys")
+	// All txs must carry the same plan hash.
+	var planHash common.Hash
+	for i, tx := range result.Transactions {
+		require.NotNil(t, tx.AccessList)
+		for _, entry := range *tx.AccessList {
+			require.NotNil(t, entry.Address)
+			if entry.Address == bundle.BundleOnly {
+				require.Len(t, entry.StorageKeys, 1)
+				if i == 0 {
+					planHash = entry.StorageKeys[0]
+				} else {
+					require.Equal(t, planHash, entry.StorageKeys[0], "tx %d has different plan hash", i)
+				}
+			}
 		}
 	}
-	require.True(t, found, "BundleOnly marker not found in access list")
 }
 
 func Test_PrepareBundle_ExplicitGasLimit_NotOverwritten(t *testing.T) {
@@ -576,43 +658,6 @@ func Test_PrepareBundle_MultipleTxs_AllOfPlan(t *testing.T) {
 			}
 		}
 		require.True(t, found, "tx %d missing BundleOnly marker", i)
-	}
-}
-
-func Test_PrepareBundle_PlanHashConsistentAcrossTxs(t *testing.T) {
-	addr1 := common.Address{1}
-	addr2 := common.Address{2}
-
-	be := rpctest.NewBackendBuilder(t).
-		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
-		WithAccount(addr2, rpctest.AccountState{Balance: big.NewInt(1e18)}).
-		Build()
-
-	api := NewPublicBundleAPI(be)
-
-	args := PrepareBundleArgs{
-		Transactions: []ethapi.TransactionArgs{
-			{From: &addr1, To: &addr2, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
-			{From: &addr2, To: &addr1, Nonce: rpctest.ToHexUint64(0), Value: rpctest.ToHexBigInt(big.NewInt(1e15))},
-		},
-	}
-
-	result, err := api.PrepareBundle(t.Context(), args)
-	require.NoError(t, err)
-
-	// All txs must carry the same plan hash.
-	var planHash common.Hash
-	for i, tx := range result.Transactions {
-		for _, entry := range *tx.AccessList {
-			if entry.Address == bundle.BundleOnly {
-				require.Len(t, entry.StorageKeys, 1)
-				if i == 0 {
-					planHash = entry.StorageKeys[0]
-				} else {
-					require.Equal(t, planHash, entry.StorageKeys[0], "tx %d has different plan hash", i)
-				}
-			}
-		}
 	}
 }
 

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -186,7 +186,8 @@ func Test_resolveBlockRange(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := resolveBlockRange(tc.currentBlock, tc.earliest, tc.latest)
+			r, err := resolveBlockRange(tc.currentBlock, tc.earliest, tc.latest)
+			require.NoError(t, err)
 			require.EqualValues(t, tc.wantEarliest, r.Earliest)
 			require.EqualValues(t, tc.wantLatest, r.Latest)
 		})
@@ -312,12 +313,24 @@ func Test_asTransaction_TxType(t *testing.T) {
 			wantType: types.DynamicFeeTxType,
 		},
 		{
-			name: "zero gas price returns dynamic fee tx",
+			name: "zero gas price with gas fee cap returns dynamic fee tx",
 			msg: &core.Message{
-				To:       &to,
-				GasPrice: big.NewInt(0),
-				GasLimit: params.TxGas,
-				Value:    big.NewInt(0),
+				To:        &to,
+				GasPrice:  big.NewInt(0),
+				GasFeeCap: big.NewInt(1),
+				GasLimit:  params.TxGas,
+				Value:     big.NewInt(0),
+			},
+			wantType: types.DynamicFeeTxType,
+		},
+		{
+			name: "zero gas price with gas tip cap returns dynamic fee tx",
+			msg: &core.Message{
+				To:        &to,
+				GasPrice:  big.NewInt(0),
+				GasTipCap: big.NewInt(1),
+				GasLimit:  params.TxGas,
+				Value:     big.NewInt(0),
 			},
 			wantType: types.DynamicFeeTxType,
 		},
@@ -376,8 +389,9 @@ func Test_PrepareBundle_SingleTx_GasAndPriceEstimated(t *testing.T) {
 
 	args := PrepareBundleArgs{
 		Transactions: []ethapi.TransactionArgs{{
-			From: &addr1,
-			To:   &addr2,
+			From:  &addr1,
+			To:    &addr2,
+			Nonce: rpctest.ToHexUint64(0),
 		}},
 	}
 
@@ -405,8 +419,9 @@ func Test_PrepareBundle_SingleTx_AccessListContainsPlanHash(t *testing.T) {
 
 	args := PrepareBundleArgs{
 		Transactions: []ethapi.TransactionArgs{{
-			From: &addr1,
-			To:   &addr2,
+			From:  &addr1,
+			To:    &addr2,
+			Nonce: rpctest.ToHexUint64(0),
 		}},
 	}
 
@@ -439,9 +454,10 @@ func Test_PrepareBundle_ExplicitGasLimit_NotOverwritten(t *testing.T) {
 
 	args := PrepareBundleArgs{
 		Transactions: []ethapi.TransactionArgs{{
-			From: &addr1,
-			To:   &addr2,
-			Gas:  &explicitGas,
+			From:  &addr1,
+			To:    &addr2,
+			Nonce: rpctest.ToHexUint64(0),
+			Gas:   &explicitGas,
 		}},
 	}
 
@@ -464,8 +480,9 @@ func Test_PrepareBundle_DefaultBlockRange_IsCurrentBlockPlusOne(t *testing.T) {
 
 	args := PrepareBundleArgs{
 		Transactions: []ethapi.TransactionArgs{{
-			From: &addr1,
-			To:   &addr2,
+			From:  &addr1,
+			To:    &addr2,
+			Nonce: rpctest.ToHexUint64(0),
 		}},
 	}
 
@@ -490,8 +507,9 @@ func Test_PrepareBundle_ExplicitBlockRange_IsRespected(t *testing.T) {
 
 	args := PrepareBundleArgs{
 		Transactions: []ethapi.TransactionArgs{{
-			From: &addr1,
-			To:   &addr2,
+			From:  &addr1,
+			To:    &addr2,
+			Nonce: rpctest.ToHexUint64(0),
 		}},
 		EarliestBlock: &earliest,
 		LatestBlock:   &latest,
@@ -502,6 +520,27 @@ func Test_PrepareBundle_ExplicitBlockRange_IsRespected(t *testing.T) {
 
 	require.EqualValues(t, earliest, result.ExecutionPlan.Earliest)
 	require.EqualValues(t, latest, result.ExecutionPlan.Latest)
+}
+
+func Test_PrepareBundle_MissingNonce_ReturnsError(t *testing.T) {
+	addr1 := common.Address{1}
+	addr2 := common.Address{2}
+
+	be := rpctest.NewBackendBuilder(t).
+		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+		Build()
+
+	api := NewPublicBundleAPI(be)
+
+	args := PrepareBundleArgs{
+		Transactions: []ethapi.TransactionArgs{{
+			From: &addr1,
+			To:   &addr2,
+		}},
+	}
+
+	_, err := api.PrepareBundle(t.Context(), args)
+	require.ErrorContains(t, err, "transaction 0 is missing nonce")
 }
 
 func Test_PrepareBundle_MultipleTxs_AllOfPlan(t *testing.T) {


### PR DESCRIPTION
This PR introduces new RPC function sonic_prepareBundle. This function streamlines the creation of transaction bundles by preparing an execution plan based on the provided transaction order, to be executed within a specified block range.