### PR TITLE
Add bundle stress tests

### DIFF
--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -64,12 +64,10 @@ func TestBundle_StressWithManyNonceBlockedBundles(t *testing.T) {
 		planHashes[i] = plan.Hash()
 	}
 
-	// Iteratively send in all bundles except the first one (with nonce 0)
-	// which will be blocked until the transaction with nonce 0 is executed.
-	for i := range N {
-		_, err = net.Send(envelopes[i+1])
-		require.NoError(t, err)
-	}
+	// Send in all bundles except the first one (with nonce 0) which will be
+	// blocked until the transaction with nonce 0 is executed.
+	_, err = net.SendAll(envelopes[1:])
+	require.NoError(t, err)
 
 	// Send the bundle containing the transaction with nonce 0 which unblocks
 	// all the other bundles.

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -92,10 +92,10 @@ func TestBundle_StressWithManyNonceBlockedBundles(t *testing.T) {
 	}
 }
 
-func TestBundle_StressWithManyRollingBackBundles(t *testing.T) {
+func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 	// Increase these numbers for profiling to increase load on the system.
-	const B = 2 // Number of bundles
-	const S = 1 // Number of steps per bundle
+	const B = 1 // Number of bundles
+	const S = 1 // Number of expensive steps per bundle
 
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.TransactionBundles = true
@@ -111,23 +111,26 @@ func TestBundle_StressWithManyRollingBackBundles(t *testing.T) {
 	signer := types.LatestSignerForChainID(net.GetChainId())
 
 	// Create all needed accounts and endow in parallel.
-	accounts := tests.MakeAccountsWithBalance(t, net, B, big.NewInt(1e18))
+	accounts := tests.MakeAccountsWithBalance(t, net, B*(S+2), big.NewInt(1e18))
 
 	envelopes := make([]*types.Transaction, B)
 	planHashes := make([]common.Hash, B)
 
-	// Create B bundles that will roll back.
+	// Create B bundles.
 	for i := range B {
-		// Create S-1 successful steps and 1 invalid step causing the whole bundle to roll back.
-		steps := make([]bundle.BuilderStep, S)
-		for j := range S - 1 {
-			steps[j] = Step(t, net, accounts[i], &types.AccessListTx{Nonce: uint64(j)})
+		// Create S expensive successful steps and 1 invalid step causing the whole layer to roll back.
+		steps := make([]bundle.BuilderStep, S+1)
+		for j := range S {
+			steps[j] = Step(t, net, accounts[S*i+j], &types.AccessListTx{})
 		}
-		steps[S-1] = Step(t, net, accounts[i], &types.AccessListTx{Nonce: uint64(S - 1), Gas: 1})
+		steps[S] = Step(t, net, accounts[S*i+S], &types.AccessListTx{Gas: 1})
 
 		envelope, _, plan := bundle.NewBuilder().
 			WithSigner(signer).
-			AllOf(steps...).
+			AllOf(
+				bundle.AllOf(steps...).WithFlags(bundle.EF_TolerateFailed),
+				Step(t, net, accounts[S*i+S+1], &types.AccessListTx{}),
+			).
 			BuildEnvelopeBundleAndPlan()
 
 		envelopes[i] = envelope
@@ -142,8 +145,9 @@ func TestBundle_StressWithManyRollingBackBundles(t *testing.T) {
 	infos, err := WaitForBundleExecutions(t.Context(), client.Client(), planHashes)
 	require.NoError(t, err)
 
-	// Check that all bundles were rolled back.
+	// Check that all bundles were executed successfully but only the last
+	// outer transaction ended up in the block.
 	for _, info := range infos {
-		require.Zero(t, info.Count)
+		require.EqualValues(t, 1, info.Count)
 	}
 }

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/tests/contracts/add"
 	"github.com/0xsoniclabs/sonic/tests/contracts/store"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -111,54 +112,75 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	// Deploy the store contract.
-	storeAddr := tests.MustDeployContract(t, net, store.DeployStore)
-	storeFillInput := tests.MustGetMethodParameters(
-		t, store.StoreMetaData, "fill",
-		// arguments: from, until, value (1100 slots is about the maximum
-		// number of slots that can be filled within the block gas limit)
-		big.NewInt(0), big.NewInt(1100), big.NewInt(1),
-	)
-
-	signer := types.LatestSignerForChainID(net.GetChainId())
-
 	// Create all needed accounts and endow in parallel.
 	accounts := tests.MakeAccountsWithBalance(t, net, B*3, big.NewInt(1e18))
 
-	envelopes := make([]*types.Transaction, B)
-	planHashes := make([]common.Hash, B)
-
-	// Create B bundles.
-	for i := range B {
-		envelope, _, plan := bundle.NewBuilder().
-			WithSigner(signer).
-			AllOf(
-				bundle.AllOf(
-					Step(t, net, accounts[i*3], &types.AccessListTx{
-						To:   &storeAddr,
-						Data: storeFillInput,
-					}),
-					Step(t, net, accounts[i*3+1], &types.AccessListTx{Gas: 1}),
-				).WithFlags(bundle.EF_TolerateFailed),
-				Step(t, net, accounts[i*3+2], &types.AccessListTx{}),
-			).
-			BuildEnvelopeBundleAndPlan()
-
-		envelopes[i] = envelope
-		planHashes[i] = plan.Hash()
+	cases := map[string]struct {
+		contractAddr  common.Address
+		contractInput []byte
+	}{
+		"ComputeHeavy": {
+			contractAddr: tests.MustDeployContract(t, net, add.DeployAdd),
+			contractInput: tests.MustGetMethodParameters(
+				t, add.AddMetaData, "add",
+				// arguments: iter (128_000 iterations is about the maximum
+				// number of iterations that can be executed within the
+				// block gas limit)
+				big.NewInt(128_000),
+			),
+		},
+		"DbHeavy": {
+			contractAddr: tests.MustDeployContract(t, net, store.DeployStore),
+			contractInput: tests.MustGetMethodParameters(
+				t, store.StoreMetaData, "fill",
+				// arguments: from, until, value (1100 slots is about the
+				// maximum number of slots that can be filled within the
+				// block gas limit)
+				big.NewInt(0), big.NewInt(1100), big.NewInt(1),
+			),
+		},
 	}
 
-	// Send all bundles.
-	_, err = net.SendAll(envelopes)
-	require.NoError(t, err)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			signer := types.LatestSignerForChainID(net.GetChainId())
 
-	// Wait for all bundles to be processed.
-	infos, err := WaitForBundleExecutions(t.Context(), client.Client(), planHashes)
-	require.NoError(t, err)
+			envelopes := make([]*types.Transaction, B)
+			planHashes := make([]common.Hash, B)
 
-	// Check that all bundles were executed successfully but only the last
-	// outer transaction ended up in the block.
-	for _, info := range infos {
-		require.EqualValues(t, 1, info.Count)
+			// Create B bundles.
+			for i := range B {
+				envelope, _, plan := bundle.NewBuilder().
+					WithSigner(signer).
+					AllOf(
+						bundle.AllOf(
+							Step(t, net, accounts[i*3], &types.AccessListTx{
+								To:   &tc.contractAddr,
+								Data: tc.contractInput,
+							}),
+							Step(t, net, accounts[i*3+1], &types.AccessListTx{Gas: 1}),
+						).WithFlags(bundle.EF_TolerateFailed),
+						Step(t, net, accounts[i*3+2], &types.AccessListTx{}),
+					).
+					BuildEnvelopeBundleAndPlan()
+
+				envelopes[i] = envelope
+				planHashes[i] = plan.Hash()
+			}
+
+			// Send all bundles.
+			_, err = net.SendAll(envelopes)
+			require.NoError(t, err)
+
+			// Wait for all bundles to be processed.
+			infos, err := WaitForBundleExecutions(t.Context(), client.Client(), planHashes)
+			require.NoError(t, err)
+
+			// Check that all bundles were executed successfully but only the
+			// last outer transaction ended up in the block.
+			for _, info := range infos {
+				require.EqualValues(t, 1, info.Count)
+			}
+		})
 	}
 }

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/tests/contracts/store"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -93,9 +94,11 @@ func TestBundle_StressWithManyNonceBlockedBundles(t *testing.T) {
 }
 
 func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
-	// Increase these numbers for profiling to increase load on the system.
+	// This test runs `B` bundles of the shape:
+	// AllOf(AllOf[TolerateFailed](expensive tx, failing tx), successful tx).
+
+	// Increase this number for profiling to increase load on the system.
 	const B = 1 // Number of bundles
-	const S = 1 // Number of expensive steps per bundle
 
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.TransactionBundles = true
@@ -108,28 +111,36 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
+	// Deploy the store contract.
+	storeAddr := tests.MustDeployContract(t, net, store.DeployStore)
+	storeFillInput := tests.MustGetMethodParameters(
+		t, store.StoreMetaData, "fill",
+		// arguments: from, until, value (1100 slots is about the maximum
+		// number of slots that can be filled within the block gas limit)
+		big.NewInt(0), big.NewInt(1100), big.NewInt(1),
+	)
+
 	signer := types.LatestSignerForChainID(net.GetChainId())
 
 	// Create all needed accounts and endow in parallel.
-	accounts := tests.MakeAccountsWithBalance(t, net, B*(S+2), big.NewInt(1e18))
+	accounts := tests.MakeAccountsWithBalance(t, net, B*3, big.NewInt(1e18))
 
 	envelopes := make([]*types.Transaction, B)
 	planHashes := make([]common.Hash, B)
 
 	// Create B bundles.
 	for i := range B {
-		// Create S expensive successful steps and 1 invalid step causing the whole layer to roll back.
-		steps := make([]bundle.BuilderStep, S+1)
-		for j := range S {
-			steps[j] = Step(t, net, accounts[S*i+j], &types.AccessListTx{})
-		}
-		steps[S] = Step(t, net, accounts[S*i+S], &types.AccessListTx{Gas: 1})
-
 		envelope, _, plan := bundle.NewBuilder().
 			WithSigner(signer).
 			AllOf(
-				bundle.AllOf(steps...).WithFlags(bundle.EF_TolerateFailed),
-				Step(t, net, accounts[S*i+S+1], &types.AccessListTx{}),
+				bundle.AllOf(
+					Step(t, net, accounts[i*3], &types.AccessListTx{
+						To:   &storeAddr,
+						Data: storeFillInput,
+					}),
+					Step(t, net, accounts[i*3+1], &types.AccessListTx{Gas: 1}),
+				).WithFlags(bundle.EF_TolerateFailed),
+				Step(t, net, accounts[i*3+2], &types.AccessListTx{}),
 			).
 			BuildEnvelopeBundleAndPlan()
 

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package bundles
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundle_StressWithManyNonceBlockedBundles(t *testing.T) {
+	// Increase this number for profiling to increase load on the system.
+	const N = 2 // Number of blocked bundles
+
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	signer := types.LatestSignerForChainID(net.GetChainId())
+
+	// Create all needed accounts and endow in parallel.
+	account := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+
+	envelopes := make([]*types.Transaction, N+1)
+	bundles := make([]*bundle.TransactionBundle, N+1)
+	planHashes := make([]common.Hash, N+1)
+
+	// Create N+1 bundles with transactions with increasing nonces.
+	for i := range N + 1 {
+		envelope, bundle, plan := bundle.NewBuilder().
+			WithSigner(signer).
+			AllOf(Step(t, net, account, &types.AccessListTx{Nonce: uint64(i)})).
+			BuildEnvelopeBundleAndPlan()
+
+		envelopes[i] = envelope
+		bundles[i] = bundle
+		planHashes[i] = plan.Hash()
+	}
+
+	// Iteratively send in all bundles except the first one (with nonce 0)
+	// which will be blocked until the transaction with nonce 0 is executed.
+	for i := range N {
+		_, err = net.Send(envelopes[i+1])
+		require.NoError(t, err)
+	}
+
+	// Send the bundle containing the transaction with nonce 0 which unblocks
+	// all the other bundles.
+	_, err = net.Send(envelopes[0])
+	require.NoError(t, err)
+
+	// Wait for all bundles to be processed.
+	infos, err := WaitForBundleExecutions(t.Context(), client.Client(), planHashes)
+	require.NoError(t, err)
+
+	// Check that all obtained infos match the respective transactions.
+	for i, info := range infos {
+		require.EqualValues(t, len(bundles[i].Transactions), info.Count)
+
+		for j, tx := range bundles[i].GetTransactionsInReferencedOrder() {
+			receipt, err := client.TransactionReceipt(t.Context(), tx.Hash())
+			require.NoError(t, err)
+			require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+			require.Equal(t, int(receipt.BlockNumber.Uint64()), int(info.Block))
+			require.Equal(t, int(receipt.TransactionIndex), int(info.Position)+j)
+		}
+	}
+}
+
+func TestBundle_StressWithManyRollingBackBundles(t *testing.T) {
+	// Increase these numbers for profiling to increase load on the system.
+	const B = 2 // Number of bundles
+	const S = 1 // Number of steps per bundle
+
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	signer := types.LatestSignerForChainID(net.GetChainId())
+
+	// Create all needed accounts and endow in parallel.
+	accounts := tests.MakeAccountsWithBalance(t, net, B, big.NewInt(1e18))
+
+	envelopes := make([]*types.Transaction, B)
+	planHashes := make([]common.Hash, B)
+
+	// Create B bundles that will roll back.
+	for i := range B {
+		// Create S-1 successful steps and 1 invalid step causing the whole bundle to roll back.
+		steps := make([]bundle.BuilderStep, S)
+		for j := range S - 1 {
+			steps[j] = Step(t, net, accounts[i], &types.AccessListTx{Nonce: uint64(j)})
+		}
+		steps[S-1] = Step(t, net, accounts[i], &types.AccessListTx{Nonce: uint64(S - 1), Gas: 1})
+
+		envelope, _, plan := bundle.NewBuilder().
+			WithSigner(signer).
+			AllOf(steps...).
+			BuildEnvelopeBundleAndPlan()
+
+		envelopes[i] = envelope
+		planHashes[i] = plan.Hash()
+	}
+
+	// Send all bundles.
+	_, err = net.SendAll(envelopes)
+	require.NoError(t, err)
+
+	// Wait for all bundles to be processed.
+	infos, err := WaitForBundleExecutions(t.Context(), client.Client(), planHashes)
+	require.NoError(t, err)
+
+	// Check that all bundles were rolled back.
+	for _, info := range infos {
+		require.Zero(t, info.Count)
+	}
+}

--- a/tests/contracts/add/Add.go
+++ b/tests/contracts/add/Add.go
@@ -1,0 +1,234 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package add
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// AddMetaData contains all meta data concerning the Add contract.
+var AddMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"iter\",\"type\":\"uint256\"}],\"name\":\"add\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f5ffd5b506101c88061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610029575f3560e01c80631003e2d21461002d575b5f5ffd5b610047600480360381019061004291906100cb565b61005d565b6040516100549190610105565b60405180910390f35b5f5f5f90505f5f90505b8381101561008a57818061007a9061014b565b9250508080600101915050610067565b5080915050919050565b5f5ffd5b5f819050919050565b6100aa81610098565b81146100b4575f5ffd5b50565b5f813590506100c5816100a1565b92915050565b5f602082840312156100e0576100df610094565b5b5f6100ed848285016100b7565b91505092915050565b6100ff81610098565b82525050565b5f6020820190506101185f8301846100f6565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61015582610098565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036101875761018661011e565b5b60018201905091905056fea26469706673582212209f6d6acc143c6d9476ecacf6739a417ed550f2876e34ea53b597c0fe75fc3e4864736f6c634300081e0033",
+}
+
+// AddABI is the input ABI used to generate the binding from.
+// Deprecated: Use AddMetaData.ABI instead.
+var AddABI = AddMetaData.ABI
+
+// AddBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use AddMetaData.Bin instead.
+var AddBin = AddMetaData.Bin
+
+// DeployAdd deploys a new Ethereum contract, binding an instance of Add to it.
+func DeployAdd(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Add, error) {
+	parsed, err := AddMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(AddBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Add{AddCaller: AddCaller{contract: contract}, AddTransactor: AddTransactor{contract: contract}, AddFilterer: AddFilterer{contract: contract}}, nil
+}
+
+// Add is an auto generated Go binding around an Ethereum contract.
+type Add struct {
+	AddCaller     // Read-only binding to the contract
+	AddTransactor // Write-only binding to the contract
+	AddFilterer   // Log filterer for contract events
+}
+
+// AddCaller is an auto generated read-only Go binding around an Ethereum contract.
+type AddCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AddTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type AddTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AddFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type AddFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AddSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type AddSession struct {
+	Contract     *Add              // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AddCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type AddCallerSession struct {
+	Contract *AddCaller    // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// AddTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type AddTransactorSession struct {
+	Contract     *AddTransactor    // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AddRaw is an auto generated low-level Go binding around an Ethereum contract.
+type AddRaw struct {
+	Contract *Add // Generic contract binding to access the raw methods on
+}
+
+// AddCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type AddCallerRaw struct {
+	Contract *AddCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AddTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type AddTransactorRaw struct {
+	Contract *AddTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAdd creates a new instance of Add, bound to a specific deployed contract.
+func NewAdd(address common.Address, backend bind.ContractBackend) (*Add, error) {
+	contract, err := bindAdd(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Add{AddCaller: AddCaller{contract: contract}, AddTransactor: AddTransactor{contract: contract}, AddFilterer: AddFilterer{contract: contract}}, nil
+}
+
+// NewAddCaller creates a new read-only instance of Add, bound to a specific deployed contract.
+func NewAddCaller(address common.Address, caller bind.ContractCaller) (*AddCaller, error) {
+	contract, err := bindAdd(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AddCaller{contract: contract}, nil
+}
+
+// NewAddTransactor creates a new write-only instance of Add, bound to a specific deployed contract.
+func NewAddTransactor(address common.Address, transactor bind.ContractTransactor) (*AddTransactor, error) {
+	contract, err := bindAdd(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AddTransactor{contract: contract}, nil
+}
+
+// NewAddFilterer creates a new log filterer instance of Add, bound to a specific deployed contract.
+func NewAddFilterer(address common.Address, filterer bind.ContractFilterer) (*AddFilterer, error) {
+	contract, err := bindAdd(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AddFilterer{contract: contract}, nil
+}
+
+// bindAdd binds a generic wrapper to an already deployed contract.
+func bindAdd(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := AddMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Add *AddRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Add.Contract.AddCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Add *AddRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Add.Contract.AddTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Add *AddRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Add.Contract.AddTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Add *AddCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Add.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Add *AddTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Add.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Add *AddTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Add.Contract.contract.Transact(opts, method, params...)
+}
+
+// Add is a free data retrieval call binding the contract method 0x1003e2d2.
+//
+// Solidity: function add(uint256 iter) pure returns(uint256)
+func (_Add *AddCaller) Add(opts *bind.CallOpts, iter *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Add.contract.Call(opts, &out, "add", iter)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Add is a free data retrieval call binding the contract method 0x1003e2d2.
+//
+// Solidity: function add(uint256 iter) pure returns(uint256)
+func (_Add *AddSession) Add(iter *big.Int) (*big.Int, error) {
+	return _Add.Contract.Add(&_Add.CallOpts, iter)
+}
+
+// Add is a free data retrieval call binding the contract method 0x1003e2d2.
+//
+// Solidity: function add(uint256 iter) pure returns(uint256)
+func (_Add *AddCallerSession) Add(iter *big.Int) (*big.Int, error) {
+	return _Add.Contract.Add(&_Add.CallOpts, iter)
+}

--- a/tests/contracts/add/add.sol
+++ b/tests/contracts/add/add.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract Add {
+    function add(uint iter) public pure returns (uint) {
+        uint count = 0;
+        for (uint i = 0; i < iter; i++) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/tests/contracts/add/gen.go
+++ b/tests/contracts/add/gen.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package add
+
+//go:generate solc --bin add.sol --abi add.sol -o build --overwrite
+//go:generate abigen --bin=build/Add.bin --abi=build/Add.abi --pkg=add --out=Add.go

--- a/tests/contracts/store/Store.go
+++ b/tests/contracts/store/Store.go
@@ -1,0 +1,307 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package store
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// StoreMetaData contains all meta data concerning the Store contract.
+var StoreMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"int256\",\"name\":\"from\",\"type\":\"int256\"},{\"internalType\":\"int256\",\"name\":\"to\",\"type\":\"int256\"},{\"internalType\":\"int256\",\"name\":\"value\",\"type\":\"int256\"}],\"name\":\"fill\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"int256\",\"name\":\"key\",\"type\":\"int256\"}],\"name\":\"get\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"\",\"type\":\"int256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCount\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"\",\"type\":\"int256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"int256\",\"name\":\"key\",\"type\":\"int256\"},{\"internalType\":\"int256\",\"name\":\"value\",\"type\":\"int256\"}],\"name\":\"put\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x60806040525f5f553480156011575f5ffd5b506103e58061001f5f395ff3fe608060405234801561000f575f5ffd5b506004361061004a575f3560e01c80638110c48f1461004e578063846719e01461006a578063a87d942c1461009a578063e37f1e80146100b8575b5f5ffd5b6100686004803603810190610063919061025a565b6100d4565b005b610084600480360381019061007f9190610298565b61013f565b60405161009191906102d2565b60405180910390f35b6100a2610194565b6040516100af91906102d2565b60405180910390f35b6100d260048036038101906100cd91906102eb565b61019c565b005b8060015f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8481526020019081526020015f20819055505f5f81548092919061013690610368565b91905055505050565b5f60015f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8381526020019081526020015f20549050919050565b5f5f54905090565b5f8390505b82811215610207578160015f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8381526020019081526020015f208190555080806001019150506101a1565b505f5f81548092919061021990610368565b9190505550505050565b5f5ffd5b5f819050919050565b61023981610227565b8114610243575f5ffd5b50565b5f8135905061025481610230565b92915050565b5f5f604083850312156102705761026f610223565b5b5f61027d85828601610246565b925050602061028e85828601610246565b9150509250929050565b5f602082840312156102ad576102ac610223565b5b5f6102ba84828501610246565b91505092915050565b6102cc81610227565b82525050565b5f6020820190506102e55f8301846102c3565b92915050565b5f5f5f6060848603121561030257610301610223565b5b5f61030f86828701610246565b935050602061032086828701610246565b925050604061033186828701610246565b9150509250925092565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61037282610227565b91507f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82036103a4576103a361033b565b5b60018201905091905056fea26469706673582212201fa625b744e8fa6cdcb445fb731d2cf8d7d6f1381308c7fd5a0ea7466979b20164736f6c634300081e0033",
+}
+
+// StoreABI is the input ABI used to generate the binding from.
+// Deprecated: Use StoreMetaData.ABI instead.
+var StoreABI = StoreMetaData.ABI
+
+// StoreBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use StoreMetaData.Bin instead.
+var StoreBin = StoreMetaData.Bin
+
+// DeployStore deploys a new Ethereum contract, binding an instance of Store to it.
+func DeployStore(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Store, error) {
+	parsed, err := StoreMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(StoreBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Store{StoreCaller: StoreCaller{contract: contract}, StoreTransactor: StoreTransactor{contract: contract}, StoreFilterer: StoreFilterer{contract: contract}}, nil
+}
+
+// Store is an auto generated Go binding around an Ethereum contract.
+type Store struct {
+	StoreCaller     // Read-only binding to the contract
+	StoreTransactor // Write-only binding to the contract
+	StoreFilterer   // Log filterer for contract events
+}
+
+// StoreCaller is an auto generated read-only Go binding around an Ethereum contract.
+type StoreCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StoreTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type StoreTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StoreFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type StoreFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StoreSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type StoreSession struct {
+	Contract     *Store            // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// StoreCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type StoreCallerSession struct {
+	Contract *StoreCaller  // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// StoreTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type StoreTransactorSession struct {
+	Contract     *StoreTransactor  // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// StoreRaw is an auto generated low-level Go binding around an Ethereum contract.
+type StoreRaw struct {
+	Contract *Store // Generic contract binding to access the raw methods on
+}
+
+// StoreCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type StoreCallerRaw struct {
+	Contract *StoreCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// StoreTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type StoreTransactorRaw struct {
+	Contract *StoreTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewStore creates a new instance of Store, bound to a specific deployed contract.
+func NewStore(address common.Address, backend bind.ContractBackend) (*Store, error) {
+	contract, err := bindStore(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{StoreCaller: StoreCaller{contract: contract}, StoreTransactor: StoreTransactor{contract: contract}, StoreFilterer: StoreFilterer{contract: contract}}, nil
+}
+
+// NewStoreCaller creates a new read-only instance of Store, bound to a specific deployed contract.
+func NewStoreCaller(address common.Address, caller bind.ContractCaller) (*StoreCaller, error) {
+	contract, err := bindStore(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StoreCaller{contract: contract}, nil
+}
+
+// NewStoreTransactor creates a new write-only instance of Store, bound to a specific deployed contract.
+func NewStoreTransactor(address common.Address, transactor bind.ContractTransactor) (*StoreTransactor, error) {
+	contract, err := bindStore(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StoreTransactor{contract: contract}, nil
+}
+
+// NewStoreFilterer creates a new log filterer instance of Store, bound to a specific deployed contract.
+func NewStoreFilterer(address common.Address, filterer bind.ContractFilterer) (*StoreFilterer, error) {
+	contract, err := bindStore(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &StoreFilterer{contract: contract}, nil
+}
+
+// bindStore binds a generic wrapper to an already deployed contract.
+func bindStore(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := StoreMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Store *StoreRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Store.Contract.StoreCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Store *StoreRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Store.Contract.StoreTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Store *StoreRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Store.Contract.StoreTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Store *StoreCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Store.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Store *StoreTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Store.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Store *StoreTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Store.Contract.contract.Transact(opts, method, params...)
+}
+
+// Get is a free data retrieval call binding the contract method 0x846719e0.
+//
+// Solidity: function get(int256 key) view returns(int256)
+func (_Store *StoreCaller) Get(opts *bind.CallOpts, key *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _Store.contract.Call(opts, &out, "get", key)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Get is a free data retrieval call binding the contract method 0x846719e0.
+//
+// Solidity: function get(int256 key) view returns(int256)
+func (_Store *StoreSession) Get(key *big.Int) (*big.Int, error) {
+	return _Store.Contract.Get(&_Store.CallOpts, key)
+}
+
+// Get is a free data retrieval call binding the contract method 0x846719e0.
+//
+// Solidity: function get(int256 key) view returns(int256)
+func (_Store *StoreCallerSession) Get(key *big.Int) (*big.Int, error) {
+	return _Store.Contract.Get(&_Store.CallOpts, key)
+}
+
+// GetCount is a free data retrieval call binding the contract method 0xa87d942c.
+//
+// Solidity: function getCount() view returns(int256)
+func (_Store *StoreCaller) GetCount(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Store.contract.Call(opts, &out, "getCount")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetCount is a free data retrieval call binding the contract method 0xa87d942c.
+//
+// Solidity: function getCount() view returns(int256)
+func (_Store *StoreSession) GetCount() (*big.Int, error) {
+	return _Store.Contract.GetCount(&_Store.CallOpts)
+}
+
+// GetCount is a free data retrieval call binding the contract method 0xa87d942c.
+//
+// Solidity: function getCount() view returns(int256)
+func (_Store *StoreCallerSession) GetCount() (*big.Int, error) {
+	return _Store.Contract.GetCount(&_Store.CallOpts)
+}
+
+// Fill is a paid mutator transaction binding the contract method 0xe37f1e80.
+//
+// Solidity: function fill(int256 from, int256 to, int256 value) returns()
+func (_Store *StoreTransactor) Fill(opts *bind.TransactOpts, from *big.Int, to *big.Int, value *big.Int) (*types.Transaction, error) {
+	return _Store.contract.Transact(opts, "fill", from, to, value)
+}
+
+// Fill is a paid mutator transaction binding the contract method 0xe37f1e80.
+//
+// Solidity: function fill(int256 from, int256 to, int256 value) returns()
+func (_Store *StoreSession) Fill(from *big.Int, to *big.Int, value *big.Int) (*types.Transaction, error) {
+	return _Store.Contract.Fill(&_Store.TransactOpts, from, to, value)
+}
+
+// Fill is a paid mutator transaction binding the contract method 0xe37f1e80.
+//
+// Solidity: function fill(int256 from, int256 to, int256 value) returns()
+func (_Store *StoreTransactorSession) Fill(from *big.Int, to *big.Int, value *big.Int) (*types.Transaction, error) {
+	return _Store.Contract.Fill(&_Store.TransactOpts, from, to, value)
+}
+
+// Put is a paid mutator transaction binding the contract method 0x8110c48f.
+//
+// Solidity: function put(int256 key, int256 value) returns()
+func (_Store *StoreTransactor) Put(opts *bind.TransactOpts, key *big.Int, value *big.Int) (*types.Transaction, error) {
+	return _Store.contract.Transact(opts, "put", key, value)
+}
+
+// Put is a paid mutator transaction binding the contract method 0x8110c48f.
+//
+// Solidity: function put(int256 key, int256 value) returns()
+func (_Store *StoreSession) Put(key *big.Int, value *big.Int) (*types.Transaction, error) {
+	return _Store.Contract.Put(&_Store.TransactOpts, key, value)
+}
+
+// Put is a paid mutator transaction binding the contract method 0x8110c48f.
+//
+// Solidity: function put(int256 key, int256 value) returns()
+func (_Store *StoreTransactorSession) Put(key *big.Int, value *big.Int) (*types.Transaction, error) {
+	return _Store.Contract.Put(&_Store.TransactOpts, key, value)
+}

--- a/tests/contracts/store/gen.go
+++ b/tests/contracts/store/gen.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package store
+
+//go:generate solc --bin store.sol --abi store.sol -o build --overwrite
+//go:generate abigen --bin=build/Store.bin --abi=build/Store.abi --pkg=store --out=Store.go

--- a/tests/contracts/store/store.sol
+++ b/tests/contracts/store/store.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract Store {
+    int private count = 0;
+    mapping(address => mapping(int => int)) private data;
+
+    function put(int key, int value) public {
+        data[msg.sender][key] = value;
+        count++;
+    }
+
+    function fill(int from, int to, int value) public {
+        for (int key = from; key < to; key++) {
+            data[msg.sender][key] = value;
+        }
+        count++;
+    }
+
+    function get(int key) public view returns (int) {
+        return data[msg.sender][key];
+    }
+
+    function getCount() public view returns (int) {
+        return count;
+    }
+}

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -513,12 +513,13 @@ func MustGetMethodParameters(
 	t testing.TB,
 	bindMetadata *bind.MetaData,
 	methodName string,
+	args ...any,
 ) []byte {
 	t.Helper()
 
 	abi, err := bindMetadata.GetAbi()
 	require.NoError(t, err, "failed to get counter abi; %v", err)
-	input, err := abi.Pack(methodName)
+	input, err := abi.Pack(methodName, args...)
 	require.NoError(t, err, "failed to pack input for method %s; %v", methodName, err)
 
 	return input


### PR DESCRIPTION
This PR adds two stress tests for bundles:
- submitting multiple bundles which are blocked by the nonce which only get unblocked by the very last bundle sent in
- submitting multiple bundles which have an inner group that is expensive (computationally or Db accesses) and rolls back in an outer group that does little work and succeeds, so the work during processing vs work of tx in block ratio is high.

The parameters for the size of these tests have been set to small values to speed up CI. For experimentation, these values should be set to larger values.