### PR TITLE
Enable the emitor throttler by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -417,7 +417,9 @@ func MakeAllConfigsFromFile(ctx *cli.Context, configFile string) (*Config, error
 		return nil, err
 	}
 
-	cfg.Emitter.ThrottlerConfig.Enabled = ctx.GlobalBoolT(flags.EnableThrottlingFlag.Name)
+	if ctx.GlobalIsSet(flags.EnableThrottlingFlag.Name) {
+		cfg.Emitter.ThrottlerConfig.Enabled = ctx.GlobalBoolT(flags.EnableThrottlingFlag.Name)
+	}
 	if ctx.GlobalIsSet(flags.ThrottlingDominantThresholdFlag.Name) {
 		cfg.Emitter.ThrottlerConfig.DominantStakeThreshold = ctx.GlobalFloat64(flags.ThrottlingDominantThresholdFlag.Name)
 	}

--- a/gossip/emitter/config/config.go
+++ b/gossip/emitter/config/config.go
@@ -129,7 +129,7 @@ func DefaultConfig() Config {
 
 func DefaultThrottlerConfig() ThrottlerConfig {
 	return ThrottlerConfig{
-		Enabled:                false,
+		Enabled:                true,
 		DominantStakeThreshold: 0.75,
 		DominatingTimeout:      3,
 		NonDominatingTimeout:   100,


### PR DESCRIPTION
This PR enables the event emitter throttling in the default configuration.