### PR TITLE
Release acquired StateDB in prechecker

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -109,6 +109,7 @@ func getBundleState(
 	// the bundle. This is a quicker check than actually running the bundle in
 	// full to determine whether it can succeed or not.
 	stateDb := chain.StateDB()
+	defer stateDb.Release()
 	state := checkForNonceConflicts(bundle, signer, stateDb)
 	if !state.Executable {
 		return state
@@ -144,7 +145,9 @@ type ChainState interface {
 	GetEvmChainConfig(blockHeight idx.Block) *params.ChainConfig
 
 	// StateDB returns a context for running transactions on the head state of
-	// the chain. A non-committable state-DB instance is sufficient.
+	// the chain. A non-committable state-DB instance is sufficient. The user
+	// takes ownership of the returned StateDB and is responsible for releasing
+	// it when it is no longer needed.
 	StateDB() state.StateDB
 
 	// GetLatestHeader returns the latest block header of the chain.

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -136,7 +136,8 @@ func Test_GetBundleState_FailedTrialRun_ReturnsNonExecutable(t *testing.T) {
 		NetworkID: 1,
 		Upgrades:  opera.Upgrades{TransactionBundles: true},
 	}).AnyTimes()
-	chainState.EXPECT().StateDB().Return(stateDb).AnyTimes()
+	chainState.EXPECT().StateDB().Return(stateDb)
+	stateDb.EXPECT().Release()
 
 	envelope := bundle.NewBuilder().
 		SetEarliest(currentBlock - 5).
@@ -167,7 +168,8 @@ func Test_GetBundleState_ValidBundle_ReturnsRunnable(t *testing.T) {
 		NetworkID: 1,
 		Upgrades:  opera.Upgrades{TransactionBundles: true},
 	}).AnyTimes()
-	chainState.EXPECT().StateDB().Return(stateDb).AnyTimes()
+	chainState.EXPECT().StateDB().Return(stateDb)
+	stateDb.EXPECT().Release()
 
 	// Build a bundle with a valid block window.
 	envelope := bundle.NewBuilder().
@@ -238,7 +240,8 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 				NetworkID: 1,
 				Upgrades:  opera.Upgrades{TransactionBundles: true},
 			}).AnyTimes()
-			chainState.EXPECT().StateDB().Return(db).AnyTimes()
+			chainState.EXPECT().StateDB().Return(db)
+			db.EXPECT().Release()
 
 			chainId := big.NewInt(1)
 			signer := types.LatestSignerForChainID(chainId)


### PR DESCRIPTION
This PR adds a missing release to the state DB acquired by the bundle-state evaluator.