### PR TITLE
Extend timeout for concurrent bundles to be processed.

### DIFF
--- a/tests/bundles/concurrent_bundles_test.go
+++ b/tests/bundles/concurrent_bundles_test.go
@@ -160,7 +160,7 @@ func testRandomlyFailingBundles(
 	}
 
 	// Wait for execution
-	timeout, timeoutCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	timeout, timeoutCancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer timeoutCancel()
 	infos, err := WaitForBundleExecutions(timeout, client.Client(), planHashes)
 	if err != nil {


### PR DESCRIPTION
This PR attempts to fix https://github.com/0xsoniclabs/sonic-admin/issues/729

As suspected, reducing the context timeout makes this error happen consistently. Just as well, doubling the timeout makes it not fail during race detection anymore. 
Race detection ran in: https://scala.fantom.network/job/Sonic/job/Unit-test-race-detection/394/console