### PR TITLE
Refactor bundle integration tests

### DIFF
--- a/tests/bundles/bundle_execution_flags_test.go
+++ b/tests/bundles/bundle_execution_flags_test.go
@@ -24,19 +24,13 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBundle_ExecutionFlagsOfSingleTxAreInterpretedCorrectly(t *testing.T) {
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -156,7 +150,8 @@ func TestBundle_ExecutionFlagsOfSingleTxAreInterpretedCorrectly(t *testing.T) {
 				BuildEnvelopeBundleAndPlan()
 
 			// Send the bundle.
-			require.NoError(t, client.SendTransaction(t.Context(), envelope))
+			_, err = net.Send(envelope)
+			require.NoError(t, err)
 
 			if c.expectRollback {
 				timeoutCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
@@ -193,12 +188,7 @@ func TestBundle_ExecutionFlagsOfSingleTxAreInterpretedCorrectly(t *testing.T) {
 }
 
 func TestBundle_AllOfGroupSucceedsIfAllStepsTolerated(t *testing.T) {
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -289,7 +279,8 @@ func TestBundle_AllOfGroupSucceedsIfAllStepsTolerated(t *testing.T) {
 				BuildEnvelopeBundleAndPlan()
 
 			// Send the bundle.
-			require.NoError(t, client.SendTransaction(t.Context(), envelope))
+			_, err = net.Send(envelope)
+			require.NoError(t, err)
 
 			// Wait for the bundle to be processed.
 			info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
@@ -312,12 +303,7 @@ func TestBundle_AllOfGroupSucceedsIfAllStepsTolerated(t *testing.T) {
 }
 
 func TestBundle_OneOfGroupSucceedsOnFirstToleratedStep(t *testing.T) {
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -410,7 +396,8 @@ func TestBundle_OneOfGroupSucceedsOnFirstToleratedStep(t *testing.T) {
 				BuildEnvelopeBundleAndPlan()
 
 			// Send the bundle.
-			require.NoError(t, client.SendTransaction(t.Context(), envelope))
+			_, err = net.Send(envelope)
+			require.NoError(t, err)
 
 			if !slices.Contains(c.expectInBlock[:], true) {
 				timeoutCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)

--- a/tests/bundles/bundle_test_utils.go
+++ b/tests/bundles/bundle_test_utils.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/api/sonicapi"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -124,4 +125,13 @@ func getBlockTxsHashes(t *testing.T, client *tests.PooledEhtClient, blockNumber 
 		blockTxsHashes = append(blockTxsHashes, tx.Hash())
 	}
 	return blockTxsHashes
+}
+
+func GetIntegrationTestNetWithBundlesEnabled(t *testing.T) *tests.IntegrationTestNet {
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+
+	return tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
 }

--- a/tests/bundles/bundle_tx_test.go
+++ b/tests/bundles/bundle_tx_test.go
@@ -35,14 +35,13 @@ import (
 // not standalone). The RPC must preserve it so the bundle constraint survives
 // access-list recreation by wallets or tooling.
 func TestCreateAccessList_PreservesBundleOnlyMarker(t *testing.T) {
+	net := tests.StartIntegrationTestNet(t)
 
-	session := tests.StartIntegrationTestNet(t)
-
-	client, err := session.GetClient()
+	client, err := net.GetClient()
 	require.NoError(t, err)
 	defer client.Close()
 
-	sender := tests.MakeAccountWithBalance(t, session, big.NewInt(1e18))
+	sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 
 	// callCreateAccessList is a helper that calls eth_createAccessList with the
 	// given access list and returns the resulting access list.

--- a/tests/bundles/concurrent_bundles_test.go
+++ b/tests/bundles/concurrent_bundles_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/revert"
 	"github.com/ethereum/go-ethereum"
@@ -34,12 +33,7 @@ import (
 
 func TestBundles_RunBundlesInParallel(t *testing.T) {
 	// Create a list of successful and failing bundles.
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	t.Run("succeeding bundles", func(t *testing.T) {
 		testSucceedingConcurrentBundles(t, net)
@@ -64,13 +58,7 @@ func testSucceedingConcurrentBundles(
 	defer client.Close()
 
 	// Create all needed accounts and endow in parallel.
-	accounts := tests.NewAccounts(N * W)
-	addresses := make([]common.Address, len(accounts))
-	for i, cur := range accounts {
-		addresses[i] = cur.Address()
-	}
-	_, err = net.EndowAccounts(addresses, big.NewInt(1e18))
-	require.NoError(err)
+	accounts := tests.MakeAccountsWithBalance(t, net, N*W, big.NewInt(1e18))
 
 	envelopes := make([]*types.Transaction, N)
 	planHashes := make([]common.Hash, N)
@@ -86,7 +74,7 @@ func testSucceedingConcurrentBundles(
 		planHashes[i] = plan.Hash()
 	}
 
-	// Submit all envelops to be processed in parallel.
+	// Submit all envelopes to be processed in parallel.
 	_, err = net.SendAll(envelopes)
 	require.NoError(err)
 
@@ -119,23 +107,14 @@ func testRandomlyFailingBundles(
 
 	require := require.New(t)
 
-	_, receipt, err := tests.DeployContract(net, revert.DeployRevert)
-	require.NoError(err)
-	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
-	revertContractAddress := receipt.ContractAddress
+	revertContractAddress := tests.MustDeployContract(t, net, revert.DeployRevert)
 
 	client, err := net.GetClient()
 	require.NoError(err)
 	defer client.Close()
 
 	// Create all needed accounts and endow in parallel.
-	accounts := tests.NewAccounts(N * W)
-	addresses := make([]common.Address, len(accounts))
-	for i, cur := range accounts {
-		addresses[i] = cur.Address()
-	}
-	_, err = net.EndowAccounts(addresses, big.NewInt(1e18))
-	require.NoError(err)
+	accounts := tests.MakeAccountsWithBalance(t, net, N*W, big.NewInt(1e18))
 
 	envelopes := make([]*types.Transaction, N)
 	planHashes := make([]common.Hash, N)

--- a/tests/bundles/nested_bundle_test.go
+++ b/tests/bundles/nested_bundle_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -29,12 +28,7 @@ import (
 )
 
 func TestBundle_NestedBundlesCanBeExecuted(t *testing.T) {
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -47,12 +41,10 @@ func TestBundle_NestedBundlesCanBeExecuted(t *testing.T) {
 	blockNumber, err := client.BlockNumber(t.Context())
 	require.NoError(t, err)
 
-	tx := tests.SetTransactionDefaults(t, net, &types.AccessListTx{}, sender)
-
 	innerEnvelope, innerBundle, innerPlan := bundle.NewBuilder().
 		WithSigner(signer).
 		SetEarliest(blockNumber).
-		AllOf(bundle.Step(sender.PrivateKey, tx)).
+		AllOf(Step(t, net, sender, &types.AccessListTx{})).
 		BuildEnvelopeBundleAndPlan()
 
 	outerEnvelope, outerBundle, outerPlan := bundle.NewBuilder().
@@ -62,7 +54,8 @@ func TestBundle_NestedBundlesCanBeExecuted(t *testing.T) {
 		BuildEnvelopeBundleAndPlan()
 
 	// Run the bundle.
-	require.NoError(t, client.SendTransaction(t.Context(), outerEnvelope))
+	_, err = net.Send(outerEnvelope)
+	require.NoError(t, err)
 
 	// Wait for the bundle to be processed.
 	outerInfo, err := WaitForBundleExecution(t.Context(), client.Client(), outerPlan.Hash())

--- a/tests/bundles/only_run_once_test.go
+++ b/tests/bundles/only_run_once_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,12 +29,9 @@ import (
 )
 
 func TestBundle_RunOnlyOnce_ExecutionPlanSubmittedMultipleTimesInDifferentEnvelopesIsOnlyProcessedOnce(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{Upgrades: &upgrades})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(err)
@@ -102,14 +98,9 @@ func TestBundle_RunOnlyOnce_ExecutionPlanSubmittedMultipleTimesInDifferentEnvelo
 }
 
 func TestBundle_RunOnlyOnce_NestedBundleSubmittedMultipleTimesInSameBundleIsOnlyProcessedOnce(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(err)
@@ -171,14 +162,9 @@ func TestBundle_RunOnlyOnce_NestedBundleSubmittedMultipleTimesInSameBundleIsOnly
 }
 
 func TestBundle_RunOnlyOnce_FailedGroupsCanBeRetried(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(err)

--- a/tests/bundles/run_bundle_test.go
+++ b/tests/bundles/run_bundle_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -30,12 +29,7 @@ import (
 )
 
 func TestBundle_CanBeProcessedByTheNetwork(t *testing.T) {
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -57,20 +51,14 @@ func TestBundle_CanBeProcessedByTheNetwork(t *testing.T) {
 		WithSigner(signer).
 		SetEarliest(block).
 		AllOf(
-			bundle.Step(
-				senderA.PrivateKey,
-				tests.SetTransactionDefaults(t, net, &types.AccessListTx{
-					To:    &addrB,
-					Value: big.NewInt(1),
-				}, senderA),
-			),
-			bundle.Step(
-				senderB.PrivateKey,
-				tests.SetTransactionDefaults(t, net, &types.AccessListTx{
-					To:    &addrA,
-					Value: big.NewInt(1),
-				}, senderB),
-			),
+			Step(t, net, senderA, &types.AccessListTx{
+				To:    &addrB,
+				Value: big.NewInt(1),
+			}),
+			Step(t, net, senderB, &types.AccessListTx{
+				To:    &addrA,
+				Value: big.NewInt(1),
+			}),
 		).
 		BuildEnvelopeBundleAndPlan()
 
@@ -79,7 +67,8 @@ func TestBundle_CanBeProcessedByTheNetwork(t *testing.T) {
 	require.ErrorIs(t, err, ethereum.NotFound)
 
 	// Run the bundle.
-	require.NoError(t, client.SendTransaction(t.Context(), envelope))
+	_, err = net.Send(envelope)
+	require.NoError(t, err)
 
 	// Wait for the bundle to be processed.
 	info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/add"
 	"github.com/0xsoniclabs/sonic/tests/contracts/store"
@@ -34,12 +33,7 @@ func TestBundle_StressWithManyNonceBlockedBundles(t *testing.T) {
 	// Increase this number for profiling to increase load on the system.
 	const N = 2 // Number of blocked bundles
 
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -101,12 +95,7 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 	// Increase this number for profiling to increase load on the system.
 	const B = 1 // Number of bundles
 
-	upgrades := opera.GetBrioUpgrades()
-	upgrades.TransactionBundles = true
-
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-	})
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR aligns the bundle integration tests to use the newest tooling available, reducing boilerplate code and making the test setup more consistent.

- add `GetIntegrationTestNetWithBundlesEnabled` and use it throughout
- use `net.Send` instead of `client.SendTransaction` if not used already
- replace manual creation and endowment of accounts by `MakeAccountsWithBalance` if not used already
- use deployment helpers
- use `Step` instead of `bundle.Step(sender.PrivateKey, tests.SetTransactionDefaults(..., sender))`