### PR TITLE
Fix issues preventing prepare bundle from having reproducible plan hash

### DIFF
--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -142,7 +142,8 @@ func toBundleExecutionPlanLevel(level any) (bundle.ExecutionStep, error) {
 	case RPCExecutionPlanGroup:
 		return toBundleExecutionGroup(l)
 	}
-	return bundle.ExecutionStep{}, fmt.Errorf("invalid execution plan level: must have either executionStep or group")
+	return bundle.ExecutionStep{},
+		fmt.Errorf("invalid execution plan level: must have either executionStep or group")
 }
 
 func toBundleExecutionGroup(l RPCExecutionPlanGroup) (bundle.ExecutionStep, error) {
@@ -155,7 +156,8 @@ func toBundleExecutionGroup(l RPCExecutionPlanGroup) (bundle.ExecutionStep, erro
 		steps[i] = step
 	}
 
-	if !l.OneOf && !l.TolerateFailures && len(steps) == 1 {
+	// if it's not a group, skip it
+	if !l.TolerateFailures && len(steps) == 1 {
 		return steps[0], nil
 	}
 

--- a/api/sonicapi/execution_plan_test.go
+++ b/api/sonicapi/execution_plan_test.go
@@ -389,6 +389,7 @@ func Test_NewRPCExecutionPlanComposable_FromBundleExecutionPlan(t *testing.T) {
 			recreated, err := ToBundleExecutionPlan(rpcPlan)
 			require.NoError(t, err)
 			require.Equal(t, recreated, tc.plan)
+			require.Equal(t, recreated.Hash(), tc.plan.Hash())
 
 			var deserialized RPCExecutionPlanComposable
 			expectCanBeDeserialized(t, &deserialized, tc.expectedJson)

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -400,7 +400,7 @@ func toTransactionForBundles(step ethapi.TransactionArgs) *types.Transaction {
 	tx := step.ToTransaction()
 
 	// legacy transactions cannot be included in a bundle.
-	// if a the transaction arguments correspond to a legacy transaction,
+	// if the transaction arguments correspond to a legacy transaction,
 	// promote it to an access list transaction to host the bundle marker.
 	if tx.Type() == types.LegacyTxType {
 		tx = types.NewTx(&types.AccessListTx{

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -339,7 +339,7 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 			return empty, fmt.Errorf("transaction in bundle must include from")
 		}
 
-		tx := step.ToTransaction()
+		tx := ToTransactionForBundles(step.TransactionArgs)
 		hash := signer.Hash(tx)
 
 		return bundle.NewTxStep(bundle.TxReference{
@@ -380,6 +380,10 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 			steps[i] = childStep
 		}
 
+		if !step.TolerateFailures && len(steps) == 1 {
+			return steps[0], nil
+		}
+
 		return bundle.NewGroupStep(
 			step.OneOf,
 			steps...,
@@ -387,6 +391,28 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 	}
 
 	return empty, fmt.Errorf("invalid execution proposal level: must have either executionStep or group")
+}
+
+// ToTransactionForBundles converts ethapi.TransactionArgs to types.Transaction
+// for computing execution plan transaction reference hashes. Legacy transactions
+// are promoted to AccessList transactions to prevent poisoning the plan hash.
+func ToTransactionForBundles(step ethapi.TransactionArgs) *types.Transaction {
+	tx := step.ToTransaction()
+
+	// legacy transactions cannot be included in a bundle.
+	// if a the transaction arguments correspond to a legacy transaction,
+	// promote it to an access list transaction to host the bundle marker.
+	if tx.Type() == types.LegacyTxType {
+		tx = types.NewTx(&types.AccessListTx{
+			Nonce:    tx.Nonce(),
+			To:       tx.To(),
+			Value:    tx.Value(),
+			Gas:      tx.Gas(),
+			Data:     tx.Data(),
+			GasPrice: tx.GasPrice(),
+		})
+	}
+	return tx
 }
 
 func transform(

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -339,7 +339,7 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 			return empty, fmt.Errorf("transaction in bundle must include from")
 		}
 
-		tx := ToTransactionForBundles(step.TransactionArgs)
+		tx := toTransactionForBundles(step.TransactionArgs)
 		hash := signer.Hash(tx)
 
 		return bundle.NewTxStep(bundle.TxReference{
@@ -393,10 +393,10 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 	return empty, fmt.Errorf("invalid execution proposal level: must have either executionStep or group")
 }
 
-// ToTransactionForBundles converts ethapi.TransactionArgs to types.Transaction
+// toTransactionForBundles converts ethapi.TransactionArgs to types.Transaction
 // for computing execution plan transaction reference hashes. Legacy transactions
 // are promoted to AccessList transactions to prevent poisoning the plan hash.
-func ToTransactionForBundles(step ethapi.TransactionArgs) *types.Transaction {
+func toTransactionForBundles(step ethapi.TransactionArgs) *types.Transaction {
 	tx := step.ToTransaction()
 
 	// legacy transactions cannot be included in a bundle.

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -797,4 +798,274 @@ func Test_transform(t *testing.T) {
 	}
 
 	require.Equal(t, expected, newProposal)
+}
+
+func Test_convertProposalToPlan(t *testing.T) {
+
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	key1, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	address1 := crypto.PubkeyToAddress(key1.PublicKey)
+	key2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	address2 := crypto.PubkeyToAddress(key2.PublicKey)
+
+	tests := map[string]struct {
+		proposal RPCExecutionProposal
+		plan     bundle.ExecutionPlan
+	}{
+		"simple proposal with one step": {
+			proposal: RPCExecutionProposal{
+				BlockRange: &RPCRange{
+					Earliest: *rpctest.ToHexUint64(0),
+					Latest:   *rpctest.ToHexUint64(1023),
+				},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:  &address1,
+								To:    &common.Address{123},
+								Nonce: rpctest.ToHexUint64(1),
+								Gas: rpctest.ToHexUint64(21000 +
+									// NOTE: builder adds marker costs
+									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+							},
+						},
+					},
+				},
+			},
+			plan: bundle.NewBuilder().
+				SetEarliest(0).SetLatest(1023).
+				WithSigner(signer).
+				With(
+					bundle.Step(key1, &types.AccessListTx{
+						To:    &common.Address{123},
+						Nonce: 1,
+						Gas:   21000,
+					}),
+				).
+				BuildBundle().Plan,
+		},
+		"two steps in one group": {
+			proposal: RPCExecutionProposal{
+				BlockRange: &RPCRange{
+					Earliest: *rpctest.ToHexUint64(0),
+					Latest:   *rpctest.ToHexUint64(1023),
+				},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:  &address1,
+								To:    &common.Address{123},
+								Nonce: rpctest.ToHexUint64(1),
+								Gas: rpctest.ToHexUint64(21000 +
+									// NOTE: builder adds marker costs
+									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+							},
+						},
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:  &address2,
+								To:    &common.Address{1},
+								Nonce: rpctest.ToHexUint64(2),
+								Gas: rpctest.ToHexUint64(21000 +
+									// NOTE: builder adds marker costs
+									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+							},
+						},
+					},
+				},
+			},
+			plan: bundle.NewBuilder().
+				SetEarliest(0).SetLatest(1023).
+				WithSigner(signer).
+				AllOf(
+					bundle.Step(key1, &types.AccessListTx{
+						To:    &common.Address{123},
+						Nonce: 1,
+						Gas:   21000,
+					}),
+					bundle.Step(key2, &types.AccessListTx{
+						To:    &common.Address{1},
+						Nonce: 2,
+						Gas:   21000,
+					}),
+				).
+				BuildBundle().Plan,
+		},
+		"different execution flags in steps": {
+			proposal: RPCExecutionProposal{
+				BlockRange: &RPCRange{
+					Earliest: *rpctest.ToHexUint64(0),
+					Latest:   *rpctest.ToHexUint64(1023),
+				},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:  &address1,
+								To:    &common.Address{123},
+								Nonce: rpctest.ToHexUint64(1),
+								Gas: rpctest.ToHexUint64(21000 +
+									// NOTE: builder adds marker costs
+									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+							},
+							TolerateFailed: true,
+						},
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:  &address2,
+								To:    &common.Address{1},
+								Nonce: rpctest.ToHexUint64(2),
+								Gas: rpctest.ToHexUint64(21000 +
+									// NOTE: builder adds marker costs
+									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+							},
+							TolerateInvalid: true,
+						},
+					},
+				},
+			},
+			plan: bundle.NewBuilder().
+				SetEarliest(0).SetLatest(1023).
+				WithSigner(signer).
+				AllOf(
+					bundle.Step(key1, &types.AccessListTx{
+						To:    &common.Address{123},
+						Nonce: 1,
+						Gas:   21000,
+					}).WithFlags(bundle.EF_TolerateFailed),
+					bundle.Step(key2, &types.AccessListTx{
+						To:    &common.Address{1},
+						Nonce: 2,
+						Gas:   21000,
+					}).WithFlags(bundle.EF_TolerateInvalid),
+				).
+				BuildBundle().Plan,
+		},
+		"OneOf group": {
+
+			proposal: RPCExecutionProposal{
+				BlockRange: &RPCRange{
+					Earliest: *rpctest.ToHexUint64(0),
+					Latest:   *rpctest.ToHexUint64(1023),
+				},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							OneOf: true,
+							Steps: []any{
+								RPCExecutionStepProposal{
+									TransactionArgs: ethapi.TransactionArgs{
+										From:  &address1,
+										To:    &common.Address{123},
+										Nonce: rpctest.ToHexUint64(1),
+										Gas: rpctest.ToHexUint64(21000 +
+											// NOTE: builder adds marker costs
+											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+									},
+								},
+								RPCExecutionStepProposal{
+									TransactionArgs: ethapi.TransactionArgs{
+										From:  &address2,
+										To:    &common.Address{1},
+										Nonce: rpctest.ToHexUint64(2),
+										Gas: rpctest.ToHexUint64(21000 +
+											// NOTE: builder adds marker costs
+											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			plan: bundle.NewBuilder().
+				SetEarliest(0).SetLatest(1023).
+				WithSigner(signer).
+				OneOf(
+					bundle.Step(key1, &types.AccessListTx{
+						To:    &common.Address{123},
+						Nonce: 1,
+						Gas:   21000,
+					}),
+					bundle.Step(key2, &types.AccessListTx{
+						To:    &common.Address{1},
+						Nonce: 2,
+						Gas:   21000,
+					}),
+				).
+				BuildBundle().Plan,
+		},
+		"OneOf group with different execution flags in steps": {
+			proposal: RPCExecutionProposal{
+				BlockRange: &RPCRange{
+					Earliest: *rpctest.ToHexUint64(0),
+					Latest:   *rpctest.ToHexUint64(1023),
+				},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							OneOf: true,
+							Steps: []any{
+								RPCExecutionStepProposal{
+									TransactionArgs: ethapi.TransactionArgs{
+										From:  &address1,
+										To:    &common.Address{123},
+										Nonce: rpctest.ToHexUint64(1),
+										Gas: rpctest.ToHexUint64(21000 +
+											// NOTE: builder adds marker costs
+											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+									},
+									TolerateFailed: true,
+								},
+								RPCExecutionStepProposal{
+									TransactionArgs: ethapi.TransactionArgs{
+										From:  &address2,
+										To:    &common.Address{1},
+										Nonce: rpctest.ToHexUint64(2),
+										Gas: rpctest.ToHexUint64(21000 +
+											// NOTE: builder adds marker costs
+											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+									},
+									TolerateInvalid: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			plan: bundle.NewBuilder().
+				SetEarliest(0).SetLatest(1023).
+				WithSigner(signer).
+				OneOf(
+					bundle.Step(key1, &types.AccessListTx{
+						To:    &common.Address{123},
+						Nonce: 1,
+						Gas:   21000,
+					}).WithFlags(bundle.EF_TolerateFailed),
+					bundle.Step(key2, &types.AccessListTx{
+						To:    &common.Address{1},
+						Nonce: 2,
+						Gas:   21000,
+					}).WithFlags(bundle.EF_TolerateInvalid),
+				).
+				BuildBundle().Plan,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			plan, err := convertProposalToPlan(signer, tt.proposal)
+			require.NoError(t, err)
+			require.Equal(t, tt.plan, plan)
+			require.Equal(t, tt.plan.Hash(), plan.Hash())
+
+			t.Log("plan", plan.Root.String())
+		})
+	}
 }

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -811,6 +811,8 @@ func Test_convertProposalToPlan(t *testing.T) {
 	require.NoError(t, err)
 	address2 := crypto.PubkeyToAddress(key2.PublicKey)
 
+	const bundleMarkerCost = params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas
+
 	tests := map[string]struct {
 		proposal RPCExecutionProposal
 		plan     bundle.ExecutionPlan
@@ -828,9 +830,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 								From:  &address1,
 								To:    &common.Address{123},
 								Nonce: rpctest.ToHexUint64(1),
-								Gas: rpctest.ToHexUint64(21000 +
-									// NOTE: builder adds marker costs
-									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+								Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 							},
 						},
 					},
@@ -861,9 +861,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 								From:  &address1,
 								To:    &common.Address{123},
 								Nonce: rpctest.ToHexUint64(1),
-								Gas: rpctest.ToHexUint64(21000 +
-									// NOTE: builder adds marker costs
-									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+								Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 							},
 						},
 						RPCExecutionStepProposal{
@@ -871,9 +869,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 								From:  &address2,
 								To:    &common.Address{1},
 								Nonce: rpctest.ToHexUint64(2),
-								Gas: rpctest.ToHexUint64(21000 +
-									// NOTE: builder adds marker costs
-									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+								Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 							},
 						},
 					},
@@ -920,9 +916,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 								From:  &address2,
 								To:    &common.Address{1},
 								Nonce: rpctest.ToHexUint64(2),
-								Gas: rpctest.ToHexUint64(21000 +
-									// NOTE: builder adds marker costs
-									params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+								Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 							},
 							TolerateInvalid: true,
 						},
@@ -963,9 +957,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 										From:  &address1,
 										To:    &common.Address{123},
 										Nonce: rpctest.ToHexUint64(1),
-										Gas: rpctest.ToHexUint64(21000 +
-											// NOTE: builder adds marker costs
-											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+										Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 									},
 								},
 								RPCExecutionStepProposal{
@@ -973,9 +965,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 										From:  &address2,
 										To:    &common.Address{1},
 										Nonce: rpctest.ToHexUint64(2),
-										Gas: rpctest.ToHexUint64(21000 +
-											// NOTE: builder adds marker costs
-											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+										Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 									},
 								},
 							},
@@ -1017,9 +1007,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 										From:  &address1,
 										To:    &common.Address{123},
 										Nonce: rpctest.ToHexUint64(1),
-										Gas: rpctest.ToHexUint64(21000 +
-											// NOTE: builder adds marker costs
-											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+										Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 									},
 									TolerateFailed: true,
 								},
@@ -1028,9 +1016,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 										From:  &address2,
 										To:    &common.Address{1},
 										Nonce: rpctest.ToHexUint64(2),
-										Gas: rpctest.ToHexUint64(21000 +
-											// NOTE: builder adds marker costs
-											params.TxAccessListAddressGas + params.TxAccessListStorageKeyGas),
+										Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
 									},
 									TolerateInvalid: true,
 								},

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -770,11 +770,7 @@ func Test_PrepareBundle_FlatTransactions_SingleTx(t *testing.T) {
 	require.True(t, found, "expected BundleOnly marker in access list")
 
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	group, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
-	require.True(t, ok)
-	require.False(t, group.OneOf)
-	require.Len(t, group.Steps, 1)
-	_, ok = group.Steps[0].(RPCExecutionStepComposable)
+	_, ok := result.ExecutionPlan.Steps[0].(RPCExecutionStepComposable)
 	require.True(t, ok)
 }
 
@@ -884,7 +880,7 @@ func Test_PrepareBundle_SingleChildGroup_TolerateFailures_NotUnwrapped(t *testin
 	require.Len(t, group.Steps, 1)
 }
 
-func Test_PrepareBundle_SingleChildGroup_Plain_NotUnwrapped(t *testing.T) {
+func Test_PrepareBundle_SingleChildGroup_Plain_IsUnwrapped(t *testing.T) {
 	addr1 := common.Address{1}
 	addr2 := common.Address{2}
 
@@ -912,12 +908,10 @@ func Test_PrepareBundle_SingleChildGroup_Plain_NotUnwrapped(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Transactions, 1)
 
-	// Plain group must not collapse its single child.
+	// Plain group must collapses its single child.
 	require.Len(t, result.ExecutionPlan.Steps, 1)
-	group, ok := result.ExecutionPlan.Steps[0].(RPCExecutionPlanGroup)
+	_, ok := result.ExecutionPlan.Steps[0].(RPCExecutionStepComposable)
 	require.True(t, ok, "expected group, not leaf")
-	require.False(t, group.OneOf)
-	require.Len(t, group.Steps, 1)
 }
 
 // stripBundleMarker removes the BundleOnly access-list entry from txArgs so that
@@ -1103,7 +1097,7 @@ func Test_PrepareBundle_PlanHashesMatchTransactions(t *testing.T) {
 			expectedHashes := make([]common.Hash, len(result.Transactions))
 			for i, txArgs := range result.Transactions {
 				clean := stripBundleMarker(txArgs)
-				tx := clean.ToTransaction()
+				tx := toTransactionForBundles(clean)
 				expectedHashes[i] = signer.Hash(tx)
 			}
 			planHashes := collectLeafHashes(result.ExecutionPlan.Steps)

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -908,7 +908,7 @@ func Test_PrepareBundle_SingleChildGroup_Plain_IsUnwrapped(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Transactions, 1)
 
-	// Plain group must collapses its single child.
+	// Plain group must collapse it's single child.
 	require.Len(t, result.ExecutionPlan.Steps, 1)
 	_, ok := result.ExecutionPlan.Steps[0].(RPCExecutionStepComposable)
 	require.True(t, ok, "expected group, not leaf")


### PR DESCRIPTION
This PR fixes two issues:

- `ethapi.transactionArgs` -> `types.Transaction` creates legacy tx when possible. They need to be at least access list to be added to a bundle
- proposal to plan constructed plans (allOff(A)  while RPCPlan to plan creates (A) when converted into `bundle.ExecutionPlan` 

Although generated bundles could be executed, these issues prevented hashes from being equivalent, and therefore from validating the workflow. 