### PR TITLE
Ensure upgrades can not be disabled

### DIFF
--- a/tests/network_rules_update/network_rules_update_test.go
+++ b/tests/network_rules_update/network_rules_update_test.go
@@ -485,3 +485,44 @@ func TestNetworkRulesUpdate_BrioFeaturesBecomeAvailable_WhenBrioUpgradesEnabled(
 		}
 	}
 }
+
+func TestNetworkRulesUpdate_AllegroAndBrioCanNotBeDisabledOnceEnabled(t *testing.T) {
+	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
+		tests.IntegrationTestNetOptions{
+			Upgrades: tests.AsPointer(opera.GetBrioUpgrades()),
+		},
+	)
+
+	// Verify that both Allegro and Brio are enabled initially
+	rules := tests.GetNetworkRules(t, net)
+	require.True(t, rules.Upgrades.Allegro, "Allegro should be enabled initially")
+	require.True(t, rules.Upgrades.Brio, "Brio should be enabled initially")
+
+	t.Run("Allegro upgrade can not be disabled", func(t *testing.T) {
+		type rulesType struct {
+			Upgrades struct{ Allegro bool }
+		}
+		tests.UpdateNetworkRules(t, net, rulesType{
+			Upgrades: struct{ Allegro bool }{Allegro: false},
+		})
+		net.AdvanceEpoch(t, 1)
+
+		rules := tests.GetNetworkRules(t, net)
+		require.True(t, rules.Upgrades.Allegro,
+			"Allegro should still be enabled after attempting to disable it")
+	})
+
+	t.Run("Brio upgrade can not be disabled", func(t *testing.T) {
+		type rulesType struct {
+			Upgrades struct{ Brio bool }
+		}
+		tests.UpdateNetworkRules(t, net, rulesType{
+			Upgrades: struct{ Brio bool }{Brio: false},
+		})
+		net.AdvanceEpoch(t, 1)
+
+		rules := tests.GetNetworkRules(t, net)
+		require.True(t, rules.Upgrades.Brio,
+			"Brio should still be enabled after attempting to disable it")
+	})
+}

--- a/tests/network_rules_update/network_rules_update_test.go
+++ b/tests/network_rules_update/network_rules_update_test.go
@@ -486,7 +486,7 @@ func TestNetworkRulesUpdate_BrioFeaturesBecomeAvailable_WhenBrioUpgradesEnabled(
 	}
 }
 
-func TestNetworkRulesUpdate_AllegroAndBrioCanNotBeDisabledOnceEnabled(t *testing.T) {
+func TestNetworkRulesUpdate_AllegroAndBrioCannotBeDisabledOnceEnabled(t *testing.T) {
 	net := tests.StartIntegrationTestNetWithFakeGenesis(t,
 		tests.IntegrationTestNetOptions{
 			Upgrades: tests.AsPointer(opera.GetBrioUpgrades()),
@@ -498,7 +498,7 @@ func TestNetworkRulesUpdate_AllegroAndBrioCanNotBeDisabledOnceEnabled(t *testing
 	require.True(t, rules.Upgrades.Allegro, "Allegro should be enabled initially")
 	require.True(t, rules.Upgrades.Brio, "Brio should be enabled initially")
 
-	t.Run("Allegro upgrade can not be disabled", func(t *testing.T) {
+	t.Run("Allegro upgrade cannot be disabled", func(t *testing.T) {
 		type rulesType struct {
 			Upgrades struct{ Allegro bool }
 		}
@@ -512,7 +512,7 @@ func TestNetworkRulesUpdate_AllegroAndBrioCanNotBeDisabledOnceEnabled(t *testing
 			"Allegro should still be enabled after attempting to disable it")
 	})
 
-	t.Run("Brio upgrade can not be disabled", func(t *testing.T) {
+	t.Run("Brio upgrade cannot be disabled", func(t *testing.T) {
 		type rulesType struct {
 			Upgrades struct{ Brio bool }
 		}


### PR DESCRIPTION
This PR adds an integration tests that ensures that upgrades can not be disabled once they have been enabled.