### PR TITLE
Make state processor report effective gas price

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -860,6 +860,12 @@ func applyTransaction(
 	receipt.Bloom = types.CreateBloom(receipt)
 	receipt.BlockNumber = blockNumber
 	receipt.TransactionIndex = uint(statedb.TxIndex())
+
+	// Set the effective gas price in the receipt. By registering it here, at
+	// the source, down-stream consumers of the receipts do not have to
+	// replicate the code for computing effective gas prices.
+	receipt.EffectiveGasPrice = msg.GasPrice
+
 	return receipt, result.UsedGas, nil
 }
 

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -145,7 +145,8 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 				Bloom: types.CreateBloom(&types.Receipt{
 					Logs: []*types.Log{logMsg0},
 				}),
-				Logs: []*types.Log{logMsg0},
+				Logs:              []*types.Log{logMsg0},
+				EffectiveGasPrice: big.NewInt(0),
 			}, processed[0].Receipt)
 
 			require.Nil(processed[1].Receipt)
@@ -161,7 +162,8 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 				Bloom: types.CreateBloom(&types.Receipt{
 					Logs: []*types.Log{logMsg2},
 				}),
-				Logs: []*types.Log{logMsg2},
+				Logs:              []*types.Log{logMsg2},
+				EffectiveGasPrice: big.NewInt(0),
 			}, processed[2].Receipt)
 
 			require.Nil(processed[3].Receipt)
@@ -240,7 +242,8 @@ func TestProcess_DetectsTransactionThatCanNotBeConvertedIntoAMessage(t *testing.
 				Bloom: types.CreateBloom(&types.Receipt{
 					Logs: []*types.Log{logMsg1},
 				}),
-				Logs: []*types.Log{logMsg1},
+				Logs:              []*types.Log{logMsg1},
+				EffectiveGasPrice: big.NewInt(0),
 			}, processed[1].Receipt)
 		})
 	}
@@ -731,6 +734,87 @@ func TestApplyTransaction_ApplyMessageError_RevertsSnapshotIfPrague(t *testing.T
 			require.ErrorContains(t, err, "max initcode size exceeded")
 			require.Nil(t, receipt)
 			require.Equal(t, uint64(0), gasUsed)
+		})
+	}
+}
+
+func TestApplyTransaction_SetsEffectiveGasPriceInReceipt(t *testing.T) {
+	gasPrices := []*big.Int{
+		big.NewInt(0),
+		big.NewInt(100),
+		big.NewInt(math.MaxInt64),
+		new(big.Int).Lsh(big.NewInt(1), 200),
+	}
+
+	for _, price := range gasPrices {
+		t.Run(fmt.Sprintf("%v", price), func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			state := state.NewMockStateDB(ctrl)
+
+			// -- setup to get a simple transaction to pass --
+
+			blockContext := vm.BlockContext{
+				BlockNumber: big.NewInt(123),
+				BaseFee:     big.NewInt(0),
+				Transfer: func(_ vm.StateDB, _ common.Address, _ common.Address, amount *uint256.Int) {
+					// do nothing
+				},
+				CanTransfer: func(_ vm.StateDB, _ common.Address, amount *uint256.Int) bool {
+					return true
+				},
+				Random: &common.Hash{}, // < signals Revision >= Merge
+			}
+
+			evm := vm.NewEVM(blockContext, state, &params.ChainConfig{
+				LondonBlock:        new(big.Int).SetUint64(0),
+				MergeNetsplitBlock: new(big.Int).SetUint64(0),
+				ShanghaiTime:       new(uint64),
+				CancunTime:         new(uint64),
+			}, vm.Config{})
+
+			// accept everything else that is needed to get the transaction to run
+			any := gomock.Any()
+			balance := new(uint256.Int).Lsh(uint256.NewInt(1), 240)
+			state.EXPECT().GetBalance(any).Return(balance).AnyTimes()
+			state.EXPECT().SubBalance(any, any, any).AnyTimes()
+			state.EXPECT().Prepare(any, any, any, any, any, any).AnyTimes()
+			state.EXPECT().GetNonce(any).AnyTimes()
+			state.EXPECT().SetNonce(any, any, any).AnyTimes()
+			state.EXPECT().GetCode(any).AnyTimes()
+			state.EXPECT().Snapshot().AnyTimes()
+			state.EXPECT().Exist(any).Return(true).AnyTimes()
+			state.EXPECT().AddBalance(any, any, any).AnyTimes()
+			state.EXPECT().GetRefund().AnyTimes()
+			state.EXPECT().AddRefund(any).AnyTimes()
+			state.EXPECT().GetLogs(any, any).AnyTimes()
+			state.EXPECT().EndTransaction().AnyTimes()
+			state.EXPECT().TxIndex().AnyTimes()
+
+			gp := new(core.GasPool).AddGas(1000000)
+			var usedGas uint64
+
+			blockNum := big.NewInt(12)
+
+			tx := types.NewTx(&types.LegacyTx{})
+
+			// -- end of setup --
+
+			// The only thing we really care of is that the GasPrice of the
+			// message is stored in the receipt.
+			msg := &core.Message{
+				GasPrice:  price,
+				GasFeeCap: new(big.Int).Add(price, big.NewInt(1000)),
+				GasTipCap: big.NewInt(100),
+				To:        &common.Address{},
+				Value:     big.NewInt(0),
+				GasLimit:  21_000,
+			}
+
+			receipt, _, err := applyTransaction(msg, gp, state, blockNum, tx, &usedGas, evm, nil)
+			require.NoError(err)
+
+			require.Equal(price, receipt.EffectiveGasPrice)
 		})
 	}
 }


### PR DESCRIPTION
This PR updates the state processor to also report the effective gas price in receipts.

The state processor, itself responsible for charging the gas prices, is the source of truth of the charged gas prices. However, currently, those are not included in the receipts. They are reconstructed in the RPC, as needed.

By reporting this fees in the receipts from the source, down-stream consumers can use this information directly, without the need to recompute it, and risking to derive different prices due to diverging code.

This is the first of a range of PRs aiming to improve the tracking of spend gas fees, in particular by adding support for the tracking of bundles (see #903)