### PR TITLE
Preserve gas tip computation

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2013,8 +2013,7 @@ func (s *PublicTransactionPoolAPI) formatTxReceipt(header *evmcore.EvmHeader, tx
 	if header.BaseFee == nil {
 		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())
 	} else {
-		// EffectiveGasTip returns an error for negative values, this is no problem here
-		gasTip, _ := gasprice.EffectiveGasTip(tx, header.BaseFee)
+		gasTip := tx.EffectiveGasTipValue(header.BaseFee)
 		gasPrice := new(big.Int).Add(header.BaseFee, gasTip)
 		fields["effectiveGasPrice"] = hexutil.Uint64(gasPrice.Uint64())
 	}

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2014,7 +2014,7 @@ func (s *PublicTransactionPoolAPI) formatTxReceipt(header *evmcore.EvmHeader, tx
 		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())
 	} else {
 		// EffectiveGasTip returns an error for negative values, this is no problem here
-		gasTip, _ := tx.EffectiveGasTip(header.BaseFee)
+		gasTip, _ := gasprice.EffectiveGasTip(tx, header.BaseFee)
 		gasPrice := new(big.Int).Add(header.BaseFee, gasTip)
 		fields["effectiveGasPrice"] = hexutil.Uint64(gasPrice.Uint64())
 	}

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -185,8 +185,8 @@ func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 
 	// To ensure backwards compatibility the gas tip calculation has to be
 	// preserved in its current form. In case of an error due to a negative
-	// result, the tip is still computed correctly and is used in the
-	// codebase, so we ignore the error here.
+	// result, the computed tip still needs to be used as reported by the
+	// function for backward compatibility with previous client versions.
 	gasTip, _ := gasprice.EffectiveGasTip(tx, baseFee)
 	return new(big.Int).Add(baseFee, gasTip)
 }

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
+	"github.com/0xsoniclabs/sonic/gossip/gasprice"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/drivertype"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
@@ -182,7 +183,7 @@ func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 		return tx.GasPrice()
 	}
 	// EffectiveGasTip returns an error for negative values, this is no problem here
-	gasTip, _ := tx.EffectiveGasTip(baseFee)
+	gasTip, _ := gasprice.EffectiveGasTip(tx, baseFee)
 	return new(big.Int).Add(baseFee, gasTip)
 }
 

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -182,7 +182,11 @@ func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 	if baseFee == nil {
 		return tx.GasPrice()
 	}
-	// EffectiveGasTip returns an error for negative values, this is no problem here
+
+	// To ensure backwards compatibility the gas tip calculation has to be
+	// preserved in its current form. In case of an error due to a negative
+	// result, the tip is still computed correctly and is used in the
+	// codebase, so we ignore the error here.
 	gasTip, _ := gasprice.EffectiveGasTip(tx, baseFee)
 	return new(big.Int).Add(baseFee, gasTip)
 }

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/gossip/gasprice"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -128,8 +129,8 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		if i+1 < len(txs) {
 			next := txs[i+1]
 			fromNext, _ := types.Sender(signer, next)
-			tip, err := txi.EffectiveGasTip(baseFee)
-			nextTip, nextErr := next.EffectiveGasTip(baseFee)
+			tip, err := gasprice.EffectiveGasTip(txi, baseFee)
+			nextTip, nextErr := gasprice.EffectiveGasTip(next, baseFee)
 			if err != nil || nextErr != nil {
 				t.Errorf("error calculating effective tip: %v, %v", err, nextErr)
 			}

--- a/gossip/gasprice/gas_tip.go
+++ b/gossip/gasprice/gas_tip.go
@@ -1,0 +1,74 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package gasprice
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
+)
+
+// To ensure that the effective gas tip calculation is consistent across different versions
+// of the codebase, we have this helper function that can be used in all places where the
+// effective gas tip needs to be calculated.
+// Based on geth 1.16.9 which is used in sonic 2.1.6
+// https://github.com/0xsoniclabs/go-ethereum/blob/879ee1854e078ae6a6958f7cd40094377fd90b98/core/types/transaction.go#L358
+
+// EffectiveGasTip returns the effective miner gasTipCap for the given base fee.
+// Note: if the effective gasTipCap would be negative, this method
+// returns ErrGasFeeCapTooLow, and value is undefined.
+func EffectiveGasTip(tx *types.Transaction, baseFee *big.Int) (*big.Int, error) {
+	dst := new(uint256.Int)
+	base := new(uint256.Int)
+	if baseFee != nil {
+		if base.SetFromBig(baseFee) {
+			return nil, types.ErrUint256Overflow
+		}
+	}
+	err := calcEffectiveGasTip(tx, dst, base)
+	return dst.ToBig(), err
+}
+
+// calcEffectiveGasTip calculates the effective gas tip of the transaction and
+// saves the result to dst.
+func calcEffectiveGasTip(tx *types.Transaction, dst *uint256.Int, baseFee *uint256.Int) error {
+	if baseFee == nil {
+		if dst.SetFromBig(tx.GasTipCap()) {
+			return types.ErrUint256Overflow
+		}
+		return nil
+	}
+
+	var err error
+	if dst.SetFromBig(tx.GasFeeCap()) {
+		return types.ErrUint256Overflow
+	}
+	if dst.Cmp(baseFee) < 0 {
+		err = types.ErrGasFeeCapTooLow
+	}
+
+	dst.Sub(dst, baseFee)
+	gasTipCap := new(uint256.Int)
+	if gasTipCap.SetFromBig(tx.GasTipCap()) {
+		return types.ErrUint256Overflow
+	}
+	if gasTipCap.Cmp(dst) < 0 {
+		dst.Set(gasTipCap)
+	}
+	return err
+}

--- a/gossip/gasprice/gas_tip.go
+++ b/gossip/gasprice/gas_tip.go
@@ -31,11 +31,9 @@ import (
 
 // EffectiveGasTip returns the effective miner gasTipCap for the given base fee.
 // Note: if the effective gasTipCap would be negative, this method
-// returns ErrGasFeeCapTooLow, and value is undefined.
-// Due to usages of this function in consensus critical code,
-// the current tip computation has to be preserved.
-// Even if an error is returned due to a negative result,
-// the tip is still computed correctly and is used in the codebase.
+// returns ErrGasFeeCapTooLow, but the resulting value is still
+// consensus critical. Thus, the result produced by this function,
+// even in the error case needs to be preserved as is.
 func EffectiveGasTip(tx *types.Transaction, baseFee *big.Int) (*big.Int, error) {
 	dst := new(uint256.Int)
 	base := new(uint256.Int)

--- a/gossip/gasprice/gas_tip.go
+++ b/gossip/gasprice/gas_tip.go
@@ -32,6 +32,10 @@ import (
 // EffectiveGasTip returns the effective miner gasTipCap for the given base fee.
 // Note: if the effective gasTipCap would be negative, this method
 // returns ErrGasFeeCapTooLow, and value is undefined.
+// Due to usages of this function in consensus critical code,
+// the current tip computation has to be preserved.
+// Even if an error is returned due to a negative result,
+// the tip is still computed correctly and is used in the codebase.
 func EffectiveGasTip(tx *types.Transaction, baseFee *big.Int) (*big.Int, error) {
 	dst := new(uint256.Int)
 	base := new(uint256.Int)

--- a/gossip/gasprice/gas_tip_test.go
+++ b/gossip/gasprice/gas_tip_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package geth_compatibility
+package gasprice
 
 import (
 	"math/big"
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGethDependency_EffectiveGasTipProducesUnchangedResults(t *testing.T) {
+func TestGasTip_EffectiveGasTipProducesUnchangedResults(t *testing.T) {
 	tests := map[string]struct {
 		baseFee     int64
 		gasTipCap   int64
@@ -76,14 +76,14 @@ func TestGethDependency_EffectiveGasTipProducesUnchangedResults(t *testing.T) {
 				GasFeeCap: big.NewInt(test.gasFeeCap),
 			}
 			tx := types.NewTx(txData)
-			effectiveTip, err := tx.EffectiveGasTip(big.NewInt(test.baseFee))
+			effectiveTip, err := EffectiveGasTip(tx, big.NewInt(test.baseFee))
 			require.NoError(t, err)
 			require.Zero(t, big.NewInt(test.expectedTip).Cmp(effectiveTip))
 		})
 	}
 }
 
-func TestGethDependency_EffectiveGasTipReturnsUnchangedErrors(t *testing.T) {
+func TestGasTip_EffectiveGasTipReturnsUnchangedErrors(t *testing.T) {
 	overflow := big.NewInt(0).Lsh(big.NewInt(1), 256) // 2^256 overflows uint256
 	tests := map[string]struct {
 		baseFee   *big.Int
@@ -121,7 +121,7 @@ func TestGethDependency_EffectiveGasTipReturnsUnchangedErrors(t *testing.T) {
 				GasFeeCap: test.gasFeeCap,
 			}
 			tx := types.NewTx(txData)
-			tip, err := tx.EffectiveGasTip(test.baseFee)
+			tip, err := EffectiveGasTip(tx, test.baseFee)
 			require.Error(t, err)
 
 			if test.expectedTip == nil {

--- a/gossip/gasprice/reactive.go
+++ b/gossip/gasprice/reactive.go
@@ -264,7 +264,7 @@ func (gpo *Oracle) calcTxpoolStat() txpoolStat {
 	for _, tx := range sorted {
 		for p < uint64(len(s.percentiles)) && gasCounter >= p*maxGasToIndex/uint64(len(s.percentiles)) {
 			// EffectiveGasTip returns an error for negative values, this is no problem here
-			gasTip, _ := tx.EffectiveGasTip(minGasPrice)
+			gasTip, _ := EffectiveGasTip(tx, minGasPrice)
 			s.percentiles[p] = gasTip
 			if s.percentiles[p].Sign() < 0 {
 				s.percentiles[p] = minGasPrice

--- a/gossip/gasprice/reactive.go
+++ b/gossip/gasprice/reactive.go
@@ -263,7 +263,6 @@ func (gpo *Oracle) calcTxpoolStat() txpoolStat {
 	p := uint64(0)
 	for _, tx := range sorted {
 		for p < uint64(len(s.percentiles)) && gasCounter >= p*maxGasToIndex/uint64(len(s.percentiles)) {
-			// EffectiveGasTip returns an error for negative values, this is no problem here
 			gasTip := tx.EffectiveGasTipValue(minGasPrice)
 			s.percentiles[p] = gasTip
 			if s.percentiles[p].Sign() < 0 {

--- a/gossip/gasprice/reactive.go
+++ b/gossip/gasprice/reactive.go
@@ -264,7 +264,7 @@ func (gpo *Oracle) calcTxpoolStat() txpoolStat {
 	for _, tx := range sorted {
 		for p < uint64(len(s.percentiles)) && gasCounter >= p*maxGasToIndex/uint64(len(s.percentiles)) {
 			// EffectiveGasTip returns an error for negative values, this is no problem here
-			gasTip, _ := EffectiveGasTip(tx, minGasPrice)
+			gasTip := tx.EffectiveGasTipValue(minGasPrice)
 			s.percentiles[p] = gasTip
 			if s.percentiles[p].Sign() < 0 {
 				s.percentiles[p] = minGasPrice

--- a/tests/gas_subsidies/registry_update_test.go
+++ b/tests/gas_subsidies/registry_update_test.go
@@ -190,6 +190,7 @@ func TestRegistryUpdate_UpdatesAreEffectiveImmediately(t *testing.T) {
 
 	// Fetch the payment transaction for this sponsored transaction.
 	payments := []*types.Transaction{}
+	basefees := []*big.Int{}
 	for _, tx := range []*types.Transaction{tx1, tx2, tx4} {
 		receipt, err := client.TransactionReceipt(t.Context(), tx.Hash())
 		require.NoError(err)
@@ -204,6 +205,7 @@ func TestRegistryUpdate_UpdatesAreEffectiveImmediately(t *testing.T) {
 		require.Equal(types.ReceiptStatusSuccessful, subtractReceipt.Status)
 
 		payments = append(payments, payment)
+		basefees = append(basefees, block.BaseFee())
 	}
 
 	// The first two transactions are charged using the old registry. Since both
@@ -220,13 +222,13 @@ func TestRegistryUpdate_UpdatesAreEffectiveImmediately(t *testing.T) {
 	// correct according to the respective registry config and block gas price.
 	paymentData0 := makePaymentFeeData(t,
 		gasUsed,
-		receipts[0].EffectiveGasPrice,
+		basefees[0],
 		initialRegistryConfig.OverheadCharge)
 	require.Equal(paymentData0, payments[0].Data()[36:])
 
 	paymentData1 := makePaymentFeeData(t,
 		gasUsed,
-		receipts[1].EffectiveGasPrice,
+		basefees[1],
 		initialRegistryConfig.OverheadCharge)
 	require.Equal(paymentData1, payments[1].Data()[36:])
 
@@ -234,7 +236,7 @@ func TestRegistryUpdate_UpdatesAreEffectiveImmediately(t *testing.T) {
 	// the corresponding payment transaction is payments[2] for the last transaction.
 	paymentData2 := makePaymentFeeData(t,
 		gasUsed,
-		receipts[3].EffectiveGasPrice,
+		basefees[2],
 		proxyRegistryConfig.OverheadCharge)
 	require.Equal(paymentData2, payments[2].Data()[36:])
 


### PR DESCRIPTION
Geth's internal functions can change behavior any time, we want to preserve the current gas tip computation even if the geth dependency is updated. 