### PR TITLE
Enable bundle semantics with brio and bundle execution with bundle flag

### DIFF
--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -633,7 +633,7 @@ func Test_trialRunBundle_DoesRunTransactionsThroughEVMAndReturnsIfTransactionsGo
 				ChainID: big.NewInt(1),
 			}).AnyTimes()
 			chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
-				Upgrades: opera.Upgrades{TransactionBundles: true},
+				Upgrades: opera.Upgrades{Brio: true, TransactionBundles: true},
 			}).AnyTimes()
 
 			// setup of the state DB to support the EVM execution, the actual

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -44,13 +44,14 @@ import (
 //
 // StateProcessor implements Processor.
 type StateProcessor struct {
-	config   *params.ChainConfig // Chain configuration options
-	bc       DummyChain          // Canonical block chain
-	upgrades opera.Upgrades      // Enabled network upgrades
+	config    *params.ChainConfig // Chain configuration options
+	bc        DummyChain          // Canonical block chain
+	upgrades  opera.Upgrades      // Enabled network upgrades
+	forReplay bool                // Whether the state processor is used for replaying transactions or for head state processing.
 }
 
-// NewStateProcessor initializes a new StateProcessor.
-func NewStateProcessor(
+// NewStateProcessorForHeadState initializes a new StateProcessor for head state processing.
+func NewStateProcessorForHeadState(
 	config *params.ChainConfig,
 	bc DummyChain,
 	upgrades opera.Upgrades,
@@ -59,6 +60,20 @@ func NewStateProcessor(
 		config:   config,
 		bc:       bc,
 		upgrades: upgrades,
+	}
+}
+
+// NewStateProcessorForReplay initializes a new StateProcessor for replaying transactions.
+func NewStateProcessorForReplay(
+	config *params.ChainConfig,
+	bc DummyChain,
+	upgrades opera.Upgrades,
+) *StateProcessor {
+	return &StateProcessor{
+		config:    config,
+		bc:        bc,
+		upgrades:  upgrades,
+		forReplay: true,
 	}
 }
 
@@ -134,7 +149,7 @@ func (p *StateProcessor) ProcessWithDifficulty(
 	// Iterate over and process the individual transactions
 	return runTransactions(newRunContext(
 		signer, header.BaseFee, statedb, gp, blockNumber, usedGas,
-		onNewLog, p.upgrades, &transactionRunner{evm{vmenv}},
+		onNewLog, p.upgrades, &transactionRunner{evm{vmenv}}, p.forReplay,
 	), block.Transactions, 0, trueTxOffset)
 }
 
@@ -151,6 +166,7 @@ type runContext struct {
 	onNewLog    func(*types.Log)
 	upgrades    opera.Upgrades
 	runner      _transactionRunner
+	forReplay   bool // Whether the context is used for replaying transactions or for head state processing.
 }
 
 // newRunContext creates a new runContext instance bundling the given parameters
@@ -167,6 +183,7 @@ func newRunContext(
 	onNewLog func(*types.Log),
 	upgrades opera.Upgrades,
 	runner _transactionRunner,
+	isReplay bool,
 ) *runContext {
 	return &runContext{
 		signer:      signer,
@@ -178,6 +195,7 @@ func newRunContext(
 		onNewLog:    onNewLog,
 		upgrades:    upgrades,
 		runner:      runner,
+		forReplay:   isReplay,
 	}
 }
 
@@ -216,8 +234,8 @@ func runTransactions(
 		nextId := legacyTxIndexOffset + len(processedTxs) // < counts also skipped transactions
 
 		// Bundle-only transactions are only valid within a bundle and must
-		// be rejected at the top level.
-		if context.upgrades.Brio && bundle.IsBundleOnly(tx) {
+		// be rejected at the top level when processing the head state.
+		if !context.forReplay && context.upgrades.Brio && bundle.IsBundleOnly(tx) {
 			processedTxs = append(processedTxs, ProcessedTransaction{Transaction: tx})
 			continue
 		}
@@ -631,7 +649,7 @@ func NewTransactionProcessorForBlock(
 	// in the scheduler. See the scheduler.Schedule method for details. The
 	// total gas used for attempting to schedule transactions is not limited.
 	gasLimit := uint64(math.MaxUint64)
-	stateProcessor := NewStateProcessor(chainCfg, chain, rules.Upgrades)
+	stateProcessor := NewStateProcessorForHeadState(chainCfg, chain, rules.Upgrades)
 	return stateProcessor.BeginBlock(block, state, vmConfig, gasLimit, nil)
 }
 
@@ -693,6 +711,7 @@ func (tp *TransactionProcessor) Run(i int, tx *types.Transaction) ProcessSummary
 	return runTransactions(newRunContext(
 		tp.signer, tp.header.BaseFee, tp.stateDb, tp.gp, tp.blockNumber,
 		&tp.usedGas, tp.onNewLog, tp.upgrades, &transactionRunner{evm{tp.vmEnvironment}},
+		false,
 	), []*types.Transaction{tx}, i, i)
 }
 

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -214,6 +214,14 @@ func runTransactions(
 		// transaction index offset to be tracked.
 
 		nextId := legacyTxIndexOffset + len(processedTxs) // < counts also skipped transactions
+
+		// Bundle-only transactions are only valid within a bundle and must
+		// be rejected at the top level.
+		if context.upgrades.Brio && bundle.IsBundleOnly(tx) {
+			processedTxs = append(processedTxs, ProcessedTransaction{Transaction: tx})
+			continue
+		}
+
 		txs, _ := runTransaction(context, tx, nextId, trueTxIndexOffset)
 
 		for _, tx := range txs {
@@ -240,9 +248,14 @@ func runTransaction(
 ) ([]ProcessedTransaction, core_types.TransactionResult) {
 	// Since a transaction bundle has a gas-price of 0 it would be considered a
 	// sponsorship request. Thus, we need to check for bundles first.
-	if context.upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
-		return context.runner.runTransactionBundle(context, tx, legacyTxIndexOffset, trueTxIndexOffset)
-	} else if context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
+	if context.upgrades.Brio && bundle.IsEnvelope(tx) {
+		if context.upgrades.TransactionBundles {
+			return context.runner.runTransactionBundle(context, tx, legacyTxIndexOffset, trueTxIndexOffset)
+		} else {
+			return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid
+		}
+	}
+	if context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
 		res, result := context.runner.runSponsoredTransaction(context, tx, legacyTxIndexOffset, trueTxIndexOffset)
 		return res, result
 	} else {

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -94,7 +94,7 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 
 	chainConfig := params.ChainConfig{}
 	chain := NewMockDummyChain(ctrl)
-	processor := NewStateProcessor(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
 
 	tests := map[string]processFunction{
 		"bulk":        processor.Process,
@@ -203,7 +203,7 @@ func TestProcess_DetectsTransactionThatCanNotBeConvertedIntoAMessage(t *testing.
 	}
 
 	state := getStateDbMockForTransactions(ctrl, transactions)
-	processor := NewStateProcessor(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
 	tests := map[string]processFunction{
 		"bulk":        processor.Process,
 		"incremental": processor.process_iteratively,
@@ -264,7 +264,7 @@ func TestProcess_TracksParentBlockHashIfPragueIsEnabled(t *testing.T) {
 		}
 		chain := NewMockDummyChain(ctrl)
 
-		processor := NewStateProcessor(&chainConfig, chain, opera.Upgrades{})
+		processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
 
 		tests := map[string]processFunction{
 			"bulk":        processor.Process,
@@ -312,7 +312,7 @@ func TestProcess_FailingTransactionAreSkippedButTheBlockIsNotTerminated(t *testi
 
 	chainConfig := params.ChainConfig{}
 	chain := NewMockDummyChain(ctrl)
-	processor := NewStateProcessor(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
 
 	block := &EvmBlock{
 		EvmHeader: EvmHeader{
@@ -371,7 +371,7 @@ func TestProcess_EnforcesGasLimitBySkippingExcessiveTransactions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	chainConfig := params.ChainConfig{}
 	chain := NewMockDummyChain(ctrl)
-	processor := NewStateProcessor(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
 
 	tests := map[string]processFunction{
 		"bulk":        processor.Process,
@@ -458,7 +458,7 @@ func TestProcess_EnforcesGasLimitBySkippingExcessiveTransactions(t *testing.T) {
 
 func TestProcess_UsesDifficultyOfOne(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	processor := NewStateProcessor(&params.ChainConfig{}, nil, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, opera.Upgrades{})
 
 	state, block := createScenarioWithTxCheckingDifficulty(ctrl, big.NewInt(1))
 
@@ -482,7 +482,7 @@ func TestProcessWithDifficulty_UsesProvidedDifficulty(t *testing.T) {
 	for _, difficulty := range []*big.Int{big.NewInt(0), big.NewInt(2), big.NewInt(42)} {
 		t.Run(fmt.Sprintf("difficulty=%s", difficulty.String()), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			processor := NewStateProcessor(&params.ChainConfig{}, nil, opera.Upgrades{})
+			processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, opera.Upgrades{})
 
 			state, block := createScenarioWithTxCheckingDifficulty(ctrl, difficulty)
 			results := processor.ProcessWithDifficulty(
@@ -562,7 +562,7 @@ func TestProcess_ForwardsCorrectIndexToTransactionProcessor(t *testing.T) {
 		t.Run(fmt.Sprintf("offset=%d", offset), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			upgrades := opera.Upgrades{Brio: true, TransactionBundles: true}
-			processor := NewStateProcessor(&params.ChainConfig{}, nil, upgrades)
+			processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, upgrades)
 
 			any := gomock.Any()
 			state := state.NewMockStateDB(ctrl)
@@ -1317,6 +1317,60 @@ func TestRunTransactions_EnvelopeAndBundleOnly_SemanticsEnabledByBrio_ExecutionE
 			} else {
 				require.Equal(t, ProcessedTransaction{tc.tx, &types.Receipt{}}, processed[0])
 			}
+		})
+	}
+}
+
+func TestRunTransactions_BundleOnlyTxsAreNotFilteredDuringReplay(t *testing.T) {
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	envelopeTx := getTransactionBundle(t)
+	txBundle, _, err := bundle.ValidateEnvelope(signer, envelopeTx)
+	require.NoError(t, err)
+	bundleOnlyTx := txBundle.GetTransactionsInReferencedOrder()[0]
+
+	cases := map[string]struct {
+		brio               bool
+		transactionBundles bool
+	}{
+		"PreBrio/WithoutBundles": {
+			brio:               false,
+			transactionBundles: false,
+		},
+		"PreBrio/WithBundles": {
+			brio:               false,
+			transactionBundles: true,
+		},
+		"PostBrio/WithoutBundles": {
+			brio:               true,
+			transactionBundles: false,
+		},
+		"PostBrio/WithBundles": {
+			brio:               true,
+			transactionBundles: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			runner := NewMock_transactionRunner(ctrl)
+			context := &runContext{
+				runner: runner,
+				upgrades: opera.Upgrades{
+					Brio:               tc.brio,
+					TransactionBundles: tc.transactionBundles,
+				},
+				forReplay: true, // this is the relevant part for this test
+			}
+
+			runner.EXPECT().runRegularTransaction(context, bundleOnlyTx, 0, 0).
+				Return(ProcessedTransaction{Transaction: bundleOnlyTx, Receipt: &types.Receipt{}}, core_types.TransactionResultSuccessful)
+
+			summary := runTransactions(context, []*types.Transaction{bundleOnlyTx}, 0, 0)
+			processed := summary.ProcessedTransactions
+			require.Len(t, processed, 1)
+			require.Equal(t, ProcessedTransaction{bundleOnlyTx, &types.Receipt{}}, processed[0])
 		})
 	}
 }

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -561,7 +561,7 @@ func TestProcess_ForwardsCorrectIndexToTransactionProcessor(t *testing.T) {
 	for _, offset := range []int{0, 1, 42} {
 		t.Run(fmt.Sprintf("offset=%d", offset), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			upgrades := opera.Upgrades{TransactionBundles: true}
+			upgrades := opera.Upgrades{Brio: true, TransactionBundles: true}
 			processor := NewStateProcessor(&params.ChainConfig{}, nil, upgrades)
 
 			any := gomock.Any()
@@ -924,7 +924,7 @@ func TestRunTransactions_RunsAllTransactionsAndCollectsProcessedTransactions(t *
 
 	context := &runContext{
 		runner:   runner,
-		upgrades: opera.Upgrades{GasSubsidies: true, TransactionBundles: true},
+		upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
 	}
 	gomock.InOrder(
 		runner.EXPECT().runRegularTransaction(context, txs[0], 0, 4).Return(
@@ -1010,6 +1010,7 @@ func TestRunTransactions_ProvidesNextIndexAsOriginalIndexPlusNumberOfPreviouslyP
 	context := &runContext{
 		runner: runner,
 		upgrades: opera.Upgrades{
+			Brio:               true,
 			GasSubsidies:       true,
 			TransactionBundles: true,
 		},
@@ -1221,28 +1222,103 @@ func TestRunTransactions_BundlesEnabled_RunsSponsorshipRequestWithSponsorship(t 
 	require.Nil(t, processed[0].Receipt)
 }
 
-func TestRunTransactions_BundlesEnabled_RunsTransactionBundleAsBundle(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	runner := NewMock_transactionRunner(ctrl)
+func TestRunTransactions_EnvelopeAndBundleOnly_SemanticsEnabledByBrio_ExecutionEnabledByBundleFlag(t *testing.T) {
+	signer := types.LatestSignerForChainID(big.NewInt(1))
 
-	tx := getTransactionBundle(t)
+	envelopeTx := getTransactionBundle(t)
+	txBundle, _, err := bundle.ValidateEnvelope(signer, envelopeTx)
+	require.NoError(t, err)
+	bundleOnlyTx := txBundle.Transactions[txBundle.Plan.Root.GetTransactionReferencesInReferencedOrder()[0]]
 
-	context := &runContext{
-		runner:   runner,
-		upgrades: opera.Upgrades{TransactionBundles: true},
+	cases := map[string]struct {
+		tx                 *types.Transaction
+		brio               bool
+		transactionBundles bool
+		expectRunRegular   bool
+		expectRunBundle    bool
+		expectInvalid      bool
+	}{
+		"Envelope/PreBrio/WithoutBundles": {
+			tx:                 envelopeTx,
+			brio:               false,
+			transactionBundles: false,
+			expectRunRegular:   true,
+		},
+		"Envelope/PreBrio/WithBundles": {
+			tx:                 envelopeTx,
+			brio:               false,
+			transactionBundles: true,
+			expectRunRegular:   true,
+		},
+		"Envelope/PostBrio/WithoutBundles": {
+			tx:                 envelopeTx,
+			brio:               true,
+			transactionBundles: false,
+			expectInvalid:      true,
+		},
+		"Envelope/PostBrio/WithBundles": {
+			tx:                 envelopeTx,
+			brio:               true,
+			transactionBundles: true,
+			expectRunBundle:    true,
+		},
+		"BundleOnly/PreBrio/WithoutBundles": {
+			tx:                 bundleOnlyTx,
+			brio:               false,
+			transactionBundles: false,
+			expectRunRegular:   true,
+		},
+		"BundleOnly/PreBrio/WithBundles": {
+			tx:                 bundleOnlyTx,
+			brio:               false,
+			transactionBundles: true,
+			expectRunRegular:   true,
+		},
+		"BundleOnly/PostBrio/WithoutBundles": {
+			tx:                 bundleOnlyTx,
+			brio:               true,
+			transactionBundles: false,
+			expectInvalid:      true,
+		},
+		"BundleOnly/PostBrio/WithBundles": {
+			tx:                 bundleOnlyTx,
+			brio:               true,
+			transactionBundles: true,
+			expectInvalid:      true,
+		},
 	}
-	runner.EXPECT().runTransactionBundle(context, tx, 10, 15).Return(
-		[]ProcessedTransaction{{
-			Transaction: tx,
-			Receipt:     nil,
-		}},
-		core_types.TransactionResultSuccessful,
-	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 10, 15)
-	processed := summary.ProcessedTransactions
-	require.Len(t, processed, 1)
-	require.Equal(t, tx, processed[0].Transaction)
-	require.Nil(t, processed[0].Receipt)
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			runner := NewMock_transactionRunner(ctrl)
+			context := &runContext{
+				runner: runner,
+				upgrades: opera.Upgrades{
+					Brio:               tc.brio,
+					TransactionBundles: tc.transactionBundles,
+				},
+			}
+
+			if tc.expectRunRegular {
+				runner.EXPECT().runRegularTransaction(context, tc.tx, 0, 0).
+					Return(ProcessedTransaction{Transaction: tc.tx, Receipt: &types.Receipt{}}, core_types.TransactionResultSuccessful)
+			}
+			if tc.expectRunBundle {
+				runner.EXPECT().runTransactionBundle(context, tc.tx, 0, 0).
+					Return([]ProcessedTransaction{{Transaction: tc.tx, Receipt: &types.Receipt{}}}, core_types.TransactionResultSuccessful)
+			}
+
+			summary := runTransactions(context, []*types.Transaction{tc.tx}, 0, 0)
+			processed := summary.ProcessedTransactions
+			require.Len(t, processed, 1)
+			if tc.expectInvalid {
+				require.Equal(t, ProcessedTransaction{tc.tx, nil}, processed[0])
+			} else {
+				require.Equal(t, ProcessedTransaction{tc.tx, &types.Receipt{}}, processed[0])
+			}
+		})
+	}
 }
 
 func TestRunSponsoredTransaction_InsufficientGas_SkipsTransaction(t *testing.T) {
@@ -2822,7 +2898,7 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyAndTrueTransactionOffsetToBun
 				ctrl := gomock.NewController(t)
 				runner := NewMock_transactionRunner(ctrl)
 
-				upgrades := opera.Upgrades{GasSubsidies: true, TransactionBundles: true}
+				upgrades := opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true}
 				ctxt := &runContext{runner: runner, upgrades: upgrades}
 				bundleTransactionRunner := &bundleTransactionRunner{
 					ctxt:           ctxt,
@@ -3308,7 +3384,7 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 			stateDb.EXPECT().AddProcessedBundle(any, any).AnyTimes()
 
 			signer := types.LatestSignerForChainID(big.NewInt(1))
-			upgrades := opera.Upgrades{GasSubsidies: true, TransactionBundles: true}
+			upgrades := opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true}
 			ctxt := &runContext{
 				signer:      signer,
 				usedGas:     new(uint64),

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -1228,7 +1228,7 @@ func TestRunTransactions_EnvelopeAndBundleOnly_SemanticsEnabledByBrio_ExecutionE
 	envelopeTx := getTransactionBundle(t)
 	txBundle, _, err := bundle.ValidateEnvelope(signer, envelopeTx)
 	require.NoError(t, err)
-	bundleOnlyTx := txBundle.Transactions[txBundle.Plan.Root.GetTransactionReferencesInReferencedOrder()[0]]
+	bundleOnlyTx := txBundle.GetTransactionsInReferencedOrder()[0]
 
 	cases := map[string]struct {
 		tx                 *types.Transaction

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -142,7 +142,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 }
 
 func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) evmcore.ProcessSummary {
-	evmProcessor := p.processorFactory.NewStateProcessor(p.evmCfg, p.reader, p.rules.Upgrades)
+	evmProcessor := p.processorFactory.NewStateProcessorForHeadState(p.evmCfg, p.reader, p.rules.Upgrades)
 	legacyTxsOffset := uint(len(p.processedTxs))
 	trueTxsOffset := int(0)
 	for _, tx := range p.processedTxs {
@@ -211,7 +211,13 @@ func (p *OperaEVMProcessor) Finalize() (evmBlock *evmcore.EvmBlock, numSkipped i
 // _stateProcessorFactory is an internal interface to allow introducing mocked
 // state processors in tests.
 type _stateProcessorFactory interface {
-	NewStateProcessor(
+	NewStateProcessorForHeadState(
+		evmCfg *params.ChainConfig,
+		reader evmcore.DummyChain,
+		upgrades opera.Upgrades,
+	) _stateProcessor
+
+	NewStateProcessorForReplay(
 		evmCfg *params.ChainConfig,
 		reader evmcore.DummyChain,
 		upgrades opera.Upgrades,
@@ -236,10 +242,18 @@ type _stateProcessor interface {
 // _stateProcessorFactory using the real evmcore.StateProcessor.
 type stateProcessorFactory struct{}
 
-func (stateProcessorFactory) NewStateProcessor(
+func (stateProcessorFactory) NewStateProcessorForHeadState(
 	evmCfg *params.ChainConfig,
 	reader evmcore.DummyChain,
 	upgrades opera.Upgrades,
 ) _stateProcessor {
-	return evmcore.NewStateProcessor(evmCfg, reader, upgrades)
+	return evmcore.NewStateProcessorForHeadState(evmCfg, reader, upgrades)
+}
+
+func (stateProcessorFactory) NewStateProcessorForReplay(
+	evmCfg *params.ChainConfig,
+	reader evmcore.DummyChain,
+	upgrades opera.Upgrades,
+) _stateProcessor {
+	return evmcore.NewStateProcessorForReplay(evmCfg, reader, upgrades)
 }

--- a/gossip/blockproc/evmmodule/evm_mock.go
+++ b/gossip/blockproc/evmmodule/evm_mock.go
@@ -45,18 +45,32 @@ func (m *Mock_stateProcessorFactory) EXPECT() *Mock_stateProcessorFactoryMockRec
 	return m.recorder
 }
 
-// NewStateProcessor mocks base method.
-func (m *Mock_stateProcessorFactory) NewStateProcessor(evmCfg *params.ChainConfig, reader evmcore.DummyChain, upgrades opera.Upgrades) _stateProcessor {
+// NewStateProcessorForHeadState mocks base method.
+func (m *Mock_stateProcessorFactory) NewStateProcessorForHeadState(evmCfg *params.ChainConfig, reader evmcore.DummyChain, upgrades opera.Upgrades) _stateProcessor {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewStateProcessor", evmCfg, reader, upgrades)
+	ret := m.ctrl.Call(m, "NewStateProcessorForHeadState", evmCfg, reader, upgrades)
 	ret0, _ := ret[0].(_stateProcessor)
 	return ret0
 }
 
-// NewStateProcessor indicates an expected call of NewStateProcessor.
-func (mr *Mock_stateProcessorFactoryMockRecorder) NewStateProcessor(evmCfg, reader, upgrades any) *gomock.Call {
+// NewStateProcessorForHeadState indicates an expected call of NewStateProcessorForHeadState.
+func (mr *Mock_stateProcessorFactoryMockRecorder) NewStateProcessorForHeadState(evmCfg, reader, upgrades any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStateProcessor", reflect.TypeOf((*Mock_stateProcessorFactory)(nil).NewStateProcessor), evmCfg, reader, upgrades)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStateProcessorForHeadState", reflect.TypeOf((*Mock_stateProcessorFactory)(nil).NewStateProcessorForHeadState), evmCfg, reader, upgrades)
+}
+
+// NewStateProcessorForReplay mocks base method.
+func (m *Mock_stateProcessorFactory) NewStateProcessorForReplay(evmCfg *params.ChainConfig, reader evmcore.DummyChain, upgrades opera.Upgrades) _stateProcessor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewStateProcessorForReplay", evmCfg, reader, upgrades)
+	ret0, _ := ret[0].(_stateProcessor)
+	return ret0
+}
+
+// NewStateProcessorForReplay indicates an expected call of NewStateProcessorForReplay.
+func (mr *Mock_stateProcessorFactoryMockRecorder) NewStateProcessorForReplay(evmCfg, reader, upgrades any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStateProcessorForReplay", reflect.TypeOf((*Mock_stateProcessorFactory)(nil).NewStateProcessorForReplay), evmCfg, reader, upgrades)
 }
 
 // Mock_stateProcessor is a mock of _stateProcessor interface.

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -203,7 +203,7 @@ func TestOperaEVMProcessor_Execute_StateProcessorIntroducesTransactions_Produces
 	stateProcessor := NewMock_stateProcessor(ctrl)
 
 	any := gomock.Any()
-	factory.EXPECT().NewStateProcessor(any, any, any).Return(stateProcessor).AnyTimes()
+	factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor).AnyTimes()
 
 	summary := evmcore.ProcessSummary{
 		ProcessedTransactions: []evmcore.ProcessedTransaction{
@@ -251,7 +251,7 @@ func TestOperaEVMProcessor_Execute_StateProcessorProducesTransactionsAndBundles_
 	stateProcessor := NewMock_stateProcessor(ctrl)
 
 	any := gomock.Any()
-	factory.EXPECT().NewStateProcessor(any, any, any).Return(stateProcessor).AnyTimes()
+	factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor).AnyTimes()
 
 	summary := evmcore.ProcessSummary{
 		ProcessedTransactions: []evmcore.ProcessedTransaction{
@@ -297,7 +297,7 @@ func TestOperaEVMProcessor_Execute_UsesLengthOfProcessedTransactionsAsTransactio
 			stateProcessor := NewMock_stateProcessor(ctrl)
 
 			any := gomock.Any()
-			factory.EXPECT().NewStateProcessor(any, any, any).Return(stateProcessor)
+			factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor)
 
 			stateProcessor.EXPECT().
 				Process(any, any, any, any, any, any, any).
@@ -350,7 +350,7 @@ func TestOperaEVMProcessor_Execute_UsesNumberOfTransactionsWithReceiptsAsTransac
 			stateProcessor := NewMock_stateProcessor(ctrl)
 
 			any := gomock.Any()
-			factory.EXPECT().NewStateProcessor(any, any, any).Return(stateProcessor)
+			factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor)
 
 			wantedOffset := 0
 			for _, cur := range processedTransactions {

--- a/tests/block_verifiability_utils.go
+++ b/tests/block_verifiability_utils.go
@@ -225,7 +225,7 @@ func (s *State) ApplyBlock(
 	upgrades := rules.Upgrades
 	upgrades.GasSubsidies = false
 
-	processor := evmcore.NewStateProcessor(
+	processor := evmcore.NewStateProcessorForReplay(
 		chainConfig,
 		historyAdapter{history: s.blockHashHistory},
 		upgrades,


### PR DESCRIPTION
This PR adds additional checks to the state processor, to make sure that bundle (envelope and bundle only txs) semantics are interpreted post-brio and the execution of envelopes is controlled by the bundle feature flag.
It also adds unit tests to verify envelopes and bundle only tx are executed (or skipped) accordingly.

Here is the expected behavior:
- bundle-only transactions (transactions marked as being part of bundle):
  - Pre-Brio: run as regular transactions or sponsored transactions if their gas price is 0
  - Post-Brio: skipped
- envelopes:
  - Pre-Brio: run as regular transactions or sponsored transactions if their gas price is 0
  - Post-Brio:
    - bundles disabled: skipped
    - bundles enabled: processed as bundled tx