### PR TITLE
Prevent bundleGetInfoFrom from returning non-existing block numbers

### DIFF
--- a/api/sonicapi/get_bundle_info.go
+++ b/api/sonicapi/get_bundle_info.go
@@ -50,20 +50,19 @@ func (a *PublicBundleAPI) GetBundleInfo(
 		return nil, nil
 	}
 
-	result := &RPCBundleInfo{
-		Block:    rpc.BlockNumber(info.BlockNumber),
-		Position: hexutil.Uint(info.Position.Offset),
-		Count:    hexutil.Uint(info.Position.Count),
-	}
-
-	if block, err := a.b.BlockByNumber(ctx, result.Block); err != nil || block == nil {
+	blockNumber := rpc.BlockNumber(info.BlockNumber)
+	if block, err := a.b.BlockByNumber(ctx, blockNumber); err != nil || block == nil {
 		// althoug store has been notified about the bundle execution, the block is
 		// not yet available. To avoid returning potentially stale information,
 		// nil is returned, forcing the caller to retry until the block becomes available.
-		return nil, nil
+		return nil, err
 	}
 
-	return result, nil
+	return &RPCBundleInfo{
+		Block:    blockNumber,
+		Position: hexutil.Uint(info.Position.Offset),
+		Count:    hexutil.Uint(info.Position.Count),
+	}, nil
 }
 
 // RPCBundleInfo is the JSON RPC message returned by the GetBundleInfo API, which

--- a/api/sonicapi/get_bundle_info.go
+++ b/api/sonicapi/get_bundle_info.go
@@ -45,16 +45,25 @@ func (a *PublicBundleAPI) GetBundleInfo(
 
 	// Check whether the given execution plan got already executed.
 	info := a.b.GetBundleExecutionInfo(executionPlanHash)
-	if info != nil {
-		return &RPCBundleInfo{
-			Block:    rpc.BlockNumber(info.BlockNumber),
-			Position: hexutil.Uint(info.Position.Offset),
-			Count:    hexutil.Uint(info.Position.Count),
-		}, nil
+	if info == nil {
+		// bundle is unknown,
+		return nil, nil
 	}
 
-	// Otherwise, the state is unknown (default).
-	return nil, nil
+	result := &RPCBundleInfo{
+		Block:    rpc.BlockNumber(info.BlockNumber),
+		Position: hexutil.Uint(info.Position.Offset),
+		Count:    hexutil.Uint(info.Position.Count),
+	}
+
+	if block, err := a.b.BlockByNumber(ctx, result.Block); err != nil || block == nil {
+		// althoug store has been notified about the bundle execution, the block is
+		// not yet available. To avoid returning potentially stale information,
+		// nil is returned, forcing the caller to retry until the block becomes available.
+		return nil, nil
+	}
+
+	return result, nil
 }
 
 // RPCBundleInfo is the JSON RPC message returned by the GetBundleInfo API, which

--- a/api/sonicapi/get_bundle_info.go
+++ b/api/sonicapi/get_bundle_info.go
@@ -52,7 +52,7 @@ func (a *PublicBundleAPI) GetBundleInfo(
 
 	blockNumber := rpc.BlockNumber(info.BlockNumber)
 	if block, err := a.b.BlockByNumber(ctx, blockNumber); err != nil || block == nil {
-		// althoug store has been notified about the bundle execution, the block is
+		// Although the store has been notified about the bundle execution, the block is
 		// not yet available. To avoid returning potentially stale information,
 		// nil is returned, forcing the caller to retry until the block becomes available.
 		return nil, err

--- a/api/sonicapi/get_bundle_info_test.go
+++ b/api/sonicapi/get_bundle_info_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -57,6 +58,9 @@ func Test_GetBundleInfo_KnownBundle_ReturnsInfo(t *testing.T) {
 			Count:  2,
 		},
 	})
+	be.EXPECT().BlockByNumber(gomock.Any(), rpc.BlockNumber(123)).
+		Return(&evmcore.EvmBlock{}, nil)
+
 	res, err := api.GetBundleInfo(t.Context(), hash)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -97,4 +101,23 @@ func expectJsonEqual[T any](t testing.TB, expected string, value T) {
 		t.Logf("Actual JSON:   %s", string(encoded))
 		t.FailNow()
 	}
+}
+
+func Test_GetBundleInfo_ReturnsNilIfBlockIsNotAvailable(t *testing.T) {
+	ctr := gomock.NewController(t)
+	be := NewMockBundleApiBackend(ctr)
+	api := NewPublicBundleAPI(be)
+
+	hash := common.Hash{123}
+	be.EXPECT().GetBundleExecutionInfo(hash).Return(&bundle.ExecutionInfo{
+		BlockNumber: 123,
+		Position: bundle.PositionInBlock{
+			Offset: 1,
+			Count:  2,
+		},
+	})
+	be.EXPECT().BlockByNumber(gomock.Any(), rpc.BlockNumber(123)).Return(nil, nil)
+	res, err := api.GetBundleInfo(t.Context(), hash)
+	require.NoError(t, err)
+	require.Nil(t, res)
 }

--- a/api/sonicapi/get_bundle_info_test.go
+++ b/api/sonicapi/get_bundle_info_test.go
@@ -18,6 +18,7 @@ package sonicapi
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -120,4 +121,23 @@ func Test_GetBundleInfo_ReturnsNilIfBlockIsNotAvailable(t *testing.T) {
 	res, err := api.GetBundleInfo(t.Context(), hash)
 	require.NoError(t, err)
 	require.Nil(t, res)
+}
+
+func Test_GetBundleInfo_ReturnsErrorIfBlockReturnsError(t *testing.T) {
+	ctr := gomock.NewController(t)
+	be := NewMockBundleApiBackend(ctr)
+	api := NewPublicBundleAPI(be)
+
+	hash := common.Hash{123}
+	be.EXPECT().GetBundleExecutionInfo(hash).Return(&bundle.ExecutionInfo{
+		BlockNumber: 123,
+		Position: bundle.PositionInBlock{
+			Offset: 1,
+			Count:  2,
+		},
+	})
+	expectedErr := errors.New("some error")
+	be.EXPECT().BlockByNumber(gomock.Any(), rpc.BlockNumber(123)).Return(nil, expectedErr)
+	_, err := api.GetBundleInfo(t.Context(), hash)
+	require.ErrorIs(t, err, expectedErr)
 }


### PR DESCRIPTION
The changes here solve an issue manifested as flaky tests:  the reported block number where a bundle has executed may not yet be completed and therefore not found if queried. 

The solution proposed is to report unknown bundle, and let user poll again.