### PR TITLE
Keep ProcessedBundleHistoryHash Zero until the first bundle is executed

### DIFF
--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -47,10 +47,10 @@ import (
 //
 // The hash of the processed bundle's history is computed as follows:
 //  - initially, the hash is zero
-//  - for every update, the hash is updated as follows:
+//  - the zero hash is kept until the first executed bundle
+//  - thereafter, for every block, the hash is updated as follows:
 //      addedExecPlanHash = Xor(<hashes of newly added execution plans>)
-//      deletedExecPlanHash = Xor(<hashes of deleted execution plans>)
-//      newHash = Keccak256(oldHash || addedExecPlanHash || deletedExecPlanHash || blockNum)
+//      newHash = Keccak256(oldHash || addedExecPlanHash || blockNum)
 //
 // The hash can be used to verify that validators remain aligned on their bundle
 // processing history.
@@ -72,12 +72,18 @@ func (s *Store) AddProcessedBundles(
 	addedHash := s.addNewBundles(blockNum, executedBundles, batch)
 
 	// Delete outdated hashes.
-	deletedHash := s.deleteOutdatedBundles(blockNum, batch)
+	s.deleteOutdatedBundles(blockNum, batch)
 
 	// Update the state hash.
 	_, oldHash := s.GetProcessedBundleHistoryHash()
 
-	newHash := computeNewBundleStateHash(oldHash, addedHash, deletedHash, blockNum)
+	// keep the zero hash until a bundle is executed and from then onwards,
+	// compute it for every block.
+	if oldHash == (common.Hash{}) && len(executedBundles) == 0 {
+		return
+	}
+
+	newHash := computeNewBundleStateHash(oldHash, addedHash, blockNum)
 
 	err := batch.Put(nil, append(
 		bigendian.Uint64ToBytes(blockNum),
@@ -123,8 +129,7 @@ func (s *Store) addNewBundles(
 // deleteOutdatedBundles deletes the entries of processed bundles that got
 // processed too far in the past, and returns the XOR of their hashes to update the
 // history hash.
-func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) common.Hash {
-	deletedHash := common.Hash{}
+func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 	if blockNum >= bundle.MaxBlockRange-1 {
 		// enough blocks have passed to start cleaning up the store
 		highestOutdatedBlockNumber := blockNum - bundle.MaxBlockRange + 1
@@ -152,34 +157,28 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) common.
 			if err != nil {
 				s.Log.Crit("failed to delete old processed bundle hash", "error", err)
 			}
-			deletedHash = xorHash(deletedHash, hash)
 		}
 	}
-	return deletedHash
 }
 
 // computeNewBundleStateHash computes the new hash of the processed bundles history
-// based on the previous hash, the added and deleted execution plan hashes, and
-// the block number of the update.
+// based on the previous hash, the added and the block number of the update.
 //
 // This hash is used to verify than clients remain aligned on their bundle
 // processing history
 func computeNewBundleStateHash(
 	oldHash common.Hash,
 	addedPlans common.Hash,
-	removedPlans common.Hash,
 	blockNumber uint64,
 ) common.Hash {
 	// size of the update buffer is:
 	//  - 32 bytes for the previous hash
 	//  - 32 bytes for the added hashes
-	//  - 32 bytes for the deleted hashes
 	//  - 8 bytes for the block number
-	update := make([]byte, 3*32+8)
+	update := make([]byte, 2*32+8)
 	copy(update[:32], oldHash.Bytes())
 	copy(update[32:64], addedPlans.Bytes())
-	copy(update[64:96], removedPlans.Bytes())
-	binary.BigEndian.PutUint64(update[96:], blockNumber)
+	binary.BigEndian.PutUint64(update[64:], blockNumber)
 	newHash := common.Hash(crypto.Keccak256(update))
 
 	return newHash

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -66,15 +66,6 @@ func (s *Store) AddProcessedBundles(
 	s.processedBundleMutex.Lock()
 	defer s.processedBundleMutex.Unlock()
 
-	// Register and index new hashes.
-	table := s.table.ProcessedBundles
-	batch := table.NewBatch()
-	addedHash := s.addNewBundles(blockNum, executedBundles, batch)
-
-	// Delete outdated hashes.
-	s.deleteOutdatedBundles(blockNum, batch)
-
-	// Update the state hash.
 	_, oldHash := s.GetProcessedBundleHistoryHash()
 
 	// keep the zero hash until a bundle is executed and from then onwards,
@@ -83,6 +74,15 @@ func (s *Store) AddProcessedBundles(
 		return
 	}
 
+	// Register and index new hashes.
+	table := s.table.ProcessedBundles
+	batch := table.NewBatch()
+	addedHash := s.addNewBundles(blockNum, executedBundles, batch)
+
+	// Delete outdated hashes.
+	s.deleteOutdatedBundles(blockNum, batch)
+
+	// Update the history hash of processed bundles.
 	newHash := computeNewBundleStateHash(oldHash, addedHash, blockNum)
 
 	err := batch.Put(nil, append(
@@ -126,9 +126,8 @@ func (s *Store) addNewBundles(
 	return addedHash
 }
 
-// deleteOutdatedBundles deletes the entries of processed bundles that got
-// processed too far in the past, and returns the XOR of their hashes to update the
-// history hash.
+// deleteOutdatedBundles deletes the entries of processed bundles that were
+// processed too far in the past.
 func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 	if blockNum >= bundle.MaxBlockRange-1 {
 		// enough blocks have passed to start cleaning up the store
@@ -162,9 +161,9 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 }
 
 // computeNewBundleStateHash computes the new hash of the processed bundles history
-// based on the previous hash, the added and the block number of the update.
+// based on the previous hash, the added plans hash and the block number of the update.
 //
-// This hash is used to verify than clients remain aligned on their bundle
+// This hash is used to verify that clients remain aligned on their bundle
 // processing history
 func computeNewBundleStateHash(
 	oldHash common.Hash,

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -203,12 +203,12 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 
 func TestStore_AddProcessedBundles_LogsOnBatchPutNewEntryError(t *testing.T) {
 	store, table, log, batch, _ := storeTableLogMocks(t)
-
 	injectedErr := errors.New("new entry put error")
 	batch.EXPECT().Put(gomock.Any(), gomock.Any()).Return(injectedErr)
 
 	table.EXPECT().NewBatch().Return(batch)
-	table.EXPECT().Get(gomock.Any()).Return(nil, nil)
+	oldHistoryEntry := []byte{8 + 32 - 1: 0x42}
+	table.EXPECT().Get(gomock.Any()).Return(oldHistoryEntry, nil)
 
 	expectCrit(log, "failed to update hash of processed bundles", "error", injectedErr)
 	// In production, a Crit log call causes the logger to exit the process.
@@ -226,7 +226,8 @@ func TestStore_AddProcessedBundles_LogsOnBatchWriteError(t *testing.T) {
 	batch.EXPECT().Write().Return(injectedErr)
 
 	table.EXPECT().NewBatch().Return(batch)
-	table.EXPECT().Get(gomock.Any()).Return(nil, nil)
+	oldHistoryEntry := []byte{8 + 32 - 1: 0x42}
+	table.EXPECT().Get(gomock.Any()).Return(oldHistoryEntry, nil)
 
 	expectCrit(log, "failed to write batch for updating processed bundles", "error", injectedErr)
 	// In production, a Crit log call causes the logger to exit the process.
@@ -536,10 +537,7 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 				}
 			}
 
-			hash := store.deleteOutdatedBundles(c.finishingBlock, batch)
-			if c.expectDeleted {
-				require.Equal(t, existingBundleHash, hash)
-			}
+			store.deleteOutdatedBundles(c.finishingBlock, batch)
 		})
 	}
 }
@@ -567,68 +565,6 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 	store.deleteOutdatedBundles(bundle.MaxBlockRange+10, batch)
 }
 
-func TestStore_deleteOutdatedBundles_ReturnsXorHashOfDeletedEntries(t *testing.T) {
-
-	cases := map[string]struct {
-		storedBundles map[common.Hash]bundle.PositionInBlock
-	}{
-		"empty list": {
-			storedBundles: map[common.Hash]bundle.PositionInBlock{},
-		},
-		"single bundle": {
-			storedBundles: map[common.Hash]bundle.PositionInBlock{
-				{1, 2, 3}: {},
-			},
-		},
-		"two bundles": {
-			storedBundles: map[common.Hash]bundle.PositionInBlock{
-				{1, 2, 3}: {},
-				{4, 5, 6}: {},
-			},
-		},
-		"more than two bundles": {
-			storedBundles: map[common.Hash]bundle.PositionInBlock{
-				{1, 2, 3}: {},
-				{4, 5, 6}: {},
-				{7, 8, 9}: {},
-			},
-		},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-
-			store, table, _, batch, it := storeTableLogMocks(t)
-			existingBundleKeys := make(map[common.Hash][]byte, len(c.storedBundles))
-			for hash := range c.storedBundles {
-				existingBundleKeys[hash] = getIndexKey(1, hash)
-			}
-
-			table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
-
-			for hash, key := range existingBundleKeys {
-				gomock.InOrder(
-					it.EXPECT().Next().Return(true),
-					it.EXPECT().Key().Return(key),
-					batch.EXPECT().Delete(getIndexKey(1, hash)).Return(nil),
-					batch.EXPECT().Delete(getEntryKey(hash)).Return(nil),
-				)
-			}
-
-			it.EXPECT().Next().Return(false)
-			it.EXPECT().Release()
-
-			deletedHash := store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch)
-
-			expectedDeletedHash := common.Hash{}
-			for hash := range c.storedBundles {
-				expectedDeletedHash = xorHash(expectedDeletedHash, hash)
-			}
-			require.Equal(t, expectedDeletedHash, deletedHash)
-		})
-	}
-}
-
 func TestStore_deleteOutdatedBundles_IgnoresKeysOfWrongLength(t *testing.T) {
 	// log mock is ignored because no log called should be triggered.
 	store, table, _, batch, it := storeTableLogMocks(t)
@@ -642,7 +578,7 @@ func TestStore_deleteOutdatedBundles_IgnoresKeysOfWrongLength(t *testing.T) {
 	)
 	table.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(it)
 
-	require.Zero(t, store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch))
+	store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch)
 }
 
 func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
@@ -771,8 +707,8 @@ func TestStore_computeNewBundleStateHash_CorrectlyProcessesEdgeCases(t *testing.
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := computeNewBundleStateHash(tc.oldHash, tc.addedHash, tc.deletedHash, tc.blockNum)
-			ref := referenceComputeStateHash(tc.blockNum, tc.oldHash, tc.addedHash, tc.deletedHash)
+			got := computeNewBundleStateHash(tc.oldHash, tc.addedHash, tc.blockNum)
+			ref := referenceComputeStateHash(tc.blockNum, tc.oldHash, tc.addedHash)
 			require.Equal(t, ref, got, "actual implementation should match alternative implementation")
 		})
 	}
@@ -822,6 +758,27 @@ func TestStore_ProcessedBundles_TablesAreInitiallyEmpty(t *testing.T) {
 	require.NoError(iter.Error())
 }
 
+func TestStore_ProcessedBundles_ZeroHistoryHashIsPreserve_WhenNoBundlesAreExecuted(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	for i := range bundle.MaxBlockRange + 2 {
+		// nil bundles executed
+		store.AddProcessedBundles(i, nil)
+		blockNum, hash := store.GetProcessedBundleHistoryHash()
+		require.Equal(uint64(0), blockNum)
+		require.Equal(common.Hash{}, hash)
+
+		// empty block bundles executed
+		store.AddProcessedBundles(i, map[common.Hash]bundle.PositionInBlock{})
+		blockNum, hash = store.GetProcessedBundleHistoryHash()
+		require.Equal(uint64(0), blockNum)
+		require.Equal(common.Hash{}, hash)
+
+	}
+}
+
 func TestStore_ProcessedBundles_UpdatesHistoryHash(t *testing.T) {
 	require := require.New(t)
 
@@ -832,9 +789,6 @@ func TestStore_ProcessedBundles_UpdatesHistoryHash(t *testing.T) {
 	cases := map[string]struct {
 		bundles map[common.Hash]bundle.PositionInBlock
 	}{
-		"empty block": {
-			bundles: map[common.Hash]bundle.PositionInBlock{},
-		},
 		"single new bundle": {
 			bundles: map[common.Hash]bundle.PositionInBlock{
 				hash1: {Offset: 0, Count: 1},
@@ -859,7 +813,7 @@ func TestStore_ProcessedBundles_UpdatesHistoryHash(t *testing.T) {
 			for hash := range tc.bundles {
 				addedHash = xorHash(addedHash, hash)
 			}
-			expectedHash := referenceComputeStateHash(1, initialHash, addedHash, common.Hash{})
+			expectedHash := referenceComputeStateHash(1, initialHash, addedHash)
 			_, gotHash := store.GetProcessedBundleHistoryHash()
 			require.Equal(expectedHash, gotHash)
 		})
@@ -1080,19 +1034,184 @@ func TestStore_EnumerateProcessedBundles_LogsOnCrit_IteratorWrongSize(t *testing
 	}
 }
 
+func TestStore_ProcessedBundles_HistoryHashConverges_ForStoresStartingAtDifferentBlocks(t *testing.T) {
+	// This test verifies that two stores processing the same bundles converge
+	// to the same history hash regardless of where each store begins.
+	require := require.New(t)
+
+	blockHistory := map[uint64]map[common.Hash]bundle.PositionInBlock{
+		0: nil,
+		1: nil,
+		2: nil,
+		3: nil,
+		4: nil,
+		5: nil,
+		6: nil,
+		7: nil,
+		8: nil,
+		9: nil,
+		10: {
+			common.Hash{1, 2, 3}: {Offset: 0, Count: 1},
+		},
+		11: nil,
+	}
+
+	store1, err := NewMemStore(t)
+	require.NoError(err)
+
+	// Step 1: Store 1 processes blocks 0-11, first bundle is executed at block 10.
+	for block := range blockHistory {
+		if block < 10 {
+			store1.AddProcessedBundles(uint64(block), blockHistory[block])
+			_, hash := store1.GetProcessedBundleHistoryHash()
+			// Check 1: History hash remains zero before the first bundle is executed.
+			require.Equal(common.Hash{}, hash,
+				"store1 history hash should remain zero before first bundle at block %d", block)
+		}
+	}
+
+	store1.AddProcessedBundles(10, blockHistory[10])
+	_, hashAt10 := store1.GetProcessedBundleHistoryHash()
+	require.NotEqual(common.Hash{}, hashAt10, "store1 hash should be non-zero after first bundle at block 10")
+
+	store1.AddProcessedBundles(11, blockHistory[11])
+	_, hashAt11 := store1.GetProcessedBundleHistoryHash()
+
+	require.NotEqual(hashAt10, hashAt11, "after the first bundle is executed history hash should always vary")
+
+	// Step 2: Store 2 starts at block 5 with history hash zero, then runs the same blocks.
+	store2, err := NewMemStore(t)
+	require.NoError(err)
+
+	for block := uint64(5); block < 10; block++ {
+		store2.AddProcessedBundles(uint64(block), blockHistory[block])
+		_, hash := store2.GetProcessedBundleHistoryHash()
+		require.Equal(common.Hash{}, hash,
+			"store2 history hash should remain zero before first bundle at block %d", block)
+	}
+
+	store2.AddProcessedBundles(10, blockHistory[10])
+	_, store2HashAt10 := store2.GetProcessedBundleHistoryHash()
+
+	store2.AddProcessedBundles(11, blockHistory[11])
+	_, store2HashAt11 := store2.GetProcessedBundleHistoryHash()
+
+	// Check 2: Both stores share the same history hash from block 10 to 11.
+	require.Equal(hashAt10, store2HashAt10, "both stores should have the same hash at block 10")
+	require.Equal(hashAt11, store2HashAt11, "both stores should have the same hash at block 11")
+}
+
+func TestStore_ProcessedBundles_EmptyBundlesChangeHash_AfterFirstBundleExecuted(t *testing.T) {
+	// This test verifies that once the history hash becomes non-zero
+	// (i.e. after the first bundle is executed), adding an empty bundle list
+	// or nil still causes the hash to change.
+	require := require.New(t)
+
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// Adding nil or empty bundles before the first execution keeps the hash zero.
+	store.AddProcessedBundles(1, nil)
+	_, hash := store.GetProcessedBundleHistoryHash()
+	require.Equal(common.Hash{}, hash, "hash should remain zero with nil bundles before first execution")
+
+	store.AddProcessedBundles(2, map[common.Hash]bundle.PositionInBlock{})
+	_, hash = store.GetProcessedBundleHistoryHash()
+	require.Equal(common.Hash{}, hash, "hash should remain zero with empty map before first execution")
+
+	// Execute the first bundle — hash becomes non-zero.
+	store.AddProcessedBundles(3, map[common.Hash]bundle.PositionInBlock{
+		{1, 2, 3}: {Offset: 0, Count: 1},
+	})
+	_, hashAfterFirstBundle := store.GetProcessedBundleHistoryHash()
+	require.NotEqual(common.Hash{}, hashAfterFirstBundle, "hash should be non-zero after first bundle")
+
+	// Once the hash is non-zero, nil and empty bundle lists must still advance the hash.
+	store.AddProcessedBundles(4, nil)
+	_, hashAfterNil := store.GetProcessedBundleHistoryHash()
+	require.NotEqual(hashAfterFirstBundle, hashAfterNil,
+		"nil bundle list should change the hash once history hash is non-zero")
+
+	store.AddProcessedBundles(5, map[common.Hash]bundle.PositionInBlock{})
+	_, hashAfterEmpty := store.GetProcessedBundleHistoryHash()
+	require.NotEqual(hashAfterNil, hashAfterEmpty,
+		"empty bundle map should change the hash once history hash is non-zero")
+}
+
+func TestStore_ProcessedBundles_HistoryHashRemainsZero_WhenNoBundlesAreEverProcessed(t *testing.T) {
+	// This test verifies that the history hash stays zero across an arbitrary
+	// number of blocks when no bundles are ever executed, including blocks
+	// that would trigger the pruning of old entries.
+
+	require := require.New(t)
+
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	for block := range 3 * bundle.MaxBlockRange {
+		store.AddProcessedBundles(uint64(block), nil)
+		_, hash := store.GetProcessedBundleHistoryHash()
+		require.Equal(common.Hash{}, hash,
+			"history hash should remain zero at block %d (nil)", block)
+
+		store.AddProcessedBundles(uint64(block), map[common.Hash]bundle.PositionInBlock{})
+		_, hash = store.GetProcessedBundleHistoryHash()
+		require.Equal(common.Hash{}, hash,
+			"history hash should remain zero at block %d (empty map)", block)
+	}
+}
+
+func TestStore_ProcessedBundles_DeletingEntries_DoesNotAffectHistoryHash(t *testing.T) {
+	// This test verifies that the automatic pruning of old bundle entries
+	// (triggered once enough blocks have passed) does not alter the history hash.
+
+	require := require.New(t)
+
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// Execute the first bundle at block 0 so the history hash becomes non-zero.
+	firstBundleHash := common.Hash{1, 2, 3}
+	store.AddProcessedBundles(0, map[common.Hash]bundle.PositionInBlock{
+		firstBundleHash: {Offset: 0, Count: 1},
+	})
+	_, hashAt0 := store.GetProcessedBundleHistoryHash()
+	require.NotEqual(common.Hash{}, hashAt0)
+
+	// Compute the expected hash by replaying the same updates manually,
+	// independent of any internal pruning.
+	expectedHash := hashAt0
+	for block := uint64(1); block <= bundle.MaxBlockRange; block++ {
+		expectedHash = referenceComputeStateHash(block, expectedHash, common.Hash{})
+	}
+
+	// Advance enough blocks to trigger pruning of the entry at block 0.
+	for block := uint64(1); block <= bundle.MaxBlockRange; block++ {
+		store.AddProcessedBundles(block, nil)
+	}
+
+	// The entry from block 0 must have been pruned.
+	require.False(store.HasBundleRecentlyBeenProcessed(firstBundleHash),
+		"entry from block 0 should have been pruned after MaxBlockRange blocks")
+
+	// The history hash must match the manually computed value — pruning must not affect it.
+	_, actualHash := store.GetProcessedBundleHistoryHash()
+	require.Equal(expectedHash, actualHash,
+		"history hash should not be affected by the deletion of old entries")
+}
+
 // --- helper functions ---
 
 // referenceComputeStateHash is a reference implementation of the hash
 // computation for the processed bundles state. To be used by tests.
 func referenceComputeStateHash(
 	blockNum uint64,
-	oldHash, addedHash, deletedHash common.Hash,
+	oldHash, addedHash common.Hash,
 ) common.Hash {
 
 	var data []byte
 	data = append(data, oldHash.Bytes()...)
 	data = append(data, addedHash.Bytes()...)
-	data = append(data, deletedHash.Bytes()...)
 	data = binary.BigEndian.AppendUint64(data, blockNum)
 	return common.Hash(crypto.Keccak256(data))
 }

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -203,6 +203,7 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 
 func TestStore_AddProcessedBundles_LogsOnBatchPutNewEntryError(t *testing.T) {
 	store, table, log, batch, _ := storeTableLogMocks(t)
+
 	injectedErr := errors.New("new entry put error")
 	batch.EXPECT().Put(gomock.Any(), gomock.Any()).Return(injectedErr)
 
@@ -665,7 +666,7 @@ func TestStore_xorHash_ReturnsExpectedResult(t *testing.T) {
 func TestStore_computeNewBundleStateHash_CorrectlyProcessesEdgeCases(t *testing.T) {
 	// this test checks that the computeNewBundleStateHash function correctly processes edge cases, such as:
 	//  - blockNum being zero or very large
-	//  - oldHash, addedHash, and deletedHash having specific patterns (e.g., all zeros, all 0xff, etc.)
+	//  - oldHash and addedHash having specific patterns (e.g., all zeros, all 0xff, etc.)
 	//  - combinations of the above
 
 	hashDomain := []common.Hash{
@@ -682,24 +683,20 @@ func TestStore_computeNewBundleStateHash_CorrectlyProcessesEdgeCases(t *testing.
 		math.MaxUint64}
 
 	type testCase struct {
-		oldHash     common.Hash
-		addedHash   common.Hash
-		deletedHash common.Hash
-		blockNum    uint64
+		oldHash   common.Hash
+		addedHash common.Hash
+		blockNum  uint64
 	}
 	testCases := map[string]testCase{}
 	for _, oldHash := range hashDomain {
 		for _, addedHash := range hashDomain {
-			for _, deletedHash := range hashDomain {
-				for _, blockNum := range blockNumberDomain {
-					name := fmt.Sprintf("oldHash=%s/addedHash=%s/deletedHash=%s/blockNum=%d",
-						oldHash.Hex(), addedHash.Hex(), deletedHash.Hex(), blockNum)
-					testCases[name] = testCase{
-						oldHash:     oldHash,
-						addedHash:   addedHash,
-						deletedHash: deletedHash,
-						blockNum:    blockNum,
-					}
+			for _, blockNum := range blockNumberDomain {
+				name := fmt.Sprintf("oldHash=%s/addedHash=%s/blockNum=%d",
+					oldHash.Hex(), addedHash.Hex(), blockNum)
+				testCases[name] = testCase{
+					oldHash:   oldHash,
+					addedHash: addedHash,
+					blockNum:  blockNum,
 				}
 			}
 		}
@@ -708,7 +705,7 @@ func TestStore_computeNewBundleStateHash_CorrectlyProcessesEdgeCases(t *testing.
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got := computeNewBundleStateHash(tc.oldHash, tc.addedHash, tc.blockNum)
-			ref := referenceComputeStateHash(tc.blockNum, tc.oldHash, tc.addedHash)
+			ref := referenceComputeStateHash(tc.oldHash, tc.addedHash, tc.blockNum)
 			require.Equal(t, ref, got, "actual implementation should match alternative implementation")
 		})
 	}
@@ -758,7 +755,7 @@ func TestStore_ProcessedBundles_TablesAreInitiallyEmpty(t *testing.T) {
 	require.NoError(iter.Error())
 }
 
-func TestStore_ProcessedBundles_ZeroHistoryHashIsPreserve_WhenNoBundlesAreExecuted(t *testing.T) {
+func TestStore_ProcessedBundles_ZeroHistoryHashIsPreserved_WhenNoBundlesAreExecuted(t *testing.T) {
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
@@ -813,7 +810,7 @@ func TestStore_ProcessedBundles_UpdatesHistoryHash(t *testing.T) {
 			for hash := range tc.bundles {
 				addedHash = xorHash(addedHash, hash)
 			}
-			expectedHash := referenceComputeStateHash(1, initialHash, addedHash)
+			expectedHash := referenceComputeStateHash(initialHash, addedHash, 1)
 			_, gotHash := store.GetProcessedBundleHistoryHash()
 			require.Equal(expectedHash, gotHash)
 		})
@@ -1059,17 +1056,16 @@ func TestStore_ProcessedBundles_HistoryHashConverges_ForStoresStartingAtDifferen
 	store1, err := NewMemStore(t)
 	require.NoError(err)
 
-	// Step 1: Store 1 processes blocks 0-11, first bundle is executed at block 10.
-	for block := range blockHistory {
-		if block < 10 {
-			store1.AddProcessedBundles(uint64(block), blockHistory[block])
-			_, hash := store1.GetProcessedBundleHistoryHash()
-			// Check 1: History hash remains zero before the first bundle is executed.
-			require.Equal(common.Hash{}, hash,
-				"store1 history hash should remain zero before first bundle at block %d", block)
-		}
+	// Step 1: Store 1 processes blocks 0-9 without bundles
+	for block := range uint64(10) {
+		store1.AddProcessedBundles(uint64(block), blockHistory[block])
+		_, hash := store1.GetProcessedBundleHistoryHash()
+		// Check 1: History hash remains zero before the first bundle is executed.
+		require.Equal(common.Hash{}, hash,
+			"store1 history hash should remain zero before first bundle at block %d", block)
 	}
 
+	// first bundle is executed at block 10.
 	store1.AddProcessedBundles(10, blockHistory[10])
 	_, hashAt10 := store1.GetProcessedBundleHistoryHash()
 	require.NotEqual(common.Hash{}, hashAt10, "store1 hash should be non-zero after first bundle at block 10")
@@ -1182,7 +1178,7 @@ func TestStore_ProcessedBundles_DeletingEntries_DoesNotAffectHistoryHash(t *test
 	// independent of any internal pruning.
 	expectedHash := hashAt0
 	for block := uint64(1); block <= bundle.MaxBlockRange; block++ {
-		expectedHash = referenceComputeStateHash(block, expectedHash, common.Hash{})
+		expectedHash = referenceComputeStateHash(expectedHash, common.Hash{}, block)
 	}
 
 	// Advance enough blocks to trigger pruning of the entry at block 0.
@@ -1205,8 +1201,8 @@ func TestStore_ProcessedBundles_DeletingEntries_DoesNotAffectHistoryHash(t *test
 // referenceComputeStateHash is a reference implementation of the hash
 // computation for the processed bundles state. To be used by tests.
 func referenceComputeStateHash(
-	blockNum uint64,
 	oldHash, addedHash common.Hash,
+	blockNum uint64,
 ) common.Hash {
 
 	var data []byte


### PR DESCRIPTION
**Problem**
The history hash formula for processed bundles would change even before bundles where ever processed, which mean 2 nodes starting from different block heights would have different `ProcessedBundleHistoryHash` even if no bundle was ever processed -defeating the purpose of the hash as a cross-validator alignment check.

**Solution**
The `ProcessedBundleHistoryHash` is now held at zero until the first bundle is executed. Empty or nil bundle maps before that point are no-ops on the hash, so validators that haven't seen any bundles yet remain in a clean initial state.

Additionally:
The deleted hash has been deleted from the formula entirely. The new formula remains deterministic regardless of when a validator joined the network, as long as both start from the zero value for `ProcessedBundleHistoryHash`, which is the default. 
This will also serve for the purpose of validating the import of this table during genesis import. But that will be a follow-up task.

This PR implements https://github.com/0xsoniclabs/sonic-admin/issues/735