### PR TITLE
Add test covering the interaction of `sonic_prepareBundle` and `sonic_submitBundle`

### DIFF
--- a/api/rpc_test/tools.go
+++ b/api/rpc_test/tools.go
@@ -19,12 +19,14 @@ package rpctest
 import (
 	"crypto/ecdsa"
 	"math/big"
+	"testing"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
 )
 
 // This file contains utility functions and types for the RPC tests.
@@ -36,14 +38,13 @@ type Wallet struct {
 }
 
 // NewWallet creates a new wallet with a random private key.
-func NewWallet() (*Wallet, error) {
+func NewWallet(t testing.TB) *Wallet {
+	t.Helper()
 	key, err := crypto.GenerateKey()
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err, "failed to generate wallet key")
 	return &Wallet{
 		PrivateKey: key,
-	}, nil
+	}
 }
 
 // Address returns the public address corresponding to the private key.

--- a/api/rpc_test/tools_test.go
+++ b/api/rpc_test/tools_test.go
@@ -27,15 +27,13 @@ import (
 )
 
 func Test_Wallet_NewWallet(t *testing.T) {
-	acc, err := NewWallet()
-	require.NoError(t, err)
+	acc := NewWallet(t)
 	require.NotNil(t, acc)
 	require.NotNil(t, acc.PrivateKey)
 }
 
 func Test_Wallet_Address(t *testing.T) {
-	acc, err := NewWallet()
-	require.NoError(t, err)
+	acc := NewWallet(t)
 
 	expectedAddr := crypto.PubkeyToAddress(acc.PrivateKey.PublicKey)
 	require.Equal(t, &expectedAddr, acc.Address())

--- a/api/rpc_test/trace_test.go
+++ b/api/rpc_test/trace_test.go
@@ -29,10 +29,8 @@ import (
 )
 
 func Test_TraceSimpleTransfer(t *testing.T) {
-	acc1, err := NewWallet()
-	require.NoError(t, err)
-	acc2, err := NewWallet()
-	require.NoError(t, err)
+	acc1 := NewWallet(t)
+	acc2 := NewWallet(t)
 	transferBalance := big.NewInt(1e17)
 
 	be := NewBackendBuilder(t).

--- a/api/sonicapi/bundles_api_integration_test.go
+++ b/api/sonicapi/bundles_api_integration_test.go
@@ -87,12 +87,14 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 					{
 						"from": "ACCOUNT1",
 						"to": "ACCOUNT2",
-						"nonce": "0x0"
+						"nonce": "0x0",
+						"gas": "0x5208"
 					},
 					{
 						"from": "ACCOUNT2",
 						"to": "ACCOUNT1",
-						"nonce": "0x0"
+						"nonce": "0x0",
+						"gas": "0x5208"
 					}
 				]
 			}`,
@@ -105,36 +107,19 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 						"from": "ACCOUNT1",
 						"to": "ACCOUNT2",
 						"nonce": "0x0",
+						"gas": "0x5208",
 						"tolerateFailed": true
 					},
 					{
 						"from": "ACCOUNT2",
 						"to": "ACCOUNT1",
 						"nonce": "0x0",
+						"gas": "0x5208",
 						"tolerateInvalid": true
 					}
 			   ]
 			}`,
 			expectedBundle: "AllOf(Step[TolerateFailed](A),Step[TolerateInvalid](B))",
-		},
-		"gas price and gas limit prefilled": {
-			request: `{
-			   "steps": [	
-					{
-						"from": "ACCOUNT1",
-						"to": "ACCOUNT2",
-						"nonce": "0x0",
-						"gasPrice": "0x3b9aca00",
-						"gas": "0x5208"
-					},
-					{
-						"from": "ACCOUNT2",
-						"to": "ACCOUNT1",
-						"nonce": "0x0"
-					}
-			   ]
-			}`,
-			expectedBundle: "AllOf(A,B)",
 		},
 		"nested groups": {
 			request: `{
@@ -143,7 +128,8 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 					{
 						"from": "ACCOUNT1",
 						"to": "ACCOUNT2",
-						"nonce": "0x0"
+						"nonce": "0x0",
+						"gas": "0x5208"
 					},
 					{
 						"oneOf": true,
@@ -151,12 +137,14 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 							{
 								"from": "ACCOUNT2",
 								"to": "ACCOUNT1",
-								"nonce": "0x0"
+								"nonce": "0x0",
+								"gas": "0x5208"
 							},
 							{
 								"from": "ACCOUNT1",
 								"to": "ACCOUNT2",
-								"nonce": "0x1"
+								"nonce": "0x1",
+								"gas": "0x5208"
 							}
 						]
 					}
@@ -171,7 +159,8 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 					{
 						"from": "ACCOUNT1",
 						"to": "ACCOUNT2",
-						"nonce": "0x0"
+						"nonce": "0x0",
+						"gas": "0x5208"
 					},
 					{
 						"oneOf": true,
@@ -179,12 +168,14 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 							{
 								"from": "ACCOUNT2",
 								"to": "ACCOUNT1",
-								"nonce": "0x0"
+								"nonce": "0x0",
+								"gas": "0x5208"
 							},
 							{
 								"from": "ACCOUNT1",
 								"to": "ACCOUNT2",
-								"nonce": "0x0"
+								"nonce": "0x0",
+								"gas": "0x5208"
 							}
 						]
 					}

--- a/api/sonicapi/bundles_api_integration_test.go
+++ b/api/sonicapi/bundles_api_integration_test.go
@@ -240,7 +240,7 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 				SignedTransactions: make([]hexutil.Bytes, len(prepared.Transactions)),
 				ExecutionPlan:      prepared.ExecutionPlan,
 			}
-			// This code replicates third party wallets signing the bundled transactions
+			// This loop replicates third-party wallets signing the bundled transactions
 			for i, tx := range prepared.Transactions {
 				// Note: all transactions at this stage have access list, therefore
 				// toTransactionForBundles is not needed.

--- a/api/sonicapi/bundles_api_intergration_test.go
+++ b/api/sonicapi/bundles_api_intergration_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -40,12 +39,12 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 	// and recognized by the transaction pool as a valid bundle envelope
 	// with the correct execution plan hash.
 
-	accounts := make(map[string]account)
-	accounts["ACCOUNT1"] = newAccount(t)
-	accounts["ACCOUNT2"] = newAccount(t)
+	accounts := make(map[string]*rpctest.Wallet)
+	accounts["ACCOUNT1"] = rpctest.NewWallet(t)
+	accounts["ACCOUNT2"] = rpctest.NewWallet(t)
 	addrToKey := make(map[common.Address]*ecdsa.PrivateKey)
 	for _, acc := range accounts {
-		addrToKey[acc.address] = acc.key
+		addrToKey[*acc.Address()] = acc.PrivateKey
 	}
 
 	tests := map[string]struct {
@@ -204,7 +203,7 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 			beBuilder := rpctest.NewBackendBuilder(t).
 				WithPool(pool)
 			for _, acc := range accounts {
-				beBuilder.WithAccount(acc.address, rpctest.AccountState{
+				beBuilder.WithAccount(*acc.Address(), rpctest.AccountState{
 					Nonce:   0,
 					Balance: big.NewInt(1e18), // 1 ETH
 				})
@@ -217,7 +216,7 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 
 			input := test.request
 			for placeholder, account := range accounts {
-				input = strings.ReplaceAll(input, placeholder, account.address.Hex())
+				input = strings.ReplaceAll(input, placeholder, account.Address().Hex())
 			}
 
 			// ============ PrepareBundle ==================
@@ -265,21 +264,6 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 			require.Equal(t, reconstructedPlan.Hash(), submitted,
 				"submit must return the same execution plan as reconstructed and pooled")
 		})
-	}
-}
-
-// account is a helper to keep keys and addresses together in this test.
-type account struct {
-	address common.Address
-	key     *ecdsa.PrivateKey
-}
-
-func newAccount(t testing.TB) account {
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-	return account{
-		address: crypto.PubkeyToAddress(key.PublicKey),
-		key:     key,
 	}
 }
 

--- a/api/sonicapi/bundles_api_intergration_test.go
+++ b/api/sonicapi/bundles_api_intergration_test.go
@@ -1,0 +1,301 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package sonicapi
+
+import (
+	"crypto/ecdsa"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	rpctest "github.com/0xsoniclabs/sonic/api/rpc_test"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
+
+	// This test covers the integration of PrepareBundle and SubmitBundle,
+	// ensuring that a bundle prepared by the API can be successfully submitted
+	// and recognized by the transaction pool as a valid bundle envelope
+	// with the correct execution plan hash.
+
+	accounts := make(map[string]account)
+	accounts["ACCOUNT1"] = newAccount(t)
+	accounts["ACCOUNT2"] = newAccount(t)
+	addrToKey := make(map[common.Address]*ecdsa.PrivateKey)
+	for _, acc := range accounts {
+		addrToKey[acc.address] = acc.key
+	}
+
+	tests := map[string]struct {
+		request        string
+		expectedBundle string
+	}{
+		"one tx bundle": {
+			request: `{
+			   "steps": [	
+					{
+						"from": "ACCOUNT1",
+						"to": "ACCOUNT2",
+						"nonce": "0x0"
+					}
+			   ]
+			}`,
+			expectedBundle: "A",
+		},
+		"two independent steps": {
+			request: `{
+			   "steps": [	
+					{
+						"from": "ACCOUNT1",
+						"to": "ACCOUNT2",
+						"nonce": "0x0"
+					},
+					{
+						"from": "ACCOUNT2",
+						"to": "ACCOUNT1",
+						"nonce": "0x0"
+					}
+			   ]
+			}`,
+			expectedBundle: "AllOf(A,B)",
+		},
+		"oneOf with two steps": {
+			request: `{
+				"oneOf": true,
+				"steps": [
+					{
+						"from": "ACCOUNT1",
+						"to": "ACCOUNT2",
+						"nonce": "0x0"
+					},
+					{
+						"from": "ACCOUNT2",
+						"to": "ACCOUNT1",
+						"nonce": "0x0"
+					}
+				]
+			}`,
+			expectedBundle: "OneOf(A,B)",
+		},
+		"execution flags": {
+			request: `{
+			   "steps": [	
+					{
+						"from": "ACCOUNT1",
+						"to": "ACCOUNT2",
+						"nonce": "0x0",
+						"tolerateFailed": true
+					},
+					{
+						"from": "ACCOUNT2",
+						"to": "ACCOUNT1",
+						"nonce": "0x0",
+						"tolerateInvalid": true
+					}
+			   ]
+			}`,
+			expectedBundle: "AllOf(Step[TolerateFailed](A),Step[TolerateInvalid](B))",
+		},
+		"gas price and gas limit prefilled": {
+			request: `{
+			   "steps": [	
+					{
+						"from": "ACCOUNT1",
+						"to": "ACCOUNT2",
+						"nonce": "0x0",
+						"gasPrice": "0x3b9aca00",
+						"gas": "0x5208"
+					},
+					{
+						"from": "ACCOUNT2",
+						"to": "ACCOUNT1",
+						"nonce": "0x0"
+					}
+			   ]
+			}`,
+			expectedBundle: "AllOf(A,B)",
+		},
+		"nested groups": {
+			request: `{
+				"oneOf": true,
+				"steps": [
+					{
+						"from": "ACCOUNT1",
+						"to": "ACCOUNT2",
+						"nonce": "0x0"
+					},
+					{
+						"oneOf": true,
+						"steps": [
+							{
+								"from": "ACCOUNT2",
+								"to": "ACCOUNT1",
+								"nonce": "0x0"
+							},
+							{
+								"from": "ACCOUNT1",
+								"to": "ACCOUNT2",
+								"nonce": "0x1"
+							}
+						]
+					}
+				]
+			}`,
+			expectedBundle: "OneOf(A,OneOf(B,C))",
+		},
+		"nested group with repeated transaction reference": {
+			request: `{
+				"oneOf": true,
+				"steps": [
+					{
+						"from": "ACCOUNT1",
+						"to": "ACCOUNT2",
+						"nonce": "0x0"
+					},
+					{
+						"oneOf": true,
+						"steps": [
+							{
+								"from": "ACCOUNT2",
+								"to": "ACCOUNT1",
+								"nonce": "0x0"
+							},
+							{
+								"from": "ACCOUNT1",
+								"to": "ACCOUNT2",
+								"nonce": "0x0"
+							}
+						]
+					}
+				]
+			}`,
+			expectedBundle: "OneOf(A,OneOf(B,A))",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			ctrl := gomock.NewController(t)
+			pool := rpctest.NewMockTxPool(ctrl)
+
+			beBuilder := rpctest.NewBackendBuilder(t).
+				WithPool(pool)
+			for _, acc := range accounts {
+				beBuilder.WithAccount(acc.address, rpctest.AccountState{
+					Nonce:   0,
+					Balance: big.NewInt(1e18), // 1 ETH
+				})
+			}
+			be := beBuilder.Build()
+			api := NewPublicBundleAPI(be)
+			signer := be.GetSigner()
+
+			// ============ fill-in templated inputs ==================
+
+			input := test.request
+			for placeholder, account := range accounts {
+				input = strings.ReplaceAll(input, placeholder, account.address.Hex())
+			}
+
+			// ============ PrepareBundle ==================
+
+			var proposal RPCExecutionProposal
+			err := json.Unmarshal([]byte(input), &proposal)
+			require.NoError(t, err, "test input must be a valid RPCExecutionProposal")
+
+			prepared, err := api.PrepareBundle(t.Context(), proposal)
+			require.NoError(t, err)
+
+			reconstructedPlan, err := ToBundleExecutionPlan(prepared.ExecutionPlan)
+			require.NoError(t, err)
+
+			require.Equal(t, test.expectedBundle, reconstructedPlan.Root.String(),
+				"prepared execution plan does not match expected")
+
+			// ============ SubmitBundle ==================
+
+			submitArgs := SubmitBundleArgs{
+				SignedTransactions: make([]hexutil.Bytes, len(prepared.Transactions)),
+				ExecutionPlan:      prepared.ExecutionPlan,
+			}
+			// This code replicates third party wallets signing the bundled transactions
+			for i, tx := range prepared.Transactions {
+				// Note: all transactions at this stage have access list, therefore
+				// toTransactionForBundles is not needed.
+				signedTx, err := types.SignTx(tx.ToTransaction(), signer, addrToKey[*tx.From])
+				require.NoError(t, err)
+
+				encodedTx, err := signedTx.MarshalBinary()
+				require.NoError(t, err)
+
+				submitArgs.SignedTransactions[i] = encodedTx
+			}
+
+			pool.EXPECT().AddLocal(isAnEnvelope{}).Do(func(tx *types.Transaction) {
+				_, extractedPlan, err := bundle.ValidateEnvelope(signer, tx)
+				require.NoError(t, err)
+				require.Equal(t, reconstructedPlan.Hash(), extractedPlan.Hash())
+			})
+
+			submitted, err := api.SubmitBundle(t.Context(), submitArgs)
+			require.NoError(t, err)
+			require.Equal(t, reconstructedPlan.Hash(), submitted,
+				"submit must return the same execution plan as reconstructed and pooled")
+		})
+	}
+}
+
+// account is a helper to keep keys and addresses together in this test.
+type account struct {
+	address common.Address
+	key     *ecdsa.PrivateKey
+}
+
+func newAccount(t testing.TB) account {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	return account{
+		address: crypto.PubkeyToAddress(key.PublicKey),
+		key:     key,
+	}
+}
+
+// isAnEnvelope is a gomock matcher that checks if a transaction is a bundle envelope
+type isAnEnvelope struct{}
+
+func (m isAnEnvelope) Matches(x interface{}) bool {
+
+	tx, ok := x.(*types.Transaction)
+	if !ok {
+		return false
+	}
+
+	return bundle.IsEnvelope(tx)
+}
+
+func (m isAnEnvelope) String() string {
+	return "is a bundle envelope"
+}

--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -150,7 +150,7 @@ func toBundleExecutionGroup(l RPCExecutionPlanGroup) (bundle.ExecutionStep, erro
 		steps[i] = step
 	}
 
-	// Single children without flags do not need to be in an extra group
+	// Single child without flags does not need to be in an extra group
 	if !l.TolerateFailures && len(steps) == 1 {
 		return steps[0], nil
 	}

--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -150,7 +150,7 @@ func toBundleExecutionGroup(l RPCExecutionPlanGroup) (bundle.ExecutionStep, erro
 		steps[i] = step
 	}
 
-	// if it's not a group, skip it
+	// Single children without flags do not need to be in an extra group
 	if !l.TolerateFailures && len(steps) == 1 {
 		return steps[0], nil
 	}


### PR DESCRIPTION
This test covers the integration of `PrepareBundle` and `SubmitBundle`, ensuring that a bundle prepared by the API can be successfully submitted and recognized by the transaction pool as a valid bundle envelope with the correct execution plan hash.