### PR TITLE
Add utilities to identify and parse fee-charging transactions

### DIFF
--- a/gossip/blockproc/subsidies/subsidies.go
+++ b/gossip/blockproc/subsidies/subsidies.go
@@ -176,6 +176,35 @@ type NonceSource interface {
 	GetNonce(addr common.Address) uint64
 }
 
+// IsFeeChargeTransaction returns true if the transaction is a fee-charge
+// transaction created by GetFeeChargeTransaction. It checks that the
+// transaction is internal, targets the subsidies registry, and carries
+// calldata with the correct length and deductFees function selector.
+func IsFeeChargeTransaction(tx *types.Transaction) bool {
+	if tx == nil || !internaltx.IsInternal(tx) {
+		return false
+	}
+	if tx.To() == nil || *tx.To() != registry.GetAddress() {
+		return false
+	}
+	input := tx.Data()
+	if len(input) != 4+2*32 {
+		return false
+	}
+	selector := binary.BigEndian.Uint32(input[:4])
+	return selector == registry.DeductFeesFunctionSelector
+}
+
+// ParseFeeChargeAmount extracts the fee amount from the input data of a fee
+// charge transaction created by GetFeeChargeTransaction.
+func ParseFeeChargeAmount(tx *types.Transaction) (*uint256.Int, error) {
+	if !IsFeeChargeTransaction(tx) {
+		return nil, fmt.Errorf("transaction is not a fee charge transaction")
+	}
+	input := tx.Data()
+	return new(uint256.Int).SetBytes32(input[36:68]), nil
+}
+
 // --- utility functions ---
 
 // getGasConfig queries the subsidies registry contract for the current gas

--- a/gossip/blockproc/subsidies/subsidies_test.go
+++ b/gossip/blockproc/subsidies/subsidies_test.go
@@ -664,6 +664,103 @@ func TestGetFeeChargeTransaction_FeeOverflows_ReturnsError(t *testing.T) {
 	require.ErrorContains(err, "fee calculation overflow")
 }
 
+func TestIsFeeChargeTransaction_ValidFeeChargeTransaction_ReturnsTrue(t *testing.T) {
+	addr := registry.GetAddress()
+	tx := types.NewTx(&types.LegacyTx{To: &addr, Data: createDeductFeesInput(FundId{}, uint256.Int{})})
+	require.True(t, internaltx.IsInternal(tx))
+	require.True(t, IsFeeChargeTransaction(tx))
+}
+
+func TestIsFeeChargeTransaction_NilTransaction_ReturnsFalse(t *testing.T) {
+	require.False(t, IsFeeChargeTransaction(nil))
+}
+
+func TestIsFeeChargeTransaction_NonInternalTransaction_ReturnsFalse(t *testing.T) {
+	addr := registry.GetAddress()
+	tx := types.NewTx(&types.LegacyTx{
+		To:   &addr,
+		Data: createDeductFeesInput(FundId{}, uint256.Int{}),
+		V:    big.NewInt(1),
+	})
+	require.False(t, internaltx.IsInternal(tx))
+	require.False(t, IsFeeChargeTransaction(tx))
+}
+
+func TestIsFeeChargeTransaction_NilRecipient_ReturnsFalse(t *testing.T) {
+	tx := types.NewTx(&types.LegacyTx{Data: createDeductFeesInput(FundId{}, uint256.Int{})})
+	require.True(t, internaltx.IsInternal(tx))
+	require.False(t, IsFeeChargeTransaction(tx))
+}
+
+func TestIsFeeChargeTransaction_WrongRecipient_ReturnsFalse(t *testing.T) {
+	addr := common.Address{0x42}
+	tx := types.NewTx(&types.LegacyTx{To: &addr, Data: createDeductFeesInput(FundId{}, uint256.Int{})})
+	require.True(t, internaltx.IsInternal(tx))
+	require.False(t, IsFeeChargeTransaction(tx))
+}
+
+func TestIsFeeChargeTransaction_WrongDataLength_ReturnsFalse(t *testing.T) {
+	addr := registry.GetAddress()
+	tests := map[string]int{
+		"too short": 4 + 2*32 - 1,
+		"too long":  4 + 2*32 + 1,
+	}
+	for name, length := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx := types.NewTx(&types.LegacyTx{To: &addr, Data: make([]byte, length)})
+			require.True(t, internaltx.IsInternal(tx))
+			require.False(t, IsFeeChargeTransaction(tx))
+		})
+	}
+}
+
+func TestIsFeeChargeTransaction_WrongSelector_ReturnsFalse(t *testing.T) {
+	data := createDeductFeesInput(FundId{}, uint256.Int{})
+	binary.BigEndian.PutUint32(data, registry.DeductFeesFunctionSelector+1)
+	addr := registry.GetAddress()
+	tx := types.NewTx(&types.LegacyTx{To: &addr, Data: data})
+	require.True(t, internaltx.IsInternal(tx))
+	require.False(t, IsFeeChargeTransaction(tx))
+}
+
+func TestParseFeeChargeAmount_ValidInput_ReturnsFee(t *testing.T) {
+	tests := map[string]*uint256.Int{
+		"zero fee":  new(uint256.Int),
+		"small fee": uint256.NewInt(1_000),
+		"large fee": uint256.NewInt(0).Lsh(uint256.NewInt(1), 200),
+	}
+	for name, fee := range tests {
+		t.Run(name, func(t *testing.T) {
+			addr := registry.GetAddress()
+			tx := types.NewTx(&types.LegacyTx{
+				To:   &addr,
+				Data: createDeductFeesInput(FundId{}, *fee),
+			})
+			require.True(t, IsFeeChargeTransaction(tx))
+			got, err := ParseFeeChargeAmount(tx)
+			require.NoError(t, err)
+			require.Equal(t, fee, got)
+		})
+	}
+}
+
+func TestParseFeeChargeAmount_NotAFeeChargeTransaction_ReturnsError(t *testing.T) {
+	tests := map[string]*types.Transaction{
+		"nil transaction": nil,
+		"non-internal transaction": types.NewTx(&types.LegacyTx{
+			To:   &common.Address{},
+			Data: createDeductFeesInput(FundId{}, uint256.Int{}),
+			V:    big.NewInt(1),
+		}),
+	}
+	for name, tx := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseFeeChargeAmount(tx)
+			require.ErrorContains(t, err, "transaction is not a fee charge transaction")
+		})
+	}
+}
+
 func TestGetGasConfig_ValidSetup_ReturnsExpectedConfig(t *testing.T) {
 	cases := []gasConfig{}
 	values := []uint64{0, 1, 42, 1000, 15000, 125000, 1_000_000, math.MaxUint64}


### PR DESCRIPTION
This PR introduces two new utilities for subsidized transactions:
- `IsFeeChargeTransaction` to identify internal transactions introduced by the block processor to charge fees for sponsored transactions
- `ParseFeeChargeAmount` to extract the amount of fees charged for a sponsored transaction from a fee-charge transaction

Both utilities are preparations for improving the mechanism of tracking transaction fees in Sonic. For a full integration see #903.