### PR TITLE
Add support for bundles to single proposer mode

### DIFF
--- a/gossip/emitter/scheduler/processor.go
+++ b/gossip/emitter/scheduler/processor.go
@@ -103,12 +103,14 @@ func (p *evmProcessor) run(tx *types.Transaction) (
 	// TODO: add a minimum efficiency filter to avoid very inefficient bundles
 	// to be distributed in the network
 	// (see https://github.com/0xsoniclabs/sonic-admin/issues/740).
+	hasAcceptedTransaction := false
 	for _, pt := range processed {
 		if pt.Receipt != nil {
+			hasAcceptedTransaction = true
 			gasUsed += pt.Receipt.GasUsed
 		}
 	}
-	return gasUsed > 0, gasUsed
+	return hasAcceptedTransaction, gasUsed
 }
 
 func (p *evmProcessor) release() {

--- a/gossip/emitter/scheduler/processor.go
+++ b/gossip/emitter/scheduler/processor.go
@@ -94,20 +94,21 @@ func (p *evmProcessor) run(tx *types.Transaction) (
 
 	// A single input transaction can lead to multiple processed transactions.
 	// For instance, a sponsored transaction may be accompanied by a fee
-	// charging transaction. We consider the transaction successful if the
-	// provided transaction was executed, and we sum up the gas used by all
-	// non-skipped transactions, as this is the total gas cost of running the
-	// provided transaction.
-	txWasProcessed := false
+	// charging transaction. Or a bundle envelope may result in an arbitrary
+	// number of transactions to be processed. We consider the input transaction
+	// successful if it results in at least one accepted transaction. We also
+	// sum up the gas used by all accepted transactions, as this is the total
+	// gas cost of running the input transaction.
+	//
+	// TODO: add a minimum efficiency filter to avoid very inefficient bundles
+	// to be distributed in the network
+	// (see https://github.com/0xsoniclabs/sonic-admin/issues/740).
 	for _, pt := range processed {
 		if pt.Receipt != nil {
 			gasUsed += pt.Receipt.GasUsed
-			if pt.Transaction == tx {
-				txWasProcessed = true
-			}
 		}
 	}
-	return txWasProcessed, gasUsed
+	return gasUsed > 0, gasUsed
 }
 
 func (p *evmProcessor) release() {

--- a/gossip/emitter/scheduler/processor_test.go
+++ b/gossip/emitter/scheduler/processor_test.go
@@ -119,15 +119,15 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecution(t *testing.T
 		require.False(t, success)
 	})
 
-	t.Run("no gas consumed", func(t *testing.T) {
+	t.Run("multiple failed transactions", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		runner := NewMockevmProcessorRunner(ctrl)
 		txA := &types.Transaction{}
 		txB := &types.Transaction{}
 		runner.EXPECT().Run(0, gomock.Any()).Return(evmcore.ProcessSummary{
 			ProcessedTransactions: []evmcore.ProcessedTransaction{
-				{Transaction: txA, Receipt: &types.Receipt{GasUsed: 0}},
-				{Transaction: txB, Receipt: &types.Receipt{GasUsed: 0}},
+				{Transaction: txA, Receipt: nil},
+				{Transaction: txB, Receipt: nil},
 			},
 		})
 		processor := &evmProcessor{processor: runner}

--- a/gossip/emitter/scheduler/processor_test.go
+++ b/gossip/emitter/scheduler/processor_test.go
@@ -78,7 +78,7 @@ func TestEvmProcessor_Run_IfExecutionProducesMultipleProcessedTransactions_SumsU
 	require.Equal(t, uint64(30), gasUsed)
 }
 
-func TestEvmProcessor_Run_IfRequestedTransactionIsNotExecuted_AFailedExecutionIsReported(t *testing.T) {
+func TestEvmProcessor_Run_IfRequestedTransactionIsNotExecuted_TheTransactionIsStillAccepted(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	runner := NewMockevmProcessorRunner(ctrl)
 
@@ -92,7 +92,7 @@ func TestEvmProcessor_Run_IfRequestedTransactionIsNotExecuted_AFailedExecutionIs
 
 	processor := &evmProcessor{processor: runner}
 	success, _ := processor.run(tx)
-	require.False(t, success)
+	require.True(t, success)
 }
 
 func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecution(t *testing.T) {
@@ -119,20 +119,21 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecution(t *testing.T
 		require.False(t, success)
 	})
 
-	t.Run("different transaction", func(t *testing.T) {
+	t.Run("no gas consumed", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		runner := NewMockevmProcessorRunner(ctrl)
 		txA := &types.Transaction{}
 		txB := &types.Transaction{}
 		runner.EXPECT().Run(0, gomock.Any()).Return(evmcore.ProcessSummary{
 			ProcessedTransactions: []evmcore.ProcessedTransaction{
-				{Transaction: txB, Receipt: &types.Receipt{GasUsed: 10}},
+				{Transaction: txA, Receipt: &types.Receipt{GasUsed: 0}},
+				{Transaction: txB, Receipt: &types.Receipt{GasUsed: 0}},
 			},
 		})
 		processor := &evmProcessor{processor: runner}
 		success, gasUsed := processor.run(txA)
 		require.False(t, success)
-		require.Equal(t, uint64(10), gasUsed)
+		require.Equal(t, uint64(0), gasUsed)
 	})
 }
 

--- a/tests/bundles/concurrent_bundles_test.go
+++ b/tests/bundles/concurrent_bundles_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/tests/contracts/revert"
 	"github.com/ethereum/go-ethereum"
@@ -32,8 +33,25 @@ import (
 )
 
 func TestBundles_RunBundlesInParallel(t *testing.T) {
-	// Create a list of successful and failing bundles.
-	net := GetIntegrationTestNetWithBundlesEnabled(t)
+	testCases := map[string]bool{
+		"distributed_block_formation": false,
+		"single_proposer":             true,
+	}
+
+	for name, mode := range testCases {
+		t.Run(name, func(t *testing.T) {
+			upgrades := opera.GetBrioUpgrades()
+			upgrades.TransactionBundles = true
+			upgrades.SingleProposerBlockFormation = mode
+			testBundles_RunBundlesInParallel(t, tests.IntegrationTestNetOptions{
+				Upgrades: &upgrades,
+			})
+		})
+	}
+}
+
+func testBundles_RunBundlesInParallel(t *testing.T, options tests.IntegrationTestNetOptions) {
+	net := tests.StartIntegrationTestNet(t, options)
 
 	t.Run("succeeding bundles", func(t *testing.T) {
 		testSucceedingConcurrentBundles(t, net)

--- a/tests/bundles/run_bundle_test.go
+++ b/tests/bundles/run_bundle_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -29,7 +30,25 @@ import (
 )
 
 func TestBundle_CanBeProcessedByTheNetwork(t *testing.T) {
-	net := GetIntegrationTestNetWithBundlesEnabled(t)
+	testCases := map[string]bool{
+		"distributed_block_formation": false,
+		"single_proposer":             true,
+	}
+
+	for name, mode := range testCases {
+		t.Run(name, func(t *testing.T) {
+			upgrades := opera.GetBrioUpgrades()
+			upgrades.TransactionBundles = true
+			upgrades.SingleProposerBlockFormation = mode
+			testBundle_CanBeProcessedByTheNetworkUsing(t, tests.IntegrationTestNetOptions{
+				Upgrades: &upgrades,
+			})
+		})
+	}
+}
+
+func testBundle_CanBeProcessedByTheNetworkUsing(t *testing.T, options tests.IntegrationTestNetOptions) {
+	net := tests.StartIntegrationTestNet(t, options)
 
 	client, err := net.GetClient()
 	require.NoError(t, err)


### PR DESCRIPTION
With this PR support for bundles is added in the single-proposer mode.

The only change requires is to accept transactions in the scheduler even if their execution does not lead to an inclusion of those transactions in the resulting block. For bundles, this is always the case, since the envelopes are discarded.