### PR TITLE
Include usedGas in state processor snapshots

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -498,6 +498,7 @@ func (b *bundleTransactionRunner) CreateSnapshot() int {
 		legacyTxOffset:                 b.legacyTxOffset,
 		trueTxOffset:                   b.trueTxOffset,
 		processedTransactionListLength: len(b.processedTransactions),
+		usedGas:                        *b.ctxt.usedGas,
 	}
 	b.snapshots = append(b.snapshots, snapshot)
 	return len(b.snapshots) - 1
@@ -516,6 +517,7 @@ func (b *bundleTransactionRunner) RevertToSnapshot(id int) {
 	b.legacyTxOffset = snapshot.legacyTxOffset
 	b.trueTxOffset = snapshot.trueTxOffset
 	b.processedTransactions = b.processedTransactions[:snapshot.processedTransactionListLength]
+	b.ctxt.usedGas = &snapshot.usedGas
 	b.snapshots = b.snapshots[:id]
 }
 
@@ -524,6 +526,7 @@ type bundleTransactionRunnerSnapshot struct {
 	legacyTxOffset                 int
 	trueTxOffset                   int
 	processedTransactionListLength int
+	usedGas                        uint64
 }
 
 // _evm is an interface to an EVM instance that can be used to run a single

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -517,7 +517,7 @@ func (b *bundleTransactionRunner) RevertToSnapshot(id int) {
 	b.legacyTxOffset = snapshot.legacyTxOffset
 	b.trueTxOffset = snapshot.trueTxOffset
 	b.processedTransactions = b.processedTransactions[:snapshot.processedTransactionListLength]
-	b.ctxt.usedGas = &snapshot.usedGas
+	*b.ctxt.usedGas = snapshot.usedGas
 	b.snapshots = b.snapshots[:id]
 }
 

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2665,8 +2665,9 @@ func TestBundleTransactionRunner_CreatingAndRevertingSnapshotsDoesNotAlterUsedGa
 	address := ctxt.usedGas
 
 	snapshotId = bundleTransactionRunner.CreateSnapshot()
-	bundleTransactionRunner.RevertToSnapshot(snapshotId)
+	require.Same(t, address, ctxt.usedGas)
 
+	bundleTransactionRunner.RevertToSnapshot(snapshotId)
 	require.Same(t, address, ctxt.usedGas)
 }
 

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2591,7 +2591,8 @@ func TestBundleTransactionRunner_CreateSnapshot_CallsInterTxSnapshotOnStateDbAnd
 
 	state.EXPECT().InterTxSnapshot().Return(123)
 
-	ctxt := &runContext{statedb: state}
+	usedGas := uint64(11)
+	ctxt := &runContext{statedb: state, usedGas: &usedGas}
 	bundleTransactionRunner := &bundleTransactionRunner{
 		ctxt:                  ctxt,
 		legacyTxOffset:        12,
@@ -2606,6 +2607,7 @@ func TestBundleTransactionRunner_CreateSnapshot_CallsInterTxSnapshotOnStateDbAnd
 	require.Equal(t, 12, bundleTransactionRunner.snapshots[0].legacyTxOffset)
 	require.Equal(t, 13, bundleTransactionRunner.snapshots[0].trueTxOffset)
 	require.Equal(t, 14, bundleTransactionRunner.snapshots[0].processedTransactionListLength)
+	require.EqualValues(t, 11, bundleTransactionRunner.snapshots[0].usedGas)
 }
 
 func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOnStateDbAndResetsLocalState(t *testing.T) {
@@ -2615,7 +2617,8 @@ func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOn
 	snapshotId := 123
 	state.EXPECT().RevertToInterTxSnapshot(snapshotId)
 
-	ctxt := &runContext{statedb: state}
+	usedGas := uint64(11)
+	ctxt := &runContext{statedb: state, usedGas: &usedGas}
 	bundleTransactionRunner := &bundleTransactionRunner{
 		ctxt:                  ctxt,
 		legacyTxOffset:        50,
@@ -2628,6 +2631,7 @@ func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOn
 		legacyTxOffset:                 14,
 		trueTxOffset:                   15,
 		processedTransactionListLength: 5,
+		usedGas:                        6,
 	}}
 	bundleTransactionRunner.RevertToSnapshot(0)
 
@@ -2635,6 +2639,7 @@ func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOn
 	require.Equal(t, 14, bundleTransactionRunner.legacyTxOffset)
 	require.Equal(t, 15, bundleTransactionRunner.trueTxOffset)
 	require.Len(t, bundleTransactionRunner.processedTransactions, 5)
+	require.EqualValues(t, 6, *ctxt.usedGas)
 }
 
 func TestBundleTransactionRunner_RevertToSnapshot_InvalidId_TriggerInvalidRevertInStateDB(t *testing.T) {

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2056,6 +2056,7 @@ func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResu
 		statedb:     state,
 		signer:      signer,
 		baseFee:     big.NewInt(1),
+		usedGas:     new(uint64),
 		gasPool:     gasPool,
 		upgrades:    opera.Upgrades{TransactionBundles: true},
 		blockNumber: big.NewInt(0),
@@ -2098,6 +2099,7 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReturnsBundleOnlyTransactionAn
 		statedb:     state,
 		signer:      signer,
 		baseFee:     big.NewInt(1),
+		usedGas:     new(uint64),
 		upgrades:    opera.Upgrades{TransactionBundles: true},
 		blockNumber: big.NewInt(0),
 		runner:      runner,
@@ -2216,6 +2218,7 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 			context := &runContext{
 				statedb: state,
 				signer:  signer,
+				usedGas: new(uint64),
 				upgrades: opera.Upgrades{
 					GasSubsidies:       true,
 					TransactionBundles: true,
@@ -2793,7 +2796,7 @@ func TestBundleTransactionRunner_Snapshot_CoversTxOffsets(t *testing.T) {
 	state.EXPECT().RevertToInterTxSnapshot(gomock.Any()).AnyTimes()
 
 	runner := &bundleTransactionRunner{
-		ctxt:           &runContext{statedb: state},
+		ctxt:           &runContext{statedb: state, usedGas: new(uint64)},
 		legacyTxOffset: 5,
 		trueTxOffset:   7,
 	}
@@ -2884,7 +2887,7 @@ func TestBundleTransactionRunner_Snapshot_CoversProcessedTransactions(t *testing
 	}
 
 	runner := &bundleTransactionRunner{
-		ctxt:                  &runContext{statedb: state},
+		ctxt:                  &runContext{statedb: state, usedGas: new(uint64)},
 		processedTransactions: processedTransactions[:1],
 	}
 
@@ -3199,6 +3202,7 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 			upgrades := opera.Upgrades{GasSubsidies: true, TransactionBundles: true}
 			ctxt := &runContext{
 				signer:      signer,
+				usedGas:     new(uint64),
 				upgrades:    upgrades,
 				blockNumber: big.NewInt(0),
 				statedb:     stateDb,

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2645,6 +2645,31 @@ func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOn
 	require.EqualValues(t, 6, *ctxt.usedGas)
 }
 
+func TestBundleTransactionRunner_CreatingAndRevertingSnapshotsDoesNotAlterUsedGasAddressOfContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := state.NewMockStateDB(ctrl)
+
+	snapshotId := 123
+	state.EXPECT().InterTxSnapshot().Return(snapshotId)
+	state.EXPECT().RevertToInterTxSnapshot(snapshotId)
+
+	usedGas := uint64(11)
+	ctxt := &runContext{statedb: state, usedGas: &usedGas}
+	bundleTransactionRunner := &bundleTransactionRunner{
+		ctxt:                  ctxt,
+		legacyTxOffset:        50,
+		trueTxOffset:          51,
+		processedTransactions: make([]ProcessedTransaction, 100),
+	}
+
+	address := ctxt.usedGas
+
+	snapshotId = bundleTransactionRunner.CreateSnapshot()
+	bundleTransactionRunner.RevertToSnapshot(snapshotId)
+
+	require.Same(t, address, ctxt.usedGas)
+}
+
 func TestBundleTransactionRunner_RevertToSnapshot_InvalidId_TriggerInvalidRevertInStateDB(t *testing.T) {
 	tests := []int{-10, -1, 5, 10}
 	for _, id := range tests {


### PR DESCRIPTION
This PR captures the `usedGas` in the snapshots of the `bundleTransactionRunner`. This is needed in order for the used gas of a block to line up with the sum of the gas consumed by its transactions.
A block replay test (which will be added in an upcoming PR), also confirmed that this fix is needed.