### PR TITLE
Add checked Uint64 arithmetic utility library

### DIFF
--- a/utils/checked/uint64.go
+++ b/utils/checked/uint64.go
@@ -1,0 +1,93 @@
+package checked
+
+import (
+	"math"
+
+	"github.com/0xsoniclabs/carmen/go/common"
+)
+
+// ErrOverflow is returned when unwrapping a checked Uint64 that has overflowed.
+const ErrOverflow = common.ConstError("arithmetic overflow")
+
+type checkedUint64 struct {
+	value    uint64
+	overflow bool
+}
+
+// Uint64 creates a new checked Uint64 with the given value.
+func Uint64(value uint64) checkedUint64 {
+	return checkedUint64{value: value}
+}
+
+// Overflow creates a new checked Uint64 that has overflowed.
+func Overflow() checkedUint64 {
+	return checkedUint64{overflow: true}
+}
+
+// IsOverflown returns true if the checked Uint64 has overflowed, and false otherwise.
+func (s checkedUint64) IsOverflown() bool {
+	return s.overflow
+}
+
+// Unwrap returns the value of the checked Uint64 if it has not overflowed, and
+// an [ErrOverflow] otherwise.
+func (s checkedUint64) Unwrap() (uint64, error) {
+	if s.overflow {
+		return 0, ErrOverflow
+	}
+	return s.value, nil
+}
+
+// Add returns the sum of a and b as a checked Uint64 that can be used for
+// further arithmetic operations. If the sum overflows, the returned checked
+// Uint64 will be in an overflowed state. If any of the inputs is in an
+// overflowed state, the result will also be in an overflowed state.
+func Add[A, B arg](a A, b B) checkedUint64 {
+	x := from(a)
+	y := from(b)
+	if x.overflow || y.overflow || x.value > math.MaxUint64-y.value {
+		return Overflow()
+	}
+	return Uint64(x.value + y.value)
+}
+
+// Mul returns the product of a and b as a checked Uint64 that can be used for
+// further arithmetic operations. If the product overflows, the returned checked
+// Uint64 will be in an overflowed state. If any of the inputs is in an
+// overflowed state, the result will also be in an overflowed state.
+func Mul[A, B arg](a A, b B) checkedUint64 {
+	x := from(a)
+	y := from(b)
+	if x.overflow || y.overflow {
+		return Overflow()
+	}
+	if y.value != 0 && x.value > math.MaxUint64/y.value {
+		return Overflow()
+	}
+	return Uint64(x.value * y.value)
+}
+
+type arg interface {
+	uint8 | uint16 | uint32 | uint64 | uint | checkedUint64
+}
+
+// from is an internal convenience utility that converts arithmetic values or
+// checked uint64 instances into checkedUint64 values.
+func from[T arg](a T) checkedUint64 {
+	var res checkedUint64
+	switch x := any(a).(type) {
+	case uint:
+		res = Uint64(uint64(x))
+	case uint8:
+		res = Uint64(uint64(x))
+	case uint16:
+		res = Uint64(uint64(x))
+	case uint32:
+		res = Uint64(uint64(x))
+	case uint64:
+		res = Uint64(x)
+	case checkedUint64:
+		res = x
+	}
+	return res
+}

--- a/utils/checked/uint64.go
+++ b/utils/checked/uint64.go
@@ -1,3 +1,19 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
 package checked
 
 import (
@@ -6,32 +22,32 @@ import (
 	"github.com/0xsoniclabs/carmen/go/common"
 )
 
-// ErrOverflow is returned when unwrapping a checked Uint64 that has overflowed.
+// ErrOverflow is returned when unwrapping a U64 that has overflowed.
 const ErrOverflow = common.ConstError("arithmetic overflow")
 
-type checkedUint64 struct {
+type U64 struct {
 	value    uint64
 	overflow bool
 }
 
 // Uint64 creates a new checked Uint64 with the given value.
-func Uint64(value uint64) checkedUint64 {
-	return checkedUint64{value: value}
+func Uint64(value uint64) U64 {
+	return U64{value: value}
 }
 
 // Overflow creates a new checked Uint64 that has overflowed.
-func Overflow() checkedUint64 {
-	return checkedUint64{overflow: true}
+func Overflow() U64 {
+	return U64{overflow: true}
 }
 
 // IsOverflown returns true if the checked Uint64 has overflowed, and false otherwise.
-func (s checkedUint64) IsOverflown() bool {
+func (s U64) IsOverflown() bool {
 	return s.overflow
 }
 
 // Unwrap returns the value of the checked Uint64 if it has not overflowed, and
 // an [ErrOverflow] otherwise.
-func (s checkedUint64) Unwrap() (uint64, error) {
+func (s U64) Unwrap() (uint64, error) {
 	if s.overflow {
 		return 0, ErrOverflow
 	}
@@ -42,7 +58,7 @@ func (s checkedUint64) Unwrap() (uint64, error) {
 // further arithmetic operations. If the sum overflows, the returned checked
 // Uint64 will be in an overflowed state. If any of the inputs is in an
 // overflowed state, the result will also be in an overflowed state.
-func Add[A, B arg](a A, b B) checkedUint64 {
+func Add[A, B arg](a A, b B) U64 {
 	x := from(a)
 	y := from(b)
 	if x.overflow || y.overflow || x.value > math.MaxUint64-y.value {
@@ -55,7 +71,7 @@ func Add[A, B arg](a A, b B) checkedUint64 {
 // further arithmetic operations. If the product overflows, the returned checked
 // Uint64 will be in an overflowed state. If any of the inputs is in an
 // overflowed state, the result will also be in an overflowed state.
-func Mul[A, B arg](a A, b B) checkedUint64 {
+func Mul[A, B arg](a A, b B) U64 {
 	x := from(a)
 	y := from(b)
 	if x.overflow || y.overflow {
@@ -68,13 +84,13 @@ func Mul[A, B arg](a A, b B) checkedUint64 {
 }
 
 type arg interface {
-	uint8 | uint16 | uint32 | uint64 | uint | checkedUint64
+	uint8 | uint16 | uint32 | uint64 | uint | U64
 }
 
 // from is an internal convenience utility that converts arithmetic values or
 // checked uint64 instances into checkedUint64 values.
-func from[T arg](a T) checkedUint64 {
-	var res checkedUint64
+func from[T arg](a T) U64 {
+	var res U64
 	switch x := any(a).(type) {
 	case uint:
 		res = Uint64(uint64(x))
@@ -86,7 +102,7 @@ func from[T arg](a T) checkedUint64 {
 		res = Uint64(uint64(x))
 	case uint64:
 		res = Uint64(x)
-	case checkedUint64:
+	case U64:
 		res = x
 	}
 	return res

--- a/utils/checked/uint64.go
+++ b/utils/checked/uint64.go
@@ -30,22 +30,22 @@ type U64 struct {
 	overflow bool
 }
 
-// Uint64 creates a new checked Uint64 with the given value.
+// Uint64 creates a new checked U64 with the given value.
 func Uint64(value uint64) U64 {
 	return U64{value: value}
 }
 
-// Overflow creates a new checked Uint64 that has overflowed.
+// Overflow creates a new checked U64 that has overflowed.
 func Overflow() U64 {
 	return U64{overflow: true}
 }
 
-// IsOverflown returns true if the checked Uint64 has overflowed, and false otherwise.
+// IsOverflown returns true if the checked U64 has overflowed, and false otherwise.
 func (s U64) IsOverflown() bool {
 	return s.overflow
 }
 
-// Unwrap returns the value of the checked Uint64 if it has not overflowed, and
+// Unwrap returns the value of the checked U64 if it has not overflowed, and
 // an [ErrOverflow] otherwise.
 func (s U64) Unwrap() (uint64, error) {
 	if s.overflow {
@@ -54,11 +54,11 @@ func (s U64) Unwrap() (uint64, error) {
 	return s.value, nil
 }
 
-// Add returns the sum of a and b as a checked Uint64 that can be used for
+// Add returns the sum of a and b as a checked U64 that can be used for
 // further arithmetic operations. If the sum overflows, the returned checked
-// Uint64 will be in an overflowed state. If any of the inputs is in an
+// U64 will be in an overflowed state. If any of the inputs is in an
 // overflowed state, the result will also be in an overflowed state.
-func Add[A, B arg](a A, b B) U64 {
+func Add[A, B unsignedInt](a A, b B) U64 {
 	x := from(a)
 	y := from(b)
 	if x.overflow || y.overflow || x.value > math.MaxUint64-y.value {
@@ -67,11 +67,11 @@ func Add[A, B arg](a A, b B) U64 {
 	return Uint64(x.value + y.value)
 }
 
-// Mul returns the product of a and b as a checked Uint64 that can be used for
+// Mul returns the product of a and b as a checked U64 that can be used for
 // further arithmetic operations. If the product overflows, the returned checked
-// Uint64 will be in an overflowed state. If any of the inputs is in an
+// U64 will be in an overflowed state. If any of the inputs is in an
 // overflowed state, the result will also be in an overflowed state.
-func Mul[A, B arg](a A, b B) U64 {
+func Mul[A, B unsignedInt](a A, b B) U64 {
 	x := from(a)
 	y := from(b)
 	if x.overflow || y.overflow {
@@ -83,13 +83,13 @@ func Mul[A, B arg](a A, b B) U64 {
 	return Uint64(x.value * y.value)
 }
 
-type arg interface {
+type unsignedInt interface {
 	uint8 | uint16 | uint32 | uint64 | uint | U64
 }
 
 // from is an internal convenience utility that converts arithmetic values or
 // checked U64 instances into U64 values.
-func from[T arg](a T) U64 {
+func from[T unsignedInt](a T) U64 {
 	var res U64
 	switch x := any(a).(type) {
 	case uint:

--- a/utils/checked/uint64.go
+++ b/utils/checked/uint64.go
@@ -88,7 +88,7 @@ type arg interface {
 }
 
 // from is an internal convenience utility that converts arithmetic values or
-// checked uint64 instances into checkedUint64 values.
+// checked U64 instances into U64 values.
 func from[T arg](a T) U64 {
 	var res U64
 	switch x := any(a).(type) {

--- a/utils/checked/uint64_test.go
+++ b/utils/checked/uint64_test.go
@@ -1,0 +1,175 @@
+package checked
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrOverflow_ProvidesExpectedErrorMessage(t *testing.T) {
+	require.EqualError(t, ErrOverflow, "arithmetic overflow")
+}
+
+func TestUint64_CreatesValueWithGivenInput(t *testing.T) {
+	tests := []uint64{
+		0, 1, 15, 255, 74645221587, math.MaxUint64 - 1, math.MaxUint64,
+	}
+
+	for _, test := range tests {
+		wrapped := Uint64(test)
+		unwrapped, err := wrapped.Unwrap()
+		require.NoError(t, err)
+		require.False(t, wrapped.IsOverflown())
+		require.Equal(t, test, unwrapped)
+	}
+}
+
+func TestOverflow_CreatesOverflowValue(t *testing.T) {
+	wrapped := Overflow()
+	require.True(t, wrapped.IsOverflown())
+	_, err := wrapped.Unwrap()
+	require.ErrorIs(t, err, ErrOverflow)
+}
+
+func TestUnwrap_NonOverflowingValue_ReturnsValue(t *testing.T) {
+	tests := []uint64{
+		0, 1, 15, 255, 74645221587, math.MaxUint64 - 1, math.MaxUint64,
+	}
+
+	for _, test := range tests {
+		wrapped := checkedUint64{value: test}
+		unwrapped, err := wrapped.Unwrap()
+		require.NoError(t, err)
+		require.Equal(t, test, unwrapped)
+	}
+}
+
+func TestUnwrap_OverflowingValue_ReturnsError(t *testing.T) {
+	wrapped := checkedUint64{overflow: true}
+	_, err := wrapped.Unwrap()
+	require.ErrorIs(t, err, ErrOverflow)
+}
+
+func TestAdd_AddsNumbersWhenNotOverflowing(t *testing.T) {
+	values := []uint64{
+		0, 1, 15, 97, math.MaxUint64/2 - 1, math.MaxUint64 / 2,
+	}
+	for _, a := range values {
+		for _, b := range values {
+			result, err := Add(a, b).Unwrap()
+			require.NoError(t, err)
+			require.Equal(t, a+b, result)
+		}
+	}
+}
+
+func TestAdd_ReturnsOverflowWhenResultOverflows(t *testing.T) {
+	tests := []struct {
+		a, b uint64
+	}{
+		{math.MaxUint64, 1},
+		{math.MaxUint64 - 1, 2},
+		{math.MaxUint64 - 5, 10},
+		{math.MaxUint64 / 2, math.MaxUint64 - math.MaxUint64/2 + 1},
+	}
+
+	for _, test := range tests {
+		result := Add(test.a, test.b)
+		require.True(t, result.IsOverflown())
+	}
+}
+
+func TestAdd_AddingAnOverflowingValueReturnsOverflow(t *testing.T) {
+	require := require.New(t)
+	values := []uint64{
+		0, 1, 15, 97, math.MaxUint64 - 1, math.MaxUint64,
+	}
+
+	require.Equal(Overflow(), Add(Overflow(), Overflow()))
+	for _, a := range values {
+		require.Equal(Overflow(), Add(a, Overflow()))
+		require.Equal(Overflow(), Add(Overflow(), a))
+	}
+}
+
+func TestMul_MultipliesNumbersWhenNotOverflowing(t *testing.T) {
+	values := []uint64{
+		0, 1, 15, 97, math.MaxUint32 - 1, math.MaxUint32,
+	}
+	for _, a := range values {
+		for _, b := range values {
+			result, err := Mul(a, b).Unwrap()
+			require.NoError(t, err, "a=%d, b=%d", a, b)
+			require.Equal(t, a*b, result)
+		}
+	}
+}
+
+func TestMul_ReturnsOverflowWhenResultOverflows(t *testing.T) {
+	tests := []struct {
+		a, b uint64
+	}{
+		{math.MaxUint64, 2},
+		{math.MaxUint64 - 1, 3},
+		{math.MaxUint64 / 2, 3},
+		{math.MaxUint32 + 1, math.MaxUint32 + 1},
+	}
+
+	for _, test := range tests {
+		result := Mul(test.a, test.b)
+		require.True(t, result.IsOverflown())
+	}
+}
+
+func TestMul_MultiplyingWithAnOverflowingValueReturnsOverflow(t *testing.T) {
+	require := require.New(t)
+	values := []uint64{
+		0, 1, 15, 97, math.MaxUint64 - 1, math.MaxUint64,
+	}
+
+	require.Equal(Overflow(), Mul(Overflow(), Overflow()))
+	for _, a := range values {
+		require.Equal(Overflow(), Mul(a, Overflow()))
+		require.Equal(Overflow(), Mul(Overflow(), a))
+	}
+}
+
+func Test_from_ConvertsUint64ToCheckedUint64(t *testing.T) {
+	tests := []uint64{
+		0, 1, 15, 255, 74645221587, math.MaxUint64 - 1, math.MaxUint64,
+	}
+
+	for _, test := range tests {
+		result := from(test)
+		require.False(t, result.IsOverflown())
+		require.Equal(t, test, result.value)
+	}
+}
+
+func Test_from_ConvertsOtherUnsignedIntsToCheckedUint64(t *testing.T) {
+	require := require.New(t)
+	require.Equal(Uint64(5), from(uint8(5)))
+	require.Equal(Uint64(17), from(uint16(17)))
+	require.Equal(Uint64(742), from(uint32(742)))
+
+	require.Equal(Uint64(math.MaxUint), from(uint(math.MaxUint)))
+	require.Equal(Uint64(math.MaxUint8), from(uint8(math.MaxUint8)))
+	require.Equal(Uint64(math.MaxUint16), from(uint16(math.MaxUint16)))
+	require.Equal(Uint64(math.MaxUint32), from(uint32(math.MaxUint32)))
+	require.Equal(Uint64(math.MaxUint64), from(uint64(math.MaxUint64)))
+}
+
+func Test_from_ReturnsCheckedUint64AsIs(t *testing.T) {
+	tests := []checkedUint64{
+		Uint64(0),
+		Uint64(1),
+		Uint64(15),
+		Overflow(),
+	}
+
+	for _, test := range tests {
+		result := from(test)
+		require.Equal(t, test, result)
+	}
+}

--- a/utils/checked/uint64_test.go
+++ b/utils/checked/uint64_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
 package checked
 
 import (
@@ -38,7 +54,7 @@ func TestUnwrap_NonOverflowingValue_ReturnsValue(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		wrapped := checkedUint64{value: test}
+		wrapped := U64{value: test}
 		unwrapped, err := wrapped.Unwrap()
 		require.NoError(t, err)
 		require.Equal(t, test, unwrapped)
@@ -46,7 +62,7 @@ func TestUnwrap_NonOverflowingValue_ReturnsValue(t *testing.T) {
 }
 
 func TestUnwrap_OverflowingValue_ReturnsError(t *testing.T) {
-	wrapped := checkedUint64{overflow: true}
+	wrapped := U64{overflow: true}
 	_, err := wrapped.Unwrap()
 	require.ErrorIs(t, err, ErrOverflow)
 }
@@ -161,7 +177,7 @@ func Test_from_ConvertsOtherUnsignedIntsToCheckedUint64(t *testing.T) {
 }
 
 func Test_from_ReturnsCheckedUint64AsIs(t *testing.T) {
-	tests := []checkedUint64{
+	tests := []U64{
 		Uint64(0),
 		Uint64(1),
 		Uint64(15),


### PR DESCRIPTION
Adds a utility library for simplifying handling overflows when performing calculations on `uint64` values.

Especially when dealing with gas cost computations, overflow issues need to be considered. Checking for overflows after every single step can be cumbersome. With this utility library, overflow checks can be conducted using a shared library, improving the readability of the resulting code.

See #868 for example uses of this utility.