### PR TITLE
Add parser for epoch sealing transactions

### DIFF
--- a/opera/contracts/driver/drivercall/driver_calls.go
+++ b/opera/contracts/driver/drivercall/driver_calls.go
@@ -19,8 +19,10 @@ package drivercall
 import (
 	_ "embed"
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -102,9 +104,10 @@ func DeactivateValidator(validatorID idx.ValidatorID, status uint64) []byte {
 	return data
 }
 
-// ParseSealEpochArgs decodes a sealEpoch call and returns the originated
-// transaction fee per validator (one entry per validator in epoch order).
-// Returns an error if data does not encode a sealEpoch call.
+// ParseSealEpochArgs decodes a sealEpoch call and returns the validator epoch
+// metrics (missed blocks, uptime, and originated transaction fee), one
+// entry per validator in epoch order. Returns an error if data does not
+// encode a sealEpoch call.
 func ParseSealEpochArgs(tx *types.Transaction) ([]ValidatorEpochMetric, error) {
 	if tx == nil || !internaltx.IsInternal(tx) {
 		return nil, fmt.Errorf("transaction is nil or not internal")
@@ -130,16 +133,62 @@ func ParseSealEpochArgs(tx *types.Transaction) ([]ValidatorEpochMetric, error) {
 	}
 
 	// Reconstruct the ValidatorEpochMetric slice from the unpacked arguments.
-	offlineTimes := args[0].([]*big.Int)
-	offlineBlocks := args[1].([]*big.Int)
-	uptimes := args[2].([]*big.Int)
-	fees := args[3].([]*big.Int)
+	return convertSealEpochArgs(args)
+}
 
+func convertSealEpochArgs(args []any) ([]ValidatorEpochMetric, error) {
+	if len(args) != 4 {
+		return nil, fmt.Errorf("expected 4 arguments for sealEpoch, got %d", len(args))
+	}
+
+	// Check the types.
+	offlineTimes, ok := args[0].([]*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for offlineTimes argument")
+	}
+	offlineBlocks, ok := args[1].([]*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for offlineBlocks argument")
+	}
+	uptimes, ok := args[2].([]*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for uptimes argument")
+	}
+	fees, ok := args[3].([]*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for fees argument")
+	}
+
+	// Check the length.
 	l := len(offlineTimes)
 	if len(offlineBlocks) != l || len(uptimes) != l || len(fees) != l {
 		return nil, fmt.Errorf("argument array lengths do not match")
 	}
 
+	// Check the range limits
+	for _, cur := range offlineBlocks {
+		if !cur.IsUint64() {
+			return nil, fmt.Errorf("offlineBlocks contains value that doesn't fit in uint64")
+		}
+	}
+	for _, cur := range offlineTimes {
+		if !cur.IsInt64() {
+			return nil, fmt.Errorf("offlineTimes contains value that doesn't fit in int64")
+		}
+		if val := cur.Int64(); val > math.MaxInt64/int64(time.Second) {
+			return nil, fmt.Errorf("offlineTimes contains value that is too large to be a valid offline time in seconds")
+		}
+	}
+	for _, cur := range uptimes {
+		if !cur.IsInt64() {
+			return nil, fmt.Errorf("uptimes contains value that doesn't fit in int64")
+		}
+		if val := cur.Int64(); val > math.MaxInt64/int64(time.Second) {
+			return nil, fmt.Errorf("uptimes contains value that is too large to be a valid uptime in seconds")
+		}
+	}
+
+	// Convert to metrics.
 	metrics := make([]ValidatorEpochMetric, l)
 	for i := range metrics {
 		metrics[i] = ValidatorEpochMetric{

--- a/opera/contracts/driver/drivercall/driver_calls.go
+++ b/opera/contracts/driver/drivercall/driver_calls.go
@@ -18,17 +18,21 @@ package drivercall
 
 import (
 	_ "embed"
+	"fmt"
 	"math/big"
 	"strings"
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/opera/contracts/driver"
 	"github.com/0xsoniclabs/sonic/opera/genesis/gpos"
 	"github.com/0xsoniclabs/sonic/utils"
+	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 )
 
 //go:embed NodeDriverAbi.json
@@ -96,4 +100,56 @@ func SetGenesisDelegation(d Delegation) []byte {
 func DeactivateValidator(validatorID idx.ValidatorID, status uint64) []byte {
 	data, _ := sAbi.Pack("deactivateValidator", utils.U64toBig(uint64(validatorID)), utils.U64toBig(status))
 	return data
+}
+
+// ParseSealEpochArgs decodes a sealEpoch call and returns the originated
+// transaction fee per validator (one entry per validator in epoch order).
+// Returns an error if data does not encode a sealEpoch call.
+func ParseSealEpochArgs(tx *types.Transaction) ([]ValidatorEpochMetric, error) {
+	if tx == nil || !internaltx.IsInternal(tx) {
+		return nil, fmt.Errorf("transaction is nil or not internal")
+	}
+	if tx.To() == nil || *tx.To() != driver.ContractAddress {
+		return nil, fmt.Errorf("transaction does not target the node driver contract")
+	}
+	data := tx.Data()
+
+	if len(data) < 4 {
+		return nil, fmt.Errorf("data too short to contain a function selector")
+	}
+	method, err := sAbi.MethodById(data[:4])
+	if err != nil {
+		return nil, fmt.Errorf("unknown method: %w", err)
+	}
+	if method.Name != "sealEpoch" {
+		return nil, fmt.Errorf("expected sealEpoch, got %s", method.Name)
+	}
+	args, err := method.Inputs.Unpack(data[4:])
+	if err != nil {
+		return nil, fmt.Errorf("failed to unpack sealEpoch arguments: %w", err)
+	}
+
+	// Reconstruct the ValidatorEpochMetric slice from the unpacked arguments.
+	offlineTimes := args[0].([]*big.Int)
+	offlineBlocks := args[1].([]*big.Int)
+	uptimes := args[2].([]*big.Int)
+	fees := args[3].([]*big.Int)
+
+	l := len(offlineTimes)
+	if len(offlineBlocks) != l || len(uptimes) != l || len(fees) != l {
+		return nil, fmt.Errorf("argument array lengths do not match")
+	}
+
+	metrics := make([]ValidatorEpochMetric, l)
+	for i := range metrics {
+		metrics[i] = ValidatorEpochMetric{
+			Missed: opera.BlocksMissed{
+				BlocksNum: idx.Block(offlineBlocks[i].Uint64()),
+				Period:    inter.FromUnix(offlineTimes[i].Int64()),
+			},
+			Uptime:          inter.FromUnix(uptimes[i].Int64()),
+			OriginatedTxFee: fees[i],
+		}
+	}
+	return metrics, nil
 }

--- a/opera/contracts/driver/drivercall/driver_calls_test.go
+++ b/opera/contracts/driver/drivercall/driver_calls_test.go
@@ -17,8 +17,10 @@
 package drivercall
 
 import (
+	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
@@ -181,4 +183,150 @@ func newInternalDriverTx(data []byte) *types.Transaction {
 		To:   &to,
 		Data: data,
 	})
+}
+
+func TestConvertSealEpochArgs_Success(t *testing.T) {
+	tests := map[string][]ValidatorEpochMetric{
+		"empty list": {},
+		"single validator": {{
+			Missed: opera.BlocksMissed{
+				BlocksNum: 42,
+				Period:    inter.FromUnix(100),
+			},
+			Uptime:          inter.FromUnix(900),
+			OriginatedTxFee: big.NewInt(1_000_000),
+		}},
+		"multiple validators": {
+			{
+				Missed: opera.BlocksMissed{
+					BlocksNum: 0,
+					Period:    inter.FromUnix(0),
+				},
+				Uptime:          inter.FromUnix(0),
+				OriginatedTxFee: big.NewInt(0),
+			},
+			{
+				Missed: opera.BlocksMissed{
+					BlocksNum: 7,
+					Period:    inter.FromUnix(300),
+				},
+				Uptime:          inter.FromUnix(700),
+				OriginatedTxFee: big.NewInt(500),
+			},
+			{
+				Missed: opera.BlocksMissed{
+					BlocksNum: 1000,
+					Period:    inter.FromUnix(86400),
+				},
+				Uptime:          inter.FromUnix(86400),
+				OriginatedTxFee: new(big.Int).Lsh(big.NewInt(1), 200), // large fee, no range limit
+			},
+		},
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := convertSealEpochArgs(metricsToArgs(input))
+			require.NoError(t, err)
+			require.Len(t, got, len(input))
+			for i := range input {
+				require.Equal(t, input[i].Missed, got[i].Missed)
+				require.Equal(t, input[i].Uptime, got[i].Uptime)
+				require.Zero(t, input[i].OriginatedTxFee.Cmp(got[i].OriginatedTxFee))
+			}
+		})
+	}
+}
+
+func TestConvertSealEpochArgs_Errors(t *testing.T) {
+	valid := []*big.Int{big.NewInt(1)}
+
+	t.Run("wrong number of arguments", func(t *testing.T) {
+		_, err := convertSealEpochArgs([]any{valid, valid, valid}) // only 3 instead of 4
+		require.ErrorContains(t, err, "expected 4 arguments for sealEpoch, got 3")
+	})
+
+	t.Run("wrong type for offlineTimes", func(t *testing.T) {
+		_, err := convertSealEpochArgs([]any{[]int{1}, valid, valid, valid})
+		require.ErrorContains(t, err, "unexpected type for offlineTimes argument")
+	})
+
+	t.Run("wrong type for offlineBlocks", func(t *testing.T) {
+		_, err := convertSealEpochArgs([]any{valid, []int{1}, valid, valid})
+		require.ErrorContains(t, err, "unexpected type for offlineBlocks argument")
+	})
+
+	t.Run("wrong type for uptimes", func(t *testing.T) {
+		_, err := convertSealEpochArgs([]any{valid, valid, []int{1}, valid})
+		require.ErrorContains(t, err, "unexpected type for uptimes argument")
+	})
+
+	t.Run("wrong type for fees", func(t *testing.T) {
+		_, err := convertSealEpochArgs([]any{valid, valid, valid, []int{1}})
+		require.ErrorContains(t, err, "unexpected type for fees argument")
+	})
+
+	t.Run("array length mismatch in offlineBlocks", func(t *testing.T) {
+		two := []*big.Int{big.NewInt(1), big.NewInt(2)}
+		_, err := convertSealEpochArgs([]any{valid, two, valid, valid})
+		require.ErrorContains(t, err, "argument array lengths do not match")
+	})
+
+	t.Run("array length mismatch in uptimes", func(t *testing.T) {
+		two := []*big.Int{big.NewInt(1), big.NewInt(2)}
+		_, err := convertSealEpochArgs([]any{valid, valid, two, valid})
+		require.ErrorContains(t, err, "argument array lengths do not match")
+	})
+
+	t.Run("array length mismatch in fees", func(t *testing.T) {
+		two := []*big.Int{big.NewInt(1), big.NewInt(2)}
+		_, err := convertSealEpochArgs([]any{valid, valid, valid, two})
+		require.ErrorContains(t, err, "argument array lengths do not match")
+	})
+
+	t.Run("offlineBlocks out of uint64 range", func(t *testing.T) {
+		overflow := new(big.Int).Lsh(big.NewInt(1), 64) // > math.MaxUint64
+		_, err := convertSealEpochArgs([]any{valid, []*big.Int{overflow}, valid, valid})
+		require.ErrorContains(t, err, "offlineBlocks contains value that doesn't fit in uint64")
+	})
+
+	t.Run("offlineTimes out of int64 range", func(t *testing.T) {
+		overflow := new(big.Int).Lsh(big.NewInt(1), 63) // > math.MaxInt64
+		_, err := convertSealEpochArgs([]any{[]*big.Int{overflow}, valid, valid, valid})
+		require.ErrorContains(t, err, "offlineTimes contains value that doesn't fit in int64")
+	})
+
+	t.Run("offlineTimes out of max-seconds range", func(t *testing.T) {
+		overflow := big.NewInt(math.MaxInt64/int64(time.Second) + 1)
+		_, err := convertSealEpochArgs([]any{[]*big.Int{overflow}, valid, valid, valid})
+		require.ErrorContains(t, err, "offlineTimes contains value that is too large to be a valid offline time in seconds")
+	})
+
+	t.Run("uptimes out of int64 range", func(t *testing.T) {
+		overflow := new(big.Int).Lsh(big.NewInt(1), 63) // > math.MaxInt64
+		_, err := convertSealEpochArgs([]any{valid, valid, []*big.Int{overflow}, valid})
+		require.ErrorContains(t, err, "uptimes contains value that doesn't fit in int64")
+	})
+
+	t.Run("uptimes out of max-seconds range", func(t *testing.T) {
+		overflow := big.NewInt(math.MaxInt64/int64(time.Second) + 1)
+		_, err := convertSealEpochArgs([]any{valid, valid, []*big.Int{overflow}, valid})
+		require.ErrorContains(t, err, "uptimes contains value that is too large to be a valid uptime in seconds")
+	})
+}
+
+// metricsToArgs converts a ValidatorEpochMetric slice into the []any format
+// expected by convertSealEpochArgs, using the same encoding as SealEpoch.
+func metricsToArgs(metrics []ValidatorEpochMetric) []any {
+	offlineTimes := make([]*big.Int, len(metrics))
+	offlineBlocks := make([]*big.Int, len(metrics))
+	uptimes := make([]*big.Int, len(metrics))
+	fees := make([]*big.Int, len(metrics))
+	for i, m := range metrics {
+		offlineTimes[i] = new(big.Int).SetUint64(uint64(m.Missed.Period.Unix()))
+		offlineBlocks[i] = new(big.Int).SetUint64(uint64(m.Missed.BlocksNum))
+		uptimes[i] = new(big.Int).SetUint64(uint64(m.Uptime.Unix()))
+		fees[i] = m.OriginatedTxFee
+	}
+	return []any{offlineTimes, offlineBlocks, uptimes, fees}
 }

--- a/opera/contracts/driver/drivercall/driver_calls_test.go
+++ b/opera/contracts/driver/drivercall/driver_calls_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package drivercall
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/opera/contracts/driver"
+	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
+)
+
+func TestParseSealEpochArgs_Success(t *testing.T) {
+	tests := map[string][]ValidatorEpochMetric{
+		"empty list": {},
+		"single validator": {{
+			Missed: opera.BlocksMissed{
+				BlocksNum: 42,
+				Period:    inter.FromUnix(100),
+			},
+			Uptime:          inter.FromUnix(900),
+			OriginatedTxFee: big.NewInt(1_000_000),
+		}},
+		"multiple validators": {
+			{
+				Missed: opera.BlocksMissed{
+					BlocksNum: 0,
+					Period:    inter.FromUnix(0),
+				},
+				Uptime:          inter.FromUnix(0),
+				OriginatedTxFee: big.NewInt(0),
+			},
+			{
+				Missed: opera.BlocksMissed{
+					BlocksNum: 7,
+					Period:    inter.FromUnix(300),
+				},
+				Uptime:          inter.FromUnix(700),
+				OriginatedTxFee: big.NewInt(500),
+			},
+			{
+				Missed: opera.BlocksMissed{
+					BlocksNum: 1000,
+					Period:    inter.FromUnix(86400),
+				},
+				Uptime:          inter.FromUnix(86400),
+				OriginatedTxFee: new(big.Int).Lsh(big.NewInt(1), 200),
+			},
+		},
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx := newInternalDriverTx(SealEpoch(input))
+			got, err := ParseSealEpochArgs(tx)
+			require.NoError(t, err)
+
+			require.Len(t, got, len(input))
+			for i := range input {
+				require.Equal(t, input[i].Missed, got[i].Missed)
+				require.Equal(t, input[i].Uptime, got[i].Uptime)
+
+				want := input[i].OriginatedTxFee
+				got := got[i].OriginatedTxFee
+				require.True(t, want.Cmp(got) == 0, "want %v, got %v", want, got)
+			}
+		})
+	}
+}
+
+func TestParseSealEpochArgs_Errors(t *testing.T) {
+	validData := SealEpoch([]ValidatorEpochMetric{})
+
+	t.Run("nil transaction", func(t *testing.T) {
+		_, err := ParseSealEpochArgs(nil)
+		require.ErrorContains(t, err, "transaction is nil or not internal")
+	})
+
+	t.Run("non-internal transaction", func(t *testing.T) {
+		tx := types.NewTx(&types.LegacyTx{
+			V: big.NewInt(1),
+		})
+		require.False(t, internaltx.IsInternal(tx))
+		_, err := ParseSealEpochArgs(tx)
+		require.ErrorContains(t, err, "transaction is nil or not internal")
+	})
+
+	t.Run("transaction with nil To", func(t *testing.T) {
+		tx := types.NewTx(&types.LegacyTx{
+			To:   nil,
+			Data: validData,
+		})
+		_, err := ParseSealEpochArgs(tx)
+		require.ErrorContains(t, err, "transaction does not target the node driver contract")
+	})
+
+	t.Run("transaction targeting wrong contract address", func(t *testing.T) {
+		tx := types.NewTx(&types.LegacyTx{
+			To:   &common.Address{1, 2, 3},
+			Data: validData,
+		})
+		_, err := ParseSealEpochArgs(tx)
+		require.ErrorContains(t, err, "transaction does not target the node driver contract")
+	})
+
+	t.Run("data too short to hold a selector", func(t *testing.T) {
+		for _, data := range [][]byte{nil, {}, {1}, {1, 2}, {1, 2, 3}} {
+			tx := newInternalDriverTx(data)
+			_, err := ParseSealEpochArgs(tx)
+			require.ErrorContains(t, err, "data too short to contain a function selector")
+		}
+	})
+
+	t.Run("unknown four-byte selector", func(t *testing.T) {
+		// 4-byte selector that does not match any method in the ABI.
+		data := append([]byte{1, 2, 3, 4}, make([]byte, 128)...)
+		tx := newInternalDriverTx(data)
+		_, err := ParseSealEpochArgs(tx)
+		require.ErrorContains(t, err, "unknown method")
+	})
+
+	t.Run("valid selector but wrong method", func(t *testing.T) {
+		// sealEpochValidators is a different ABI method on the same contract.
+		data := SealEpochValidators([]idx.ValidatorID{1, 2, 3})
+		tx := newInternalDriverTx(data)
+		_, err := ParseSealEpochArgs(tx)
+		require.ErrorContains(t, err, "expected sealEpoch")
+	})
+
+	t.Run("truncated arguments", func(t *testing.T) {
+		// Keep the sealEpoch 4-byte selector but truncate the ABI payload.
+		full := SealEpoch([]ValidatorEpochMetric{{
+			Missed:          opera.BlocksMissed{BlocksNum: 1, Period: inter.FromUnix(1)},
+			Uptime:          inter.FromUnix(1),
+			OriginatedTxFee: big.NewInt(1),
+		}})
+		tx := newInternalDriverTx(full[:6]) // selector (4 bytes) + 2 garbage bytes
+		_, err := ParseSealEpochArgs(tx)
+		require.ErrorContains(t, err, "failed to unpack sealEpoch arguments")
+	})
+
+	t.Run("array length mismatch", func(t *testing.T) {
+		// Pack a sealEpoch call where offlineBlocks has a different length than
+		// the other three arrays to trigger the length-mismatch check.
+		twoElems := []*big.Int{big.NewInt(1), big.NewInt(2)}
+		threeElems := []*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)}
+		data, err := sAbi.Pack("sealEpoch", twoElems, threeElems, twoElems, twoElems)
+		require.NoError(t, err)
+		tx := newInternalDriverTx(data)
+		_, err = ParseSealEpochArgs(tx)
+		require.ErrorContains(t, err, "argument array lengths do not match")
+	})
+}
+
+// newInternalDriverTx creates an unsigned (internal) transaction targeting
+// the node driver contract with the given call data.
+func newInternalDriverTx(data []byte) *types.Transaction {
+	to := driver.ContractAddress
+	return types.NewTx(&types.LegacyTx{
+		To:   &to,
+		Data: data,
+	})
+}


### PR DESCRIPTION
This PR adds a utility for decoding the arguments provided to `sealEpoch` transactions at the end of each epoch.

This utility provides a first building block for building end-to-end integration tests verifying the content of those arguments.

For a full example making use of this function see #903.