### PR TITLE
Add GetPredecessor to store [gfile bundles]

### DIFF
--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -43,6 +43,7 @@ import (
 // In the underlying table, the following keys are used:
 //  - key: [] 							 -> [uint64, hash]          // last block and hash for which the processed bundles have been stored
 //  - key: ['e']<execPlanHash> 			 -> [block,position,count]  // for a recently processed bundle (auto-pruned)
+//  - key: ['h']<blockNum> 				 -> hash                    // cumulative history hash at that block (auto-pruned)
 //  - key: ['i']<blockNum, execPlanHash> -> []         				// for a processed bundle at a specific block number, to handle cleanups
 //
 // The hash of the processed bundle's history is computed as follows:
@@ -85,10 +86,13 @@ func (s *Store) AddProcessedBundles(
 	// Update the history hash of processed bundles.
 	newHash := computeNewBundleStateHash(oldHash, addedHash, blockNum)
 
-	err := batch.Put(nil, append(
-		bigendian.Uint64ToBytes(blockNum),
-		newHash.Bytes()...,
-	))
+	err := errors.Join(
+		batch.Put(nil, append(
+			bigendian.Uint64ToBytes(blockNum),
+			newHash.Bytes()...,
+		)),
+		batch.Put(getBlockHistoryHashKey(blockNum), newHash.Bytes()),
+	)
 	if err != nil {
 		s.Log.Crit("failed to update hash of processed bundles", "error", err)
 	}
@@ -152,6 +156,7 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 			err := errors.Join(
 				batch.Delete(getIndexKey(oldBundleBlockNumber, hash)),
 				batch.Delete(getEntryKey(hash)),
+				batch.Delete(getBlockHistoryHashKey(oldBundleBlockNumber)),
 			)
 			if err != nil {
 				s.Log.Crit("failed to delete old processed bundle hash", "error", err)
@@ -250,6 +255,26 @@ func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
 	return blockNum, hash
 }
 
+// GetOldestRetainedBundleHistoryHash returns the block number and bundle
+// history hash for the oldest block still retained in the store.
+// Returns ok=false when no per-block hashes have been stored yet (i.e. no
+// bundle has ever been executed).
+func (s *Store) GetOldestRetainedBundleHistoryHash() (blockNum uint64, hash common.Hash, ok bool) {
+	it := s.table.ProcessedBundles.NewIterator([]byte{'h'}, nil)
+	defer it.Release()
+	if !it.Next() {
+		return 0, common.Hash{}, false
+	}
+	key := it.Key()
+	// key layout: 1 byte prefix + 8 bytes block number
+	if len(key) != 1+8 {
+		s.Log.Crit("invalid per-block history hash key length", "length", len(key))
+	}
+	blockNum = binary.BigEndian.Uint64(key[1:])
+	hash = common.BytesToHash(it.Value())
+	return blockNum, hash, true
+}
+
 // SetProcessedBundlesHistoryHash sets the block number and hash of the
 // processed bundles history. This should be used only during genesis initialization.
 func (s *Store) SetProcessedBundlesHistoryHash(blockNum uint64, hash common.Hash) {
@@ -317,6 +342,12 @@ func getIndexKey(blockNum uint64, hash common.Hash) []byte {
 	return append(
 		append([]byte{'i'}, bigendian.Uint64ToBytes(blockNum)...),
 		hash.Bytes()...)
+}
+
+// getBlockHistoryHashKey returns the key used to store the cumulative history hash
+// for a specific block number.
+func getBlockHistoryHashKey(blockNum uint64) []byte {
+	return append([]byte{'h'}, bigendian.Uint64ToBytes(blockNum)...)
 }
 
 // xorHash returns the XOR of two hashes.

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -156,7 +156,6 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 		err := errors.Join(
 			batch.Delete(getIndexKey(oldBundleBlockNumber, hash)),
 			batch.Delete(getEntryKey(hash)),
-			batch.Delete(getBlockHistoryHashKey(oldBundleBlockNumber)),
 		)
 		if err != nil {
 			s.Log.Crit("failed to delete old processed bundle hash", "error", err)

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -139,7 +139,7 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 
 	highestOutdatedBlockNumber := blockNum - bundle.MaxBlockRange + 1
 
-	// Prune bundle-index entries and all associated keys ('i', 'e', 'h').
+	// Prune bundle-index and entries keys ('i', 'e').
 	// key layout for 'i': 1 byte prefix + 8 bytes blockNum + 32 bytes execPlanHash
 	it := s.table.ProcessedBundles.NewIterator([]byte{'i'}, nil)
 	defer it.Release()
@@ -162,8 +162,7 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 		}
 	}
 
-	// Also prune per-block history-hash entries for blocks that had no bundles
-	// (those blocks have an 'h' key but no 'i' key, so the loop above misses them).
+	// Prune blocks history hash entries.
 	// key layout for 'h': 1 byte prefix + 8 bytes blockNum
 	it2 := s.table.ProcessedBundles.NewIterator([]byte{'h'}, nil)
 	defer it2.Release()

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -133,34 +133,52 @@ func (s *Store) addNewBundles(
 // deleteOutdatedBundles deletes the entries of processed bundles that were
 // processed too far in the past.
 func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
-	if blockNum >= bundle.MaxBlockRange-1 {
-		// enough blocks have passed to start cleaning up the store
-		highestOutdatedBlockNumber := blockNum - bundle.MaxBlockRange + 1
-		it := s.table.ProcessedBundles.NewIterator([]byte{'i'}, nil)
-		defer it.Release()
-		for it.Next() {
-			key := it.Key()
-			// size of the key used to index processed bundle is:
-			//  - 1 byte for the prefix
-			//  - 8 bytes for the block number
-			//  - 32 bytes for the hash
-			if len(key) != 1+8+32 {
-				continue
-			}
-			oldBundleBlockNumber := binary.BigEndian.Uint64(key[1 : 1+8])
-			if oldBundleBlockNumber > highestOutdatedBlockNumber {
-				// the bundle is not old enough to be deleted
-				break
-			}
-			hash := common.BytesToHash(key[1+8:])
-			err := errors.Join(
-				batch.Delete(getIndexKey(oldBundleBlockNumber, hash)),
-				batch.Delete(getEntryKey(hash)),
-				batch.Delete(getBlockHistoryHashKey(oldBundleBlockNumber)),
-			)
-			if err != nil {
-				s.Log.Crit("failed to delete old processed bundle hash", "error", err)
-			}
+	if blockNum < bundle.MaxBlockRange-1 {
+		return
+	}
+
+	highestOutdatedBlockNumber := blockNum - bundle.MaxBlockRange + 1
+
+	// Prune bundle-index entries and all associated keys ('i', 'e', 'h').
+	// key layout for 'i': 1 byte prefix + 8 bytes blockNum + 32 bytes execPlanHash
+	it := s.table.ProcessedBundles.NewIterator([]byte{'i'}, nil)
+	defer it.Release()
+	for it.Next() {
+		key := it.Key()
+		if len(key) != 1+8+32 {
+			continue
+		}
+		oldBundleBlockNumber := binary.BigEndian.Uint64(key[1 : 1+8])
+		if oldBundleBlockNumber > highestOutdatedBlockNumber {
+			break
+		}
+		hash := common.BytesToHash(key[1+8:])
+		err := errors.Join(
+			batch.Delete(getIndexKey(oldBundleBlockNumber, hash)),
+			batch.Delete(getEntryKey(hash)),
+			batch.Delete(getBlockHistoryHashKey(oldBundleBlockNumber)),
+		)
+		if err != nil {
+			s.Log.Crit("failed to delete old processed bundle hash", "error", err)
+		}
+	}
+
+	// Also prune per-block history-hash entries for blocks that had no bundles
+	// (those blocks have an 'h' key but no 'i' key, so the loop above misses them).
+	// key layout for 'h': 1 byte prefix + 8 bytes blockNum
+	it2 := s.table.ProcessedBundles.NewIterator([]byte{'h'}, nil)
+	defer it2.Release()
+	for it2.Next() {
+		key := it2.Key()
+		if len(key) != 1+8 {
+			continue
+		}
+		oldBlockNumber := binary.BigEndian.Uint64(key[1:])
+		if oldBlockNumber > highestOutdatedBlockNumber {
+			break
+		}
+		if err := batch.Delete(getBlockHistoryHashKey(oldBlockNumber)); err != nil {
+			s.Log.Crit("failed to delete old block history hash", "error", err)
 		}
 	}
 }
@@ -257,8 +275,8 @@ func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
 
 // GetOldestRetainedBundleHistoryHash returns the block number and bundle
 // history hash for the oldest block still retained in the store.
-// Returns ok=false when no per-block hashes have been stored yet (i.e. no
-// bundle has ever been executed).
+// Returns ok=false when no retained per-block history-hash entries are
+// present in the store.
 func (s *Store) GetOldestRetainedBundleHistoryHash() (blockNum uint64, hash common.Hash, ok bool) {
 	it := s.table.ProcessedBundles.NewIterator([]byte{'h'}, nil)
 	defer it.Release()
@@ -270,8 +288,12 @@ func (s *Store) GetOldestRetainedBundleHistoryHash() (blockNum uint64, hash comm
 	if len(key) != 1+8 {
 		s.Log.Crit("invalid per-block history hash key length", "length", len(key))
 	}
+	value := it.Value()
+	if len(value) != 32 {
+		s.Log.Crit("invalid per-block history hash value length", "length", len(value))
+	}
 	blockNum = binary.BigEndian.Uint64(key[1:])
-	hash = common.BytesToHash(it.Value())
+	hash = common.BytesToHash(value)
 	return blockNum, hash, true
 }
 

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -161,6 +161,9 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 			s.Log.Crit("failed to delete old processed bundle hash", "error", err)
 		}
 	}
+	if err := it.Error(); err != nil {
+		s.Log.Crit("failed to iterate old processed bundles for deletion", "error", err)
+	}
 
 	// Prune blocks history hash entries.
 	// key layout for 'h': 1 byte prefix + 8 bytes blockNum
@@ -178,6 +181,9 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 		if err := batch.Delete(getBlockHistoryHashKey(oldBlockNumber)); err != nil {
 			s.Log.Crit("failed to delete old block history hash", "error", err)
 		}
+	}
+	if err := it2.Error(); err != nil {
+		s.Log.Crit("failed to iterate old block history hashes for deletion", "error", err)
 	}
 }
 
@@ -279,6 +285,9 @@ func (s *Store) GetOldestRetainedBundleHistoryHash() (blockNum uint64, hash comm
 	it := s.table.ProcessedBundles.NewIterator([]byte{'h'}, nil)
 	defer it.Release()
 	if !it.Next() {
+		if err := it.Error(); err != nil {
+			s.Log.Crit("failed to iterate bundle history hashes", "error", err)
+		}
 		return 0, common.Hash{}, false
 	}
 	key := it.Key()

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -175,7 +175,7 @@ func (s *Store) deleteOutdatedBundles(blockNum uint64, batch kvdb.Batch) {
 			continue
 		}
 		oldBlockNumber := binary.BigEndian.Uint64(key[1:])
-		if oldBlockNumber > highestOutdatedBlockNumber {
+		if oldBlockNumber >= highestOutdatedBlockNumber {
 			break
 		}
 		if err := batch.Delete(getBlockHistoryHashKey(oldBlockNumber)); err != nil {
@@ -278,7 +278,10 @@ func (s *Store) GetProcessedBundleHistoryHash() (uint64, common.Hash) {
 }
 
 // GetOldestRetainedBundleHistoryHash returns the block number and bundle
-// history hash for the oldest block still retained in the store.
+// history hash for the oldest retained block that is still within the
+// MaxBlockRange window. The store keeps one extra predecessor 'h' entry
+// before this block to allow independent verification of the hash chain,
+// but this function skips it and returns the first in-range entry.
 // Returns ok=false when no retained per-block history-hash entries are
 // present in the store.
 func (s *Store) GetOldestRetainedBundleHistoryHash() (blockNum uint64, hash common.Hash, ok bool) {
@@ -295,6 +298,29 @@ func (s *Store) GetOldestRetainedBundleHistoryHash() (blockNum uint64, hash comm
 	if len(key) != 1+8 {
 		s.Log.Crit("invalid per-block history hash key length", "length", len(key))
 	}
+
+	// The store retains one extra 'h' entry (the predecessor) at
+	// highestOutdatedBlockNumber so that the hash at the first in-range
+	// block can be verified: hash(K) = Keccak256(hash(K-1) || xor(...) || K).
+	// Skip this predecessor entry and return the first in-range one.
+	latestBlockNumber, _ := s.GetProcessedBundleHistoryHash()
+	if latestBlockNumber >= bundle.MaxBlockRange-1 {
+		highestOutdatedBlockNumber := latestBlockNumber - bundle.MaxBlockRange + 1
+		firstEntryBlock := binary.BigEndian.Uint64(key[1:])
+		if firstEntryBlock <= highestOutdatedBlockNumber {
+			if !it.Next() {
+				if err := it.Error(); err != nil {
+					s.Log.Crit("failed to iterate bundle history hashes", "error", err)
+				}
+				return 0, common.Hash{}, false
+			}
+			key = it.Key()
+			if len(key) != 1+8 {
+				s.Log.Crit("invalid per-block history hash key length", "length", len(key))
+			}
+		}
+	}
+
 	value := it.Value()
 	if len(value) != 32 {
 		s.Log.Crit("invalid per-block history hash value length", "length", len(value))

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -330,6 +330,34 @@ func (s *Store) GetOldestRetainedBundleHistoryHash() (blockNum uint64, hash comm
 	return blockNum, hash, true
 }
 
+// GetPredecessorBundleHistoryHash returns the block number and hash of the
+// predecessor 'h' entry — the very first entry in the 'h' key space. When
+// pruning has occurred this is the single retained entry that precedes the
+// oldest in-range block, allowing the hash chain to be independently verified.
+// When no pruning has occurred yet, it coincides with the oldest retained
+// entry. Returns ok=false when no 'h' entries exist at all.
+func (s *Store) GetPredecessorBundleHistoryHash() (blockNum uint64, hash common.Hash, ok bool) {
+	it := s.table.ProcessedBundles.NewIterator([]byte{'h'}, nil)
+	defer it.Release()
+	if !it.Next() {
+		if err := it.Error(); err != nil {
+			s.Log.Crit("failed to iterate bundle history hashes", "error", err)
+		}
+		return 0, common.Hash{}, false
+	}
+	key := it.Key()
+	if len(key) != 1+8 {
+		s.Log.Crit("invalid per-block history hash key length", "length", len(key))
+	}
+	value := it.Value()
+	if len(value) != 32 {
+		s.Log.Crit("invalid per-block history hash value length", "length", len(value))
+	}
+	blockNum = binary.BigEndian.Uint64(key[1:])
+	hash = common.BytesToHash(value)
+	return blockNum, hash, true
+}
+
 // SetProcessedBundlesHistoryHash sets the block number and hash of the
 // processed bundles history. This should be used only during genesis initialization.
 func (s *Store) SetProcessedBundlesHistoryHash(blockNum uint64, hash common.Hash) {

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
@@ -254,22 +255,41 @@ func TestStore_AddProcessedBundles_LogsOnBatchWriteError(t *testing.T) {
 }
 
 func TestStore_AddProcessedBundles_RemovesOldHistoryHash_EvenForBlockNumberWithoutBundles(t *testing.T) {
+	// This test verifies that as new blocks are added, the history hash of old
+	// blocks are removed even if those blocks don't have bundles.
+
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
+	// Run enough blocks that some 'h' entries from bundle-less blocks get pruned.
+	const totalBlocks = bundle.MaxBlockRange * 2
+	const firstBundle = bundle.MaxBlockRange / 2
+	for currentBlock := uint64(1); currentBlock <= totalBlocks; currentBlock++ {
+		for block := range currentBlock {
+			// add a single block with bundles
+			if block == firstBundle {
+				store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+					uint64ToHash(block): {},
+				})
+			} else {
+				// add blocks without bundles to advance the block number and trigger pruning
+				store.AddProcessedBundles(block, nil)
+			}
+		}
 
-	// Populate the store with MaxBlockRange+1 blocks so the first entry gets pruned.
-	for block := range bundle.MaxBlockRange + 2 {
-		// add a single block with bundles
-		if block == 1 {
-			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
-				uint64ToHash(block): {},
-			})
+		oldestBlock, _, ok := store.GetOldestRetainedBundleHistoryHash()
+		if currentBlock > firstBundle {
+			require.True(t, ok)
 		} else {
-			// add blocks without bundles to advance the block number and trigger pruning
-			store.AddProcessedBundles(block, nil)
+			// before the first bundle there should be no history hash
+			require.False(t, ok)
+		}
+		for block := range oldestBlock {
+			got, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
+			require.NoError(t, err)
+			require.Empty(t, got, "history hash entry for block %d should have been deleted", block)
 		}
 	}
-
+}
 
 func TestStore_AddProcessedBundles_HistoryHashIsConsistentWithPerBlockHash(t *testing.T) {
 	// This test verifies that as new bundles are added the history hash reported
@@ -387,27 +407,40 @@ func TestStore_GetOldestRetainedBundleHistoryHash_ReturnsZero_WhenNoBundlesExecu
 }
 
 func TestStore_GetOldestRetainedBundleHistoryHash_AdvancesAfterPruning(t *testing.T) {
+	// This test verifies that the oldest history hash advances as blocks
+	// are added and old ones are pruned.
+
 	require := require.New(t)
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
-	var expectedOldestHash common.Hash
-	// Populate MaxBlockRange+1 blocks so the first entry gets pruned.
-	for block := range bundle.MaxBlockRange + 2 {
-		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
-			uint64ToHash(block): {},
-		})
-		if block == 3 {
-			_, expectedOldestHash = store.GetProcessedBundleHistoryHash()
+	const totalBlocks = bundle.MaxBlockRange * 2
+	for currentBlock := uint64(1); currentBlock <= totalBlocks; currentBlock++ {
+		var expectedOldestHash common.Hash
+		expectedOldestBlock := uint64(0)
+		foundOldest := false
+		// Run enough blocks that some 'h' entries from bundle-less blocks get pruned.
+		for block := range currentBlock {
+			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+				uint64ToHash(block): {},
+			})
+			// stop recording the expected oldest block and hash once we encounter
+			// a block that is in range.
+			if !bundle.MakeMaxRangeStartingAt(block).IsInRange(currentBlock) || foundOldest {
+				continue
+			}
+			// Capture the first block not in range.
+			expectedOldestBlock, expectedOldestHash = store.GetProcessedBundleHistoryHash()
+			foundOldest = true
 		}
-	}
 
-	gotBlock, gotHash, ok := store.GetOldestRetainedBundleHistoryHash()
-	require.True(ok)
-	require.Equal(uint64(3), gotBlock,
-		"oldest retained block should be 3 after pruning the entry at block 0")
-	require.NotZero(gotHash, "history hash should not be zero after bundles have been executed")
-	require.Equal(expectedOldestHash, gotHash, "oldest retained hash should be the one at block 3")
+		gotBlock, gotHash, ok := store.GetOldestRetainedBundleHistoryHash()
+		require.True(ok)
+		require.Equal(expectedOldestBlock, gotBlock,
+			"oldest retained block should be the smallest block stored")
+		require.Equal(expectedOldestHash, gotHash,
+			"oldest retained hash should match the stored hash at that block")
+	}
 }
 
 func TestStore_addNewBundles_EncodesInfoCorrectly(t *testing.T) {

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -164,6 +164,7 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 			table.EXPECT().Get(gomock.Any())
 
 			batch.EXPECT().Put(nil, BlockHashTableValueMatcher{blockNum: block})
+			batch.EXPECT().Put(getBlockHistoryHashKey(block), gomock.Any())
 			batch.EXPECT().Write().Return(nil)
 
 			info1 := bundle.ExecutionInfo{
@@ -191,6 +192,7 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 				hash := uint64ToHash(toDelete)
 				batch.EXPECT().Delete(getEntryKey(hash)).Return(nil)
 				batch.EXPECT().Delete(getIndexKey(toDelete, hash)).Return(nil)
+				batch.EXPECT().Delete(getBlockHistoryHashKey(toDelete)).Return(nil)
 				it.EXPECT().Release()
 			}
 
@@ -204,18 +206,24 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 func TestStore_AddProcessedBundles_LogsOnBatchPutNewEntryError(t *testing.T) {
 	store, table, log, batch, _ := storeTableLogMocks(t)
 
-	injectedErr := errors.New("new entry put error")
-	batch.EXPECT().Put(gomock.Any(), gomock.Any()).Return(injectedErr)
+	historyHashErr := errors.New("new entry put error")
+	blockHistoryHashErr := errors.New("block history hash put error")
+	// Put calls for nil key and block-hash key are issued; both return the error.
+	batch.EXPECT().Put(nil, gomock.Any()).Return(historyHashErr)
+	batch.EXPECT().Put(getBlockHistoryHashKey(1), gomock.Any()).
+		Return(blockHistoryHashErr)
 
 	table.EXPECT().NewBatch().Return(batch)
 	oldHistoryEntry := []byte{8 + 32 - 1: 0x42}
 	table.EXPECT().Get(gomock.Any()).Return(oldHistoryEntry, nil)
 
-	expectCrit(log, "failed to update hash of processed bundles", "error", injectedErr)
+	compoundErr := errors.Join(historyHashErr, blockHistoryHashErr)
+	expectCrit(log, "failed to update hash of processed bundles", "error", compoundErr)
 	// In production, a Crit log call causes the logger to exit the process.
 	// To prevent the test from exiting, the mock logger is configured to panic instead.
 	require.PanicsWithValue(t,
-		fmt.Sprintf("failed to update hash of processed bundles: %v", []any{"error", injectedErr}),
+		fmt.Sprintf("failed to update hash of processed bundles: %v",
+			[]any{"error", compoundErr}),
 		func() { store.AddProcessedBundles(1, nil) })
 }
 
@@ -223,7 +231,8 @@ func TestStore_AddProcessedBundles_LogsOnBatchWriteError(t *testing.T) {
 	store, table, log, batch, _ := storeTableLogMocks(t)
 
 	injectedErr := errors.New("batch write error")
-	batch.EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil)
+	// Both Put calls (nil key and block-hash key) are issued.
+	batch.EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	batch.EXPECT().Write().Return(injectedErr)
 
 	table.EXPECT().NewBatch().Return(batch)
@@ -294,6 +303,58 @@ func TestStore_GetProcessedBundleHistoryHash_LogsOnInvalidStateLength(t *testing
 	require.PanicsWithValue(t,
 		fmt.Sprintf("invalid state length for processed bundles: %v", []any{"length", 3}),
 		func() { store.GetProcessedBundleHistoryHash() })
+}
+
+func TestStore_GetOldestRetainedBundleHistoryHash_ReturnsFalseWhenEmpty(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	_, _, ok := store.GetOldestRetainedBundleHistoryHash()
+	require.False(ok, "should return false when no bundles have been executed yet")
+}
+
+func TestStore_GetOldestRetainedBundleHistoryHash_ReturnsZero_WhenNoBundlesExecuted(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// add blocks without bundles
+	for block := range bundle.MaxBlockRange + 2 {
+		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{})
+		blockNum, hash := store.GetProcessedBundleHistoryHash()
+		require.Zero(blockNum)
+		require.Zero(hash)
+	}
+
+	gotBlock, gotHash, ok := store.GetOldestRetainedBundleHistoryHash()
+	require.False(ok)
+	require.Equal(uint64(0), gotBlock, "oldest block should be 0")
+	require.Zero(gotHash, "oldest hash should be zero")
+}
+
+func TestStore_GetOldestRetainedBundleHistoryHash_AdvancesAfterPruning(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	var expectedOldestHash common.Hash
+	// Populate MaxBlockRange+1 blocks so the first entry gets pruned.
+	for block := range bundle.MaxBlockRange + 2 {
+		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+			uint64ToHash(block): {},
+		})
+		if block == 3 {
+			_, expectedOldestHash = store.GetProcessedBundleHistoryHash()
+		}
+	}
+
+	gotBlock, gotHash, ok := store.GetOldestRetainedBundleHistoryHash()
+	require.True(ok)
+	require.Equal(uint64(3), gotBlock,
+		"oldest retained block should be 3 after pruning the entry at block 0")
+	require.NotZero(gotHash, "history hash should not be zero after bundels have been executed")
+	require.Equal(expectedOldestHash, gotHash, "oldest retained hash should be the one at block 3")
 }
 
 func TestStore_addNewBundles_EncodesInfoCorrectly(t *testing.T) {
@@ -535,6 +596,7 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 				if c.expectDeleted {
 					batch.EXPECT().Delete(getIndexKey(c.storedBundleBlockNumber, existingBundleHash))
 					batch.EXPECT().Delete(getEntryKey(existingBundleHash))
+					batch.EXPECT().Delete(getBlockHistoryHashKey(c.storedBundleBlockNumber))
 				}
 			}
 
@@ -558,8 +620,9 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 	for i := range 10 {
 		it.EXPECT().Next().Return(true)
 		it.EXPECT().Key().Return(getIndexKey(uint64(i), uint64ToHash(uint64(i))))
-		batch.EXPECT().Delete(gomock.Any())
-		batch.EXPECT().Delete(gomock.Any())
+		batch.EXPECT().Delete(gomock.Any()) // index key
+		batch.EXPECT().Delete(gomock.Any()) // entry key
+		batch.EXPECT().Delete(gomock.Any()) // block history hash key
 	}
 	it.EXPECT().Next().Return(false)
 
@@ -587,8 +650,10 @@ func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
 
 	injectedErrDeleteEntry := errors.New("entry delete error")
 	injectedErrDeleteIndex := errors.New("index delete error")
+	injectedErrDeleteBlockHistory := errors.New("block history delete error")
 	batch.EXPECT().Delete(gomock.Any()).Return(injectedErrDeleteEntry)
 	batch.EXPECT().Delete(gomock.Any()).Return(injectedErrDeleteIndex)
+	batch.EXPECT().Delete(gomock.Any()).Return(injectedErrDeleteBlockHistory)
 
 	gomock.InOrder(
 		it.EXPECT().Next().Return(true),
@@ -597,7 +662,10 @@ func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
 	)
 	table.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(it)
 
-	compoundErr := errors.Join(injectedErrDeleteEntry, injectedErrDeleteIndex)
+	compoundErr := errors.Join(
+		injectedErrDeleteEntry,
+		injectedErrDeleteIndex,
+		injectedErrDeleteBlockHistory)
 	expectCrit(log, "failed to delete old processed bundle hash", "error", compoundErr)
 	// In production, a Crit log call causes the logger to exit the process.
 	// To prevent the test from exiting, the mock logger is configured to panic instead.
@@ -719,6 +787,19 @@ func TestStore_GetEntryKey_ReturnsExpectedKey(t *testing.T) {
 	got := getEntryKey(hash)
 	require.Equal(expectedKey, got)
 	require.Len(got, 1+32) // 1 byte for prefix + 32 bytes for hash
+}
+
+func TestStore_GetBlockHashKey_ReturnsExpectedKey(t *testing.T) {
+	blockNumbers := []uint64{0, 1, 512, math.MaxUint64 - 1, math.MaxUint64}
+	for _, blockNum := range blockNumbers {
+		t.Run(fmt.Sprintf("blockNum=%d", blockNum), func(t *testing.T) {
+			expectedKey := append([]byte{'h'}, make([]byte, 8)...)
+			binary.BigEndian.PutUint64(expectedKey[1:9], blockNum)
+			got := getBlockHistoryHashKey(blockNum)
+			require.Equal(t, expectedKey, got)
+			require.Len(t, got, 1+8) // 1 byte prefix + 8 bytes block number
+		})
+	}
 }
 
 func TestStore_GetIndexKey_ReturnsExpectedKey(t *testing.T) {

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -194,6 +194,12 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 				batch.EXPECT().Delete(getIndexKey(toDelete, hash)).Return(nil)
 				batch.EXPECT().Delete(getBlockHistoryHashKey(toDelete)).Return(nil)
 				it.EXPECT().Release()
+
+				// Second pass: 'h' iterator for bundle-less blocks (empty in mock world).
+				it2 := NewMockdbIterator(gomock.NewController(t))
+				it2.EXPECT().Next().Return(false)
+				it2.EXPECT().Release()
+				table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 			}
 
 			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
@@ -208,7 +214,7 @@ func TestStore_AddProcessedBundles_LogsOnBatchPutNewEntryError(t *testing.T) {
 
 	historyHashErr := errors.New("new entry put error")
 	blockHistoryHashErr := errors.New("block history hash put error")
-	// Put calls for nil key and block-hash key are issued; both return the error.
+	// Put calls for nil key and block-hash key are issued; both return an error.
 	batch.EXPECT().Put(nil, gomock.Any()).Return(historyHashErr)
 	batch.EXPECT().Put(getBlockHistoryHashKey(1), gomock.Any()).
 		Return(blockHistoryHashErr)
@@ -245,6 +251,32 @@ func TestStore_AddProcessedBundles_LogsOnBatchWriteError(t *testing.T) {
 	require.PanicsWithValue(t,
 		fmt.Sprintf("failed to write batch for updating processed bundles: %v", []any{"error", injectedErr}),
 		func() { store.AddProcessedBundles(1, nil) })
+}
+
+func TestStore_AddProcessedBundles_RemovesOldHistoryHash_EvenForBlockNumberWithoutBundles(t *testing.T) {
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+
+	// Populate the store with MaxBlockRange+1 blocks so the first entry gets pruned.
+	for block := range bundle.MaxBlockRange + 2 {
+		// add a single block with bundles
+		if block == 1 {
+			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+				uint64ToHash(block): {},
+			})
+		} else {
+			// add blocks without bundles to advance the block number and trigger pruning
+			store.AddProcessedBundles(block, nil)
+		}
+	}
+
+	// as block 1 is the first bundle, block 2 should have had a history hash
+	// entry, but it should now be gone.
+	oldestBlock, oldestHash, ok := store.GetOldestRetainedBundleHistoryHash()
+	require.True(t, ok)
+	// oldest should be 3, as blocks 0, 1, and 2 are pruned.
+	require.Equal(t, uint64(3), oldestBlock)
+	require.NotZero(t, oldestHash)
 }
 
 func TestStore_GetProcessedBundleHistoryHash_InitiallyZero(t *testing.T) {
@@ -353,7 +385,7 @@ func TestStore_GetOldestRetainedBundleHistoryHash_AdvancesAfterPruning(t *testin
 	require.True(ok)
 	require.Equal(uint64(3), gotBlock,
 		"oldest retained block should be 3 after pruning the entry at block 0")
-	require.NotZero(gotHash, "history hash should not be zero after bundels have been executed")
+	require.NotZero(gotHash, "history hash should not be zero after bundles have been executed")
 	require.Equal(expectedOldestHash, gotHash, "oldest retained hash should be the one at block 3")
 }
 
@@ -581,6 +613,9 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 			// The algorithm would not contemplate any history
 			// when the block number is short enough to not to require any cleanup
 			if c.finishingBlock >= bundle.MaxBlockRange-1 {
+				it2 := NewMockdbIterator(ctrl)
+				it2.EXPECT().Release()
+
 				existingBundleKey := getIndexKey(c.storedBundleBlockNumber, existingBundleHash)
 				gomock.InOrder(
 					table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it),
@@ -589,6 +624,9 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 					// AnyTimes: when entries are not to be deleted, the iteration is stopped
 					it.EXPECT().Next().Return(false).AnyTimes(),
 				)
+				// Second pass: 'h' iterator for bundle-less blocks (empty in mock world).
+				table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
+				it2.EXPECT().Next().Return(false)
 
 				// this expectation is the core of the test:
 				// it checks that the delete calls are made if and only if the
@@ -626,6 +664,12 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 	}
 	it.EXPECT().Next().Return(false)
 
+	// Second pass: 'h' iterator for bundle-less blocks (empty in mock world).
+	it2 := NewMockdbIterator(ctrl)
+	it2.EXPECT().Release()
+	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
+	it2.EXPECT().Next().Return(false)
+
 	store.deleteOutdatedBundles(bundle.MaxBlockRange+10, batch)
 }
 
@@ -633,6 +677,7 @@ func TestStore_deleteOutdatedBundles_IgnoresKeysOfWrongLength(t *testing.T) {
 	// log mock is ignored because no log called should be triggered.
 	store, table, _, batch, it := storeTableLogMocks(t)
 
+	// 'i' iterator: returns a key of wrong length, then exhausts.
 	gomock.InOrder(
 		it.EXPECT().Next().Return(true),
 		// This is the key that will be ignored, since it does not have the correct length.
@@ -640,7 +685,13 @@ func TestStore_deleteOutdatedBundles_IgnoresKeysOfWrongLength(t *testing.T) {
 		it.EXPECT().Next().Return(false),
 		it.EXPECT().Release(),
 	)
-	table.EXPECT().NewIterator(gomock.Any(), gomock.Any()).Return(it)
+	table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
+
+	// 'h' iterator: empty in the mock world.
+	it2 := NewMockdbIterator(gomock.NewController(t))
+	it2.EXPECT().Next().Return(false)
+	it2.EXPECT().Release()
+	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 
 	store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch)
 }
@@ -789,7 +840,7 @@ func TestStore_GetEntryKey_ReturnsExpectedKey(t *testing.T) {
 	require.Len(got, 1+32) // 1 byte for prefix + 32 bytes for hash
 }
 
-func TestStore_GetBlockHashKey_ReturnsExpectedKey(t *testing.T) {
+func TestStore_GetBlockHistoryHashKey_ReturnsExpectedKey(t *testing.T) {
 	blockNumbers := []uint64{0, 1, 512, math.MaxUint64 - 1, math.MaxUint64}
 	for _, blockNum := range blockNumbers {
 		t.Run(fmt.Sprintf("blockNum=%d", blockNum), func(t *testing.T) {

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -260,33 +260,31 @@ func TestStore_AddProcessedBundles_RemovesOldHistoryHash_EvenForBlockNumberWitho
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
 	// Run enough blocks that some 'h' entries from bundle-less blocks get pruned.
-	const totalBlocks = bundle.MaxBlockRange * 2
+	const currentBlock = bundle.MaxBlockRange * 2
 	const firstBundle = bundle.MaxBlockRange / 2
-	for currentBlock := uint64(1); currentBlock <= totalBlocks; currentBlock++ {
-		for block := range currentBlock {
-			// add a single block with bundles
-			if block == firstBundle {
-				store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
-					uint64ToHash(block): {},
-				})
-			} else {
-				// add blocks without bundles to advance the block number and trigger pruning
-				store.AddProcessedBundles(block, nil)
-			}
-		}
-
-		oldestBlock, _, ok := store.GetOldestRetainedBundleHistoryHash()
-		if currentBlock > firstBundle {
-			require.True(t, ok)
+	for block := range currentBlock {
+		// add a single block with bundles
+		if block == firstBundle {
+			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+				uint64ToHash(block): {},
+			})
 		} else {
-			// before the first bundle there should be no history hash
-			require.False(t, ok)
+			// add blocks without bundles to advance the block number and trigger pruning
+			store.AddProcessedBundles(block, nil)
 		}
-		for block := range oldestBlock {
-			got, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
-			require.NoError(t, err)
-			require.Empty(t, got, "history hash entry for block %d should have been deleted", block)
-		}
+	}
+
+	oldestBlock, _, ok := store.GetOldestRetainedBundleHistoryHash()
+	if currentBlock > firstBundle {
+		require.True(t, ok)
+	} else {
+		// before the first bundle there should be no history hash
+		require.False(t, ok)
+	}
+	for block := range oldestBlock {
+		got, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
+		require.NoError(t, err)
+		require.Empty(t, got, "history hash entry for block %d should have been deleted", block)
 	}
 }
 
@@ -298,6 +296,7 @@ func TestStore_AddProcessedBundles_HistoryHashIsConsistentWithPerBlockHash(t *te
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
 
+	var historicHashes []common.Hash
 	for block := range bundle.MaxBlockRange * 2 {
 		// randomly add bundles to some blocks, but not all
 		if rand.Uint64()%2 == 0 {
@@ -309,12 +308,14 @@ func TestStore_AddProcessedBundles_HistoryHashIsConsistentWithPerBlockHash(t *te
 		}
 
 		_, currentHistoryHash := store.GetProcessedBundleHistoryHash()
-		historyHashForBlock, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
-		require.NoError(t, err)
-		if len(historyHashForBlock) == 0 {
-			require.Zero(t, currentHistoryHash)
-		} else {
-			require.Equal(t, currentHistoryHash.Bytes(), historyHashForBlock)
+		historicHashes = append(historicHashes, currentHistoryHash)
+
+		for past := range block + 1 {
+			historyHashForBlock, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(past))
+			require.NoError(t, err)
+			if len(historyHashForBlock) > 0 {
+				require.Equal(t, historicHashes[past].Bytes(), historyHashForBlock)
+			}
 		}
 	}
 }
@@ -414,6 +415,8 @@ func TestStore_GetOldestRetainedBundleHistoryHash_AdvancesAfterPruning(t *testin
 	require.NoError(err)
 
 	const totalBlocks = bundle.MaxBlockRange * 2
+	// The iteration over total blocks is to show that at different block heights
+	// the same block number can be retained, oldest or pruned.
 	for currentBlock := uint64(1); currentBlock <= totalBlocks; currentBlock++ {
 		var expectedOldestHash common.Hash
 		expectedOldestBlock := uint64(0)

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -270,13 +270,34 @@ func TestStore_AddProcessedBundles_RemovesOldHistoryHash_EvenForBlockNumberWitho
 		}
 	}
 
-	// as block 1 is the first bundle, block 2 should have had a history hash
-	// entry, but it should now be gone.
-	oldestBlock, oldestHash, ok := store.GetOldestRetainedBundleHistoryHash()
-	require.True(t, ok)
-	// oldest should be 3, as blocks 0, 1, and 2 are pruned.
-	require.Equal(t, uint64(3), oldestBlock)
-	require.NotZero(t, oldestHash)
+
+func TestStore_AddProcessedBundles_HistoryHashIsConsistentWithPerBlockHash(t *testing.T) {
+	// This test verifies that as new bundles are added the history hash reported
+	// by GetProcessedBundleHistoryHash is consistent with the hash stored
+	// for each block in the 'h' entries.
+
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+
+	for block := range bundle.MaxBlockRange * 2 {
+		// randomly add bundles to some blocks, but not all
+		if rand.Uint64()%2 == 0 {
+			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+				uint64ToHash(block): {},
+			})
+		} else {
+			store.AddProcessedBundles(block, nil)
+		}
+
+		_, currentHistoryHash := store.GetProcessedBundleHistoryHash()
+		historyHashForBlock, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
+		require.NoError(t, err)
+		if len(historyHashForBlock) == 0 {
+			require.Zero(t, currentHistoryHash)
+		} else {
+			require.Equal(t, currentHistoryHash.Bytes(), historyHashForBlock)
+		}
+	}
 }
 
 func TestStore_GetProcessedBundleHistoryHash_InitiallyZero(t *testing.T) {

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -193,7 +193,6 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 				hash := uint64ToHash(toDelete)
 				batch.EXPECT().Delete(getEntryKey(hash)).Return(nil)
 				batch.EXPECT().Delete(getIndexKey(toDelete, hash)).Return(nil)
-				batch.EXPECT().Delete(getBlockHistoryHashKey(toDelete)).Return(nil)
 				it.EXPECT().Release()
 
 				// Second pass: 'h' iterator for bundle-less blocks (empty in mock world).
@@ -688,7 +687,6 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 				if c.expectDeleted {
 					batch.EXPECT().Delete(getIndexKey(c.storedBundleBlockNumber, existingBundleHash))
 					batch.EXPECT().Delete(getEntryKey(existingBundleHash))
-					batch.EXPECT().Delete(getBlockHistoryHashKey(c.storedBundleBlockNumber))
 				}
 			}
 
@@ -714,7 +712,6 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 		it.EXPECT().Key().Return(getIndexKey(uint64(i), uint64ToHash(uint64(i))))
 		batch.EXPECT().Delete(gomock.Any()) // index key
 		batch.EXPECT().Delete(gomock.Any()) // entry key
-		batch.EXPECT().Delete(gomock.Any()) // block history hash key
 	}
 	it.EXPECT().Next().Return(false)
 
@@ -755,10 +752,8 @@ func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
 
 	injectedErrDeleteEntry := errors.New("entry delete error")
 	injectedErrDeleteIndex := errors.New("index delete error")
-	injectedErrDeleteBlockHistory := errors.New("block history delete error")
 	batch.EXPECT().Delete(gomock.Any()).Return(injectedErrDeleteEntry)
 	batch.EXPECT().Delete(gomock.Any()).Return(injectedErrDeleteIndex)
-	batch.EXPECT().Delete(gomock.Any()).Return(injectedErrDeleteBlockHistory)
 
 	gomock.InOrder(
 		it.EXPECT().Next().Return(true),
@@ -769,8 +764,7 @@ func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
 
 	compoundErr := errors.Join(
 		injectedErrDeleteEntry,
-		injectedErrDeleteIndex,
-		injectedErrDeleteBlockHistory)
+		injectedErrDeleteIndex)
 	expectCrit(log, "failed to delete old processed bundle hash", "error", compoundErr)
 	// In production, a Crit log call causes the logger to exit the process.
 	// To prevent the test from exiting, the mock logger is configured to panic instead.

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -543,6 +543,250 @@ func TestStore_AddProcessedBundles_RetainsPredecessorHashEntry(t *testing.T) {
 	}
 }
 
+func TestStore_GetPredecessorBundleHistoryHash_ReturnsFalseWhenEmpty(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	_, _, ok := store.GetPredecessorBundleHistoryHash()
+	require.False(ok, "should return false when no bundles have been executed yet")
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_ReturnsFalseWhenNoBundlesExecuted(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// Add blocks without bundles — hash stays zero, no 'h' entries written.
+	for block := range bundle.MaxBlockRange + 2 {
+		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{})
+	}
+
+	_, _, ok := store.GetPredecessorBundleHistoryHash()
+	require.False(ok, "should return false when no bundles have ever been executed")
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_ReturnsFirstBlock_BeforePruning(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// Add a few blocks with bundles — not enough to trigger pruning.
+	for block := uint64(0); block < bundle.MaxBlockRange/2; block++ {
+		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+			uint64ToHash(block): {},
+		})
+	}
+
+	predBlock, predHash, ok := store.GetPredecessorBundleHistoryHash()
+	require.True(ok)
+	require.Equal(uint64(0), predBlock,
+		"before pruning the predecessor should be the very first block")
+
+	// Before pruning, predecessor == oldest retained.
+	oldestBlock, oldestHash, hasOldest := store.GetOldestRetainedBundleHistoryHash()
+	require.True(hasOldest)
+	require.Equal(predBlock, oldestBlock,
+		"before pruning, predecessor and oldest should be the same block")
+	require.Equal(predHash, oldestHash,
+		"before pruning, predecessor and oldest should have the same hash")
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_DiffersFromOldest_AfterPruning(t *testing.T) {
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// Fill enough blocks to trigger pruning.
+	for block := uint64(0); block < bundle.MaxBlockRange+10; block++ {
+		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+			uint64ToHash(block): {},
+		})
+	}
+
+	predBlock, predHash, ok := store.GetPredecessorBundleHistoryHash()
+	require.True(ok)
+
+	oldestBlock, oldestHash, hasOldest := store.GetOldestRetainedBundleHistoryHash()
+	require.True(hasOldest)
+
+	require.Less(predBlock, oldestBlock,
+		"after pruning, predecessor block should be strictly before oldest")
+	require.Equal(oldestBlock, predBlock+1,
+		"predecessor block should be exactly one before oldest")
+	require.NotEqual(predHash, oldestHash,
+		"predecessor and oldest should have different hashes")
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_MatchesExpectedHashChain(t *testing.T) {
+	// Verifies that the predecessor hash matches the independently computed
+	// hash chain at the predecessor's block number.
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	const totalBlocks = bundle.MaxBlockRange + 50
+	for block := uint64(0); block < totalBlocks; block++ {
+		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+			uint64ToHash(block): {},
+		})
+	}
+
+	predBlock, predHash, ok := store.GetPredecessorBundleHistoryHash()
+	require.True(ok)
+
+	// Recompute the expected hash chain up to predBlock.
+	expectedHash := common.Hash{}
+	for block := uint64(0); block <= predBlock; block++ {
+		addedHash := uint64ToHash(block)
+		expectedHash = referenceComputeStateHash(expectedHash, addedHash, block)
+	}
+	require.Equal(expectedHash, predHash,
+		"predecessor hash should match the independently computed hash chain")
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_AdvancesAsPruningProgresses(t *testing.T) {
+	// Verifies that the predecessor advances block-by-block as new blocks
+	// push old 'h' entries past the pruning boundary.
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	var prevPredBlock uint64
+	pruningStarted := false
+	for block := uint64(0); block < bundle.MaxBlockRange+20; block++ {
+		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+			uint64ToHash(block): {},
+		})
+
+		predBlock, _, ok := store.GetPredecessorBundleHistoryHash()
+		require.True(ok, "block=%d: predecessor should always be present after first bundle", block)
+
+		if block >= bundle.MaxBlockRange-1 {
+			if pruningStarted {
+				require.Equal(prevPredBlock+1, predBlock,
+					"block=%d: predecessor should advance by 1 each block once pruning is active",
+					block)
+			}
+			pruningStarted = true
+		}
+		prevPredBlock = predBlock
+	}
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_WorksWithGapsBetweenBundles(t *testing.T) {
+	// Bundles only at every 10th block, but 'h' entries are written for
+	// every block once the hash is non-zero.
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	// First, trigger the hash chain with a bundle at block 0.
+	store.AddProcessedBundles(0, map[common.Hash]bundle.PositionInBlock{
+		uint64ToHash(0): {},
+	})
+
+	// Then add blocks — bundles only at multiples of 10.
+	for block := uint64(1); block < bundle.MaxBlockRange+50; block++ {
+		bundles := map[common.Hash]bundle.PositionInBlock{}
+		if block%10 == 0 {
+			bundles[uint64ToHash(block)] = bundle.PositionInBlock{}
+		}
+		store.AddProcessedBundles(block, bundles)
+	}
+
+	predBlock, predHash, ok := store.GetPredecessorBundleHistoryHash()
+	require.True(ok)
+	require.NotZero(predHash, "predecessor hash should be non-zero")
+
+	// Verify it's strictly before the oldest in-range block.
+	oldestBlock, _, hasOldest := store.GetOldestRetainedBundleHistoryHash()
+	require.True(hasOldest)
+	require.Less(predBlock, oldestBlock)
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_SingleBlock(t *testing.T) {
+	// When there is exactly one block with bundles and no pruning,
+	// predecessor should be that single block.
+	require := require.New(t)
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	store.AddProcessedBundles(42, map[common.Hash]bundle.PositionInBlock{
+		{0xaa}: {},
+	})
+
+	predBlock, predHash, ok := store.GetPredecessorBundleHistoryHash()
+	require.True(ok)
+	require.Equal(uint64(42), predBlock)
+	require.NotZero(predHash)
+
+	// Should also equal the oldest and the latest since there's only one block.
+	oldestBlock, oldestHash, hasOldest := store.GetOldestRetainedBundleHistoryHash()
+	require.True(hasOldest)
+	require.Equal(predBlock, oldestBlock)
+	require.Equal(predHash, oldestHash)
+
+	latestBlock, latestHash := store.GetProcessedBundleHistoryHash()
+	require.Equal(predBlock, latestBlock)
+	require.Equal(predHash, latestHash)
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_LogsOnIteratorError(t *testing.T) {
+	store, table, log, _, _ := storeTableLogMocks(t)
+
+	injectedErr := errors.New("iterator error")
+	it := NewMockdbIterator(gomock.NewController(t))
+	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it)
+	gomock.InOrder(
+		it.EXPECT().Next().Return(false),
+		it.EXPECT().Error().Return(injectedErr),
+		it.EXPECT().Release(),
+	)
+
+	expectCrit(log, "failed to iterate bundle history hashes", "error", injectedErr)
+	require.PanicsWithValue(t,
+		fmt.Sprintf("failed to iterate bundle history hashes: %v", []any{"error", injectedErr}),
+		func() { store.GetPredecessorBundleHistoryHash() })
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_LogsOnInvalidKeyLength(t *testing.T) {
+	store, table, log, _, _ := storeTableLogMocks(t)
+
+	it := NewMockdbIterator(gomock.NewController(t))
+	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it)
+	gomock.InOrder(
+		it.EXPECT().Next().Return(true),
+		it.EXPECT().Key().Return([]byte{0x01, 0x02}), // too short
+		it.EXPECT().Release(),
+	)
+
+	expectCrit(log, "invalid per-block history hash key length", "length", 2)
+	require.PanicsWithValue(t,
+		fmt.Sprintf("invalid per-block history hash key length: %v", []any{"length", 2}),
+		func() { store.GetPredecessorBundleHistoryHash() })
+}
+
+func TestStore_GetPredecessorBundleHistoryHash_LogsOnInvalidValueLength(t *testing.T) {
+	store, table, log, _, _ := storeTableLogMocks(t)
+
+	validKey := getBlockHistoryHashKey(5)
+
+	it := NewMockdbIterator(gomock.NewController(t))
+	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it)
+	gomock.InOrder(
+		it.EXPECT().Next().Return(true),
+		it.EXPECT().Key().Return(validKey),
+		it.EXPECT().Value().Return([]byte{0x01, 0x02, 0x03}), // 3 bytes, not 32
+		it.EXPECT().Release(),
+	)
+
+	expectCrit(log, "invalid per-block history hash value length", "length", 3)
+	require.PanicsWithValue(t,
+		fmt.Sprintf("invalid per-block history hash value length: %v", []any{"length", 3}),
+		func() { store.GetPredecessorBundleHistoryHash() })
+}
+
 func TestStore_addNewBundles_EncodesInfoCorrectly(t *testing.T) {
 	store, _, _, _, _ := storeTableLogMocks(t)
 

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -275,12 +275,8 @@ func TestStore_AddProcessedBundles_RemovesOldHistoryHash_EvenForBlockNumberWitho
 	}
 
 	oldestBlock, _, ok := store.GetOldestRetainedBundleHistoryHash()
-	if currentBlock > firstBundle {
-		require.True(t, ok)
-	} else {
-		// before the first bundle there should be no history hash
-		require.False(t, ok)
-	}
+	require.True(t, ok)
+
 	for block := range oldestBlock {
 		got, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
 		require.NoError(t, err)
@@ -411,13 +407,14 @@ func TestStore_GetOldestRetainedBundleHistoryHash_AdvancesAfterPruning(t *testin
 	// are added and old ones are pruned.
 
 	require := require.New(t)
-	store, err := NewMemStore(t)
-	require.NoError(err)
 
 	const totalBlocks = bundle.MaxBlockRange * 2
 	// The iteration over total blocks is to show that at different block heights
 	// the same block number can be retained, oldest or pruned.
 	for currentBlock := uint64(1); currentBlock <= totalBlocks; currentBlock++ {
+		store, err := NewMemStore(t)
+		require.NoError(err)
+
 		var expectedOldestHash common.Hash
 		expectedOldestBlock := uint64(0)
 		foundOldest := false

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -193,11 +193,13 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 				hash := uint64ToHash(toDelete)
 				batch.EXPECT().Delete(getEntryKey(hash)).Return(nil)
 				batch.EXPECT().Delete(getIndexKey(toDelete, hash)).Return(nil)
+				it.EXPECT().Error().Return(nil)
 				it.EXPECT().Release()
 
 				// Second pass: 'h' iterator for bundle-less blocks (empty in mock world).
 				it2 := NewMockdbIterator(gomock.NewController(t))
 				it2.EXPECT().Next().Return(false)
+				it2.EXPECT().Error().Return(nil)
 				it2.EXPECT().Release()
 				table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 			}
@@ -676,10 +678,12 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 					it.EXPECT().Key().Return(existingBundleKey),
 					// AnyTimes: when entries are not to be deleted, the iteration is stopped
 					it.EXPECT().Next().Return(false).AnyTimes(),
+					it.EXPECT().Error().Return(nil),
 				)
 				// Second pass: 'h' iterator for bundle-less blocks (empty in mock world).
 				table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 				it2.EXPECT().Next().Return(false)
+				it2.EXPECT().Error().Return(nil)
 
 				// this expectation is the core of the test:
 				// it checks that the delete calls are made if and only if the
@@ -713,10 +717,12 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 		batch.EXPECT().Delete(gomock.Any()) // index key
 		batch.EXPECT().Delete(gomock.Any()) // entry key
 	}
+	it.EXPECT().Error().Return(nil)
 	it.EXPECT().Next().Return(false)
 
 	// Second pass: 'h' iterator for bundle-less blocks (empty in mock world).
 	it2 := NewMockdbIterator(ctrl)
+	it2.EXPECT().Error().Return(nil)
 	it2.EXPECT().Release()
 	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 	it2.EXPECT().Next().Return(false)
@@ -734,6 +740,7 @@ func TestStore_deleteOutdatedBundles_IgnoresKeysOfWrongLength(t *testing.T) {
 		// This is the key that will be ignored, since it does not have the correct length.
 		it.EXPECT().Key().Return([]byte{1, 2}),
 		it.EXPECT().Next().Return(false),
+		it.EXPECT().Error().Return(nil),
 		it.EXPECT().Release(),
 	)
 	table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
@@ -741,6 +748,7 @@ func TestStore_deleteOutdatedBundles_IgnoresKeysOfWrongLength(t *testing.T) {
 	// 'h' iterator: empty in the mock world.
 	it2 := NewMockdbIterator(gomock.NewController(t))
 	it2.EXPECT().Next().Return(false)
+	it2.EXPECT().Error().Return(nil)
 	it2.EXPECT().Release()
 	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -279,11 +279,16 @@ func TestStore_AddProcessedBundles_RemovesOldHistoryHash_EvenForBlockNumberWitho
 	oldestBlock, _, ok := store.GetOldestRetainedBundleHistoryHash()
 	require.True(t, ok)
 
-	for block := range oldestBlock {
+	for block := range oldestBlock - 1 {
 		got, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
 		require.NoError(t, err)
 		require.Empty(t, got, "history hash entry for block %d should have been deleted", block)
 	}
+	// The predecessor entry (oldestBlock - 1) is intentionally retained for
+	// independent hash-chain verification, so it must still be present.
+	got, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(oldestBlock - 1))
+	require.NoError(t, err)
+	require.NotEmpty(t, got, "predecessor history hash entry for block %d should be retained", oldestBlock-1)
 }
 
 func TestStore_AddProcessedBundles_HistoryHashIsConsistentWithPerBlockHash(t *testing.T) {
@@ -441,6 +446,100 @@ func TestStore_GetOldestRetainedBundleHistoryHash_AdvancesAfterPruning(t *testin
 			"oldest retained block should be the smallest block stored")
 		require.Equal(expectedOldestHash, gotHash,
 			"oldest retained hash should match the stored hash at that block")
+	}
+}
+
+func TestStore_AddProcessedBundles_RetainsPredecessorHashEntry(t *testing.T) {
+	// This test verifies that at every block height the store retains
+	// exactly one predecessor 'h' entry before the first in-range block,
+	// all earlier entries are pruned, and GetOldestRetainedBundleHistoryHash
+	// skips the predecessor returning the first in-range entry.
+
+	require := require.New(t)
+
+	const totalBlocks = bundle.MaxBlockRange * 2
+	for currentBlock := uint64(1); currentBlock <= totalBlocks; currentBlock++ {
+		store, err := NewMemStore(t)
+		require.NoError(err)
+
+		for block := range currentBlock {
+			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
+				uint64ToHash(block): {},
+			})
+		}
+
+		latestBlock := currentBlock - 1
+		if latestBlock < bundle.MaxBlockRange-1 {
+			// Before pruning kicks in there is no predecessor; the first 'h'
+			// entry is still in range and GetOldestRetainedBundleHistoryHash
+			// must return it directly.
+			it := store.table.ProcessedBundles.NewIterator([]byte{'h'}, nil)
+			require.True(it.Next(),
+				"currentBlock=%d: 'h' iterator should have at least one entry before pruning",
+				currentBlock)
+			firstKey := it.Key()
+			firstValue := it.Value()
+			it.Release()
+
+			require.Len(firstKey, 1+8,
+				"currentBlock=%d: first 'h' key should be 1+8 bytes", currentBlock)
+			firstBlock := binary.BigEndian.Uint64(firstKey[1:])
+
+			gotBlock, gotHash, ok := store.GetOldestRetainedBundleHistoryHash()
+			require.True(ok,
+				"currentBlock=%d: GetOldestRetainedBundleHistoryHash should return ok before pruning",
+				currentBlock)
+			require.Equal(firstBlock, gotBlock,
+				"currentBlock=%d: oldest retained block should equal the first 'h' key",
+				currentBlock)
+			require.Equal(common.BytesToHash(firstValue), gotHash,
+				"currentBlock=%d: oldest retained hash should match the first 'h' value",
+				currentBlock)
+			continue
+		}
+
+		highestOutdatedBlockNumber := latestBlock - bundle.MaxBlockRange + 1
+
+		// 1. The predecessor 'h' entry at highestOutdatedBlockNumber must be retained.
+		predecessorValue, err := store.table.ProcessedBundles.Get(
+			getBlockHistoryHashKey(highestOutdatedBlockNumber))
+		require.NoError(err)
+		require.NotEmpty(predecessorValue,
+			"currentBlock=%d: predecessor 'h' entry at block %d should be retained",
+			currentBlock, highestOutdatedBlockNumber)
+
+		// 2. All 'h' entries before the predecessor must be pruned.
+		for block := uint64(0); block < highestOutdatedBlockNumber; block++ {
+			got, err := store.table.ProcessedBundles.Get(getBlockHistoryHashKey(block))
+			require.NoError(err)
+			require.Empty(got,
+				"currentBlock=%d: 'h' entry at block %d should have been pruned",
+				currentBlock, block)
+		}
+
+		// 3. GetOldestRetainedBundleHistoryHash must skip the predecessor
+		//    and return the first in-range block (highestOutdatedBlockNumber + 1).
+		gotBlock, _, ok := store.GetOldestRetainedBundleHistoryHash()
+		require.True(ok)
+		require.Equal(highestOutdatedBlockNumber+1, gotBlock,
+			"currentBlock=%d: GetOldestRetainedBundleHistoryHash should skip "+
+				"predecessor at %d and return %d",
+			currentBlock, highestOutdatedBlockNumber, highestOutdatedBlockNumber+1)
+
+		// 4. The predecessor hash must match the hash chain value that was
+		//    stored when that block was processed.
+		// We verify this by checking the 'h' entry directly equals the
+		// Keccak256 chain up to that block.
+		expectedPredecessorHash := common.Hash{}
+		for block := uint64(0); block <= highestOutdatedBlockNumber; block++ {
+			addedHash := uint64ToHash(block) // same hash we passed to AddProcessedBundles
+			expectedPredecessorHash = referenceComputeStateHash(
+				expectedPredecessorHash, addedHash, block)
+		}
+		require.Equal(expectedPredecessorHash, common.BytesToHash(predecessorValue),
+			"currentBlock=%d: predecessor hash at block %d does not match "+
+				"the expected hash chain value",
+			currentBlock, highestOutdatedBlockNumber)
 	}
 }
 


### PR DESCRIPTION
This PR adds a new method `GetPredecessorBundleHistoryHash` to the Store, that retrieves the block number and hash of the very first entry in the 'h' key space of the processed bundles table.

**Motivation**
After pruning, the store retains one extra predecessor 'h' entry just before the oldest in-range block. This predecessor hash is needed to independently verify the hash chain starting at the oldest retained block (i.e., hash(K) = Keccak256(hash(K-1) || xor(...) || K)). Previously, there was no public API to retrieve this predecessor entry directly.

This PR depends on https://github.com/0xsoniclabs/sonic/pull/893