### PR TITLE
Enable full bundle validation when pool receives bundles.

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -116,6 +116,9 @@ var (
 
 	// ErrBundleAlreadyProcessed is returned when a bundle transaction is rejected because the same bundle has already been processed recently.
 	ErrBundleAlreadyProcessed = errors.New("bundle has already been processed recently")
+
+	// ErrBundleNonExecutable is returned when a bundle transaction is rejected because it is not executable.
+	ErrBundleNonExecutable = errors.New("bundle is not executable")
 )
 
 var (

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -28,6 +28,8 @@ import (
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -397,6 +399,18 @@ func validateBundleTransactions(
 	stateDb state.StateDB,
 	signer types.Signer,
 ) error {
+	return validateBundleTransactionsInternal(tx, netRules, chainState, stateDb, signer, GetBundleState)
+}
+
+func validateBundleTransactionsInternal(
+	tx *types.Transaction,
+	netRules NetworkRules,
+	chainState StateReader,
+	stateDb state.StateDB,
+	signer types.Signer,
+	getBundleState func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState,
+) error {
+
 	// This check only covers bundle transactions, ignore the rest.
 	if !bundle.IsEnvelope(tx) {
 		return nil
@@ -423,10 +437,42 @@ func validateBundleTransactions(
 		return ErrBundleAlreadyProcessed
 	}
 
-	// Check that the bundle is runnable.
-	// TODO: this requires integration of `GetBundleState`
-	_ = stateDb
-	_ = chainState
+	// Check that the bundle is executable.
+	state := getBundleState(getBundleStateAdaptor{chainState}, stateDb, tx)
+	if !state.Executable && !state.TemporarilyBlocked {
+		err := ErrBundleNonExecutable
+		for _, reason := range state.Reasons {
+			err = errors.Join(err, errors.New(reason))
+		}
+		return err
+	}
 
 	return nil
+}
+
+// getBundleState is a helper tool to get the state of a bundle transaction
+type getBundleStateAdaptor struct {
+	StateReader
+}
+
+func (f getBundleStateAdaptor) GetCurrentNetworkRules() opera.Rules {
+	return f.CurrentRules()
+}
+
+func (f getBundleStateAdaptor) GetEvmChainConfig(idx.Block) *params.ChainConfig {
+	// FIXME: replace bundles trial-run usage of GetEvmChainConfig by a version returning
+	// current chain config directly
+	return f.CurrentConfig()
+}
+
+func (f getBundleStateAdaptor) GetLatestHeader() *EvmHeader {
+	return f.CurrentBlock().Header()
+}
+
+func (f getBundleStateAdaptor) Header(hash common.Hash, number uint64) *EvmHeader {
+	block := f.Block(hash, number)
+	if block == nil {
+		return nil
+	}
+	return block.Header()
 }

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1647,9 +1647,8 @@ func Test_validateBundleTransactions_RespectNetworkRules(t *testing.T) {
 	bundle := bundle.NewBuilder().Build()
 
 	tests := map[string]struct {
-		rules            NetworkRules
-		expectedError    error
-		expectEvaluation bool
+		rules         NetworkRules
+		expectedError error
 	}{
 		"bundle transactions disabled pre brio": {
 			rules:         NetworkRules{},
@@ -1664,9 +1663,8 @@ func Test_validateBundleTransactions_RespectNetworkRules(t *testing.T) {
 			expectedError: ErrBundleTransactionsDisabled,
 		},
 		"bundle transactions enabled post brio": {
-			rules:            NetworkRules{brio: true, transactionBundles: true},
-			expectedError:    nil,
-			expectEvaluation: true,
+			rules:         NetworkRules{brio: true, transactionBundles: true},
+			expectedError: ErrBundleAlreadyProcessed,
 		},
 	}
 
@@ -1676,16 +1674,10 @@ func Test_validateBundleTransactions_RespectNetworkRules(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			state := state.NewMockStateDB(ctrl)
-			if test.expectEvaluation {
-				state.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(false)
-			}
+			state.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(true).AnyTimes()
 
 			err := validateBundleTransactions(bundle, test.rules, nil, state, signer)
-			if test.expectedError != nil {
-				require.ErrorIs(err, test.expectedError)
-			} else {
-				require.NoError(err)
-			}
+			require.ErrorIs(err, test.expectedError)
 		})
 	}
 }
@@ -1732,6 +1724,100 @@ func Test_validateBundleTransactions_RejectsRecentlyProcessedBundles(t *testing.
 
 	err = validateBundleTransactions(envelope, bundlesEnabled, nil, state, signer)
 	require.ErrorIs(err, ErrBundleAlreadyProcessed)
+}
+
+func Test_validateBundleTransactionsInternal_EvaluatesBundleUsingGetBundleState(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	bundlesEnabled := NetworkRules{
+		brio:               true,
+		transactionBundles: true,
+	}
+
+	tests := map[string]struct {
+		bundleState BundleState
+		expectedErr error
+	}{
+		"bundle executable is accepted": {
+			bundleState: BundleState{
+				Executable: true,
+			},
+			expectedErr: nil,
+		},
+		"bundle temporarily not executable is accepted": {
+			bundleState: BundleState{
+				Executable:         false,
+				TemporarilyBlocked: true,
+			},
+			expectedErr: nil,
+		},
+		"bundle non-ever executable": {
+			bundleState: BundleState{
+				Executable:         false,
+				TemporarilyBlocked: false,
+			},
+			expectedErr: ErrBundleNonExecutable,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			reader := NewMockStateReader(ctrl)
+			stateDb := state.NewMockStateDB(ctrl)
+			stateDb.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(false)
+
+			signer := types.LatestSignerForChainID(big.NewInt(1))
+			envelope := bundle.NewBuilder().
+				With(bundle.Step(key, &types.AccessListTx{})).
+				Build()
+
+			err = validateBundleTransactionsInternal(envelope, bundlesEnabled, reader, stateDb, signer,
+				func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
+					return test.bundleState
+				})
+
+			if test.expectedErr != nil {
+				require.ErrorIs(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_validateBundleTransactionsInternal_AccumulatesRejectionReasons(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	bundlesEnabled := NetworkRules{
+		brio:               true,
+		transactionBundles: true,
+	}
+
+	ctrl := gomock.NewController(t)
+	reader := NewMockStateReader(ctrl)
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(false)
+
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	envelope := bundle.NewBuilder().
+		With(bundle.Step(key, &types.AccessListTx{})).
+		Build()
+
+	reasons := []string{"reason1", "reason2"}
+
+	err = validateBundleTransactionsInternal(envelope, bundlesEnabled, reader, stateDb, signer,
+		func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
+			return BundleState{
+				Reasons: reasons,
+			}
+		})
+	require.ErrorIs(t, err, ErrBundleNonExecutable)
+	for _, reason := range reasons {
+		require.ErrorContains(t, err, reason)
+	}
 }
 
 func TestValidateTx_AllowsSponsoredZeroGasPriceTransactions_WhenSubsidiesAreFunded(t *testing.T) {
@@ -1863,6 +1949,46 @@ func TestValidateTx_Success(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func Test_ValidateBundle_GetBundleStateAdaptor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	reader := NewMockStateReader(ctrl)
+
+	adaptor := getBundleStateAdaptor{StateReader: reader}
+
+	t.Run("current rules forwards call", func(t *testing.T) {
+		reader.EXPECT().CurrentRules()
+		adaptor.GetCurrentNetworkRules()
+	})
+
+	t.Run("current config forwards call", func(t *testing.T) {
+		reader.EXPECT().CurrentConfig()
+		adaptor.GetEvmChainConfig(1)
+	})
+
+	t.Run("current block forwards call", func(t *testing.T) {
+		reader.EXPECT().CurrentBlock()
+		adaptor.GetLatestHeader()
+	})
+
+	t.Run("block by hash and number forwards call", func(t *testing.T) {
+		hash := common.HexToHash("0x1234")
+		number := uint64(100)
+		reader.EXPECT().Block(hash, number).Return(&EvmBlock{
+			EvmHeader: EvmHeader{
+				Number: big.NewInt(int64(number)),
+			},
+		})
+		header := adaptor.Header(hash, number)
+		require.EqualValues(t, header.Number.Uint64(), number)
+	})
+
+	t.Run("missing block returns nil", func(t *testing.T) {
+		reader.EXPECT().Block(gomock.Any(), gomock.Any()).Return(nil)
+		heder := adaptor.Header(common.Hash{}, 1)
+		require.Nil(t, heder)
+	})
 }
 
 // =============================================================================

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1952,43 +1952,65 @@ func TestValidateTx_Success(t *testing.T) {
 }
 
 func Test_ValidateBundle_GetBundleStateAdaptor(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	reader := NewMockStateReader(ctrl)
+	hash := common.HexToHash("0x1234")
+	number := uint64(100)
 
-	adaptor := getBundleStateAdaptor{StateReader: reader}
-
-	t.Run("current rules forwards call", func(t *testing.T) {
-		reader.EXPECT().CurrentRules()
-		adaptor.GetCurrentNetworkRules()
-	})
-
-	t.Run("current config forwards call", func(t *testing.T) {
-		reader.EXPECT().CurrentConfig()
-		adaptor.GetEvmChainConfig(1)
-	})
-
-	t.Run("current block forwards call", func(t *testing.T) {
-		reader.EXPECT().CurrentBlock()
-		adaptor.GetLatestHeader()
-	})
-
-	t.Run("block by hash and number forwards call", func(t *testing.T) {
-		hash := common.HexToHash("0x1234")
-		number := uint64(100)
-		reader.EXPECT().Block(hash, number).Return(&EvmBlock{
-			EvmHeader: EvmHeader{
-				Number: big.NewInt(int64(number)),
+	tests := map[string]struct {
+		setup  func(reader *MockStateReader)
+		action func(adaptor *getBundleStateAdaptor)
+		check  func(t *testing.T)
+	}{
+		"current rules forwards call": {
+			setup: func(reader *MockStateReader) { reader.EXPECT().CurrentRules() },
+			action: func(adaptor *getBundleStateAdaptor) {
+				adaptor.GetCurrentNetworkRules()
 			},
-		})
-		header := adaptor.Header(hash, number)
-		require.EqualValues(t, header.Number.Uint64(), number)
-	})
+		},
+		"current config forwards call": {
+			setup: func(reader *MockStateReader) { reader.EXPECT().CurrentConfig() },
+			action: func(adaptor *getBundleStateAdaptor) {
+				adaptor.GetEvmChainConfig(1)
+			},
+		},
+		"current block forwards call": {
+			setup: func(reader *MockStateReader) { reader.EXPECT().CurrentBlock() },
+			action: func(adaptor *getBundleStateAdaptor) {
+				adaptor.GetLatestHeader()
+			},
+		},
+		"block by hash and number forwards call": {
+			setup: func(reader *MockStateReader) {
+				reader.EXPECT().Block(hash, number).Return(&EvmBlock{
+					EvmHeader: EvmHeader{
+						Number: big.NewInt(int64(number)),
+					},
+				})
+			},
+			action: func(adaptor *getBundleStateAdaptor) {
+				header := adaptor.Header(hash, number)
+				require.EqualValues(t, header.Number.Uint64(), number)
+			},
+		},
+		"missing block returns nil": {
+			setup: func(reader *MockStateReader) {
+				reader.EXPECT().Block(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			action: func(adaptor *getBundleStateAdaptor) {
+				header := adaptor.Header(common.Hash{}, 1)
+				require.Nil(t, header)
+			},
+		},
+	}
 
-	t.Run("missing block returns nil", func(t *testing.T) {
-		reader.EXPECT().Block(gomock.Any(), gomock.Any()).Return(nil)
-		heder := adaptor.Header(common.Hash{}, 1)
-		require.Nil(t, heder)
-	})
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			reader := NewMockStateReader(ctrl)
+			adaptor := &getBundleStateAdaptor{StateReader: reader}
+			tt.setup(reader)
+			tt.action(adaptor)
+		})
+	}
 }
 
 // =============================================================================

--- a/tests/bundles/bundle_execution_flags_test.go
+++ b/tests/bundles/bundle_execution_flags_test.go
@@ -24,13 +24,23 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBundle_ExecutionFlagsOfSingleTxAreInterpretedCorrectly(t *testing.T) {
-	net := GetIntegrationTestNetWithBundlesEnabled(t)
+
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+		// This tests submits clearly invalid bundles. TxPool will reject
+		// them directly, to test that they are correctly ignored, pool
+		// validation needs to be disabled.
+		ClientExtraArguments: []string{"--disable-txPool-validation"},
+	})
 
 	client, err := net.GetClient()
 	require.NoError(t, err)
@@ -303,7 +313,15 @@ func TestBundle_AllOfGroupSucceedsIfAllStepsTolerated(t *testing.T) {
 }
 
 func TestBundle_OneOfGroupSucceedsOnFirstToleratedStep(t *testing.T) {
-	net := GetIntegrationTestNetWithBundlesEnabled(t)
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+		// This tests submits clearly invalid bundles. TxPool will reject
+		// them directly, to test that they are correctly ignored, pool
+		// validation needs to be disabled.
+		ClientExtraArguments: []string{"--disable-txPool-validation"},
+	})
 
 	client, err := net.GetClient()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR connects pool validation, executed when txs are received into the pool. With the bundle state evaluation.
The TX pool will accept any bundle which is not permanently blocked. 