### PR TITLE
Make default signer of builder accessible

### DIFF
--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -155,6 +155,13 @@ func (b *builder) WithSigner(signer types.Signer) *builder {
 	return b
 }
 
+func (b *builder) GetSigner() types.Signer {
+	if b.signer != nil {
+		return b.signer
+	}
+	return types.LatestSignerForChainID(big.NewInt(1))
+}
+
 func (b *builder) With(root BuilderStep) *builder {
 	b.root = root
 	return b
@@ -185,6 +192,7 @@ func (b *builder) SetEnvelopeGasPrice(gasPrice *big.Int) *builder {
 	b.envelopeGasPrice = gasPrice
 	return b
 }
+
 func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 
 	// Set up defaults for meta flags.
@@ -198,9 +206,7 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 		latest = *b.latest
 	}
 
-	if b.signer == nil {
-		b.signer = types.LatestSignerForChainID(big.NewInt(1))
-	}
+	signer := b.GetSigner()
 
 	// Create a deep copy of the user defined execution plan to avoid side
 	// effects of the build process to affect the input.
@@ -219,7 +225,7 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 		// For nested envelopes, the gas limit needs to be accurately adjusted
 		// to pass the bundle validation test.
 		if IsEnvelope(tx) {
-			innerBundle, _, err := ValidateEnvelope(b.signer, tx)
+			innerBundle, _, err := ValidateEnvelope(signer, tx)
 			if err == nil {
 				marker := types.AccessTuple{
 					Address:     BundleOnly,
@@ -247,7 +253,7 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 
 	// Create an Execution Plan for the bundle.
 	plan := ExecutionPlan{
-		Root: root.toStep(b.signer),
+		Root: root.toStep(signer),
 		Range: BlockRange{
 			Earliest: earliest,
 			Latest:   latest,
@@ -263,7 +269,7 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 	for _, ref := range txReferences {
 		txRef := TxReference{
 			From: crypto.PubkeyToAddress(ref.key.PublicKey),
-			Hash: b.signer.Hash(types.NewTx(ref.tx)),
+			Hash: signer.Hash(types.NewTx(ref.tx)),
 		}
 		unsignedTxs[txRef] = KeyAndData{
 			key:    ref.key,
@@ -295,7 +301,7 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 	// Sign the modified TxData instances to create the final index
 	txs := make(map[TxReference]*types.Transaction)
 	for ref, entry := range unsignedTxs {
-		txs[ref] = types.MustSignNewTx(entry.key, b.signer, entry.txData)
+		txs[ref] = types.MustSignNewTx(entry.key, signer, entry.txData)
 	}
 
 	return &TransactionBundle{
@@ -321,7 +327,8 @@ func (b *builder) BuildEnvelopeBundleAndPlan() (
 		key = newKey
 	}
 	bundle, plan := b.BuildBundleAndPlan()
-	return newEnvelope(b.signer, key, b.envelopeNonce, b.envelopeGasPrice, bundle), bundle, plan
+	signer := b.GetSigner()
+	return newEnvelope(signer, key, b.envelopeNonce, b.envelopeGasPrice, bundle), bundle, plan
 }
 
 // BuildEnvelope returns an envelope transaction and its execution plan

--- a/gossip/blockproc/bundle/builder_test.go
+++ b/gossip/blockproc/bundle/builder_test.go
@@ -513,8 +513,6 @@ func TestBundleBuilder_AutomaticallyAddsGasCostsForMarkers(t *testing.T) {
 }
 
 func TestBundleBuilder_AdjustsNestedEnvelopeGasToPassValidation(t *testing.T) {
-	signer := types.LatestSignerForChainID(testChainID)
-
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
@@ -526,6 +524,7 @@ func TestBundleBuilder_AdjustsNestedEnvelopeGasToPassValidation(t *testing.T) {
 		Step(key, inner),
 	).Build()
 
+	signer := NewBuilder().GetSigner()
 	bundle, _, err := ValidateEnvelope(signer, outer)
 	require.NoError(t, err)
 
@@ -559,14 +558,12 @@ func TestBundleBuilder_DefaultsSignerIfUnspecified(t *testing.T) {
 		AllOf(Step(key, types.NewTx(&types.LegacyTx{}))).
 		Build()
 
-	signer := types.LatestSignerForChainID(big.NewInt(1))
+	signer := NewBuilder().GetSigner()
 	_, _, err = ValidateEnvelope(signer, tx)
 	require.NoError(t, err)
 }
 
 func TestBundleBuilder_CanSetGasPrice(t *testing.T) {
-	signer := types.LatestSignerForChainID(testChainID)
-
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
@@ -581,6 +578,7 @@ func TestBundleBuilder_CanSetGasPrice(t *testing.T) {
 				).
 				Build()
 
+			signer := NewBuilder().GetSigner()
 			_, _, err = ValidateEnvelope(signer, tx)
 			require.NoError(t, err)
 
@@ -594,7 +592,6 @@ func TestBundleBuilder_CanSetGasPrice(t *testing.T) {
 }
 
 func TestBundleBuilder_DefaultsGasPriceToZero(t *testing.T) {
-	signer := types.LatestSignerForChainID(testChainID)
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
@@ -606,6 +603,7 @@ func TestBundleBuilder_DefaultsGasPriceToZero(t *testing.T) {
 		).
 		Build()
 
+	signer := NewBuilder().GetSigner()
 	_, _, err = ValidateEnvelope(signer, tx)
 	require.NoError(t, err)
 
@@ -613,7 +611,6 @@ func TestBundleBuilder_DefaultsGasPriceToZero(t *testing.T) {
 }
 
 func TestBundleBuilder_SetEnvelopeNonce_SetsNonce(t *testing.T) {
-	signer := types.LatestSignerForChainID(testChainID)
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
@@ -626,6 +623,7 @@ func TestBundleBuilder_SetEnvelopeNonce_SetsNonce(t *testing.T) {
 		).
 		Build()
 
+	signer := NewBuilder().GetSigner()
 	_, _, err = ValidateEnvelope(signer, tx)
 	require.NoError(t, err)
 
@@ -633,7 +631,6 @@ func TestBundleBuilder_SetEnvelopeNonce_SetsNonce(t *testing.T) {
 }
 
 func TestBundleBuilder_SetEnvelopeSenderKey_DefaultsNonceWhenUnset(t *testing.T) {
-	signer := types.LatestSignerForChainID(testChainID)
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
@@ -646,6 +643,7 @@ func TestBundleBuilder_SetEnvelopeSenderKey_DefaultsNonceWhenUnset(t *testing.T)
 		).
 		Build()
 
+	signer := NewBuilder().GetSigner()
 	_, _, err = ValidateEnvelope(signer, tx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR adds support to the builder to retrieve the default signer through
```Go
signer := NewBuilder().GetSigner()
```
if needed. 

This helps eliminating the dependency to the global `testChainID` shared throughout the `bundle` package tests.