### PR TITLE
Add RPC type to describe bundles when calling prepare bundle. 

### DIFF
--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -34,7 +34,7 @@ import (
 //	   	"blockRange":{
 //				"earliest":"0xa",
 //				"latest":"0x15"
-//			},
+//		},
 //		"root":{
 //			"group":{
 //				"oneOf":true,
@@ -68,15 +68,15 @@ import (
 //		}
 //	}
 type RPCExecutionPlanComposable struct {
-	BlockRange RPCRange              `json:"blockRange"`
-	Root       RPCExecutionPlanLevel `json:"root"`
+	BlockRange RPCRange                                          `json:"blockRange"`
+	Root       RPCExecutionPlanLevel[RPCExecutionStepComposable] `json:"root"`
 }
 
 // RPCExecutionPlanGroup represents a group of execution steps in the JSON-serializable execution plan.
-type RPCExecutionPlanGroup struct {
-	TolerateFailures bool                    `json:"tolerateFailures,omitempty"`
-	OneOf            bool                    `json:"oneOf,omitempty"`
-	Steps            []RPCExecutionPlanLevel `json:"steps"`
+type RPCExecutionPlanGroup[T any] struct {
+	TolerateFailures bool                       `json:"tolerateFailures,omitempty"`
+	OneOf            bool                       `json:"oneOf,omitempty"`
+	Steps            []RPCExecutionPlanLevel[T] `json:"steps"`
 }
 
 // RPCExecutionStepComposable represents a single execution step in the JSON-serializable execution plan.
@@ -88,9 +88,9 @@ type RPCExecutionStepComposable struct {
 }
 
 // RPCExecutionPlanLevel represents a level in the execution plan, which can be either a single step or a group of steps.
-type RPCExecutionPlanLevel struct {
-	Single *RPCExecutionStepComposable `json:"single,omitempty"`
-	Group  *RPCExecutionPlanGroup      `json:"group,omitempty"`
+type RPCExecutionPlanLevel[T any] struct {
+	Single *T                        `json:"single,omitempty"`
+	Group  *RPCExecutionPlanGroup[T] `json:"group,omitempty"`
 }
 
 // RPCRange represents the block range for which the execution plan is valid.
@@ -100,10 +100,20 @@ type RPCRange struct {
 }
 
 // NewRPCExecutionPlanComposable converts a bundle.ExecutionPlan to an RPCExecutionPlan that can be returned by the API.
-func NewRPCExecutionPlanComposable(plan bundle.ExecutionPlan) RPCExecutionPlanComposable {
+func NewRPCExecutionPlanComposable(plan bundle.ExecutionPlan) (RPCExecutionPlanComposable, error) {
 
-	visitor := &toJsonExecutionPlanVisitor{}
-	plan.Root.Visit(visitor)
+	visitor := makeExecutionPlanVisitor(
+		func(flags bundle.ExecutionFlags, txRef bundle.TxReference) (*RPCExecutionStepComposable, error) {
+			return &RPCExecutionStepComposable{
+				TolerateFailed:  flags&bundle.EF_TolerateFailed != 0,
+				TolerateInvalid: flags&bundle.EF_TolerateInvalid != 0,
+				From:            txRef.From,
+				Hash:            txRef.Hash,
+			}, nil
+		})
+
+	// because the conversion bundle.TxReference -> RPCExecutionStepComposable cannot fail, we can ignore the error here
+	_ = plan.Root.Accept(visitor)
 
 	return RPCExecutionPlanComposable{
 		BlockRange: RPCRange{
@@ -111,7 +121,7 @@ func NewRPCExecutionPlanComposable(plan bundle.ExecutionPlan) RPCExecutionPlanCo
 			Latest:   hexutil.Uint64(plan.Range.Latest),
 		},
 		Root: visitor.result,
-	}
+	}, nil
 }
 
 func toBundleExecutionPlan(rpcPlan RPCExecutionPlanComposable) (bundle.ExecutionPlan, error) {
@@ -130,7 +140,7 @@ func toBundleExecutionPlan(rpcPlan RPCExecutionPlanComposable) (bundle.Execution
 	}, nil
 }
 
-func toBundleExecutionPlanLevel(rpcLevel RPCExecutionPlanLevel) (bundle.ExecutionStep, error) {
+func toBundleExecutionPlanLevel(rpcLevel RPCExecutionPlanLevel[RPCExecutionStepComposable]) (bundle.ExecutionStep, error) {
 	if rpcLevel.Single != nil && rpcLevel.Group != nil {
 		return bundle.ExecutionStep{},
 			fmt.Errorf("invalid execution plan level: cannot have both single and group")
@@ -168,52 +178,56 @@ func toBundleExecutionPlanLevel(rpcLevel RPCExecutionPlanLevel) (bundle.Executio
 	return bundle.ExecutionStep{}, fmt.Errorf("invalid execution plan level: must have either single or group")
 }
 
-// toJsonExecutionPlanVisitor is an implementation of the ExecutionPlanVisitor interface
-type toJsonExecutionPlanVisitor struct {
-	result     RPCExecutionPlanLevel
-	groupStack []*RPCExecutionPlanGroup
+// makeExecutionPlanVisitor creates a new instance of toJsonExecutionPlanVisitor with the provided toLeaf function.
+// This visitor can be used to convert a bundle.ExecutionPlan into a json capable
+// structure where the leaf nodes are customizable.
+// This allows to create the same structure for different use cases, such as
+// an execution plan or a proposal of a plan where all the transactions are txArguments
+func makeExecutionPlanVisitor[T any](toLeaf func(flags bundle.ExecutionFlags, txRef bundle.TxReference) (*T, error)) *toJsonExecutionPlanVisitor[T] {
+	return &toJsonExecutionPlanVisitor[T]{
+		toLeaf: toLeaf,
+	}
 }
 
-func (v *toJsonExecutionPlanVisitor) Step(flags bundle.ExecutionFlags, txRef bundle.TxReference) {
-	step := RPCExecutionStepComposable{
-		TolerateFailed:  flags&bundle.EF_TolerateFailed != 0,
-		TolerateInvalid: flags&bundle.EF_TolerateInvalid != 0,
-		From:            txRef.From,
-		Hash:            txRef.Hash,
-	}
+type toJsonExecutionPlanVisitor[T any] struct {
+	toLeaf     func(flags bundle.ExecutionFlags, txRef bundle.TxReference) (*T, error)
+	result     RPCExecutionPlanLevel[T]
+	groupStack []*RPCExecutionPlanGroup[T]
+}
 
+func (v *toJsonExecutionPlanVisitor[T]) Step(flags bundle.ExecutionFlags, txRef bundle.TxReference) error {
+	leaf, err := v.toLeaf(flags, txRef)
+	if err != nil {
+		return fmt.Errorf("failed to convert execution step to JSON: %w", err)
+	}
+	level := RPCExecutionPlanLevel[T]{Single: leaf}
 	if len(v.groupStack) > 0 {
 		currentGroup := v.groupStack[len(v.groupStack)-1]
-		currentGroup.Steps = append(currentGroup.Steps, RPCExecutionPlanLevel{
-			Single: &step,
-		})
+		currentGroup.Steps = append(currentGroup.Steps, level)
 	} else {
-		v.result = RPCExecutionPlanLevel{
-			Single: &step,
-		}
+		v.result = level
 	}
+	return nil
 }
 
-func (v *toJsonExecutionPlanVisitor) BeginGroup(oneOf bool, tolerateFailed bool) {
-	group := &RPCExecutionPlanGroup{
+func (v *toJsonExecutionPlanVisitor[T]) BeginGroup(oneOf bool, tolerateFailed bool) {
+	group := &RPCExecutionPlanGroup[T]{
 		OneOf:            oneOf,
 		TolerateFailures: tolerateFailed,
 	}
 	v.groupStack = append(v.groupStack, group)
 }
 
-func (v *toJsonExecutionPlanVisitor) EndGroup() {
+func (v *toJsonExecutionPlanVisitor[T]) EndGroup() {
 	closedGroup := v.groupStack[len(v.groupStack)-1]
 	v.groupStack = v.groupStack[:len(v.groupStack)-1]
 
 	if len(v.groupStack) > 0 {
 		currentGroup := v.groupStack[len(v.groupStack)-1]
-		currentGroup.Steps = append(currentGroup.Steps, RPCExecutionPlanLevel{
+		currentGroup.Steps = append(currentGroup.Steps, RPCExecutionPlanLevel[T]{
 			Group: closedGroup,
 		})
 	} else {
-		v.result = RPCExecutionPlanLevel{
-			Group: closedGroup,
-		}
+		v.result = RPCExecutionPlanLevel[T]{Group: closedGroup}
 	}
 }

--- a/api/sonicapi/execution_plan_test.go
+++ b/api/sonicapi/execution_plan_test.go
@@ -17,6 +17,7 @@
 package sonicapi
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
@@ -24,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewRPCExecutionPlan_CanBeConstructedFromBundleExecutionPlan(t *testing.T) {
+func TestNewRPCExecutionPlan_NewRPCExecutionPlanComposable_CanBeConstructedFromBundleExecutionPlan(t *testing.T) {
 
 	ref1 := bundle.TxReference{
 		From: common.Address{1},
@@ -351,7 +352,8 @@ func TestNewRPCExecutionPlan_CanBeConstructedFromBundleExecutionPlan(t *testing.
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			rpcPlan := NewRPCExecutionPlanComposable(tc.plan)
+			rpcPlan, err := NewRPCExecutionPlanComposable(tc.plan)
+			require.NoError(t, err)
 
 			if tc.expectedJson != "" {
 				expectJsonEqual(t, tc.expectedJson, rpcPlan)
@@ -369,33 +371,37 @@ func TestNewRPCExecutionPlan_CanBeConstructedFromBundleExecutionPlan(t *testing.
 
 func TestRPCExecutionPlan_ConvertCanReturnErrors(t *testing.T) {
 
+	type leaf = RPCExecutionStepComposable
+	type level = RPCExecutionPlanLevel[leaf]
+	type group = RPCExecutionPlanGroup[leaf]
+
 	tests := map[string]RPCExecutionPlanComposable{
 		"both single and group": {
-			Root: RPCExecutionPlanLevel{
-				Single: &RPCExecutionStepComposable{},
-				Group:  &RPCExecutionPlanGroup{},
+			Root: level{
+				Single: &leaf{},
+				Group:  &group{},
 			},
 		},
 		"both single and group nested": {
-			Root: RPCExecutionPlanLevel{
-				Group: &RPCExecutionPlanGroup{
-					Steps: []RPCExecutionPlanLevel{
+			Root: level{
+				Group: &group{
+					Steps: []level{
 						{
-							Single: &RPCExecutionStepComposable{},
-							Group:  &RPCExecutionPlanGroup{},
+							Single: &leaf{},
+							Group:  &group{},
 						},
 					},
 				},
 			},
 		},
 		"missing single and group": {
-			Root: RPCExecutionPlanLevel{},
+			Root: level{},
 		},
 
 		"missing single and group nested": {
-			Root: RPCExecutionPlanLevel{
-				Group: &RPCExecutionPlanGroup{
-					Steps: []RPCExecutionPlanLevel{
+			Root: level{
+				Group: &group{
+					Steps: []level{
 						{
 							// invalid level
 						},
@@ -411,4 +417,17 @@ func TestRPCExecutionPlan_ConvertCanReturnErrors(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func Test_toJsonExecutionPlanVisitor_CanReturnErrors(t *testing.T) {
+
+	visitor := &toJsonExecutionPlanVisitor[int]{
+		toLeaf: func(flags bundle.ExecutionFlags, txRef bundle.TxReference) (*int, error) {
+			return nil, fmt.Errorf("test error")
+		},
+	}
+
+	err := visitor.Step(0, bundle.TxReference{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "test error")
 }

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -1,0 +1,210 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package sonicapi
+
+import (
+	"fmt"
+	"math/big"
+	"slices"
+
+	"github.com/0xsoniclabs/sonic/api/ethapi"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// RPCExecutionProposal is the JSON-serializable representation of the execution proposal
+// that is returned by the API. It is designed to be easily serializable to JSON
+// and human-readable for integration purposes.
+//
+// An example of the JSON representation of an execution proposal is as follows:
+//
+//	{
+//	   	"blockRange":{
+//				"earliest":"0xa",
+//				"latest":"0x15"
+//		},
+//		"root":{
+//			"group":{
+//				"oneOf":true,
+//				"steps":[
+//					{"group":{
+//						"tolerateFailed": false,
+//						"oneOf": true,
+//						"steps":[
+//							{"single":{
+//
+//								"tolerateFailed": false,
+//								"tolerateInvalid": false,
+//
+//								"chainId":"0x1"
+//								"from":"0x0100000000000000000000000000000000000000",
+//								"to":"0x0200000000000000000000000000000000000000",
+//								"gas":"0x5208",
+//								"value":"0xde0b6b3a7640000",
+//							}}
+//						]
+//					}}
+//				]
+//			}
+//		}
+//	}
+//
+// This type uses the same single transactions description as the eth_call arguments,
+// with the addition of the tolerateFailed and tolerateInvalid flags that are
+// used to indicate if a transaction is allowed to fail or be invalid without
+// causing the entire proposal to be rejected.
+type RPCExecutionProposal struct {
+	BlockRange RPCRange                                        `json:"blockRange"`
+	Root       RPCExecutionPlanLevel[RPCExecutionStepProposal] `json:"root"`
+}
+
+type RPCExecutionStepProposal struct {
+	TolerateFailed  bool `json:"tolerateFailed,omitempty"`
+	TolerateInvalid bool `json:"tolerateInvalid,omitempty"`
+
+	ethapi.TransactionArgs
+}
+
+// createProposalRequestFromBundle creates an RPCExecutionProposal from a bundle.TransactionBundle,
+// which is the internal representation of a transaction bundle used in the execution engine.
+// This function is meant for testing purposes, therefore not exported.
+func createProposalRequestFromBundle(signer types.Signer, txBundle *bundle.TransactionBundle) (*RPCExecutionProposal, error) {
+	plan := txBundle.Plan
+
+	visitor := makeExecutionPlanVisitor(func(flags bundle.ExecutionFlags, txRef bundle.TxReference) (*RPCExecutionStepProposal, error) {
+
+		// FIXME: return error if not found
+		tx := txBundle.Transactions[txRef]
+		txArgs, err := convertToTransactonArgs(signer, tx)
+		if err != nil {
+			return nil, err
+		}
+
+		// remove bundle markers from access list
+		if txArgs.AccessList != nil {
+			cleaned := make(types.AccessList, 0, len(*txArgs.AccessList))
+			for _, entry := range *txArgs.AccessList {
+				if entry.Address != bundle.BundleOnly {
+					cleaned = append(cleaned, entry)
+				}
+			}
+			if len(cleaned) == 0 {
+				txArgs.AccessList = nil
+			} else {
+				txArgs.AccessList = &cleaned
+			}
+		}
+
+		return &RPCExecutionStepProposal{
+			TolerateFailed:  flags&bundle.EF_TolerateFailed != 0,
+			TolerateInvalid: flags&bundle.EF_TolerateInvalid != 0,
+			TransactionArgs: txArgs,
+		}, nil
+	})
+	err := plan.Root.Accept(visitor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create execution proposal: %w", err)
+	}
+
+	proposal := &RPCExecutionProposal{
+		BlockRange: RPCRange{
+			Earliest: hexutil.Uint64(plan.Range.Earliest),
+			Latest:   hexutil.Uint64(plan.Range.Latest),
+		},
+		Root: visitor.result,
+	}
+
+	return proposal, nil
+}
+
+// convertToTransactonArgs converts a types.Transaction to ethapi.TransactionArgs, which is the format used in the execution proposal.
+// If members of the transaction are not set (e.g. GasPrice for a type 2 transaction), they will be omitted from the resulting TransactionArgs.
+//
+// This function is meant for testing purposes, therefore not exported
+func convertToTransactonArgs(signer types.Signer, tx *types.Transaction) (ethapi.TransactionArgs, error) {
+
+	sender, err := types.Sender(signer, tx)
+	if err != nil {
+		return ethapi.TransactionArgs{}, fmt.Errorf("failed to derive sender for transaction: %w", err)
+	}
+
+	res := ethapi.TransactionArgs{
+		ChainID: (*hexutil.Big)(tx.ChainId()),
+		From:    &sender,
+		To:      tx.To(),
+	}
+
+	if tx.Nonce() != 0 {
+		res.Nonce = ToPtr(hexutil.Uint64(tx.Nonce()))
+	}
+
+	if tx.To() == nil && tx.Data() != nil {
+		res.Input = ToPtr(hexutil.Bytes(tx.Data()))
+	}
+	if tx.To() != nil && tx.Data() != nil {
+		res.Data = ToPtr(hexutil.Bytes(tx.Data()))
+	}
+
+	if tx.Value() != nil && tx.Value().Cmp(big.NewInt(0)) > 0 {
+		res.Value = ToPtr(hexutil.Big(*tx.Value()))
+	}
+
+	if tx.Gas() != 0 {
+		res.Gas = ToPtr(hexutil.Uint64(tx.Gas()))
+	}
+
+	// Type 1 tx
+
+	if tx.Type() >= types.AccessListTxType && len(tx.AccessList()) > 0 {
+		res.AccessList = ToPtr(tx.AccessList())
+	}
+
+	// Type 2 txs, dynamic fees
+
+	switch tx.Type() {
+	case types.LegacyTxType, types.AccessListTxType:
+		if tx.GasPrice().Cmp(big.NewInt(0)) > 0 {
+			res.GasPrice = ToPtr(hexutil.Big(*tx.GasPrice()))
+		}
+	case types.DynamicFeeTxType, types.BlobTxType, types.SetCodeTxType:
+		if tx.GasTipCap().Cmp(big.NewInt(0)) > 0 {
+			res.MaxPriorityFeePerGas = ToPtr(hexutil.Big(*tx.GasTipCap()))
+		}
+		if tx.GasFeeCap().Cmp(big.NewInt(0)) > 0 {
+			res.MaxFeePerGas = ToPtr(hexutil.Big(*tx.GasFeeCap()))
+		}
+	}
+
+	// Type 3 txs, blobs
+
+	if tx.Type() == types.BlobTxType && len(tx.BlobHashes()) > 0 {
+		return ethapi.TransactionArgs{}, fmt.Errorf("blob transactions are not supported in execution proposals")
+	}
+
+	// Type 4 txs, set code
+
+	if tx.Type() == types.SetCodeTxType && len(tx.SetCodeAuthorizations()) > 0 {
+		res.AuthorizationList = slices.Clone(tx.SetCodeAuthorizations())
+	}
+
+	return res, nil
+}
+
+func ToPtr[T any](v T) *T {
+	return &v
+}

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -1,0 +1,580 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package sonicapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
+
+	signer := types.LatestSignerForChainID(big.NewInt(2))
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		bundle bundle.TransactionBundle
+		json   string
+	}{
+		"empty bundle": {
+			bundle: bundle.NewBuilder().WithSigner(signer).BuildBundle(),
+			json: `{
+		 		"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+		 		"root":{"group":{}}
+		 	}`,
+		},
+		"simple bundle": {
+			bundle: bundle.NewBuilder().
+				WithSigner(signer).
+				With(bundle.Step(key, &types.AccessListTx{})).
+				BuildBundle(),
+			json: `{
+		 		"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+		 		"root":{
+		 			"single":{
+		 				"chainId": "0x2",
+		 				"from": "REPLACE_ADDRESS",
+		 				"gas": "0x10cc"
+		 			}
+		 		}
+		 	}`,
+		},
+		"bundle with two transactions": {
+			bundle: bundle.NewBuilder().
+				WithSigner(signer).
+				With(
+					bundle.AllOf(
+						bundle.Step(key, &types.AccessListTx{}),
+						bundle.Step(key, &types.AccessListTx{}),
+					),
+				).
+				BuildBundle(),
+			json: `{
+				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"root":{
+					"group":{
+						"steps":[
+							{
+								"single":{
+									"chainId": "0x2",
+									"from": "REPLACE_ADDRESS",
+									"gas": "0x10cc"
+								}
+							},
+							{
+								"single":{
+									"chainId": "0x2",
+									"from": "REPLACE_ADDRESS",
+									"gas": "0x10cc"
+								}
+							}
+						]
+					}
+				}
+			}`,
+		},
+		"nested bundle": {
+			bundle: bundle.NewBuilder().
+				WithSigner(signer).
+				With(
+					bundle.OneOf(
+						bundle.AllOf(
+							bundle.Step(key, &types.AccessListTx{}),
+						),
+					),
+				).
+				BuildBundle(),
+			json: `{
+				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"root":{
+					"group":{
+						"oneOf": true,
+						"steps":[
+							{
+								"group":{
+									"steps":[
+										{
+											"single":{
+												"chainId": "0x2",
+												"from": "REPLACE_ADDRESS",
+												"gas": "0x10cc"
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			}`,
+		},
+		"bundle with flags in transactions": {
+			bundle: bundle.NewBuilder().
+				WithSigner(signer).
+				With(
+					bundle.AllOf(
+						bundle.Step(key, &types.AccessListTx{}).
+							WithFlags(bundle.EF_TolerateFailed),
+						bundle.Step(key, &types.AccessListTx{}).
+							WithFlags(bundle.EF_TolerateInvalid),
+						bundle.Step(key, &types.AccessListTx{}).
+							WithFlags(bundle.EF_TolerateFailed|bundle.EF_TolerateInvalid),
+					),
+				).
+				BuildBundle(),
+			json: `{
+				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"root":{
+					"group":{
+						"steps":[
+							{
+								"single":{
+									"chainId": "0x2",
+									"from": "REPLACE_ADDRESS",
+									"gas": "0x10cc",
+									"tolerateFailed": true
+								}
+							},
+							{
+								"single":{
+									"chainId": "0x2",
+									"from": "REPLACE_ADDRESS",
+									"gas": "0x10cc",
+									"tolerateInvalid": true
+								}
+							},
+							{
+								"single":{
+									"chainId": "0x2",
+									"from": "REPLACE_ADDRESS",
+									"gas": "0x10cc",
+									"tolerateFailed": true,
+									"tolerateInvalid": true
+								}
+							}
+						]
+					}
+				}
+			}`,
+		},
+		"bundle with flags in groups": {
+			bundle: bundle.NewBuilder().
+				WithSigner(signer).
+				With(
+					bundle.AllOf(
+						bundle.OneOf(
+							bundle.Step(key, &types.AccessListTx{}),
+						),
+						bundle.OneOf(
+							bundle.Step(key, &types.AccessListTx{}),
+						).WithFlags(bundle.EF_TolerateFailed),
+						bundle.AllOf(
+							bundle.Step(key, &types.AccessListTx{}),
+						),
+						bundle.AllOf(
+							bundle.Step(key, &types.AccessListTx{}),
+						).WithFlags(bundle.EF_TolerateFailed),
+					),
+				).
+				BuildBundle(),
+			json: `{
+				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"root":{
+					"group":{
+						"steps":[
+							{
+								"group":{
+									"oneOf": true,
+									"steps":[
+										{
+											"single":{
+												"chainId": "0x2",
+												"from": "REPLACE_ADDRESS",
+												"gas": "0x10cc"
+											}
+										}
+									]
+								}
+							},
+							{
+								"group":{
+									"oneOf": true,
+									"tolerateFailures": true,
+									"steps":[
+										{
+											"single":{
+												"chainId": "0x2",
+												"from": "REPLACE_ADDRESS",
+												"gas": "0x10cc"
+											}
+										}
+									]
+								}
+							},
+							{
+								"group":{
+									"steps":[
+										{
+											"single":{
+												"chainId": "0x2",
+												"from": "REPLACE_ADDRESS",
+												"gas": "0x10cc"
+											}
+										}
+									]
+								}
+							},
+							{
+								"group":{
+									"tolerateFailures": true,
+									"steps":[
+										{
+											"single":{
+												"chainId": "0x2",
+												"from": "REPLACE_ADDRESS",
+												"gas": "0x10cc"
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				}
+			}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// check that signatures and keys are not misplaced
+			for _, tx := range tt.bundle.Transactions {
+				sender, err := signer.Sender(tx)
+				require.NoError(t, err)
+				require.Equal(t, crypto.PubkeyToAddress(key.PublicKey), sender)
+			}
+
+			proposal, err := createProposalRequestFromBundle(signer, &tt.bundle)
+			require.NoError(t, err)
+			require.NotNil(t, proposal)
+
+			json := strings.ReplaceAll(tt.json, "REPLACE_ADDRESS", crypto.PubkeyToAddress(key.PublicKey).Hex())
+
+			expectJsonEqual(t, json, proposal)
+		})
+	}
+}
+
+func TestConvertToTransactionArgs(t *testing.T) {
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	address := common.Address{1}
+
+	tests := map[string]struct {
+		tx   *types.Transaction
+		json string
+	}{
+		// empty transactions
+		"empty legacy tx": {
+			tx: types.NewTx(&types.LegacyTx{}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s"
+			}`,
+		},
+		"empty access list tx": {
+			tx: types.NewTx(&types.AccessListTx{}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s"
+			}`,
+		},
+		"empty dynamic fee tx": {
+			tx: types.NewTx(&types.DynamicFeeTx{}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s"
+			}`,
+		},
+		"empty blob tx": {
+			tx: types.NewTx(&types.BlobTx{}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0000000000000000000000000000000000000000"
+			}`,
+		},
+		"empty set code tx": {
+			tx: types.NewTx(&types.SetCodeTx{}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0000000000000000000000000000000000000000"
+			}`,
+		},
+		// trivial transactions
+		"trivial legacy tx": {
+			tx: types.NewTx(&types.LegacyTx{
+				To:    &address,
+				Nonce: 10,
+				Value: big.NewInt(12123),
+				Data:  []byte{0xAB, 0xCD},
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0100000000000000000000000000000000000000",
+				"nonce": "0xa",
+				"value": "0x2f5b",
+				"data": "0xabcd"
+			}`,
+		},
+		"trivial access list tx": {
+			tx: types.NewTx(&types.AccessListTx{
+				To:    &address,
+				Nonce: 10,
+				Value: big.NewInt(123),
+				Data:  []byte{0xAB, 0xCD},
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0100000000000000000000000000000000000000",
+				"nonce": "0xa",
+				"value": "0x7b",
+				"data": "0xabcd"
+			}`,
+		},
+		"trivial dynamic fee tx": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				To:    &address,
+				Nonce: 10,
+				Value: big.NewInt(123),
+				Data:  []byte{0xAB, 0xCD},
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0100000000000000000000000000000000000000",
+				"nonce": "0xa",
+				"value": "0x7b",
+				"data": "0xabcd"
+			}`,
+		},
+		"trivial blob tx": {
+			tx: types.NewTx(&types.BlobTx{
+				To:    address,
+				Nonce: 10,
+				Value: uint256.NewInt(123),
+				Data:  []byte{0xAB, 0xCD},
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0100000000000000000000000000000000000000",
+				"nonce": "0xa",
+				"value": "0x7b",
+				"data": "0xabcd"
+			}`,
+		},
+		"trivial set code tx": {
+			tx: types.NewTx(&types.SetCodeTx{
+				To:    address,
+				Nonce: 10,
+				Value: uint256.NewInt(123),
+				Data:  []byte{0xAB, 0xCD},
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0100000000000000000000000000000000000000",
+				"nonce": "0xa",
+				"value": "0x7b",
+				"data": "0xabcd"
+			}`,
+		},
+		// Data vs Input semantics
+		"contract create": {
+			tx: types.NewTx(&types.LegacyTx{
+				Data: slices.Repeat([]byte{0xAB}, 4),
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"input": "0xabababab"
+			}`,
+		},
+		"no create": {
+			tx: types.NewTx(&types.LegacyTx{
+				To:   &address,
+				Data: slices.Repeat([]byte{0xAB}, 4),
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0100000000000000000000000000000000000000",
+				"data": "0xabababab"
+			}`,
+		},
+		// GasLimit
+		"With Gas limit": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				Gas: 21000,
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"gas": "0x5208"
+			}`,
+		},
+		// Access list semantics
+		"Access list with entries": {
+			tx: types.NewTx(&types.AccessListTx{
+				AccessList: types.AccessList{
+					{
+						Address:     address,
+						StorageKeys: []common.Hash{{1}},
+					},
+				},
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"accessList": [
+					{
+						"address": "0x0100000000000000000000000000000000000000",
+						"storageKeys": ["0x0100000000000000000000000000000000000000000000000000000000000000"]
+					}
+				]
+			}`,
+		},
+		// Gas price semantics
+		"Legacy tx with gas price": {
+			tx: types.NewTx(&types.LegacyTx{
+				GasPrice: big.NewInt(100_000_000_000),
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"gasPrice": "0x174876e800"
+			}`,
+		},
+		"Access list tx with gas price": {
+			tx: types.NewTx(&types.AccessListTx{
+				GasPrice: big.NewInt(100_000_000_000),
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"gasPrice": "0x174876e800"
+			}`,
+		},
+		"Dynamic fee tx with max fee per gas and max priority fee per gas": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: big.NewInt(100_000_000_000),
+				GasTipCap: big.NewInt(2_000_000_000),
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"maxFeePerGas": "0x174876e800",
+				"maxPriorityFeePerGas": "0x77359400"
+			}`,
+		},
+		"Blob tx with max fee per gas and max priority fee per gas": {
+			tx: types.NewTx(&types.BlobTx{
+				GasFeeCap: uint256.NewInt(100_000_000_000),
+				GasTipCap: uint256.NewInt(2_000_000_000),
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0000000000000000000000000000000000000000",
+				"maxFeePerGas": "0x174876e800",
+				"maxPriorityFeePerGas": "0x77359400"
+			}`,
+		},
+		"Set code tx with max fee per gas and max priority fee per gas": {
+			tx: types.NewTx(&types.SetCodeTx{
+				GasFeeCap: uint256.NewInt(100_000_000_000),
+				GasTipCap: uint256.NewInt(2_000_000_000),
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0000000000000000000000000000000000000000",
+				"maxFeePerGas": "0x174876e800",
+				"maxPriorityFeePerGas": "0x77359400"
+			}`,
+		},
+		// Set code tx autorizations
+		"set code tx with authorization": {
+			tx: types.NewTx(&types.SetCodeTx{
+				To: address,
+				AuthList: []types.SetCodeAuthorization{
+					{},
+				},
+			}),
+			json: `{
+				"chainId": "0x1",
+				"from": "%s",
+				"to": "0x0100000000000000000000000000000000000000",
+				"authorizationList": [
+					{
+						"chainId": "0x0",
+						"address": "0x0000000000000000000000000000000000000000",
+						"nonce": "0x0",
+						"yParity": "0x0",
+						"r": "0x0",
+						"s": "0x0"
+					}
+				]
+			}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx, err := types.SignTx(tt.tx, signer, key)
+			require.NoError(t, err)
+
+			args, err := convertToTransactonArgs(signer, tx)
+			require.NoError(t, err)
+
+			_, err = json.Marshal(args)
+			require.NoError(t, err)
+
+			json := fmt.Sprintf(tt.json, crypto.PubkeyToAddress(key.PublicKey).Hex())
+			expectJsonEqual(t, json, args)
+		})
+	}
+}


### PR DESCRIPTION
The PR introduces a type with the same structure as the one introduced in PR https://github.com/0xsoniclabs/sonic/pull/854 but where the transaction payload is a `TransactionArguments` object.
This allows users of the API to describe composable bundles when calling `prepare bundle`. 

this PR builds on https://github.com/0xsoniclabs/sonic/pull/854