### PR TITLE
Refactor tx list to reflect tx transitions regarding bundles executability. 

### DIFF
--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -1,0 +1,33 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package evmcore
+
+// bundlePoolStatus represents the status of a bundle in the transaction pool,
+// which can be pending, queued, or rejected. This type is used to
+// manage transitions from queued to pending, pending to queued, queued to
+// rejected, and pending to rejected, based on the evaluation of the bundle's
+// executability.
+type bundlePoolStatus int
+
+const (
+	// bundlePending, the bundle hasn't yet been executed and trial-run is positive
+	bundlePending bundlePoolStatus = iota
+	// bundleQueued, the bundle hasn't yet been executed but trial-run is negative
+	bundleQueued
+	// bundleRejected, the bundle has been executed, or is not valid
+	bundleRejected
+)

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -195,9 +195,9 @@ func (m *txSortedMap) Remove(nonce uint64) bool {
 	return true
 }
 
-// Ready pops a contiguous run of transactions whose nonces begin at start and
-// are sequentially increasing, returning them for promotion from the queued
-// list into the pending list. Each candidate is passed through isExecutable;
+// Ready pops a contiguous list of transactions with incremental nonces,
+// returning them for promotion from the queued list into the pending list.
+// Each candidate is passed through isExecutable;
 // the run stops at the first transaction that returns false. This gate is
 // used to keep bundle envelope transactions in the queue when a trial-run
 // against the current state shows they are not yet executable (e.g. an
@@ -426,26 +426,25 @@ func (l *txList) Filter(
 	// If the list was strict, filter anything above the lowest nonce
 	var invalids types.Transactions
 	if l.strict {
-		maxExecutableNonce := uint64(math.MaxUint64)
+		firstInvalidNonce := uint64(math.MaxUint64)
 		for _, tx := range removed {
-			maxExecutableNonce = min(maxExecutableNonce, tx.Nonce())
+			firstInvalidNonce = min(firstInvalidNonce, tx.Nonce())
 		}
 
-		// invalidate any pending bundle with nonce less than the
-		// nonce of any removed transaction which is temporarily blocked
+		// bundles with valid nonces but non-pending status are also invalidated
 		invalidBundles := l.txs.filter(func(tx *types.Transaction) bool {
 			return bundle.IsEnvelope(tx) &&
-				tx.Nonce() < maxExecutableNonce &&
+				tx.Nonce() < firstInvalidNonce &&
 				evaluateBundleStatus(tx) == bundleQueued
 		})
 		for _, tx := range invalidBundles {
-			maxExecutableNonce = min(maxExecutableNonce, tx.Nonce())
+			firstInvalidNonce = min(firstInvalidNonce, tx.Nonce())
 		}
 
 		// invalidate any transaction with nonce greater than any
 		// removed transaction
 		invalids = l.txs.filter(func(tx *types.Transaction) bool {
-			return tx.Nonce() > maxExecutableNonce
+			return tx.Nonce() > firstInvalidNonce
 		})
 
 		// invalids are to be demoted from pending to queued, and therefore

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -100,11 +100,9 @@ func (m *txSortedMap) Forward(threshold uint64) types.Transactions {
 	return removed
 }
 
-// Filter iterates over the list of transactions and removes all of them for which
-// the specified function evaluates to true.
-// Filter, as opposed to 'filter', re-initialises the heap after the operation is done.
-// If you want to do several consecutive filterings, it's therefore better to first
-// do a .filter(func1) followed by .Filter(func2) or reheap()
+// Filter removes every transaction for which the predicate returns true and
+// rebuilds the nonce heap afterwards. Use the unexported filter method
+// instead when chaining multiple passes, followed by a single reheap call.
 func (m *txSortedMap) Filter(filter func(*types.Transaction) bool) types.Transactions {
 	removed := m.filter(filter)
 	// If transactions were removed, the heap and cache are ruined
@@ -197,14 +195,21 @@ func (m *txSortedMap) Remove(nonce uint64) bool {
 	return true
 }
 
-// Ready retrieves a sequentially increasing list of transactions starting at the
-// provided nonce that is ready for processing. The returned transactions will be
-// removed from the list.
+// Ready pops a contiguous run of transactions whose nonces begin at start and
+// are sequentially increasing, returning them for promotion from the queued
+// list into the pending list. Each candidate is passed through isExecutable;
+// the run stops at the first transaction that returns false. This gate is
+// used to keep bundle envelope transactions in the queue when a trial-run
+// against the current state shows they are not yet executable (e.g. an
+// inner transaction's preconditions are not met). Regular and sponsored
+// transactions always pass the check.
 //
-// Note, all transactions with nonces lower than start will also be returned to
-// prevent getting into and invalid state. This is not something that should ever
-// happen but better to be self correcting than failing!
-func (m *txSortedMap) Ready(start uint64) types.Transactions {
+// Transactions with nonces below start are also popped to self-correct any
+// stale entries that should have been forwarded already.
+func (m *txSortedMap) Ready(
+	start uint64,
+	isExecutable func(*types.Transaction) bool,
+) types.Transactions {
 	// Short circuit if no transactions are available
 	if m.index.Len() == 0 || (*m.index)[0] > start {
 		return nil
@@ -212,7 +217,12 @@ func (m *txSortedMap) Ready(start uint64) types.Transactions {
 	// Otherwise start accumulating incremental transactions
 	var ready types.Transactions
 	for next := (*m.index)[0]; m.index.Len() > 0 && (*m.index)[0] == next; next++ {
-		ready = append(ready, m.items[next])
+		tx := m.items[next]
+		if !isExecutable(tx) {
+			break
+		}
+
+		ready = append(ready, tx)
 		delete(m.items, next)
 		heap.Pop(m.index)
 	}
@@ -349,34 +359,59 @@ func (l *txList) Forward(threshold uint64) types.Transactions {
 	return l.txs.Forward(threshold)
 }
 
-// Filter removes all transactions from the list with a cost or gas limit higher
-// than the provided thresholds. Every removed transaction is returned for any
-// post-removal maintenance. Strict-mode invalidated transactions are also
-// returned.
+// Filter inspects every transaction in the list and classifies it as dropped,
+// invalidated, or kept, based on the account's balance, the current gas limit,
+// the sponsorship status, and the bundle execution state.
 //
-// This method uses the cached costcap and gascap to quickly decide if there's even
-// a point in calculating all the costs or if the balance covers all. If the threshold
-// is lower than the costgas cap, the caps will be reset to a new high after removing
-// the newly invalidated transactions.
+// A transaction is dropped (permanently removed) when:
+//   - Its cost exceeds costLimit and it is not a sponsored or bundle tx.
+//   - Its gas exceeds gasLimit and it is not a sponsored or bundle tx.
+//   - It is a sponsorship request whose sponsorship is no longer active
+//     (isSponsored returns false).
+//   - It is a bundle envelope whose status is bundleRejected (e.g. already
+//     executed or structurally invalid).
+//
+// In strict mode (pending list), after drops are removed, any remaining
+// transactions that would create a nonce gap are invalidated and returned
+// separately so the caller can demote them back to the queued list.
+// Bundle envelopes with a nonce below the gap whose status is bundleQueued
+// (temporarily non-executable) are also invalidated, since they block the
+// nonce sequence.
+//
+// In non-strict mode (queued list), the second return value is always nil
+// because gapped nonces are expected.
+//
+// The method short-circuits via the cached costcap/gascap when no sponsored
+// or bundle transactions are present and the caps are within limits.
 func (l *txList) Filter(
 	costLimit *big.Int,
 	gasLimit uint64,
 	isSponsored utils.TransactionCheckFunc,
+	evaluateBundleStatus func(*types.Transaction) bundlePoolStatus,
 ) (types.Transactions, types.Transactions) {
+
 	hasSponsored := l.txs.containsFunc(subsidies.IsSponsorshipRequest)
+	hasBundles := l.txs.containsFunc(bundle.IsEnvelope)
 
 	// If all transactions are below the threshold, short circuit
-	if !hasSponsored && l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
+	if !hasSponsored && !hasBundles && l.costcap.Cmp(costLimit) <= 0 && l.gascap <= gasLimit {
 		return nil, nil
 	}
 	l.costcap = new(big.Int).Set(costLimit) // Lower the caps to the thresholds
 	l.gascap = gasLimit
 
+	var bundleInvalidated bool
+
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
+		// Bundle transactions need to be checked before sponsored transactions
+		// since bundle envelopes may qualify as sponsored transactions.
 		if bundle.IsEnvelope(tx) {
-			// TODO: filter out permanently blocked bundles
-			return false
+			status := evaluateBundleStatus(tx)
+			if status != bundlePending {
+				bundleInvalidated = true
+			}
+			return status == bundleRejected
 		}
 		if subsidies.IsSponsorshipRequest(tx) {
 			return !isSponsored(tx)
@@ -384,21 +419,43 @@ func (l *txList) Filter(
 		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit) > 0
 	})
 
-	if len(removed) == 0 {
+	if len(removed) == 0 && !bundleInvalidated {
 		return nil, nil
 	}
-	var invalids types.Transactions
+
 	// If the list was strict, filter anything above the lowest nonce
+	var invalids types.Transactions
 	if l.strict {
-		lowest := uint64(math.MaxUint64)
+		maxExecutableNonce := uint64(math.MaxUint64)
 		for _, tx := range removed {
-			if nonce := tx.Nonce(); lowest > nonce {
-				lowest = nonce
-			}
+			maxExecutableNonce = min(maxExecutableNonce, tx.Nonce())
 		}
-		invalids = l.txs.filter(func(tx *types.Transaction) bool { return tx.Nonce() > lowest })
+
+		// invalidate any pending bundle with nonce less than the
+		// nonce of any removed transaction which is temporarily blocked
+		invalidBundles := l.txs.filter(func(tx *types.Transaction) bool {
+			return bundle.IsEnvelope(tx) &&
+				tx.Nonce() < maxExecutableNonce &&
+				evaluateBundleStatus(tx) == bundleQueued
+		})
+		for _, tx := range invalidBundles {
+			maxExecutableNonce = min(maxExecutableNonce, tx.Nonce())
+		}
+
+		// invalidate any transaction with nonce greater than any
+		// removed transaction
+		invalids = l.txs.filter(func(tx *types.Transaction) bool {
+			return tx.Nonce() > maxExecutableNonce
+		})
+
+		// invalids are to be demoted from pending to queued, and therefore
+		// are re-queued by the caller, who owns both tx lists.
+		invalids = append(invalidBundles, invalids...)
+
+		if len(invalids) > 0 {
+			l.txs.reheap()
+		}
 	}
-	l.txs.reheap()
 	return removed, invalids
 }
 
@@ -424,15 +481,22 @@ func (l *txList) Remove(tx *types.Transaction) (bool, types.Transactions) {
 	return true, nil
 }
 
-// Ready retrieves a sequentially increasing list of transactions starting at the
-// provided nonce that is ready for processing. The returned transactions will be
-// removed from the list.
+// Ready returns and removes a contiguous run of transactions starting at
+// start that are eligible for promotion from queued to pending. The
+// isExecutable callback gates each transaction: regular and sponsored
+// transactions always pass, while bundle envelopes are only promoted when
+// a trial-run against the current chain state confirms they are executable.
+// The run stops at the first transaction that fails the check, leaving it
+// and all higher-nonce transactions in the queue for a future promotion
+// pass.
 //
-// Note, all transactions with nonces lower than start will also be returned to
-// prevent getting into and invalid state. This is not something that should ever
-// happen but better to be self correcting than failing!
-func (l *txList) Ready(start uint64) types.Transactions {
-	return l.txs.Ready(start)
+// Transactions with nonces below start are also returned to self-correct
+// stale entries.
+func (l *txList) Ready(
+	start uint64,
+	isExecutable func(*types.Transaction) bool,
+) types.Transactions {
+	return l.txs.Ready(start, isExecutable)
 }
 
 // Len returns the length of the transaction list.

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -399,7 +399,7 @@ func (l *txList) Filter(
 	l.costcap = new(big.Int).Set(costLimit) // Lower the caps to the thresholds
 	l.gascap = gasLimit
 
-	var bundleInvalidated bool
+	var containsNonExecutableBundles bool
 
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
@@ -408,7 +408,7 @@ func (l *txList) Filter(
 		if bundle.IsEnvelope(tx) {
 			status := evaluateBundleStatus(tx)
 			if status != bundlePending {
-				bundleInvalidated = true
+				containsNonExecutableBundles = true
 			}
 			return status == bundleRejected
 		}
@@ -418,7 +418,7 @@ func (l *txList) Filter(
 		return tx.Gas() > gasLimit || tx.Cost().Cmp(costLimit) > 0
 	})
 
-	if len(removed) == 0 && !bundleInvalidated {
+	if len(removed) == 0 && !containsNonExecutableBundles {
 		return nil, nil
 	}
 
@@ -430,13 +430,13 @@ func (l *txList) Filter(
 			firstInvalidNonce = min(firstInvalidNonce, tx.Nonce())
 		}
 
-		// bundles with valid nonces but non-pending status are also invalidated
-		invalidBundles := l.txs.filter(func(tx *types.Transaction) bool {
+		// bundle envelopes with valid nonces but non-pending status are demoted
+		demotedEnvelopes := l.txs.filter(func(tx *types.Transaction) bool {
 			return bundle.IsEnvelope(tx) &&
 				tx.Nonce() < firstInvalidNonce &&
 				evaluateBundleStatus(tx) == bundleQueued
 		})
-		for _, tx := range invalidBundles {
+		for _, tx := range demotedEnvelopes {
 			firstInvalidNonce = min(firstInvalidNonce, tx.Nonce())
 		}
 
@@ -448,7 +448,7 @@ func (l *txList) Filter(
 
 		// invalids are to be demoted from pending to queued, and therefore
 		// are re-queued by the caller, who owns both tx lists.
-		invalids = append(invalidBundles, invalids...)
+		invalids = append(demotedEnvelopes, invalids...)
 
 		if len(invalids) > 0 {
 			l.txs.reheap()

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -197,13 +197,8 @@ func (m *txSortedMap) Remove(nonce uint64) bool {
 
 // Ready pops a contiguous list of transactions with incremental nonces,
 // returning them for promotion from the queued list into the pending list.
-// Each candidate is passed through isExecutable;
-// the run stops at the first transaction that returns false. This gate is
-// used to keep bundle envelope transactions in the queue when a trial-run
-// against the current state shows they are not yet executable (e.g. an
-// inner transaction's preconditions are not met). Regular and sponsored
-// transactions always pass the check.
-//
+// Each candidate is passed through isExecutable; the run stops at the first
+// transaction that returns false.
 // Transactions with nonces below start are also popped to self-correct any
 // stale entries that should have been forwarded already.
 func (m *txSortedMap) Ready(
@@ -359,9 +354,12 @@ func (l *txList) Forward(threshold uint64) types.Transactions {
 	return l.txs.Forward(threshold)
 }
 
-// Filter inspects every transaction in the list and classifies it as dropped,
-// invalidated, or kept, based on the account's balance, the current gas limit,
-// the sponsorship status, and the bundle execution state.
+// Filter removes all transactions from the list with certain conditions,
+// returning the removed transactions for any post-removal maintenance.
+// The removed transactions are classified into two categories: dropped and
+// invalid. A transaction is dropped if it cannot longer be executed, while
+// a transaction is invalid if it is temporarily non-executable due to a nonce
+// gap or pending bundle status.
 //
 // A transaction is dropped (permanently removed) when:
 //   - Its cost exceeds costLimit and it is not a sponsored or bundle tx.
@@ -378,11 +376,12 @@ func (l *txList) Forward(threshold uint64) types.Transactions {
 // (temporarily non-executable) are also invalidated, since they block the
 // nonce sequence.
 //
-// In non-strict mode (queued list), the second return value is always nil
-// because gapped nonces are expected.
+// In non-strict mode (queued list), the second return value is always nil.
 //
-// The method short-circuits via the cached costcap/gascap when no sponsored
-// or bundle transactions are present and the caps are within limits.
+// This method uses the cached costcap and gascap to quickly decide if there's even
+// a point in calculating all the costs or if the balance covers all. If the threshold
+// is lower than the costgas cap, the caps will be reset to a new high after removing
+// the newly invalidated transactions.
 func (l *txList) Filter(
 	costLimit *big.Int,
 	gasLimit uint64,
@@ -481,16 +480,11 @@ func (l *txList) Remove(tx *types.Transaction) (bool, types.Transactions) {
 }
 
 // Ready returns and removes a contiguous run of transactions starting at
-// start that are eligible for promotion from queued to pending. The
-// isExecutable callback gates each transaction: regular and sponsored
-// transactions always pass, while bundle envelopes are only promoted when
-// a trial-run against the current chain state confirms they are executable.
-// The run stops at the first transaction that fails the check, leaving it
-// and all higher-nonce transactions in the queue for a future promotion
-// pass.
-//
-// Transactions with nonces below start are also returned to self-correct
-// stale entries.
+// start that are eligible for promotion, as determined by the isExecutable
+// callback. The run stops at the first transaction that fails the check,
+// leaving it and all higher-nonce transactions in the list for a future
+// pass. Transactions with nonces below start are also returned to
+// self-correct stale entries.
 func (l *txList) Ready(
 	start uint64,
 	isExecutable func(*types.Transaction) bool,

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -449,11 +449,8 @@ func (l *txList) Filter(
 		// invalids are to be demoted from pending to queued, and therefore
 		// are re-queued by the caller, who owns both tx lists.
 		invalids = append(demotedEnvelopes, invalids...)
-
-		if len(invalids) > 0 {
-			l.txs.reheap()
-		}
 	}
+	l.txs.reheap()
 	return removed, invalids
 }
 

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -406,7 +406,7 @@ func TestTxList_Filter_RemovesAndInvalidatesTransactions(t *testing.T) {
 	}
 }
 
-func TestTxList_Filter_ShortCircuitIfAllTransacitonsAreBellowThresshold(t *testing.T) {
+func TestTxList_Filter_ShortCircuitIfAllTransactionsAreBelowThreshold(t *testing.T) {
 	require := require.New(t)
 	key, err := crypto.GenerateKey()
 	require.NoError(err)

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -19,12 +19,14 @@ package evmcore
 import (
 	"math/big"
 	"math/rand/v2"
+	"slices"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,13 +102,367 @@ func TestTxList_Filter_WithSponsoredTransactions_RetainsCovered(t *testing.T) {
 		return tx.Nonce()%2 == 0
 	}
 
-	removed, _ := list.Filter(big.NewInt(1e18), 1_000_000, checker)
+	removed, _ := list.Filter(big.NewInt(1e18), 1_000_000, checker, nil)
 
 	// All non-sponsored transactions should be removed.
 	require.Len(removed, 5)
 	for _, tx := range removed {
 		require.True(tx.Nonce()%2 == 1, "removed tx with nonce %d", tx.Nonce())
 	}
+}
+
+func TestTxList_Filter_WithBundleTransactions_RetainsPending(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	txs := make([]*types.Transaction, 10)
+	for i := range txs {
+		txs[i] = bundleTx(uint64(i), key)
+	}
+
+	list := newTxList(true)
+	for _, tx := range txs {
+		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+	}
+
+	// Each bundle transaction should be checked.
+	callCount := 0
+	checker := func(tx *types.Transaction) bundlePoolStatus {
+		callCount++
+		return bundlePending
+	}
+
+	costLimit := big.NewInt(1e18)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	require.Equal(10, callCount, "unexpected number of calls to checker")
+	require.Len(removed, 0)
+	require.Len(invalidated, 0)
+}
+
+func TestTxList_Filter_WithBundleTransactions_RemovesRejected(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	txs := make([]*types.Transaction, 10)
+	for i := range txs {
+		txs[i] = bundleTx(uint64(i), key)
+	}
+
+	list := newTxList(false)
+	for _, tx := range txs {
+		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+	}
+
+	// Each bundle transaction should be checked.
+	callCount := 0
+	checker := func(tx *types.Transaction) bundlePoolStatus {
+		callCount++
+		if tx.Nonce()%2 == 0 {
+			return bundlePending
+		}
+		return bundleRejected
+	}
+
+	costLimit := big.NewInt(1e18)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	require.Equal(10, callCount, "unexpected number of calls to checker")
+	require.Len(removed, 5, "odd nonce transactions should be removed")
+	require.Len(invalidated, 0, "list is not strict, so no transactions should be invalidated")
+}
+
+func TestTxList_Strict_Filter_WithBundleTransactions_InvalidatesTemporarilyBlocked(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	txs := make([]*types.Transaction, 10)
+	for i := range txs {
+		txs[i] = bundleTx(uint64(i), key)
+	}
+
+	list := newTxList(true)
+	for _, tx := range txs {
+		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+	}
+
+	// Each bundle transaction should be checked.
+	checker := func(tx *types.Transaction) bundlePoolStatus {
+		if tx.Nonce() < 5 {
+			return bundlePending
+		}
+		return bundleQueued
+	}
+
+	costLimit := big.NewInt(1e18)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	require.Len(removed, 0, "no transactions should be removed, just invalidated")
+	require.Len(invalidated, 5, "list is strict, so temporarily blocked transactions should be invalidated")
+}
+
+func TestTxList_Strict_Filter_WithBundleTransactions_InvalidatesGappedNonces_AfterBundleIsInvalidated(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	txs := make([]*types.Transaction, 10)
+	txs[0] = bundleTx(uint64(0), key)
+	for i := 1; i < len(txs); i++ {
+		txs[i] = transaction(uint64(i), 0, key)
+	}
+
+	list := newTxList(true)
+	for _, tx := range txs {
+		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+	}
+
+	// Each bundle transaction should be checked.
+	checker := func(tx *types.Transaction) bundlePoolStatus {
+		return bundleQueued
+	}
+
+	costLimit := big.NewInt(1e18)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	require.Len(removed, 0, "no transactions should be removed, just invalidated")
+	require.Len(invalidated, 10, "invalid bundle with nonce 0 invalidates all transactions with nonce > 0")
+}
+
+func TestTxList_Filter_RemovesAndInvalidatesTransactions(t *testing.T) {
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	gaslimit := uint64(1_000_000)
+
+	allPending := func(tx *types.Transaction) bundlePoolStatus {
+		return bundlePending
+	}
+	allRejected := func(tx *types.Transaction) bundlePoolStatus {
+		return bundleRejected
+	}
+	allQueued := func(tx *types.Transaction) bundlePoolStatus {
+		return bundleQueued
+	}
+	invalidateFromNonce := func(nonce uint64) func(tx *types.Transaction) bundlePoolStatus {
+		return func(tx *types.Transaction) bundlePoolStatus {
+			if tx.Nonce() >= nonce {
+				return bundleQueued
+			}
+			return bundlePending
+		}
+	}
+	rejectFromNonce := func(nonce uint64) func(tx *types.Transaction) bundlePoolStatus {
+		return func(tx *types.Transaction) bundlePoolStatus {
+			if tx.Nonce() >= nonce {
+				return bundleRejected
+			}
+			return bundlePending
+		}
+	}
+
+	tests := map[string]struct {
+		strict          bool
+		txs             types.Transactions
+		checker         func(*types.Transaction) bundlePoolStatus
+		wantRemoved     []uint64
+		wantInvalidated []uint64
+	}{
+		"all pending bundles are keep": {
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         allPending,
+			wantRemoved:     []uint64{},
+			wantInvalidated: []uint64{},
+		},
+		"all pending bundles are keep, strict mode": {
+			strict: true,
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         allPending,
+			wantRemoved:     []uint64{},
+			wantInvalidated: []uint64{},
+		},
+		"all queued bundles are kept, non-strict mode": {
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         allQueued,
+			wantRemoved:     []uint64{},
+			wantInvalidated: []uint64{},
+		},
+		"all queued bundles are invalidated, strict mode": {
+			strict: true,
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				bundleTx(1, key),
+				bundleTx(2, key),
+			},
+			checker:         allQueued,
+			wantRemoved:     []uint64{},
+			wantInvalidated: []uint64{0, 1, 2},
+		},
+		"all rejected bundles are removed": {
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         allRejected,
+			wantRemoved:     []uint64{0, 2, 4},
+			wantInvalidated: []uint64{},
+		},
+		"all rejected bundles are removed, gapped nonces are invalidated": {
+			strict: true,
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         allRejected,
+			wantRemoved:     []uint64{0, 2, 4},
+			wantInvalidated: []uint64{1, 3},
+		},
+		"all bundles with nonce >= 2 are queued, strict mode invalidates from nonce 2": {
+			strict: true,
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         invalidateFromNonce(2),
+			wantRemoved:     []uint64{},
+			wantInvalidated: []uint64{2, 3, 4},
+		},
+		"all bundles with nonce >= 2 are queued, non-strict mode keeps all": {
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         invalidateFromNonce(2),
+			wantRemoved:     []uint64{},
+			wantInvalidated: []uint64{},
+		},
+		"all bundles with nonce >= 2 are rejected, strict mode removes from nonce 2 and invalidates gapped nonces": {
+			strict: true,
+			txs: []*types.Transaction{
+				bundleTx(0, key),
+				transaction(1, gaslimit, key),
+				bundleTx(2, key),
+				transaction(3, gaslimit, key),
+				bundleTx(4, key),
+			},
+			checker:         rejectFromNonce(2),
+			wantRemoved:     []uint64{2, 4},
+			wantInvalidated: []uint64{3},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			list := newTxList(test.strict)
+			for _, tx := range test.txs {
+				list.Add(tx, DefaultTxPoolConfig.PriceBump)
+			}
+
+			costLimit := big.NewInt(1e18)
+			gasLimit := uint64(1_000_000)
+			removed, invalidated := list.Filter(costLimit, gasLimit, nil, test.checker)
+
+			assert.Len(t, removed, len(test.wantRemoved))
+			for _, nonce := range test.wantRemoved {
+				assert.True(t, slices.ContainsFunc(removed, func(tx *types.Transaction) bool { return tx.Nonce() == nonce }))
+			}
+
+			assert.Len(t, invalidated, len(test.wantInvalidated))
+			for _, nonce := range test.wantInvalidated {
+				assert.True(t, slices.ContainsFunc(invalidated, func(tx *types.Transaction) bool { return tx.Nonce() == nonce }))
+			}
+		})
+	}
+}
+
+func TestTxList_Filter_ShortCircuitIfAllTransacitonsAreBellowThresshold(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	list := newTxList(true)
+	for i := range 5 {
+		list.Add(transaction(uint64(i), 1_000, key), DefaultTxPoolConfig.PriceBump)
+	}
+
+	// Cost limit and gas limit are above all transactions, so Filter short-circuits.
+	removed, invalidated := list.Filter(big.NewInt(1e18), 1_000_000, nil, nil)
+	require.Len(removed, 0)
+	require.Len(invalidated, 0)
+	require.Equal(5, list.Len(), "all transactions should remain in the list")
+}
+
+func TestTxList_Ready_PromotesAllConsecutiveNonces(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	list := newTxList(true)
+	for i := range 5 {
+		list.Add(transaction(uint64(i), 1_000, key), DefaultTxPoolConfig.PriceBump)
+	}
+
+	// All transactions are executable, so all consecutive nonces are promoted.
+	ready := list.Ready(0, func(tx *types.Transaction) bool {
+		return true
+	})
+	require.Len(ready, 5)
+	for i, tx := range ready {
+		require.Equal(uint64(i), tx.Nonce())
+	}
+	require.True(list.Empty(), "all transactions should have been promoted")
+}
+
+func TestTxList_Ready_StopsWithFirstNonExecutableTransaction(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+
+	list := newTxList(true)
+	for i := range 5 {
+		list.Add(transaction(uint64(i), 1_000, key), DefaultTxPoolConfig.PriceBump)
+	}
+
+	// Only transactions with nonce < 3 are executable.
+	ready := list.Ready(0, func(tx *types.Transaction) bool {
+		return tx.Nonce() < 3
+	})
+	require.Len(ready, 3)
+	for i, tx := range ready {
+		require.Equal(uint64(i), tx.Nonce())
+	}
+	require.Equal(2, list.Len(), "nonce 3 and 4 should remain in the list")
 }
 
 func BenchmarkTxListAdd(t *testing.B) {
@@ -123,7 +479,7 @@ func BenchmarkTxListAdd(t *testing.B) {
 	t.ResetTimer()
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
-		list.Filter(minimumTip, DefaultTxPoolConfig.MinimumTip, nil)
+		list.Filter(minimumTip, DefaultTxPoolConfig.MinimumTip, nil, nil)
 	}
 }
 

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -217,7 +217,7 @@ func TestTxList_Strict_Filter_WithBundleTransactions_InvalidatesGappedNonces_Aft
 		list.Add(tx, DefaultTxPoolConfig.PriceBump)
 	}
 
-	// Each bundle transaction should be checked.
+	// Bundle transactions are to be demoted.
 	checker := func(tx *types.Transaction) bundlePoolStatus {
 		return bundleQueued
 	}

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1535,7 +1535,13 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		// Drop all transactions that are too costly (low balance or out of gas)
-		drops, _ := list.Filter(utils.Uint256ToBigInt(pool.currentState.GetBalance(addr)), pool.currentMaxGas, subsidiesChecker)
+		drops, _ := list.Filter(
+			utils.Uint256ToBigInt(pool.currentState.GetBalance(addr)),
+			pool.currentMaxGas,
+			subsidiesChecker,
+			// FIXME: replace with real evaluation
+			func(t *types.Transaction) bundlePoolStatus { return bundlePending },
+		)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
@@ -1544,7 +1550,11 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		queuedNofundsMeter.Mark(int64(len(drops)))
 
 		// Gather all executable transactions and promote them
-		readies := list.Ready(pool.pendingNonces.get(addr))
+		readies := list.Ready(
+			pool.pendingNonces.get(addr),
+			// FIXME: replace with real evaluation
+			func(t *types.Transaction) bool { return true },
+		)
 		for _, tx := range readies {
 			hash := tx.Hash()
 			if pool.promoteTx(addr, hash, tx) {
@@ -1734,7 +1744,13 @@ func (pool *TxPool) demoteUnexecutables() {
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		drops, invalids := list.Filter(utils.Uint256ToBigInt(pool.currentState.GetBalance(addr)), pool.currentMaxGas, subsidiesChecker)
+		drops, invalids := list.Filter(
+			utils.Uint256ToBigInt(pool.currentState.GetBalance(addr)),
+			pool.currentMaxGas,
+			subsidiesChecker,
+			// FIXME: replace with real evaluation
+			func(t *types.Transaction) bundlePoolStatus { return bundlePending },
+		)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			log.Trace("Removed unpayable pending transaction", "hash", hash)

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
@@ -337,6 +338,18 @@ func pricedSetCodeTxWithAuth(nonce uint64, gaslimit uint64, gasFee, tip *uint256
 		AccessList: nil,
 		AuthList:   authList,
 	})
+}
+
+// bundleTx creates a transaction that is part of a bundle with the given key and nonce.
+// the name follows the convention of other transaction creation tools in the tx pool tests.
+func bundleTx(nonce uint64, key *ecdsa.PrivateKey) *types.Transaction {
+	signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
+	return bundle.NewBuilder().
+		WithSigner(signer).
+		SetEnvelopeSenderKey(key).
+		SetEnvelopeNonce(nonce).
+		With(bundle.Step(key, &types.AccessListTx{Nonce: nonce})).
+		Build()
 }
 
 func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {


### PR DESCRIPTION
This PR introduces bundle envelope awareness into the transaction pool's core list management (txList), enabling correct promotion and demotion of bundle transactions between the queued and pending sets.

**Background**
The transaction pool maintains two sets per account:

**Pending**: transactions eligible for inclusion in the next block, with strictly sequential nonces.
**Queued**: transactions not yet promotable (e.g. future nonces, insufficient balance).

Two operations drive transitions between these sets:
**Ready** (queued → pending): called during promoteExecutables, pops a contiguous run of transactions starting at the expected nonce and moves them into pending.
**Filter** (pending → queued / removed, or queued → removed): called during demoteUnexecutables, inspects every transaction in the pending list and either keeps it, drops it permanently, or demotes it back to queued.

Transaction list has two variants, strict (for the pending list) and non-strict (for the queued list). The first variant allows to invalidate transactions previously pending when one tx is removed, previous implementation will demote all gapped nonces, the new semantics contemplate the possibility of bundles not being executable anymore, therefore making the transition to the pool to spare resources in the emitter. 