### PR TITLE
Fix baseFee in transaction tracing 

### DIFF
--- a/api/ethapi/tx_trace.go
+++ b/api/ethapi/tx_trace.go
@@ -478,7 +478,7 @@ func (s *PublicTxTraceAPI) traceTx(
 	index uint64,
 	status uint64,
 ) (*[]txtrace.ActionTrace, error) {
-	tracedEVM, cancel, err := setupTracedEVM(ctx, s.b, block, statedb, index, true, false, false)
+	tracedEVM, cancel, err := setupTracedEVM(ctx, s.b, block, statedb, index, true, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +495,7 @@ func (s *PublicTxTraceAPI) traceTx(
 		errTrace := txtrace.GetErrorTraceFromMsg(msg, block.Hash, *block.Number, tx.Hash(), index, err)
 		at := []txtrace.ActionTrace{*errTrace}
 		if status == 1 {
-			return nil, fmt.Errorf("invalid transaction replay state at %s", tx.Hash().String())
+			return nil, fmt.Errorf("invalid transaction replay state at %s, error: %s", tx.Hash().String(), err.Error())
 		}
 		return &at, nil
 	}

--- a/txtrace/trace_logger.go
+++ b/txtrace/trace_logger.go
@@ -147,7 +147,7 @@ func (tr *TraceStructLogger) Hooks() *tracing.Hooks {
 func (tr *TraceStructLogger) OnTxStart(env *tracing.VMContext, tx *types.Transaction, from common.Address) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("Tracer OnTxStart failed", r)
+			log.Error("Tracer OnTxStart failed", "error", r)
 		}
 	}()
 
@@ -167,7 +167,7 @@ func (tr *TraceStructLogger) OnTxStart(env *tracing.VMContext, tx *types.Transac
 func (tr *TraceStructLogger) OnEnter(depth int, typ byte, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("Tracer OnEnter failed", r)
+			log.Error("Tracer OnEnter failed", "error", r)
 		}
 	}()
 	var (
@@ -220,7 +220,7 @@ func (tr *TraceStructLogger) OnEnter(depth int, typ byte, from common.Address, t
 func (tr *TraceStructLogger) OnExit(depth int, output []byte, gasUsed uint64, err error, reverted bool) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("Tracer OnExit failed", r)
+			log.Error("Tracer OnExit failed", "error", r)
 		}
 	}()
 
@@ -259,7 +259,7 @@ func (tr *TraceStructLogger) OnExit(depth int, output []byte, gasUsed uint64, er
 func (tr *TraceStructLogger) OnTxEnd(receipt *types.Receipt, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("Tracer OnTxEnd failed", r)
+			log.Error("Tracer OnTxEnd failed", "error", r)
 		}
 	}()
 

--- a/txtrace/trace_logger.go
+++ b/txtrace/trace_logger.go
@@ -373,6 +373,9 @@ func (callTrace *CallTrace) lastTrace() *ActionTrace {
 // processTraces initiates final information distribution
 // accros result traces
 func (callTrace *CallTrace) processTraces() {
+	if len(callTrace.Actions) == 0 {
+		return
+	}
 	trace := &callTrace.Actions[len(callTrace.Actions)-1]
 	callTrace.processTrace(trace, []uint32{})
 }


### PR DESCRIPTION
This PR fixes setting for a setup of an EVM when replaying transactions with transaction tracing. It must use `noBaseFee` when replaying transaction to skip gas preCheck to be able to replay internal transaction.
This was introduced with a refactor and reuse of the EVM setup for `stateDiff` in transaction tracing.

Test will be in separate PR using modification to the RPC test framework