### PR TITLE
Avoid releasing db in bundles checker

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -64,19 +64,25 @@ type BundleState struct {
 	Reasons            []string // A list of human-readable strings describing why the bundle is not executable or is blocked.
 }
 
-// GetBundleState determines the state of the bundle based on the current state
-// of the blockchain and the transactions in the bundle.
+// GetBundleState determines the state of the bundle based on the current
+// chain state, state, and the transactions in the bundle.
+//
+// both chain and stateDb shall be non-nil and properly initialized.
+// The lifetime of the chainDb object is not managed by this function and
+// callers are responsible from releasing it when it is no longer needed.
 func GetBundleState(
 	chain ChainStateForBundleEval,
+	stateDb state.StateDB,
 	envelope *types.Transaction,
 ) BundleState {
-	return getBundleState(chain, envelope, trialRunBundle)
+	return getBundleState(chain, stateDb, envelope, trialRunBundle)
 }
 
 // getBundleState is the internal version of GetBundleState, allowing to inject
 // a custom trial-run function to simplify testing.
 func getBundleState(
 	chain ChainStateForBundleEval,
+	stateDb state.StateDB,
 	envelope *types.Transaction,
 	trialRunner func(*types.Transaction, ChainStateForBundleEval, state.StateDB) bool,
 ) BundleState {
@@ -106,8 +112,6 @@ func getBundleState(
 	// Next, check whether there are any nonce conflicts in the execution of
 	// the bundle. This is a quicker check than actually running the bundle in
 	// full to determine whether it can succeed or not.
-	stateDb := chain.StateDB()
-	defer stateDb.Release()
 	state := checkForNonceConflicts(bundle, signer, stateDb)
 	if !state.Executable {
 		return state
@@ -135,12 +139,6 @@ func getBundleState(
 // extra chain state information for trial-running bundles.
 type ChainStateForBundleEval interface {
 	ChainState
-
-	// StateDB returns a context for running transactions on the head state of
-	// the chain. A non-committable state-DB instance is sufficient. The user
-	// takes ownership of the returned StateDB and is responsible for releasing
-	// it when it is no longer needed.
-	StateDB() state.StateDB
 
 	// GetLatestHeader returns the latest block header of the chain.
 	GetLatestHeader() *EvmHeader

--- a/evmcore/bundle_precheck_mock.go
+++ b/evmcore/bundle_precheck_mock.go
@@ -101,20 +101,6 @@ func (mr *MockChainStateForBundleEvalMockRecorder) Header(hash, number any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Header", reflect.TypeOf((*MockChainStateForBundleEval)(nil).Header), hash, number)
 }
 
-// StateDB mocks base method.
-func (m *MockChainStateForBundleEval) StateDB() state.StateDB {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StateDB")
-	ret0, _ := ret[0].(state.StateDB)
-	return ret0
-}
-
-// StateDB indicates an expected call of StateDB.
-func (mr *MockChainStateForBundleEvalMockRecorder) StateDB() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateDB", reflect.TypeOf((*MockChainStateForBundleEval)(nil).StateDB))
-}
-
 // MockNonceSource is a mock of NonceSource interface.
 type MockNonceSource struct {
 	ctrl     *gomock.Controller

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -51,7 +51,7 @@ func Test_GetBundleState_BundlesDisabled_ReturnsNonExecutable(t *testing.T) {
 	_, _, err := bundle.ValidateEnvelope(nil, invalidBundle)
 	require.Error(t, err)
 
-	state := GetBundleState(chainState, invalidBundle)
+	state := GetBundleState(chainState, nil, invalidBundle)
 	require.Equal(t, state, makePermanentlyBlockedState("transaction bundles are not enabled on this network"))
 }
 
@@ -68,7 +68,7 @@ func Test_GetBundleState_InvalidBundle_ReturnsNonExecutable(t *testing.T) {
 	_, _, err := bundle.ValidateEnvelope(signer, invalidBundle)
 	require.Error(t, err)
 
-	state := GetBundleState(chainState, invalidBundle)
+	state := GetBundleState(chainState, nil, invalidBundle)
 	require.Equal(t, state, makePermanentlyBlockedState(fmt.Sprintf("invalid bundle: %v", err)))
 }
 
@@ -93,7 +93,7 @@ func Test_GetBundleState_OutdatedBundle_ReturnsNonExecutable(t *testing.T) {
 	_, _, err := bundle.ValidateEnvelope(signer, envelope)
 	require.NoError(t, err)
 
-	state := GetBundleState(chainState, envelope)
+	state := GetBundleState(chainState, nil, envelope)
 	require.Equal(t, state, makePermanentlyBlockedState("bundle has expired"))
 }
 
@@ -121,7 +121,7 @@ func Test_GetBundleState_FutureBundle_ReturnsTemporaryBlocked(t *testing.T) {
 	_, _, err := bundle.ValidateEnvelope(signer, envelop)
 	require.NoError(t, err)
 
-	state := GetBundleState(chainState, envelop)
+	state := GetBundleState(chainState, nil, envelop)
 	require.Equal(t, state, makeTemporaryBlockedState("bundle targets future blocks"))
 }
 
@@ -142,8 +142,6 @@ func Test_GetBundleState_FailedTrialRun_ReturnsNonExecutable(t *testing.T) {
 		NetworkID: 1,
 		Upgrades:  opera.Upgrades{TransactionBundles: true},
 	}).AnyTimes()
-	chainState.EXPECT().StateDB().Return(stateDb)
-	stateDb.EXPECT().Release()
 
 	envelope := bundle.NewBuilder().
 		SetEarliest(currentBlock - 5).
@@ -154,7 +152,7 @@ func Test_GetBundleState_FailedTrialRun_ReturnsNonExecutable(t *testing.T) {
 		return false
 	}
 
-	state := getBundleState(chainState, envelope, rejectEverything)
+	state := getBundleState(chainState, stateDb, envelope, rejectEverything)
 	require.Equal(t, state, makePermanentlyBlockedState("bundle trial-run failed"))
 }
 
@@ -174,8 +172,6 @@ func Test_GetBundleState_ValidBundle_ReturnsRunnable(t *testing.T) {
 		NetworkID: 1,
 		Upgrades:  opera.Upgrades{TransactionBundles: true},
 	}).AnyTimes()
-	chainState.EXPECT().StateDB().Return(stateDb)
-	stateDb.EXPECT().Release()
 
 	// Build a bundle with a valid block window.
 	envelope := bundle.NewBuilder().
@@ -187,7 +183,7 @@ func Test_GetBundleState_ValidBundle_ReturnsRunnable(t *testing.T) {
 		return true
 	}
 
-	state := getBundleState(chainState, envelope, acceptEverything)
+	state := getBundleState(chainState, stateDb, envelope, acceptEverything)
 	require.Equal(t, state, makeRunnableState())
 }
 
@@ -246,8 +242,6 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 				NetworkID: 1,
 				Upgrades:  opera.Upgrades{TransactionBundles: true},
 			}).AnyTimes()
-			chainState.EXPECT().StateDB().Return(db)
-			db.EXPECT().Release()
 
 			chainId := big.NewInt(1)
 			signer := types.LatestSignerForChainID(chainId)
@@ -260,7 +254,7 @@ func Test_GetBundleState_ChecksForNonceConflicts(t *testing.T) {
 				return true
 			}
 
-			got := getBundleState(chainState, envelope, acceptEverything)
+			got := getBundleState(chainState, db, envelope, acceptEverything)
 			require.Equal(t, test.result, got)
 		})
 	}

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -266,15 +266,16 @@ func (em *Emitter) isRunnableBundleTxInternal(
 		return false
 	}
 
+	stateDb := em.world.StateDB()
+	defer stateDb.Release()
+
 	// Ignore if the same bundle has already been processed.
-	if em.world.StateDB().HasBundleRecentlyBeenProcessed(plan.Hash()) {
+	if stateDb.HasBundleRecentlyBeenProcessed(plan.Hash()) {
 		return false
 	}
 
 	// Skip bundles that are not runnable in the current state.
 	adapter := &preCheckChainStateAdapter{external: em.world}
-	stateDb := em.world.StateDB()
-	defer stateDb.Release()
 	return getBundleState(adapter, stateDb, tx).Executable
 }
 

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -241,7 +241,7 @@ func (em *Emitter) isValidBundleTx(tx *types.Transaction) bool {
 
 func (em *Emitter) isRunnableBundleTxInternal(
 	tx *types.Transaction,
-	getBundleState func(evmcore.ChainStateForBundleEval, *types.Transaction) evmcore.BundleState,
+	getBundleState func(evmcore.ChainStateForBundleEval, state.StateDB, *types.Transaction) evmcore.BundleState,
 ) bool {
 	// Ignore if bundled transactions are not enabled.
 	if !em.world.GetRules().Upgrades.TransactionBundles {
@@ -273,7 +273,9 @@ func (em *Emitter) isRunnableBundleTxInternal(
 
 	// Skip bundles that are not runnable in the current state.
 	adapter := &preCheckChainStateAdapter{external: em.world}
-	return getBundleState(adapter, tx).Executable
+	stateDb := em.world.StateDB()
+	defer stateDb.Release()
+	return getBundleState(adapter, stateDb, tx).Executable
 }
 
 type preCheckChainStateAdapter struct {
@@ -282,10 +284,6 @@ type preCheckChainStateAdapter struct {
 
 func (a *preCheckChainStateAdapter) GetCurrentNetworkRules() opera.Rules {
 	return a.external.GetRules()
-}
-
-func (a *preCheckChainStateAdapter) StateDB() state.StateDB {
-	return a.external.StateDB()
 }
 
 func (a *preCheckChainStateAdapter) Header(hash common.Hash, number uint64) *evmcore.EvmHeader {

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -60,6 +60,7 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 
 			db := state.NewMockStateDB(ctrl)
 			db.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).AnyTimes()
+			db.EXPECT().Release().AnyTimes()
 
 			external := NewMockExternal(ctrl)
 			external.EXPECT().GetRules().Return(rules).AnyTimes()
@@ -142,6 +143,7 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 
 			db := state.NewMockStateDB(ctrl)
 			db.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(processed).AnyTimes()
+			db.EXPECT().Release().AnyTimes()
 
 			external := NewMockExternal(ctrl)
 			external.EXPECT().GetRules().Return(rules).AnyTimes()

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -58,13 +58,13 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 				},
 			}
 
-			state := state.NewMockStateDB(ctrl)
-			state.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).AnyTimes()
+			db := state.NewMockStateDB(ctrl)
+			db.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).AnyTimes()
 
 			external := NewMockExternal(ctrl)
 			external.EXPECT().GetRules().Return(rules).AnyTimes()
 			external.EXPECT().GetLatestBlockIndex().Return(idx.Block(100)).AnyTimes()
-			external.EXPECT().StateDB().Return(state).AnyTimes()
+			external.EXPECT().StateDB().Return(db).AnyTimes()
 
 			signer := types.LatestSignerForChainID(big.NewInt(int64(rules.NetworkID)))
 			emitter := &Emitter{
@@ -79,7 +79,7 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(err)
 
-			allBundlesRunnable := func(evmcore.ChainStateForBundleEval, *types.Transaction) evmcore.BundleState {
+			allBundlesRunnable := func(evmcore.ChainStateForBundleEval, state.StateDB, *types.Transaction) evmcore.BundleState {
 				return evmcore.BundleState{Executable: true}
 			}
 
@@ -140,13 +140,13 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 				},
 			}
 
-			state := state.NewMockStateDB(ctrl)
-			state.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(processed).AnyTimes()
+			db := state.NewMockStateDB(ctrl)
+			db.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(processed).AnyTimes()
 
 			external := NewMockExternal(ctrl)
 			external.EXPECT().GetRules().Return(rules).AnyTimes()
 			external.EXPECT().GetLatestBlockIndex().Return(idx.Block(100)).AnyTimes()
-			external.EXPECT().StateDB().Return(state).AnyTimes()
+			external.EXPECT().StateDB().Return(db).AnyTimes()
 
 			signer := types.LatestSignerForChainID(big.NewInt(1))
 			emitter := &Emitter{
@@ -161,7 +161,7 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(t, err)
 
-			getBundleState := func(evmcore.ChainStateForBundleEval, *types.Transaction) evmcore.BundleState {
+			getBundleState := func(evmcore.ChainStateForBundleEval, state.StateDB, *types.Transaction) evmcore.BundleState {
 				return evmcore.BundleState{Executable: true}
 			}
 
@@ -183,20 +183,6 @@ func Test_preCheckStateAdapter_ForwardsNetworkRuleRequest(t *testing.T) {
 	returnedRules := adapter.GetCurrentNetworkRules()
 
 	require.Equal(t, rules, returnedRules)
-}
-
-func Test_preCheckStateAdapter_ForwardsStateDBRequest(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	stateDB := state.NewMockStateDB(ctrl)
-	stateDB.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).AnyTimes()
-
-	external := NewMockExternal(ctrl)
-	external.EXPECT().StateDB().Return(stateDB)
-
-	adapter := &preCheckChainStateAdapter{external: external}
-	returnedStateDB := adapter.StateDB()
-
-	require.Same(t, stateDB, returnedStateDB)
 }
 
 func Test_preCheckStateAdapter_ForwardsHeaderRequest(t *testing.T) {


### PR DESCRIPTION
This PR removes the generation of one stateDb per evaluation of bundle and the need to release it. 
This PR enables reuse of stateDb in components which have a cached one. 