### PR TITLE
Refactor integration tests to account for tx pool filtering non-executable bundles. 

### DIFF
--- a/tests/bundles/only_run_once_test.go
+++ b/tests/bundles/only_run_once_test.go
@@ -79,10 +79,16 @@ func TestBundle_RunOnlyOnce_ExecutionPlanSubmittedMultipleTimesInDifferentEnvelo
 	}
 
 	// Submit the same bundle multiple times using different envelopes.
-	sentHashes, _, err := net.TrySendAll(envelopes)
+	sentHashes, rejected, err := net.TrySendAll(envelopes)
 	require.NoError(err)
-	require.GreaterOrEqual(len(sentHashes), 2,
-		"For this test to be meanigfull, at least 2 envelopes should have been accepted for processing simultaneously")
+	acceptedCount := 0
+	for _, hash := range sentHashes {
+		if hash != (common.Hash{}) {
+			acceptedCount++
+		}
+	}
+	require.GreaterOrEqual(acceptedCount, 2,
+		"For this test to be meaningful, at least 2 envelopes should have been accepted for processing simultaneously; rejected=%v", rejected)
 
 	bundleTxs := b.GetTransactionsInReferencedOrder()
 

--- a/tests/bundles/only_run_once_test.go
+++ b/tests/bundles/only_run_once_test.go
@@ -35,13 +35,7 @@ func TestBundle_RunOnlyOnce_ExecutionPlanSubmittedMultipleTimesInDifferentEnvelo
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.TransactionBundles = true
 
-	net := tests.StartIntegrationTestNet(t,
-		tests.IntegrationTestNetOptions{
-			Upgrades: &upgrades,
-			ClientExtraArguments: []string{
-				"--disable-txPool-validation",
-			},
-		})
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{Upgrades: &upgrades})
 
 	client, err := net.GetClient()
 	require.NoError(err)

--- a/tests/bundles/only_run_once_test.go
+++ b/tests/bundles/only_run_once_test.go
@@ -35,9 +35,13 @@ func TestBundle_RunOnlyOnce_ExecutionPlanSubmittedMultipleTimesInDifferentEnvelo
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.TransactionBundles = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := tests.StartIntegrationTestNet(t,
+		tests.IntegrationTestNetOptions{
+			Upgrades: &upgrades,
+			ClientExtraArguments: []string{
+				"--disable-txPool-validation",
+			},
+		})
 
 	client, err := net.GetClient()
 	require.NoError(err)
@@ -75,8 +79,10 @@ func TestBundle_RunOnlyOnce_ExecutionPlanSubmittedMultipleTimesInDifferentEnvelo
 	}
 
 	// Submit the same bundle multiple times using different envelopes.
-	_, err = net.SendAll(envelopes)
+	sentHashes, _, err := net.TrySendAll(envelopes)
 	require.NoError(err)
+	require.GreaterOrEqual(len(sentHashes), 2,
+		"For this test to be meanigfull, at least 2 envelopes should have been accepted for processing simultaneously")
 
 	bundleTxs := b.GetTransactionsInReferencedOrder()
 
@@ -88,6 +94,11 @@ func TestBundle_RunOnlyOnce_ExecutionPlanSubmittedMultipleTimesInDifferentEnvelo
 	// Transaction B should not be executed.
 	receiptB, err := client.TransactionReceipt(t.Context(), bundleTxs[1].Hash())
 	require.ErrorIs(err, ethereum.NotFound, "Got receipt A: %+v, receipt B: %+v", receiptA, receiptB)
+
+	// Bundle has been registered
+	info, err := GetBundleInfo(t.Context(), client.Client(), b.Plan.Hash())
+	require.NoError(err)
+	require.EqualValues(1, info.Count)
 }
 
 func TestBundle_RunOnlyOnce_NestedBundleSubmittedMultipleTimesInSameBundleIsOnlyProcessedOnce(t *testing.T) {

--- a/tests/bundles/sponsored_transaction_test.go
+++ b/tests/bundles/sponsored_transaction_test.go
@@ -140,7 +140,7 @@ func TestBundle_RevertedBundleDoesNotConsumeSponsoredFunds(t *testing.T) {
 	gas_subsidies.Fund(t, net, sponsoredSender.Address(), fundsForOneExecution)
 
 	// Create a regular sender with funds.
-	sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+	senders := tests.MakeAccountsWithBalance(t, net, 2, big.NewInt(1e18))
 
 	blockNumber, err := client.BlockNumber(t.Context())
 	require.NoError(t, err)
@@ -157,14 +157,21 @@ func TestBundle_RevertedBundleDoesNotConsumeSponsoredFunds(t *testing.T) {
 	envelope, _, plan := bundle.NewBuilder().
 		WithSigner(signer).
 		SetEarliest(blockNumber).
-		AllOf(
-			bundle.Step(
-				sponsoredSender.PrivateKey,
-				sponsoredTxData,
+		OneOf(
+			bundle.AllOf(
+				bundle.Step(
+					sponsoredSender.PrivateKey,
+					sponsoredTxData,
+				),
+				// This transaction will revert due to insufficient gas
+				Step(t, net, senders[0], &types.AccessListTx{Gas: 1}),
 			),
-			// This transaction will revert due to insufficient gas
-			Step(t, net, sender, &types.AccessListTx{Gas: 1}),
+			// this transaction makes sure that the bundle yields results
+			// even if the inner group is reverted
+			Step(t, net, senders[1], &types.AccessListTx{}),
 		).
+		// AllOf(
+		// ).
 		BuildEnvelopeBundleAndPlan()
 
 	// Run the bundle.

--- a/tests/bundles/sponsored_transaction_test.go
+++ b/tests/bundles/sponsored_transaction_test.go
@@ -166,12 +166,11 @@ func TestBundle_RevertedBundleDoesNotConsumeSponsoredFunds(t *testing.T) {
 				// This transaction will revert due to insufficient gas
 				Step(t, net, senders[0], &types.AccessListTx{Gas: 1}),
 			),
-			// this transaction makes sure that the bundle yields results
-			// even if the inner group is reverted
+			// This fallback transaction ensures the bundle as a whole is still executable,
+			// so the test verifies that only the sponsored transaction's group is reverted,
+			// not the entire bundle.
 			Step(t, net, senders[1], &types.AccessListTx{}),
 		).
-		// AllOf(
-		// ).
 		BuildEnvelopeBundleAndPlan()
 
 	// Run the bundle.


### PR DESCRIPTION
Some tests relied on the capability of non-executable bundles reaching the block processor. 
This PR attempts to rewrite the tests to keep testing the desired side effects, but contemplating that non-executable bundles will not reach the consensus layer. 