### PR TITLE
Update transaction fee tracking to cover bundles

### DIFF
--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -215,8 +215,8 @@ func (p *DriverTxListener) onNewAcceptedTransactionInternal(
 ) {
 	fee, err := ComputeEffectiveFee(tx, r)
 	if err != nil {
-		// if there is an overflow in the fee computation, the safe default
-		// is not not attribute it to any validator to not pay out any fees.
+		// If there is an overflow in the fee computation, the safe default
+		// is to avoid attributing it to any validator, so no fees are paid out.
 		log.Warn("overflow in fee computation", "tx", tx.Hash(), "usedGas", r.GasUsed, "gasPrice", r.EffectiveGasPrice, "err", err)
 		return
 	}
@@ -235,7 +235,7 @@ func (p *DriverTxListener) onNewAcceptedTransactionInternal(
 // transaction and its receipt. For regular transactions, this is simply
 // gasUsed * effectiveGasPrice. For fee charge transactions, the fee is
 // extracted from the transaction input data. If the calculation leads to a
-// 256-bit overflow, a fee of 0 is returned.
+// 256-bit overflow, the function returns a non-nil error and a nil fee.
 func ComputeEffectiveFee(
 	tx *types.Transaction,
 	r *types.Receipt,

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -17,6 +17,7 @@
 package drivermodule
 
 import (
+	"fmt"
 	"io"
 	"math"
 	"math/big"
@@ -25,8 +26,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/drivertype"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
@@ -184,6 +187,73 @@ func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 	// EffectiveGasTip returns an error for negative values, this is no problem here
 	gasTip, _ := tx.EffectiveGasTip(baseFee)
 	return new(big.Int).Add(baseFee, gasTip)
+}
+
+// OnNewAcceptedTransaction is called for every transaction accepted in a block,
+// providing the ID of the validator that has proposed the transaction in one of
+// its events, the accepted transaction, and its receipt. It is used to keep
+// track on the consumed gas on the network.
+//
+// This function is an updated version of the `OnNewReceipt` function above,
+// which is getting enabled with the Brio flag in the c_block_callback.go file.
+// Unlike the previous version, this function correctly accounts for fees of
+// sponsored and bundled transactions. The old code is preserved for backward
+// compatibility until the Brio hard-fork and to support full-history syncs.
+func (p *DriverTxListener) OnNewAcceptedTransaction(
+	originator idx.ValidatorID,
+	tx *types.Transaction,
+	r *types.Receipt,
+) {
+	p.onNewAcceptedTransactionInternal(originator, tx, r, log.Root())
+}
+
+func (p *DriverTxListener) onNewAcceptedTransactionInternal(
+	originator idx.ValidatorID,
+	tx *types.Transaction,
+	r *types.Receipt,
+	log log.Logger,
+) {
+	fee, err := ComputeEffectiveFee(tx, r)
+	if err != nil {
+		// if there is an overflow in the fee computation, the safe default
+		// is not not attribute it to any validator to not pay out any fees.
+		log.Warn("overflow in fee computation", "tx", tx.Hash(), "usedGas", r.GasUsed, "gasPrice", r.EffectiveGasPrice, "err", err)
+		return
+	}
+
+	if originator == 0 {
+		log.Warn("failed to attribute transaction to validator, fees got burned", "tx", tx.Hash(), "fees", fee)
+		return
+	}
+
+	originatorIdx := p.es.Validators.GetIdx(originator)
+	originated := p.bs.ValidatorStates[originatorIdx].Originated
+	originated.Add(originated, fee.ToBig())
+}
+
+// ComputeEffectiveFee returns the transaction fee charged for the given
+// transaction and its receipt. For regular transactions, this is simply
+// gasUsed * effectiveGasPrice. For fee charge transactions, the fee is
+// extracted from the transaction input data. If the calculation leads to a
+// 256-bit overflow, a fee of 0 is returned.
+func ComputeEffectiveFee(
+	tx *types.Transaction,
+	r *types.Receipt,
+) (*uint256.Int, error) {
+	if fee, err := subsidies.ParseFeeChargeAmount(tx); err == nil {
+		return fee, nil
+	}
+
+	gasPrice, overflow := uint256.FromBig(r.EffectiveGasPrice)
+	if overflow || gasPrice == nil {
+		return nil, fmt.Errorf("effective gas price overflow")
+	}
+	gasUsed := uint256.NewInt(r.GasUsed)
+	fee, overflow := new(uint256.Int).MulOverflow(gasUsed, gasPrice)
+	if overflow {
+		return nil, fmt.Errorf("effective fee overflow")
+	}
+	return fee, nil
 }
 
 func decodeDataBytes(l *types.Log) ([]byte, error) {

--- a/gossip/blockproc/drivermodule/driver_txs_test.go
+++ b/gossip/blockproc/drivermodule/driver_txs_test.go
@@ -14,12 +14,18 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package drivermodule_test
+package drivermodule
 
 import (
-	"github.com/0xsoniclabs/sonic/gossip/blockproc/drivermodule"
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/0xsoniclabs/sonic/logger"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
@@ -27,9 +33,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"math/big"
-	"testing"
 )
 
 const OrigOriginated = 10_000
@@ -45,7 +50,7 @@ const EffectiveGasPrice = 53
 func TestReceiptRewardWithoutFixEnabled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	module := drivermodule.NewDriverTxListenerModule()
+	module := NewDriverTxListenerModule()
 
 	blockCtx := iblockproc.BlockCtx{}
 	bs := iblockproc.BlockState{
@@ -86,7 +91,7 @@ func TestReceiptRewardWithoutFixEnabled(t *testing.T) {
 func TestReceiptRewardWithFixEnabled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	module := drivermodule.NewDriverTxListenerModule()
+	module := NewDriverTxListenerModule()
 
 	blockCtx := iblockproc.BlockCtx{}
 	bs := iblockproc.BlockState{
@@ -127,7 +132,7 @@ func TestReceiptRewardWithFixEnabled(t *testing.T) {
 func TestReceiptRewardWithBlobsAndFixEnabled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	module := drivermodule.NewDriverTxListenerModule()
+	module := NewDriverTxListenerModule()
 
 	blockCtx := iblockproc.BlockCtx{}
 	bs := iblockproc.BlockState{
@@ -166,4 +171,201 @@ func TestReceiptRewardWithBlobsAndFixEnabled(t *testing.T) {
 		t.Errorf("Originated increment not GasUsed*EffectiveGasPrice+BlobGasUsed*BlobBaseFee: expected %d, actual %d",
 			OrigOriginated+GasUsed*EffectiveGasPrice+BlobGasUsed*BlobBaseFee, originated)
 	}
+}
+
+func TestDriverTxListener_OnNewAcceptedTransaction_AddsFeesToRespectiveValidator(t *testing.T) {
+	receipt := &types.Receipt{
+		EffectiveGasPrice: big.NewInt(100),
+		GasUsed:           50,
+	}
+
+	creator := idx.ValidatorID(12)
+	other := idx.ValidatorID(14)
+
+	// build two validators with different stake
+	validatorBuilder := pos.NewBuilder()
+	validatorBuilder.Set(creator, 200)
+	validatorBuilder.Set(other, 100)
+	validators := validatorBuilder.Build()
+
+	creatorIndex := validators.GetIdx(creator)
+	otherIndex := validators.GetIdx(other)
+
+	initialFees := []*big.Int{
+		big.NewInt(1234), big.NewInt(4321),
+	}
+	state := make([]iblockproc.ValidatorBlockState, 2)
+	state[creatorIndex].Originated = new(big.Int).SetBytes(initialFees[0].Bytes())
+	state[otherIndex].Originated = new(big.Int).SetBytes(initialFees[1].Bytes())
+
+	listener := &DriverTxListener{
+		es: iblockproc.EpochState{
+			Validators: validators,
+		},
+		bs: iblockproc.BlockState{
+			ValidatorStates: state,
+		},
+	}
+
+	listener.OnNewAcceptedTransaction(creator, nil, receipt)
+
+	fee, err := ComputeEffectiveFee(nil, receipt)
+	require.NoError(t, err)
+	require.Equal(t, 1, fee.Sign())
+
+	// The creator's originated fees should have been increased.
+	want := new(big.Int).Add(initialFees[0], fee.ToBig())
+	got := listener.bs.ValidatorStates[creatorIndex].Originated
+	require.True(t, got.Cmp(want) == 0,
+		"want: %v, got %v", want, got,
+	)
+
+	// the other validator's originated fees should remain as they where.
+	want = initialFees[1]
+	got = listener.bs.ValidatorStates[otherIndex].Originated
+	require.True(t, got.Cmp(want) == 0,
+		"want: %v, got %v", want, got,
+	)
+}
+
+func TestDriverTxListener_OnNewAcceptedTransaction_WarnsOnOriginatorZero(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	log := logger.NewMockLogger(ctrl)
+
+	tx := types.NewTx(&types.LegacyTx{})
+
+	receipt := &types.Receipt{
+		EffectiveGasPrice: big.NewInt(100),
+		GasUsed:           50,
+	}
+
+	log.EXPECT().Warn(
+		"failed to attribute transaction to validator, fees got burned",
+		"tx", tx.Hash(),
+		"fees", uint256.NewInt(100*50),
+	)
+
+	listener := &DriverTxListener{}
+	listener.onNewAcceptedTransactionInternal(0, tx, receipt, log)
+}
+
+func TestDriverTxListener_OnOverflow_WarnsAndBurnsFees(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	log := logger.NewMockLogger(ctrl)
+
+	tx := types.NewTx(&types.LegacyTx{})
+
+	receipt := &types.Receipt{
+		EffectiveGasPrice: new(big.Int).Lsh(big.NewInt(1), 240),
+		GasUsed:           math.MaxUint64,
+	}
+
+	log.EXPECT().Warn(
+		"overflow in fee computation",
+		"tx", tx.Hash(),
+		"usedGas", receipt.GasUsed,
+		"gasPrice", receipt.EffectiveGasPrice,
+		"err", gomock.Any(),
+	)
+
+	listener := &DriverTxListener{}
+	listener.onNewAcceptedTransactionInternal(0, tx, receipt, log)
+}
+
+func TestComputeEffectiveFee_MultipliesEffectiveGasPriceWithUsedGas(t *testing.T) {
+	prices := []*big.Int{
+		big.NewInt(0),
+		big.NewInt(1),
+		big.NewInt(10),
+		big.NewInt(1e18),
+		new(big.Int).Lsh(big.NewInt(1), 100),
+	}
+
+	used := []uint64{
+		0, 1, 1000, 1e9, math.MaxUint64,
+	}
+
+	for _, price := range prices {
+		for _, used := range used {
+			receipt := &types.Receipt{
+				EffectiveGasPrice: price,
+				GasUsed:           used,
+			}
+
+			want := new(big.Int).Mul(
+				new(big.Int).SetUint64(used),
+				price,
+			)
+
+			got, err := ComputeEffectiveFee(nil, receipt)
+			require.NoError(t, err)
+			require.True(t,
+				want.Cmp(got.ToBig()) == 0,
+				"want %v, got %v", want, got,
+			)
+		}
+	}
+}
+
+func TestComputeEffectiveFee_UsesChargedAmountForSponsorshipPayments(t *testing.T) {
+	prices := []*big.Int{
+		big.NewInt(0),
+		big.NewInt(1),
+		big.NewInt(10),
+		big.NewInt(1e18),
+		new(big.Int).Lsh(big.NewInt(1), 100),
+	}
+
+	used := []uint64{
+		0, 1, 1000, 1e9, math.MaxUint64,
+	}
+
+	for _, price := range prices {
+		for _, used := range used {
+			t.Run(fmt.Sprintf("price=%v/used=%d", price, used), func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				nonceSource := subsidies.NewMockNonceSource(ctrl)
+				nonceSource.EXPECT().GetNonce(gomock.Any()).AnyTimes()
+
+				tx, err := subsidies.GetFeeChargeTransaction(
+					nonceSource,
+					subsidies.FundId{},
+					subsidies.GasConfig{},
+					used,
+					price,
+				)
+				require.NoError(t, err)
+
+				want := new(big.Int).Mul(
+					new(big.Int).SetUint64(used),
+					price,
+				)
+
+				got, err := ComputeEffectiveFee(tx, nil)
+				require.NoError(t, err)
+				require.True(t,
+					want.Cmp(got.ToBig()) == 0,
+					"want %v, got %v", want, got,
+				)
+			})
+		}
+	}
+}
+
+func TestComputeEffectiveFee_OverflowInGasPriceIsDetected(t *testing.T) {
+	receipt := &types.Receipt{
+		EffectiveGasPrice: new(big.Int).Lsh(big.NewInt(1), 256),
+	}
+	_, err := ComputeEffectiveFee(nil, receipt)
+	require.ErrorContains(t, err, "effective gas price overflow")
+}
+
+func TestComputeEffectiveFee_OverflowInFeeComputationIsReported(t *testing.T) {
+	receipt := &types.Receipt{
+		EffectiveGasPrice: new(big.Int).Lsh(big.NewInt(1), 256-64+1),
+		GasUsed:           math.MaxUint64,
+	}
+
+	_, err := ComputeEffectiveFee(nil, receipt)
+	require.ErrorContains(t, err, "effective fee overflow")
 }

--- a/gossip/blockproc/drivermodule/driver_txs_test.go
+++ b/gossip/blockproc/drivermodule/driver_txs_test.go
@@ -220,7 +220,7 @@ func TestDriverTxListener_OnNewAcceptedTransaction_AddsFeesToRespectiveValidator
 		"want: %v, got %v", want, got,
 	)
 
-	// the other validator's originated fees should remain as they where.
+	// the other validator's originated fees should remain as they were.
 	want = initialFees[1]
 	got = listener.bs.ValidatorStates[otherIndex].Originated
 	require.True(t, got.Cmp(want) == 0,

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -36,6 +36,7 @@ import (
 type TxListener interface {
 	OnNewLog(*types.Log)
 	OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int)
+	OnNewAcceptedTransaction(originator idx.ValidatorID, tx *types.Transaction, r *types.Receipt)
 	Finalize() iblockproc.BlockState
 	Update(bs iblockproc.BlockState, es iblockproc.EpochState)
 }

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -35,8 +35,21 @@ import (
 
 type TxListener interface {
 	OnNewLog(*types.Log)
+
+	// OnNewReceipt is called once for each transaction being accepted in a
+	// block after the block has been completed before the Brio hard-fork.
+	//
+	// WARNING: this function is no longer invoked after the Brio hard-fork. Use
+	// the OnNewAcceptedTransaction instead for post-Brio support. It is
+	// deprecated since the originator could not correctly be reported.
 	OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int)
+
+	// OnNewAcceptedTransaction is the replacement of OnNewReceipt in Brio and
+	// beyond. It is called right after the acceptance of a new transaction in
+	// a block. The originator corresponds to the validator proposing the
+	// given transaction.
 	OnNewAcceptedTransaction(originator idx.ValidatorID, tx *types.Transaction, r *types.Receipt)
+
 	Finalize() iblockproc.BlockState
 	Update(bs iblockproc.BlockState, es iblockproc.EpochState)
 }

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -63,6 +63,18 @@ func (mr *MockTxListenerMockRecorder) Finalize() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Finalize", reflect.TypeOf((*MockTxListener)(nil).Finalize))
 }
 
+// OnNewAcceptedTransaction mocks base method.
+func (m *MockTxListener) OnNewAcceptedTransaction(originator idx.ValidatorID, tx *types.Transaction, r *types.Receipt) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "OnNewAcceptedTransaction", originator, tx, r)
+}
+
+// OnNewAcceptedTransaction indicates an expected call of OnNewAcceptedTransaction.
+func (mr *MockTxListenerMockRecorder) OnNewAcceptedTransaction(originator, tx, r any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNewAcceptedTransaction", reflect.TypeOf((*MockTxListener)(nil).OnNewAcceptedTransaction), originator, tx, r)
+}
+
 // OnNewLog mocks base method.
 func (m *MockTxListener) OnNewLog(arg0 *types.Log) {
 	m.ctrl.T.Helper()

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -423,9 +423,19 @@ func consensusCallbackBeginBlockFn(
 					orderedTxs := proposal.Transactions
 					numSkippedDueToBlockLimits := 0
 					if es.Rules.Upgrades.Brio {
+						// Link transactions to their creators to attribute
+						// fees to the correct validators in processUserTransactions.
+						txCreators := make(map[common.Hash]idx.ValidatorID)
+						for _, e := range blockEvents {
+							for _, tx := range e.Transactions() {
+								if _, ok := txCreators[tx.Hash()]; !ok {
+									txCreators[tx.Hash()] = e.Creator()
+								}
+							}
+						}
 						// Limit block size and gas while adding user transactions
 						numSkippedDueToBlockLimits =
-							processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit)
+							processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit, txCreators, txListener, es.Validators)
 					} else {
 						// Pre brio there were no limits on user transactions
 						processUserTransactionsNoLimits(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit)
@@ -480,13 +490,16 @@ func consensusCallbackBeginBlockFn(
 						txPositions[tx.Hash()] = position
 					}
 
-					// call OnNewReceipt
-					for i, r := range allReceipts {
-						creator := txPositions[r.TxHash].EventCreator
-						if creator != 0 && es.Validators.Get(creator) == 0 {
-							creator = 0
+					// call OnNewReceipt (pre-Brio path only; Brio handles
+					// attribution in processUserTransactions)
+					if !es.Rules.Upgrades.Brio {
+						for i, r := range allReceipts {
+							creator := txPositions[r.TxHash].EventCreator
+							if creator != 0 && es.Validators.Get(creator) == 0 {
+								creator = 0
+							}
+							txListener.OnNewReceipt(evmBlock.Transactions[i], r, creator, evmBlock.BaseFee, evmBlock.BlobBaseFee)
 						}
-						txListener.OnNewReceipt(evmBlock.Transactions[i], r, creator, evmBlock.BaseFee, evmBlock.BlobBaseFee)
 					}
 					bs = txListener.Finalize() // TODO: refactor to not mutate the bs
 					bs.FinalizedStateRoot = hash.Hash(evmBlock.Root)
@@ -618,11 +631,16 @@ const rlpEncodedMaxHeaderSizeInBytes = 1024
 
 // processUserTransactions executes user transactions in order, adding them to the block
 // until all transactions are processed or the gas/block size limit is reached.
+// It attributes transaction fees to validators via txListener.OnNewAcceptedTransaction.
 func processUserTransactions(
 	evmProcessor blockproc.EVMProcessor,
 	blockBuilder *inter.BlockBuilder,
 	orderedTxs []*types.Transaction,
-	userTransactionGasLimit uint64) int {
+	userTransactionGasLimit uint64,
+	txCreators map[common.Hash]idx.ValidatorID,
+	txListener blockproc.TxListener,
+	validators *pos.Validators,
+) int {
 	remainingGas := userTransactionGasLimit
 	remainingSize := uint64(params.MaxBlockSize - rlpEncodedMaxHeaderSizeInBytes)
 	internalTxs := blockBuilder.GetTransactions()
@@ -639,15 +657,18 @@ func processUserTransactions(
 	for _, tx := range orderedTxs {
 		neededSpace := txSizeIncludingSubsidies(tx)
 		if neededSpace <= remainingSize {
+			creator := txCreators[tx.Hash()]
+			if creator != 0 && validators.Get(creator) == 0 {
+				creator = 0
+			}
 			for _, processed := range evmProcessor.Execute([]*types.Transaction{tx}, remainingGas).ProcessedTransactions {
-				if processed.Receipt != nil { // < nil if skipped
-					blockBuilder.AddTransaction(
-						processed.Transaction,
-						processed.Receipt,
-					)
-					remainingGas -= processed.Receipt.GasUsed
-					remainingSize -= processed.Transaction.Size()
+				if processed.Receipt == nil { // skipped
+					continue
 				}
+				blockBuilder.AddTransaction(processed.Transaction, processed.Receipt)
+				remainingGas -= processed.Receipt.GasUsed
+				remainingSize -= processed.Transaction.Size()
+				txListener.OnNewAcceptedTransaction(creator, processed.Transaction, processed.Receipt)
 			}
 		} else {
 			skippedCounter++

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -420,18 +420,32 @@ func consensusCallbackBeginBlockFn(
 						}
 					}
 
+					// memorize event position of each tx and identify origin
+					txPositions := make(map[common.Hash]ExtendedTxPosition)
+					for _, e := range blockEvents {
+						for i, tx := range e.Transactions() {
+							// If tx was met in multiple events, then assign to first ordered event
+							if _, ok := txPositions[tx.Hash()]; ok {
+								continue
+							}
+							txPositions[tx.Hash()] = ExtendedTxPosition{
+								TxPosition: evmstore.TxPosition{
+									Event:       e.ID(),
+									EventOffset: uint32(i),
+								},
+								EventCreator: e.Creator(),
+							}
+						}
+					}
+
 					orderedTxs := proposal.Transactions
 					numSkippedDueToBlockLimits := 0
 					if es.Rules.Upgrades.Brio {
 						// Link transactions to their creators to attribute
 						// fees to the correct validators in processUserTransactions.
 						txCreators := make(map[common.Hash]idx.ValidatorID)
-						for _, e := range blockEvents {
-							for _, tx := range e.Transactions() {
-								if _, ok := txCreators[tx.Hash()]; !ok {
-									txCreators[tx.Hash()] = e.Creator()
-								}
-							}
+						for hash, posInfo := range txPositions {
+							txCreators[hash] = posInfo.EventCreator
 						}
 						// Limit block size and gas while adding user transactions
 						numSkippedDueToBlockLimits =
@@ -464,23 +478,6 @@ func consensusCallbackBeginBlockFn(
 						}
 					}
 
-					// memorize event position of each tx
-					txPositions := make(map[common.Hash]ExtendedTxPosition)
-					for _, e := range blockEvents {
-						for i, tx := range e.Transactions() {
-							// If tx was met in multiple events, then assign to first ordered event
-							if _, ok := txPositions[tx.Hash()]; ok {
-								continue
-							}
-							txPositions[tx.Hash()] = ExtendedTxPosition{
-								TxPosition: evmstore.TxPosition{
-									Event:       e.ID(),
-									EventOffset: uint32(i),
-								},
-								EventCreator: e.Creator(),
-							}
-						}
-					}
 					// memorize block position of each tx
 					for i, tx := range evmBlock.Transactions {
 						// not skipped txs only

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/lachesis"
 	"github.com/Fantom-foundation/lachesis-base/utils/workers"
 	"github.com/ethereum/go-ethereum/common"
@@ -62,13 +63,17 @@ import (
 
 func TestConsensusCallback(t *testing.T) {
 
-	withSingleProposer := opera.GetAllegroUpgrades()
-	withSingleProposer.SingleProposerBlockFormation = true
+	withSingleProposer := func(upgrades opera.Upgrades) opera.Upgrades {
+		upgrades.SingleProposerBlockFormation = true
+		return upgrades
+	}
 
 	features := map[string]opera.Upgrades{
-		"sonic":           opera.GetSonicUpgrades(),
-		"allegro":         opera.GetAllegroUpgrades(),
-		"single proposer": withSingleProposer,
+		"sonic":                     opera.GetSonicUpgrades(),
+		"allegro":                   opera.GetAllegroUpgrades(),
+		"allegro + single proposer": withSingleProposer(opera.GetAllegroUpgrades()),
+		"brio":                      opera.GetBrioUpgrades(),
+		"brio + single proposer":    withSingleProposer(opera.GetBrioUpgrades()),
 	}
 
 	for name, feature := range features {
@@ -1080,6 +1085,8 @@ func TestRlpEncodedMaxHeaderSizeInBytes_IsAnUpperBound(t *testing.T) {
 func TestProcessUserTransactions_ForwardsBlockGasLimitToEVMProcessor(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+	txListener := blockproc.NewMockTxListener(ctrl)
+	txListener.EXPECT().OnNewAcceptedTransaction(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	blockBuilder := inter.NewBlockBuilder()
 
 	// Create some dummy transactions with gas usage
@@ -1106,7 +1113,7 @@ func TestProcessUserTransactions_ForwardsBlockGasLimitToEVMProcessor(t *testing.
 		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx3, Receipt: receipt3}}})
 
 	orderedTxs := []*types.Transaction{tx1, tx2, tx3}
-	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit)
+	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit, nil, txListener, nil)
 
 	// All transactions should be included
 	gotTxs := blockBuilder.GetTransactions()
@@ -1116,6 +1123,7 @@ func TestProcessUserTransactions_ForwardsBlockGasLimitToEVMProcessor(t *testing.
 func TestProcessUserTransactions_TransactionsWithNoReceiptAreNotIncluded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+	txListener := blockproc.NewMockTxListener(ctrl)
 	blockBuilder := inter.NewBlockBuilder()
 
 	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
@@ -1126,7 +1134,7 @@ func TestProcessUserTransactions_TransactionsWithNoReceiptAreNotIncluded(t *test
 		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx, Receipt: nil}}})
 
 	skippedCount :=
-		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx}, 10000)
+		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx}, 10000, nil, txListener, nil)
 
 	require.Equal(t, 0, skippedCount,
 		"transactions with no receipt should be taking into account by the evm processor")
@@ -1139,6 +1147,7 @@ func TestProcessUserTransactions_TransactionsWithNoReceiptAreNotIncluded(t *test
 func TestProcessUserTransactions_DeductsInternalTxsSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+	txListener := blockproc.NewMockTxListener(ctrl)
 	blockBuilder := inter.NewBlockBuilder()
 
 	// Add an internal tx to blockBuilder
@@ -1147,7 +1156,7 @@ func TestProcessUserTransactions_DeductsInternalTxsSize(t *testing.T) {
 
 	// Create a user tx that would only fit without the internal tx
 	userTx := types.NewTx(&types.LegacyTx{Data: make([]byte, params.MaxBlockSize/2)})
-	skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
+	skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000, nil, txListener, nil)
 
 	// Both internal and user tx should be present
 	gotTxs := blockBuilder.GetTransactions()
@@ -1158,6 +1167,8 @@ func TestProcessUserTransactions_DeductsInternalTxsSize(t *testing.T) {
 func TestProcessUserTransactions_SkipsTxsExceedingSizeLimit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+	txListener := blockproc.NewMockTxListener(ctrl)
+	txListener.EXPECT().OnNewAcceptedTransaction(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	blockBuilder := inter.NewBlockBuilder()
 
 	// Create a tx that exceeds the size limit
@@ -1175,7 +1186,7 @@ func TestProcessUserTransactions_SkipsTxsExceedingSizeLimit(t *testing.T) {
 		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx1, Receipt: &types.Receipt{}}}})
 
 	skippedCount :=
-		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{largeTx, tx0, tx1}, 10000)
+		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{largeTx, tx0, tx1}, 10000, nil, txListener, nil)
 
 	require.Equal(t, 1, skippedCount)
 
@@ -1186,6 +1197,8 @@ func TestProcessUserTransactions_SkipsTxsExceedingSizeLimit(t *testing.T) {
 
 func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransactionGas(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	txListener := blockproc.NewMockTxListener(ctrl)
+	txListener.EXPECT().OnNewAcceptedTransaction(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	statedb := state.NewMockStateDB(ctrl)
 
 	statedb.EXPECT().BeginBlock(gomock.Any())
@@ -1232,7 +1245,7 @@ func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransa
 	// the internal transaction gas is not counted towards it
 	userTransactionGasLimit := uint64(30_000)
 	skippedCount :=
-		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx0, skippedTx}, userTransactionGasLimit)
+		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx0, skippedTx}, userTransactionGasLimit, nil, txListener, nil)
 
 	// the skipped transaction is counted by the evm processor
 	require.Equal(t, 0, skippedCount)
@@ -1304,7 +1317,9 @@ func TestProcessUserTransactions_SponsoredTxSizeIsAccountedCorrectly(t *testing.
 					ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx2, Receipt: &types.Receipt{}}},
 				}).AnyTimes()
 
-			skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx0, tx1, tx2}, 10000)
+			txListener := blockproc.NewMockTxListener(ctrl)
+			txListener.EXPECT().OnNewAcceptedTransaction(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx0, tx1, tx2}, 10000, nil, txListener, nil)
 
 			gotTxs := blockBuilder.GetTransactions()
 			require.Contains(t, gotTxs, tx0)
@@ -1342,6 +1357,7 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+			txListener := blockproc.NewMockTxListener(ctrl)
 			blockBuilder := inter.NewBlockBuilder()
 
 			for _, internalTx := range internalTxs {
@@ -1351,7 +1367,7 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 
 			// Create a user tx that would only fit without the internal tx
 			userTx := types.NewTx(&types.LegacyTx{})
-			skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
+			skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000, nil, txListener, nil)
 
 			// Only internal tx should be present
 			gotTxs := blockBuilder.GetTransactions()
@@ -1359,6 +1375,88 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 			require.Equal(t, 1, skippedCount)
 		})
 	}
+}
+
+func TestProcessUserTransactions_PerformsCallBacksToTxListener(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+
+	transactions := []*types.Transaction{
+		types.NewTx(&types.LegacyTx{Nonce: 0}),
+		types.NewTx(&types.LegacyTx{Nonce: 1}),
+		types.NewTx(&types.LegacyTx{Nonce: 2}),
+	}
+
+	extras := []*types.Transaction{
+		types.NewTx(&types.LegacyTx{Nonce: 11}),
+		types.NewTx(&types.LegacyTx{Nonce: 21}),
+		types.NewTx(&types.LegacyTx{Nonce: 22}),
+	}
+
+	results := []evmcore.ProcessSummary{
+		{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: transactions[0], Receipt: &types.Receipt{}},
+		}},
+		{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: transactions[1], Receipt: &types.Receipt{}},
+			{Transaction: extras[0], Receipt: &types.Receipt{}},
+		}},
+		{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: extras[1], Receipt: &types.Receipt{}},
+			{Transaction: extras[2], Receipt: &types.Receipt{}},
+		}},
+	}
+
+	for i, tx := range transactions {
+		evmProcessor.EXPECT().
+			Execute([]*types.Transaction{tx}, gomock.Any()).
+			Return(results[i])
+	}
+
+	val1 := idx.ValidatorID(1) // validator 0 is the no-validator value
+	val2 := idx.ValidatorID(2)
+	val3 := idx.ValidatorID(3)
+
+	txCreators := map[common.Hash]idx.ValidatorID{
+		transactions[0].Hash(): val1,
+		transactions[1].Hash(): val2,
+		transactions[2].Hash(): val3,
+	}
+
+	validatorBuilder := pos.NewBuilder()
+	validatorBuilder.Set(val1, 100)
+	validatorBuilder.Set(val2, 100)
+	// val3 remains deliberately unknown
+	validators := validatorBuilder.Build()
+
+	// The expectations for the callbacks on the accepted transactions. These
+	// callbacks are the main objective of this test. They make sure that the
+	// correct creator is linked to the accepted transactions, even if the
+	// transaction causing those is not indexed in the txCreator map.
+	txListener := blockproc.NewMockTxListener(ctrl)
+	for i, res := range results {
+		creator := txCreators[transactions[i].Hash()]
+		if creator == val3 {
+			creator = 0 // < no validator
+		}
+		for _, processedTx := range res.ProcessedTransactions {
+			txListener.EXPECT().OnNewAcceptedTransaction(
+				creator,
+				processedTx.Transaction,
+				processedTx.Receipt,
+			)
+		}
+	}
+
+	processUserTransactions(
+		evmProcessor,
+		inter.NewBlockBuilder(),
+		transactions,
+		math.MaxUint64,
+		txCreators,
+		txListener,
+		validators,
+	)
 }
 
 func TestTransactionSize_ConsidersSponsoredTxs(t *testing.T) {


### PR DESCRIPTION
This PR adds support for the correct aggregation of transaction fees when processing bundles.

In order to facilitate the distribution of transaction fees among validators, a record of charged fees needs to be maintained by the sonic client. This book-keeping is conducted by the [DriverTxListener](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/blockproc/drivermodule/driver_txs.go#L62).

The `DriverTxListener` is the only implementation (besides a mock) of the [TxListener](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/blockproc/interface.go#L36) interface offered by the block formation process in the `c_block_callback.go` to inform about new transactions being accepted in a block ([here](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/c_block_callbacks.go#L489)). 

### Old Behavior
In the current client, a record of the collected gas fees is kept as follows:
- after each block is completed, a call back to the `OnNewReceipt` function for each included transaction is conducted ([here](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/c_block_callbacks.go#L489)). One of the parameters is the ID of the validator that proposed the accepted transaction in one of its events. 
- the fees  charged for the respective transaction are then added to the validator's originated transaction fees ([here](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/blockproc/drivermodule/driver_txs.go#L170-L171))
- when sealing an epoch, the total sum of originated fees is reported to the SFC to handle the fee distribution ([here](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/blockproc/drivermodule/driver_txs.go#L112-L132))

With the introduction of features like sponsored transactions and bundles, this mechanism is no longer sufficient. Sponsored transactions are payed indirectly, not derivable from the transactions receipt, and transactions ending up in blocks are not directly included in events but encoded in envelopes carried by events. Thus, the fee aggregation mechanism needs to updated.

### New Behavior
In order to preserve backward compatibility, this PR preserves the existing code for Pre-Brio configurations. However, with Brio, the following changes are added:
- callbacks notifying about new accpeted transactions now happen during the processing of each individual proposed transaction in the `processUserTransactions` function ([here](https://github.com/0xsoniclabs/sonic/blob/1c9f5392506f09d5e838d23c0dcb5734c28138e0/gossip/c_block_callbacks.go#L671))
- in the callback, the effective fees are [computed](https://github.com/0xsoniclabs/sonic/blob/1c9f5392506f09d5e838d23c0dcb5734c28138e0/gossip/blockproc/drivermodule/driver_txs.go#L216) for each accepted transaction using a new [ComputeEffectiveFee](https://github.com/0xsoniclabs/sonic/blob/1c9f5392506f09d5e838d23c0dcb5734c28138e0/gossip/blockproc/drivermodule/driver_txs.go#L239) function; this function identifies fee-payment transactions for sponsored transactions and extracts the amount of fees charged
- by integrating the callback into the `processUserTransactions` accepted transactions can be mapped locally to the validators who have proposed the transaction causing inclusion of the accepted transaction ([here](https://github.com/0xsoniclabs/sonic/blob/1c9f5392506f09d5e838d23c0dcb5734c28138e0/gossip/c_block_callbacks.go#L671))
- the old reporting method is disabled by enabling Brio ([here](https://github.com/0xsoniclabs/sonic/blob/1c9f5392506f09d5e838d23c0dcb5734c28138e0/gossip/c_block_callbacks.go#L495))

The result should be a accurate fee tracking for bundled and sponsored transactions and the preservation of the backward compatibility with pre-Brio handling.

### Gas Refunds for Validators
The new implementation of the gas-fee tracking in `driver_tx.go` does not refunds for excessive gas. The computation of that value for bundles is beyond the scope of this task, and the impact of dropping this feature is under investigation. See https://github.com/0xsoniclabs/sonic-admin/issues/748.
