### PR TITLE
Add default deserialization to bundles RPC Json types

### DIFF
--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -17,6 +17,7 @@
 package sonicapi
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
@@ -85,7 +86,7 @@ type RPCRange struct {
 func NewRPCExecutionPlanComposable(plan bundle.ExecutionPlan) (RPCExecutionPlanComposable, error) {
 	visitor := makeExecutionPlanVisitor(
 		func(flags bundle.ExecutionFlags, txRef bundle.TxReference) (any, error) {
-			return &RPCExecutionStepComposable{
+			return RPCExecutionStepComposable{
 				TolerateFailed:  flags&bundle.EF_TolerateFailed != 0,
 				TolerateInvalid: flags&bundle.EF_TolerateInvalid != 0,
 				From:            txRef.From,
@@ -107,7 +108,7 @@ func NewRPCExecutionPlanComposable(plan bundle.ExecutionPlan) (RPCExecutionPlanC
 	}, nil
 }
 
-func toBundleExecutionPlan(rpcPlan RPCExecutionPlanComposable) (bundle.ExecutionPlan, error) {
+func ToBundleExecutionPlan(rpcPlan RPCExecutionPlanComposable) (bundle.ExecutionPlan, error) {
 	root, err := toBundleExecutionGroup(rpcPlan.RPCExecutionPlanGroup)
 	if err != nil {
 		return bundle.ExecutionPlan{}, fmt.Errorf("failed to convert execution plan: %w", err)
@@ -124,7 +125,7 @@ func toBundleExecutionPlan(rpcPlan RPCExecutionPlanComposable) (bundle.Execution
 
 func toBundleExecutionPlanLevel(level any) (bundle.ExecutionStep, error) {
 	switch l := level.(type) {
-	case *RPCExecutionStepComposable:
+	case RPCExecutionStepComposable:
 		ref := bundle.NewTxStep(bundle.TxReference{
 			From: l.From,
 			Hash: l.Hash,
@@ -138,8 +139,8 @@ func toBundleExecutionPlanLevel(level any) (bundle.ExecutionStep, error) {
 		}
 		return ref.WithFlags(flags), nil
 
-	case *RPCExecutionPlanGroup:
-		return toBundleExecutionGroup(*l)
+	case RPCExecutionPlanGroup:
+		return toBundleExecutionGroup(l)
 	}
 	return bundle.ExecutionStep{}, fmt.Errorf("invalid execution plan level: must have either executionStep or group")
 }
@@ -163,6 +164,32 @@ func toBundleExecutionGroup(l RPCExecutionPlanGroup) (bundle.ExecutionStep, erro
 		group = group.WithFlags(bundle.EF_TolerateFailed)
 	}
 	return group, nil
+}
+
+func (t *RPCExecutionPlanComposable) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		BlockRange       RPCRange          `json:"blockRange,omitempty"`
+		TolerateFailures bool              `json:"tolerateFailures,omitempty"`
+		OneOf            bool              `json:"oneOf,omitempty"`
+		Steps            []json.RawMessage `json:"steps"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	t.BlockRange = raw.BlockRange
+	t.OneOf = raw.OneOf
+	t.TolerateFailures = raw.TolerateFailures
+	t.Steps = make([]any, len(raw.Steps))
+	for i, rawStep := range raw.Steps {
+		step, empty, err := unmarshalBundleGroup[RPCExecutionStepComposable](rawStep)
+		if err != nil {
+			return err
+		}
+		if !empty {
+			t.Steps[i] = step
+		}
+	}
+	return nil
 }
 
 // makeExecutionPlanVisitor creates a new instance of toJsonExecutionPlanVisitor with the provided toLeaf function.
@@ -201,11 +228,11 @@ func (v *toJsonExecutionPlanVisitor) Step(flags bundle.ExecutionFlags, txRef bun
 }
 
 func (v *toJsonExecutionPlanVisitor) BeginGroup(oneOf bool, tolerateFailed bool) {
-	group := &RPCExecutionPlanGroup{
+	group := RPCExecutionPlanGroup{
 		OneOf:            oneOf,
 		TolerateFailures: tolerateFailed,
 	}
-	v.groupStack = append(v.groupStack, group)
+	v.groupStack = append(v.groupStack, &group)
 }
 
 func (v *toJsonExecutionPlanVisitor) EndGroup() {
@@ -214,9 +241,9 @@ func (v *toJsonExecutionPlanVisitor) EndGroup() {
 
 	if len(v.groupStack) > 0 {
 		currentGroup := v.groupStack[len(v.groupStack)-1]
-		currentGroup.Steps = append(currentGroup.Steps, closedGroup)
+		currentGroup.Steps = append(currentGroup.Steps, *closedGroup)
 	} else {
-		v.result.Steps = append(v.result.Steps, closedGroup)
+		v.result.Steps = append(v.result.Steps, *closedGroup)
 	}
 }
 

--- a/api/sonicapi/execution_plan_test.go
+++ b/api/sonicapi/execution_plan_test.go
@@ -17,6 +17,7 @@
 package sonicapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -385,9 +386,14 @@ func Test_NewRPCExecutionPlanComposable_FromBundleExecutionPlan(t *testing.T) {
 
 			expectJsonEqual(t, tc.expectedJson, rpcPlan)
 
-			recreated, err := toBundleExecutionPlan(rpcPlan)
+			recreated, err := ToBundleExecutionPlan(rpcPlan)
 			require.NoError(t, err)
 			require.Equal(t, recreated, tc.plan)
+
+			var deserialized RPCExecutionPlanComposable
+			expectCanBeDeserialized(t, &deserialized, tc.expectedJson)
+
+			require.Equal(t, rpcPlan, deserialized)
 		})
 	}
 }
@@ -418,7 +424,7 @@ func Test_toBundleExecutionPlan_CanReturnErrors(t *testing.T) {
 		},
 	}
 
-	_, err := toBundleExecutionPlan(rpcPlan)
+	_, err := ToBundleExecutionPlan(rpcPlan)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid execution plan level: must have either executionStep or group")
 }
@@ -431,4 +437,10 @@ func TestNewRPCExecutionPlanComposable_ReturnsErrorWithInvalidPlan(t *testing.T)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to convert execution plan")
 	require.Contains(t, err.Error(), "invalid execution plan")
+}
+
+func expectCanBeDeserialized[T any](t testing.TB, result *T, jsonValue string) {
+	t.Helper()
+	err := json.Unmarshal([]byte(jsonValue), result)
+	require.NoError(t, err, "failed to unmarshal JSON into %T", result)
 }

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -104,11 +104,13 @@ func (p *RPCExecutionProposal) UnmarshalJSON(data []byte) error {
 	p.TolerateFailures = raw.TolerateFailures
 	p.Steps = make([]any, len(raw.Steps))
 	for i, rawStep := range raw.Steps {
-		step, err := unmarshalProposalStep(rawStep)
+		step, empty, err := unmarshalBundleGroup[RPCExecutionStepProposal](rawStep)
 		if err != nil {
 			return err
 		}
-		p.Steps[i] = step
+		if !empty {
+			p.Steps[i] = step
+		}
 	}
 	return nil
 }
@@ -130,14 +132,17 @@ func (s *RPCExecutionStepProposal) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &s.TransactionArgs)
 }
 
-// unmarshalProposalStep discriminates between a leaf (RPCExecutionStepProposal,
+// unmarshalBundleGroup discriminates between a leaf (i.e. RPCExecutionStepProposal,
 // no "steps" key) and a group (RPCExecutionPlanGroup, has "steps" key).
-func unmarshalProposalStep(data []byte) (any, error) {
+// This function returns the unmarshaled element, a boolean indicating whenever the
+// element can be optimized away and an error if the JSON is invalid. The optimization
+// boolean is used to indicate to the caller that the resulting group is empty
+func unmarshalBundleGroup[LeafType any](data []byte) (any, bool, error) {
 	var probe struct {
 		Steps *json.RawMessage `json:"steps"`
 	}
 	if err := json.Unmarshal(data, &probe); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if probe.Steps != nil {
 		var rawGroup struct {
@@ -146,27 +151,29 @@ func unmarshalProposalStep(data []byte) (any, error) {
 			Steps            []json.RawMessage `json:"steps"`
 		}
 		if err := json.Unmarshal(data, &rawGroup); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		children := make([]any, len(rawGroup.Steps))
 		for i, raw := range rawGroup.Steps {
-			child, err := unmarshalProposalStep(raw)
+			child, empty, err := unmarshalBundleGroup[LeafType](raw)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
-			children[i] = child
+			if !empty {
+				children[i] = child
+			}
 		}
 		return RPCExecutionPlanGroup{
 			OneOf:            rawGroup.OneOf,
 			TolerateFailures: rawGroup.TolerateFailures,
 			Steps:            children,
-		}, nil
+		}, len(children) == 0, nil
 	}
-	var step RPCExecutionStepProposal
+	var step LeafType
 	if err := json.Unmarshal(data, &step); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return step, nil
+	return step, false, nil
 }
 
 // createProposalRequestFromBundle creates an RPCExecutionProposal from a bundle.TransactionBundle,
@@ -199,14 +206,16 @@ func convertVisitorLeafIntoRPCExecutionPlanProposalLeaf(
 	txBundle *bundle.TransactionBundle,
 	flags bundle.ExecutionFlags,
 	txRef bundle.TxReference,
-) (*RPCExecutionStepProposal, error) {
+) (RPCExecutionStepProposal, error) {
+	empty := RPCExecutionStepProposal{}
+
 	tx, ok := txBundle.Transactions[txRef]
 	if !ok {
-		return nil, fmt.Errorf("transaction reference not found in bundle transactions: %v", txRef)
+		return empty, fmt.Errorf("transaction reference not found in bundle transactions: %v", txRef)
 	}
 	txArgs, err := convertToTransactionArgs(signer, tx)
 	if err != nil {
-		return nil, err
+		return empty, err
 	}
 
 	// remove bundle markers from access list
@@ -224,7 +233,7 @@ func convertVisitorLeafIntoRPCExecutionPlanProposalLeaf(
 		}
 	}
 
-	return &RPCExecutionStepProposal{
+	return RPCExecutionStepProposal{
 		TolerateFailed:  flags&bundle.EF_TolerateFailed != 0,
 		TolerateInvalid: flags&bundle.EF_TolerateInvalid != 0,
 		TransactionArgs: txArgs,
@@ -306,7 +315,7 @@ func convertToTransactionArgs(signer types.Signer, tx *types.Transaction) (ethap
 
 func convertProposalToPlan(signer types.Signer, proposal RPCExecutionProposal) (bundle.ExecutionPlan, error) {
 
-	root, err := convertProposalToPlanInternal(signer, &proposal.RPCExecutionPlanGroup)
+	root, err := convertProposalToPlanInternal(signer, proposal.RPCExecutionPlanGroup)
 	if err != nil {
 		return bundle.ExecutionPlan{}, err
 	}
@@ -325,9 +334,6 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 	empty := bundle.ExecutionStep{}
 
 	switch step := proposalStep.(type) {
-	case RPCExecutionPlanGroup:
-		return convertProposalToPlanInternal(signer, &step)
-
 	case RPCExecutionStepProposal:
 		if step.From == nil {
 			return empty, fmt.Errorf("transaction in bundle must include from")
@@ -350,7 +356,7 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 			return flags
 		}()), nil
 
-	case *RPCExecutionPlanGroup:
+	case RPCExecutionPlanGroup:
 
 		if len(step.Steps) == 0 {
 			return empty, fmt.Errorf("proposed group must include at least one step")
@@ -360,7 +366,7 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 		// return the child's plan directly rather than wrapping it in another group.
 		if !step.OneOf && !step.TolerateFailures && len(step.Steps) == 1 {
 			switch step.Steps[0].(type) {
-			case RPCExecutionPlanGroup, *RPCExecutionPlanGroup:
+			case RPCExecutionPlanGroup:
 				return convertProposalToPlanInternal(signer, step.Steps[0])
 			}
 		}

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -77,13 +77,6 @@ func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
 		bundle bundle.TransactionBundle
 		json   string
 	}{
-		"empty bundle": {
-			bundle: bundle.NewBuilder().WithSigner(signer).BuildBundle(),
-			json: `{
-				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
-				"steps":[{"steps":null}]
-			}`,
-		},
 		"simple bundle": {
 			bundle: bundle.NewBuilder().
 				WithSigner(signer).
@@ -193,6 +186,11 @@ func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
 			json := strings.ReplaceAll(tt.json, "REPLACE_ADDRESS", strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex()))
 
 			expectJsonEqual(t, json, proposal)
+
+			var deserialized RPCExecutionProposal
+			expectCanBeDeserialized(t, &deserialized, json)
+
+			require.Equal(t, *proposal, deserialized)
 		})
 	}
 }
@@ -715,7 +713,7 @@ func Test_convertVisitorLeafIntoRPCExecutionPlanProposalLeaf_ConvertsToProposalL
 					ref,
 				)
 				require.NoError(t, err)
-				require.Equal(t, tt.expected[i], *result)
+				require.Equal(t, tt.expected[i], result)
 
 			}
 		})

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -17,6 +17,7 @@
 package sonicapi
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -633,7 +634,7 @@ func Test_PrepareBundle_OneOfGroup_BuildsOneOfPlan(t *testing.T) {
 
 	// Single root step is the OneOf group (unwrapped since root has 1 child with no modifiers).
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	oneOfGroup, ok := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
+	oneOfGroup, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok)
 	require.True(t, oneOfGroup.OneOf, "expected OneOf group")
 	require.Len(t, oneOfGroup.Steps, 2)
@@ -670,16 +671,16 @@ func Test_PrepareBundle_TolerateFailed_Flag(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.ExecutionPlan.Steps, 1)
 
-	stepGroup, ok := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
+	stepGroup, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok, "expected step group")
 	require.Len(t, stepGroup.Steps, 2)
 
-	leafFailed, ok := stepGroup.Steps[0].(*RPCExecutionStepComposable)
+	leafFailed, ok := stepGroup.Steps[0].(RPCExecutionStepComposable)
 	require.True(t, ok, "expected leaf step")
 	require.True(t, leafFailed.TolerateFailed, "TolerateFailed must be set")
 	require.False(t, leafFailed.TolerateInvalid)
 
-	leafInvalid, ok := stepGroup.Steps[1].(*RPCExecutionStepComposable)
+	leafInvalid, ok := stepGroup.Steps[1].(RPCExecutionStepComposable)
 	require.True(t, ok, "expected leaf step")
 	require.True(t, leafInvalid.TolerateInvalid, "TolerateInvalid must be set")
 	require.False(t, leafInvalid.TolerateFailed)
@@ -717,19 +718,19 @@ func Test_PrepareBundle_NestedGroups(t *testing.T) {
 
 	// Root: 1 element (OneOf group)
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	oneOf, ok := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
+	oneOf, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok)
 	require.True(t, oneOf.OneOf)
 	require.Len(t, oneOf.Steps, 2)
 
 	// First alt is an AllOf group
-	allOf, ok := oneOf.Steps[0].(*RPCExecutionPlanGroup)
+	allOf, ok := oneOf.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok)
 	require.False(t, allOf.OneOf)
 	require.Len(t, allOf.Steps, 2)
 
 	// Second alt is a leaf
-	_, ok = oneOf.Steps[1].(*RPCExecutionStepComposable)
+	_, ok = oneOf.Steps[1].(RPCExecutionStepComposable)
 	require.True(t, ok)
 }
 
@@ -769,11 +770,11 @@ func Test_PrepareBundle_FlatTransactions_SingleTx(t *testing.T) {
 	require.True(t, found, "expected BundleOnly marker in access list")
 
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	group, ok := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
+	group, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok)
 	require.False(t, group.OneOf)
 	require.Len(t, group.Steps, 1)
-	_, ok = group.Steps[0].(*RPCExecutionStepComposable)
+	_, ok = group.Steps[0].(RPCExecutionStepComposable)
 	require.True(t, ok)
 }
 
@@ -816,7 +817,7 @@ func Test_PrepareBundle_FlatTransactions_MultipleTxs(t *testing.T) {
 
 	// Two-leaf AllOf: outer steps holds one AllOf group with two leaves
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	group, ok := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
+	group, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok)
 	require.False(t, group.OneOf)
 	require.Len(t, group.Steps, 2)
@@ -877,7 +878,7 @@ func Test_PrepareBundle_SingleChildGroup_TolerateFailures_NotUnwrapped(t *testin
 
 	// TolerateFailures flag must prevent single-child unwrap.
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	group, ok := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
+	group, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok, "expected group, not leaf")
 	require.False(t, group.OneOf)
 	require.Len(t, group.Steps, 1)
@@ -913,7 +914,7 @@ func Test_PrepareBundle_SingleChildGroup_Plain_NotUnwrapped(t *testing.T) {
 
 	// Plain group must not collapse its single child.
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	group, ok := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
+	group, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
 	require.True(t, ok, "expected group, not leaf")
 	require.False(t, group.OneOf)
 	require.Len(t, group.Steps, 1)
@@ -947,11 +948,14 @@ func collectLeafHashes(steps []any) []common.Hash {
 	var hashes []common.Hash
 	for _, s := range steps {
 		switch v := s.(type) {
-		case *RPCExecutionStepComposable:
+		case RPCExecutionStepComposable:
 			hashes = append(hashes, v.Hash)
-		case *RPCExecutionPlanGroup:
+		case RPCExecutionPlanGroup:
 			hashes = append(hashes, collectLeafHashes(v.Steps)...)
+		default:
+			panic(fmt.Sprintf("unexpected step type %T", s))
 		}
+
 	}
 	return hashes
 }
@@ -1076,9 +1080,9 @@ func Test_PrepareBundle_PlanHashesMatchTransactions(t *testing.T) {
 			},
 			wantTxCount: 2,
 			extraCheck: func(t *testing.T, result *RPCPreparedBundle) {
-				group := result.ExecutionPlan.Steps[0].(*RPCExecutionPlanGroup)
-				leaf0 := group.Steps[0].(*RPCExecutionStepComposable)
-				leaf1 := group.Steps[1].(*RPCExecutionStepComposable)
+				group := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
+				leaf0 := group.Steps[0].(RPCExecutionStepComposable)
+				leaf1 := group.Steps[1].(RPCExecutionStepComposable)
 				require.True(t, leaf0.TolerateFailed)
 				require.False(t, leaf0.TolerateInvalid)
 				require.False(t, leaf1.TolerateFailed)


### PR DESCRIPTION
This pr adds deserialization and testing for the json bundle types. 
It also solves the issue with finding pointers during types traversals. 