### PR TITLE
Factor out processor setup into utility function

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -24,11 +24,8 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	state "github.com/0xsoniclabs/sonic/inter/state"
-	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	params "github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
@@ -69,7 +66,7 @@ type BundleState struct {
 // GetBundleState determines the state of the bundle based on the current state
 // of the blockchain and the transactions in the bundle.
 func GetBundleState(
-	chain ChainState,
+	chain ChainStateForBundleEval,
 	envelope *types.Transaction,
 ) BundleState {
 	return getBundleState(chain, envelope, trialRunBundle)
@@ -78,9 +75,9 @@ func GetBundleState(
 // getBundleState is the internal version of GetBundleState, allowing to inject
 // a custom trial-run function to simplify testing.
 func getBundleState(
-	chain ChainState,
+	chain ChainStateForBundleEval,
 	envelope *types.Transaction,
-	trialRunner func(*types.Transaction, ChainState, state.StateDB) bool,
+	trialRunner func(*types.Transaction, ChainStateForBundleEval, state.StateDB) bool,
 ) BundleState {
 	chainId := big.NewInt(int64(chain.GetCurrentNetworkRules().NetworkID))
 	signer := types.LatestSignerForChainID(chainId)
@@ -133,16 +130,10 @@ func getBundleState(
 	return makeRunnableState()
 }
 
-type ChainState interface {
-	// DummyChain needs to be implemented in order to resolve past block hashes.
-	DummyChain
-
-	// GetCurrentNetworkRules returns the current network rules for the EVM.
-	GetCurrentNetworkRules() opera.Rules
-
-	// GetEvmChainConfig returns the chain configuration for the EVM at the
-	// given block height
-	GetEvmChainConfig(blockHeight idx.Block) *params.ChainConfig
+// ChainStateForBundleEval is an extension of the ChainState interface providing
+// extra chain state information for trial-running bundles.
+type ChainStateForBundleEval interface {
+	ChainState
 
 	// StateDB returns a context for running transactions on the head state of
 	// the chain. A non-committable state-DB instance is sufficient. The user
@@ -346,7 +337,7 @@ func (t *nonceTracker) restore(backup *nonceTracker) {
 
 func trialRunBundle(
 	envelope *types.Transaction,
-	chain ChainState,
+	chain ChainStateForBundleEval,
 	stateDb state.StateDB,
 ) bool {
 	// TODO: implement the actual trial-run logic, which should attempt to

--- a/evmcore/bundle_precheck_mock.go
+++ b/evmcore/bundle_precheck_mock.go
@@ -20,32 +20,32 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
-// MockChainState is a mock of ChainState interface.
-type MockChainState struct {
+// MockChainStateForBundleEval is a mock of ChainStateForBundleEval interface.
+type MockChainStateForBundleEval struct {
 	ctrl     *gomock.Controller
-	recorder *MockChainStateMockRecorder
+	recorder *MockChainStateForBundleEvalMockRecorder
 	isgomock struct{}
 }
 
-// MockChainStateMockRecorder is the mock recorder for MockChainState.
-type MockChainStateMockRecorder struct {
-	mock *MockChainState
+// MockChainStateForBundleEvalMockRecorder is the mock recorder for MockChainStateForBundleEval.
+type MockChainStateForBundleEvalMockRecorder struct {
+	mock *MockChainStateForBundleEval
 }
 
-// NewMockChainState creates a new mock instance.
-func NewMockChainState(ctrl *gomock.Controller) *MockChainState {
-	mock := &MockChainState{ctrl: ctrl}
-	mock.recorder = &MockChainStateMockRecorder{mock}
+// NewMockChainStateForBundleEval creates a new mock instance.
+func NewMockChainStateForBundleEval(ctrl *gomock.Controller) *MockChainStateForBundleEval {
+	mock := &MockChainStateForBundleEval{ctrl: ctrl}
+	mock.recorder = &MockChainStateForBundleEvalMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockChainState) EXPECT() *MockChainStateMockRecorder {
+func (m *MockChainStateForBundleEval) EXPECT() *MockChainStateForBundleEvalMockRecorder {
 	return m.recorder
 }
 
 // GetCurrentNetworkRules mocks base method.
-func (m *MockChainState) GetCurrentNetworkRules() opera.Rules {
+func (m *MockChainStateForBundleEval) GetCurrentNetworkRules() opera.Rules {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCurrentNetworkRules")
 	ret0, _ := ret[0].(opera.Rules)
@@ -53,13 +53,13 @@ func (m *MockChainState) GetCurrentNetworkRules() opera.Rules {
 }
 
 // GetCurrentNetworkRules indicates an expected call of GetCurrentNetworkRules.
-func (mr *MockChainStateMockRecorder) GetCurrentNetworkRules() *gomock.Call {
+func (mr *MockChainStateForBundleEvalMockRecorder) GetCurrentNetworkRules() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentNetworkRules", reflect.TypeOf((*MockChainState)(nil).GetCurrentNetworkRules))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentNetworkRules", reflect.TypeOf((*MockChainStateForBundleEval)(nil).GetCurrentNetworkRules))
 }
 
 // GetEvmChainConfig mocks base method.
-func (m *MockChainState) GetEvmChainConfig(blockHeight idx.Block) *params.ChainConfig {
+func (m *MockChainStateForBundleEval) GetEvmChainConfig(blockHeight idx.Block) *params.ChainConfig {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEvmChainConfig", blockHeight)
 	ret0, _ := ret[0].(*params.ChainConfig)
@@ -67,13 +67,13 @@ func (m *MockChainState) GetEvmChainConfig(blockHeight idx.Block) *params.ChainC
 }
 
 // GetEvmChainConfig indicates an expected call of GetEvmChainConfig.
-func (mr *MockChainStateMockRecorder) GetEvmChainConfig(blockHeight any) *gomock.Call {
+func (mr *MockChainStateForBundleEvalMockRecorder) GetEvmChainConfig(blockHeight any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvmChainConfig", reflect.TypeOf((*MockChainState)(nil).GetEvmChainConfig), blockHeight)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvmChainConfig", reflect.TypeOf((*MockChainStateForBundleEval)(nil).GetEvmChainConfig), blockHeight)
 }
 
 // GetLatestHeader mocks base method.
-func (m *MockChainState) GetLatestHeader() *EvmHeader {
+func (m *MockChainStateForBundleEval) GetLatestHeader() *EvmHeader {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestHeader")
 	ret0, _ := ret[0].(*EvmHeader)
@@ -81,13 +81,13 @@ func (m *MockChainState) GetLatestHeader() *EvmHeader {
 }
 
 // GetLatestHeader indicates an expected call of GetLatestHeader.
-func (mr *MockChainStateMockRecorder) GetLatestHeader() *gomock.Call {
+func (mr *MockChainStateForBundleEvalMockRecorder) GetLatestHeader() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHeader", reflect.TypeOf((*MockChainState)(nil).GetLatestHeader))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHeader", reflect.TypeOf((*MockChainStateForBundleEval)(nil).GetLatestHeader))
 }
 
 // Header mocks base method.
-func (m *MockChainState) Header(hash common.Hash, number uint64) *EvmHeader {
+func (m *MockChainStateForBundleEval) Header(hash common.Hash, number uint64) *EvmHeader {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Header", hash, number)
 	ret0, _ := ret[0].(*EvmHeader)
@@ -95,13 +95,13 @@ func (m *MockChainState) Header(hash common.Hash, number uint64) *EvmHeader {
 }
 
 // Header indicates an expected call of Header.
-func (mr *MockChainStateMockRecorder) Header(hash, number any) *gomock.Call {
+func (mr *MockChainStateForBundleEvalMockRecorder) Header(hash, number any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockChainState)(nil).Header), hash, number)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockChainStateForBundleEval)(nil).Header), hash, number)
 }
 
 // StateDB mocks base method.
-func (m *MockChainState) StateDB() state.StateDB {
+func (m *MockChainStateForBundleEval) StateDB() state.StateDB {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateDB")
 	ret0, _ := ret[0].(state.StateDB)
@@ -109,9 +109,9 @@ func (m *MockChainState) StateDB() state.StateDB {
 }
 
 // StateDB indicates an expected call of StateDB.
-func (mr *MockChainStateMockRecorder) StateDB() *gomock.Call {
+func (mr *MockChainStateForBundleEvalMockRecorder) StateDB() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateDB", reflect.TypeOf((*MockChainState)(nil).StateDB))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateDB", reflect.TypeOf((*MockChainStateForBundleEval)(nil).StateDB))
 }
 
 // MockNonceSource is a mock of NonceSource interface.

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -36,7 +36,7 @@ import (
 
 func Test_GetBundleState_BundlesDisabled_ReturnsNonExecutable(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	chainState := NewMockChainState(ctrl)
+	chainState := NewMockChainStateForBundleEval(ctrl)
 	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
 		NetworkID: 1,
 		Upgrades:  opera.Upgrades{TransactionBundles: false},
@@ -52,7 +52,7 @@ func Test_GetBundleState_BundlesDisabled_ReturnsNonExecutable(t *testing.T) {
 
 func Test_GetBundleState_InvalidBundle_ReturnsNonExecutable(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	chainState := NewMockChainState(ctrl)
+	chainState := NewMockChainStateForBundleEval(ctrl)
 	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
 		NetworkID: 1,
 		Upgrades:  opera.Upgrades{TransactionBundles: true},
@@ -68,7 +68,7 @@ func Test_GetBundleState_InvalidBundle_ReturnsNonExecutable(t *testing.T) {
 
 func Test_GetBundleState_OutdatedBundle_ReturnsNonExecutable(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	chainState := NewMockChainState(ctrl)
+	chainState := NewMockChainStateForBundleEval(ctrl)
 
 	currentBlock := uint64(100)
 	currentHeader := &EvmHeader{
@@ -93,7 +93,7 @@ func Test_GetBundleState_OutdatedBundle_ReturnsNonExecutable(t *testing.T) {
 
 func Test_GetBundleState_FutureBundle_ReturnsTemporaryBlocked(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	chainState := NewMockChainState(ctrl)
+	chainState := NewMockChainStateForBundleEval(ctrl)
 
 	currentBlock := uint64(100)
 	currentHeader := &EvmHeader{
@@ -122,7 +122,7 @@ func Test_GetBundleState_FutureBundle_ReturnsTemporaryBlocked(t *testing.T) {
 func Test_GetBundleState_FailedTrialRun_ReturnsNonExecutable(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
-	chainState := NewMockChainState(ctrl)
+	chainState := NewMockChainStateForBundleEval(ctrl)
 	stateDb := state.NewMockStateDB(ctrl)
 	stateDb.EXPECT().InterTxSnapshot().Return(12)
 	stateDb.EXPECT().RevertToInterTxSnapshot(12)
@@ -144,7 +144,7 @@ func Test_GetBundleState_FailedTrialRun_ReturnsNonExecutable(t *testing.T) {
 		SetLatest(currentBlock + 5).
 		Build()
 
-	rejectEverything := func(*types.Transaction, ChainState, state.StateDB) bool {
+	rejectEverything := func(*types.Transaction, ChainStateForBundleEval, state.StateDB) bool {
 		return false
 	}
 
@@ -154,7 +154,7 @@ func Test_GetBundleState_FailedTrialRun_ReturnsNonExecutable(t *testing.T) {
 
 func Test_GetBundleState_ValidBundle_ReturnsRunnable(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	chainState := NewMockChainState(ctrl)
+	chainState := NewMockChainStateForBundleEval(ctrl)
 	stateDb := state.NewMockStateDB(ctrl)
 	stateDb.EXPECT().InterTxSnapshot().Return(12)
 	stateDb.EXPECT().RevertToInterTxSnapshot(12)
@@ -177,7 +177,7 @@ func Test_GetBundleState_ValidBundle_ReturnsRunnable(t *testing.T) {
 		SetLatest(currentBlock + 5).
 		Build()
 
-	acceptEverything := func(*types.Transaction, ChainState, state.StateDB) bool {
+	acceptEverything := func(*types.Transaction, ChainStateForBundleEval, state.StateDB) bool {
 		return true
 	}
 
@@ -234,7 +234,7 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 			currentHeader := &EvmHeader{
 				Number: big.NewInt(0),
 			}
-			chainState := NewMockChainState(ctrl)
+			chainState := NewMockChainStateForBundleEval(ctrl)
 			chainState.EXPECT().GetLatestHeader().Return(currentHeader).AnyTimes()
 			chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
 				NetworkID: 1,
@@ -250,7 +250,7 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 			_, _, err := bundle.ValidateEnvelope(signer, envelope)
 			require.NoError(t, err)
 
-			acceptEverything := func(*types.Transaction, ChainState, state.StateDB) bool {
+			acceptEverything := func(*types.Transaction, ChainStateForBundleEval, state.StateDB) bool {
 				return true
 			}
 

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -18,8 +18,10 @@ package evmcore
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -576,6 +578,46 @@ func (e evm) _runTransaction(
 		return ProcessedTransaction{Transaction: tx}
 	}
 	return ProcessedTransaction{Transaction: tx, Receipt: receipt}
+}
+
+// ---
+
+// ChainState provides access to the chain state retained by the client required
+// for test-running transactions.
+type ChainState interface {
+	// DummyChain needs to be implemented in order to resolve past block hashes.
+	// TODO: follow-up task - simplify this to a GetBlockHash(idx.Block) method.
+	DummyChain
+
+	// GetCurrentNetworkRules returns the current network rules for the EVM.
+	GetCurrentNetworkRules() opera.Rules
+
+	// GetEvmChainConfig returns the chain configuration for the EVM at the
+	// given block height
+	GetEvmChainConfig(blockHeight idx.Block) *params.ChainConfig
+}
+
+// NewTransactionProcessorForBlock creates a new transaction processor to be used
+// for trial-running transaction sequences (e.g. in the emitter) in the context
+// of the given block.
+func NewTransactionProcessorForBlock(
+	chain ChainState,
+	state state.StateDB,
+	block *EvmBlock,
+) *TransactionProcessor {
+	// TODO: follow-up task - align this with c_block_callbacks.go
+	// see https://github.com/0xsoniclabs/sonic-admin/issues/227
+	chainCfg := chain.GetEvmChainConfig(idx.Block(block.Header().Number.Uint64()))
+	vmConfig := opera.GetVmConfig(chain.GetCurrentNetworkRules())
+
+	// The gas limit for transactions is enforced on a per-transaction level
+	// in the scheduler. See the scheduler.Schedule method for details. The
+	// total gas used for attempting to schedule transactions is not limited.
+	gasLimit := uint64(math.MaxUint64)
+	stateProcessor := NewStateProcessor(
+		chainCfg, chain, chain.GetCurrentNetworkRules().Upgrades,
+	)
+	return stateProcessor.BeginBlock(block, state, vmConfig, gasLimit, nil)
 }
 
 // BeginBlock starts the processing of a new block and returns a function to

--- a/evmcore/state_processor_mock.go
+++ b/evmcore/state_processor_mock.go
@@ -13,8 +13,11 @@ import (
 	reflect "reflect"
 
 	core_types "github.com/0xsoniclabs/sonic/evmcore/core_types"
+	opera "github.com/0xsoniclabs/sonic/opera"
+	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
 	common "github.com/ethereum/go-ethereum/common"
 	types "github.com/ethereum/go-ethereum/core/types"
+	params "github.com/ethereum/go-ethereum/params"
 	uint256 "github.com/holiman/uint256"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -154,6 +157,72 @@ func (m *Mock_evm) runWithoutBaseFeeCheck(arg0 *runContext, arg1 *types.Transact
 func (mr *Mock_evmMockRecorder) runWithoutBaseFeeCheck(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runWithoutBaseFeeCheck", reflect.TypeOf((*Mock_evm)(nil).runWithoutBaseFeeCheck), arg0, arg1, arg2)
+}
+
+// MockChainState is a mock of ChainState interface.
+type MockChainState struct {
+	ctrl     *gomock.Controller
+	recorder *MockChainStateMockRecorder
+	isgomock struct{}
+}
+
+// MockChainStateMockRecorder is the mock recorder for MockChainState.
+type MockChainStateMockRecorder struct {
+	mock *MockChainState
+}
+
+// NewMockChainState creates a new mock instance.
+func NewMockChainState(ctrl *gomock.Controller) *MockChainState {
+	mock := &MockChainState{ctrl: ctrl}
+	mock.recorder = &MockChainStateMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockChainState) EXPECT() *MockChainStateMockRecorder {
+	return m.recorder
+}
+
+// GetCurrentNetworkRules mocks base method.
+func (m *MockChainState) GetCurrentNetworkRules() opera.Rules {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentNetworkRules")
+	ret0, _ := ret[0].(opera.Rules)
+	return ret0
+}
+
+// GetCurrentNetworkRules indicates an expected call of GetCurrentNetworkRules.
+func (mr *MockChainStateMockRecorder) GetCurrentNetworkRules() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentNetworkRules", reflect.TypeOf((*MockChainState)(nil).GetCurrentNetworkRules))
+}
+
+// GetEvmChainConfig mocks base method.
+func (m *MockChainState) GetEvmChainConfig(blockHeight idx.Block) *params.ChainConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEvmChainConfig", blockHeight)
+	ret0, _ := ret[0].(*params.ChainConfig)
+	return ret0
+}
+
+// GetEvmChainConfig indicates an expected call of GetEvmChainConfig.
+func (mr *MockChainStateMockRecorder) GetEvmChainConfig(blockHeight any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvmChainConfig", reflect.TypeOf((*MockChainState)(nil).GetEvmChainConfig), blockHeight)
+}
+
+// Header mocks base method.
+func (m *MockChainState) Header(hash common.Hash, number uint64) *EvmHeader {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Header", hash, number)
+	ret0, _ := ret[0].(*EvmHeader)
+	return ret0
+}
+
+// Header indicates an expected call of Header.
+func (mr *MockChainStateMockRecorder) Header(hash, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockChainState)(nil).Header), hash, number)
 }
 
 // Mocklogger is a mock of logger interface.

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/contracts/sfc"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
+	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -3226,4 +3227,45 @@ func collectAllReferencedTransactionNonces(
 		res = append(res, int(tx.Nonce()))
 	}
 	return res
+}
+
+func TestNewTransactionProcessorForBlock_ConfiguresTransactionProcessorWithValuesFromParameters(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+
+	block := &EvmBlock{
+		EvmHeader: EvmHeader{
+			Number: big.NewInt(123),
+		},
+	}
+
+	chainCfg := &params.ChainConfig{
+		ChainID: big.NewInt(456),
+	}
+	currentRules := opera.Rules{
+		Name: "unit-test-net",
+		Upgrades: opera.Upgrades{
+			Berlin: true,
+			Brio:   true,
+		},
+	}
+
+	chain := NewMockChainState(ctrl)
+	chain.EXPECT().GetEvmChainConfig(idx.Block(block.Number.Uint64())).Return(chainCfg)
+	chain.EXPECT().GetCurrentNetworkRules().Return(currentRules).AnyTimes()
+
+	state := state.NewMockStateDB(ctrl)
+
+	processor := NewTransactionProcessorForBlock(chain, state, block)
+
+	require.Equal(block.Number, processor.blockNumber)
+	require.NotNil(processor.gp)
+	require.Equal(uint64(math.MaxUint64), processor.gp.Gas())
+	require.Equal(block.Header(), processor.header)
+	require.Nil(processor.onNewLog)
+	require.Equal(types.LatestSignerForChainID(chainCfg.ChainID), processor.signer)
+	require.Equal(state, processor.stateDb)
+	require.EqualValues(0, processor.usedGas)
+	require.NotNil(processor.vmEnvironment)
+	require.Equal(currentRules.Upgrades, processor.upgrades)
 }

--- a/gossip/emitter/scheduler/processor.go
+++ b/gossip/emitter/scheduler/processor.go
@@ -17,14 +17,9 @@
 package scheduler
 
 import (
-	"math"
-
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/inter/state"
-	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 //go:generate mockgen -source=processor.go -destination=processor_mock.go -package=scheduler
@@ -53,16 +48,7 @@ type processor interface {
 // Chain provides access to the chain state retained by the client required for
 // test-running transactions.
 type Chain interface {
-	// DummyChain needs to be implemented in order to resolve past block hashes.
-	// TODO: follow-up task - simplify this to a GetBlockHash(idx.Block) method.
-	evmcore.DummyChain
-
-	// GetCurrentNetworkRules returns the current network rules for the EVM.
-	GetCurrentNetworkRules() opera.Rules
-
-	// GetEvmChainConfig returns the chain configuration for the EVM at the
-	// given block height
-	GetEvmChainConfig(blockHeight idx.Block) *params.ChainConfig
+	evmcore.ChainState
 
 	// StateDB returns a context for running transactions on the head state of
 	// the chain. A non-committable state-DB instance is sufficient.
@@ -80,20 +66,9 @@ type evmProcessorFactory struct {
 func (p *evmProcessorFactory) beginBlock(
 	block *evmcore.EvmBlock,
 ) processor {
-	// TODO: follow-up task - align this with c_block_callbacks.go
-	chainCfg := p.chain.GetEvmChainConfig(idx.Block(block.Header().Number.Uint64()))
-	vmConfig := opera.GetVmConfig(p.chain.GetCurrentNetworkRules())
 	state := p.chain.StateDB()
-
-	// The gas limit for transactions is enforced on a per-transaction level
-	// in the scheduler. See the scheduler.Schedule method for details. The
-	// total gas used for attempting to schedule transactions is not limited.
-	gasLimit := uint64(math.MaxUint64)
-	stateProcessor := evmcore.NewStateProcessor(
-		chainCfg, p.chain, p.chain.GetCurrentNetworkRules().Upgrades,
-	)
 	return &evmProcessor{
-		processor: stateProcessor.BeginBlock(block, state, vmConfig, gasLimit, nil),
+		processor: evmcore.NewTransactionProcessorForBlock(p.chain, state, block),
 		stateDb:   state,
 	}
 }

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -241,7 +241,7 @@ func (em *Emitter) isValidBundleTx(tx *types.Transaction) bool {
 
 func (em *Emitter) isRunnableBundleTxInternal(
 	tx *types.Transaction,
-	getBundleState func(evmcore.ChainState, *types.Transaction) evmcore.BundleState,
+	getBundleState func(evmcore.ChainStateForBundleEval, *types.Transaction) evmcore.BundleState,
 ) bool {
 	// Ignore if bundled transactions are not enabled.
 	if !em.world.GetRules().Upgrades.TransactionBundles {

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -76,7 +76,7 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(err)
 
-			allBundlesRunnable := func(evmcore.ChainState, *types.Transaction) evmcore.BundleState {
+			allBundlesRunnable := func(evmcore.ChainStateForBundleEval, *types.Transaction) evmcore.BundleState {
 				return evmcore.BundleState{Executable: true}
 			}
 
@@ -155,7 +155,7 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(t, err)
 
-			getBundleState := func(evmcore.ChainState, *types.Transaction) evmcore.BundleState {
+			getBundleState := func(evmcore.ChainStateForBundleEval, *types.Transaction) evmcore.BundleState {
 				return evmcore.BundleState{Executable: true}
 			}
 


### PR DESCRIPTION
This PR factors out the setup of a step-by-step transaction processor from the single proposer scheduling code to facilitate reuse in the bundle trial-running tests added by #882.

This PR does not add new features. It mainly moves code and an affiliated interface from `emitter/scheduler/processor.go` to the `NewTransactionProcessorForBlock` function in `evmcore/state_processor.go`. The rest is resolving a name conflict (the `ChainState` for the bundle eval is renamed to `ChainStateForBundleEval`).