### PR TITLE
Add integration tests for semantics of bundles with brio and bundles flags

### DIFF
--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -52,6 +52,11 @@ func newBundlesChecker(
 		stateDb: stateDB,
 	}
 	return func(tx *types.Transaction) bundlePoolStatus {
+		// Before Brio, bundle envelopes are regular transactions and must not
+		// be subject to bundle-specific filtering in the pool.
+		if !chain.CurrentRules().Upgrades.Brio {
+			return bundlePending
+		}
 		bundleState := GetBundleState(adapter, stateDB, tx)
 		if bundleState.Executable {
 			return bundlePending

--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -52,11 +52,6 @@ func newBundlesChecker(
 		stateDb: stateDB,
 	}
 	return func(tx *types.Transaction) bundlePoolStatus {
-		// Before Brio, bundle envelopes are regular transactions and must not
-		// be subject to bundle-specific filtering in the pool.
-		if !chain.CurrentRules().Upgrades.Brio {
-			return bundlePending
-		}
 		bundleState := GetBundleState(adapter, stateDB, tx)
 		if bundleState.Executable {
 			return bundlePending

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -437,11 +437,14 @@ func (l *txList) Filter(
 		}
 
 		// bundle envelopes with valid nonces but non-pending status are demoted
-		demotedEnvelopes := l.txs.filter(func(tx *types.Transaction) bool {
-			return bundle.IsEnvelope(tx) &&
-				tx.Nonce() < firstInvalidNonce &&
-				evaluateBundleStatus(tx) == bundleQueued
-		})
+		var demotedEnvelopes types.Transactions
+		if upgrades.Brio && hasBundles {
+			demotedEnvelopes = l.txs.filter(func(tx *types.Transaction) bool {
+				return bundle.IsEnvelope(tx) &&
+					tx.Nonce() < firstInvalidNonce &&
+					evaluateBundleStatus(tx) == bundleQueued
+			})
+		}
 		for _, tx := range demotedEnvelopes {
 			firstInvalidNonce = min(firstInvalidNonce, tx.Nonce())
 		}

--- a/evmcore/tx_list.go
+++ b/evmcore/tx_list.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -387,6 +388,7 @@ func (l *txList) Filter(
 	gasLimit uint64,
 	isSponsored utils.TransactionCheckFunc,
 	evaluateBundleStatus func(*types.Transaction) bundlePoolStatus,
+	upgrades opera.Upgrades,
 ) (types.Transactions, types.Transactions) {
 
 	hasSponsored := l.txs.containsFunc(subsidies.IsSponsorshipRequest)
@@ -403,14 +405,18 @@ func (l *txList) Filter(
 
 	// Filter out all the transactions above the account's funds
 	removed := l.txs.Filter(func(tx *types.Transaction) bool {
-		// Bundle transactions need to be checked before sponsored transactions
-		// since bundle envelopes may qualify as sponsored transactions.
-		if bundle.IsEnvelope(tx) {
-			status := evaluateBundleStatus(tx)
-			if status != bundlePending {
-				containsNonExecutableBundles = true
+		// Before Brio, bundle envelopes are regular transactions and must not
+		// be subject to bundle-specific filtering in the pool.
+		if upgrades.Brio {
+			// Bundle transactions need to be checked before sponsored transactions
+			// since bundle envelopes may qualify as sponsored transactions.
+			if bundle.IsEnvelope(tx) {
+				status := evaluateBundleStatus(tx)
+				if status != bundlePending {
+					containsNonExecutableBundles = true
+				}
+				return status == bundleRejected
 			}
-			return status == bundleRejected
 		}
 		if subsidies.IsSponsorshipRequest(tx) {
 			return !isSponsored(tx)

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -95,7 +95,9 @@ func TestTxList_Filter_WithSponsoredTransactions_RetainsCovered(t *testing.T) {
 
 	list := newTxList(true)
 	for _, tx := range txs {
-		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		added, replaced := list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		require.True(added, "transaction was not added to the list")
+		require.Empty(replaced, "no transaction should have been replaced")
 	}
 
 	// Each sponsored transaction should be checked.
@@ -112,6 +114,43 @@ func TestTxList_Filter_WithSponsoredTransactions_RetainsCovered(t *testing.T) {
 	}
 }
 
+func TestTxList_Filter_TreatsEnvelopesAsNormalTx_BeforeBrio(t *testing.T) {
+	require := require.New(t)
+	key, err := crypto.GenerateKey()
+	require.NoError(err)
+	maxGas := uint64(1_000_000)
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	txs := make([]*types.Transaction, 10)
+	for i := range txs {
+		tx := bundleTx(uint64(i), key)
+
+		gasLimit := tx.Gas()
+		if i%2 != 0 {
+			gasLimit = maxGas + 1 // make it invalid
+		}
+		txs[i] = types.MustSignNewTx(key, signer, &types.LegacyTx{
+			To:       tx.To(),
+			Gas:      gasLimit,
+			GasPrice: big.NewInt(1), // not an sponsorship request
+			Value:    tx.Value(),
+			Data:     tx.Data(),
+			Nonce:    tx.Nonce(),
+		})
+	}
+
+	list := newTxList(true)
+	for _, tx := range txs {
+		added, replaced := list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		require.True(added)
+		require.Empty(replaced)
+	}
+	costLimit := big.NewInt(1e18)
+	removed, invalidated := list.Filter(costLimit, maxGas, nil, nil, opera.GetAllegroUpgrades())
+	require.Len(removed, 5)
+	require.Len(invalidated, 4)
+}
+
 func TestTxList_Filter_WithBundleTransactions_RetainsPending(t *testing.T) {
 	require := require.New(t)
 	key, err := crypto.GenerateKey()
@@ -124,7 +163,9 @@ func TestTxList_Filter_WithBundleTransactions_RetainsPending(t *testing.T) {
 
 	list := newTxList(true)
 	for _, tx := range txs {
-		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		added, replaced := list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		require.True(added, "transaction was not added to the list")
+		require.Empty(replaced, "no transaction should have been replaced")
 	}
 
 	// Each bundle transaction should be checked.
@@ -153,7 +194,9 @@ func TestTxList_Filter_WithBundleTransactions_RemovesRejected(t *testing.T) {
 
 	list := newTxList(false)
 	for _, tx := range txs {
-		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		added, replaced := list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		require.True(added, "transaction was not added to the list")
+		require.Empty(replaced, "no transaction should have been replaced")
 	}
 
 	// Each bundle transaction should be checked.
@@ -185,7 +228,9 @@ func TestTxList_Strict_Filter_WithBundleTransactions_InvalidatesTemporarilyBlock
 
 	list := newTxList(true)
 	for _, tx := range txs {
-		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		added, replaced := list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		require.True(added, "transaction was not added to the list")
+		require.Empty(replaced, "no transaction should have been replaced")
 	}
 
 	// Each bundle transaction should be checked.
@@ -215,7 +260,9 @@ func TestTxList_Strict_Filter_WithBundleTransactions_InvalidatesGappedNonces_Aft
 
 	list := newTxList(true)
 	for _, tx := range txs {
-		list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		added, replaced := list.Add(tx, DefaultTxPoolConfig.PriceBump)
+		require.True(added, "transaction was not added to the list")
+		require.Empty(replaced, "no transaction should have been replaced")
 	}
 
 	// Bundle transactions are to be demoted.

--- a/evmcore/tx_list_test.go
+++ b/evmcore/tx_list_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -102,7 +103,7 @@ func TestTxList_Filter_WithSponsoredTransactions_RetainsCovered(t *testing.T) {
 		return tx.Nonce()%2 == 0
 	}
 
-	removed, _ := list.Filter(big.NewInt(1e18), 1_000_000, checker, nil)
+	removed, _ := list.Filter(big.NewInt(1e18), 1_000_000, checker, nil, opera.GetBrioUpgrades())
 
 	// All non-sponsored transactions should be removed.
 	require.Len(removed, 5)
@@ -134,7 +135,7 @@ func TestTxList_Filter_WithBundleTransactions_RetainsPending(t *testing.T) {
 	}
 
 	costLimit := big.NewInt(1e18)
-	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker, opera.GetBrioUpgrades())
 	require.Equal(10, callCount, "unexpected number of calls to checker")
 	require.Len(removed, 0)
 	require.Len(invalidated, 0)
@@ -166,7 +167,7 @@ func TestTxList_Filter_WithBundleTransactions_RemovesRejected(t *testing.T) {
 	}
 
 	costLimit := big.NewInt(1e18)
-	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker, opera.GetBrioUpgrades())
 	require.Equal(10, callCount, "unexpected number of calls to checker")
 	require.Len(removed, 5, "odd nonce transactions should be removed")
 	require.Len(invalidated, 0, "list is not strict, so no transactions should be invalidated")
@@ -196,7 +197,7 @@ func TestTxList_Strict_Filter_WithBundleTransactions_InvalidatesTemporarilyBlock
 	}
 
 	costLimit := big.NewInt(1e18)
-	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker, opera.GetBrioUpgrades())
 	require.Len(removed, 0, "no transactions should be removed, just invalidated")
 	require.Len(invalidated, 5, "list is strict, so temporarily blocked transactions should be invalidated")
 }
@@ -223,7 +224,7 @@ func TestTxList_Strict_Filter_WithBundleTransactions_InvalidatesGappedNonces_Aft
 	}
 
 	costLimit := big.NewInt(1e18)
-	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker)
+	removed, invalidated := list.Filter(costLimit, 1_000_000, nil, checker, opera.GetBrioUpgrades())
 	require.Len(removed, 0, "no transactions should be removed, just invalidated")
 	require.Len(invalidated, 10, "invalid bundle with nonce 0 invalidates all transactions with nonce > 0")
 }
@@ -391,7 +392,7 @@ func TestTxList_Filter_RemovesAndInvalidatesTransactions(t *testing.T) {
 
 			costLimit := big.NewInt(1e18)
 			gasLimit := uint64(1_000_000)
-			removed, invalidated := list.Filter(costLimit, gasLimit, nil, test.checker)
+			removed, invalidated := list.Filter(costLimit, gasLimit, nil, test.checker, opera.GetBrioUpgrades())
 
 			assert.Len(t, removed, len(test.wantRemoved))
 			for _, nonce := range test.wantRemoved {
@@ -417,7 +418,7 @@ func TestTxList_Filter_ShortCircuitIfAllTransactionsAreBelowThreshold(t *testing
 	}
 
 	// Cost limit and gas limit are above all transactions, so Filter short-circuits.
-	removed, invalidated := list.Filter(big.NewInt(1e18), 1_000_000, nil, nil)
+	removed, invalidated := list.Filter(big.NewInt(1e18), 1_000_000, nil, nil, opera.GetBrioUpgrades())
 	require.Len(removed, 0)
 	require.Len(invalidated, 0)
 	require.Equal(5, list.Len(), "all transactions should remain in the list")
@@ -479,7 +480,7 @@ func BenchmarkTxListAdd(t *testing.B) {
 	t.ResetTimer()
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
-		list.Filter(minimumTip, DefaultTxPoolConfig.MinimumTip, nil, nil)
+		list.Filter(minimumTip, DefaultTxPoolConfig.MinimumTip, nil, nil, opera.GetBrioUpgrades())
 	}
 }
 

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -1529,8 +1529,10 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 	isSponsored := pool.getSubsidiesCheckerForReorg()
 	evaluateBundleStatus := pool.getBundlesCheckerForPromotion()
 	canPromote := func(tx *types.Transaction) bool {
-		if bundle.IsEnvelope(tx) {
-			return evaluateBundleStatus(tx) == bundlePending
+		if pool.chain.CurrentRules().Upgrades.Brio {
+			if bundle.IsEnvelope(tx) {
+				return evaluateBundleStatus(tx) == bundlePending
+			}
 		}
 		return true
 	}
@@ -1560,6 +1562,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			pool.currentMaxGas,
 			isSponsored,
 			evaluateBundleStatus,
+			pool.chain.CurrentRules().Upgrades,
 		)
 		for _, tx := range drops {
 			hash := tx.Hash()
@@ -1791,6 +1794,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			pool.currentMaxGas,
 			isSponsored,
 			isBundlePending,
+			pool.chain.CurrentRules().Upgrades,
 		)
 		for _, tx := range drops {
 			hash := tx.Hash()

--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -333,7 +333,7 @@ func (b *builder) BuildEnvelopeBundleAndPlan() (
 	}
 	bundle, plan := b.BuildBundleAndPlan()
 	signer := b.GetSigner()
-	return newEnvelope(signer, key, b.envelopeNonce, b.envelopeGasPrice, bundle), bundle, plan
+	return NewEnvelope(signer, key, b.envelopeNonce, b.envelopeGasPrice, bundle), bundle, plan
 }
 
 // BuildEnvelope returns an envelope transaction and its execution plan
@@ -446,8 +446,8 @@ type txReference struct {
 	tx  types.TxData
 }
 
-// Wraps the given bundle into an envelope transaction.
-func newEnvelope(
+// NewEnvelope wraps the given bundle into an envelope transaction.
+func NewEnvelope(
 	signer types.Signer,
 	key *ecdsa.PrivateKey,
 	nonce uint64,
@@ -478,5 +478,5 @@ func MustWrapIntoEnvelope(signer types.Signer, bundle *TransactionBundle) *types
 	if err != nil {
 		panic(fmt.Sprintf("failed to generate new key: %v", err))
 	}
-	return newEnvelope(signer, key, 0, &big.Int{}, bundle)
+	return NewEnvelope(signer, key, 0, &big.Int{}, bundle)
 }

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -363,7 +363,7 @@ func removeBundleOnlyTxs(
 	upgrades opera.Upgrades,
 	pendingTxs map[common.Address]types.Transactions) {
 
-	if !upgrades.TransactionBundles {
+	if !upgrades.Brio {
 		return
 	}
 

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -611,7 +611,7 @@ func TestEmitter_fillExtraData_EncodesExpectedData(t *testing.T) {
 	}
 }
 
-func TestRemoveBundleOnlyTxs_OnlyFiltersTxIfFeatureIsEnabled(t *testing.T) {
+func TestRemoveBundleOnlyTxs_OnlyFiltersTxIfBrioIsEnabled(t *testing.T) {
 
 	sender := common.Address{1}
 
@@ -632,7 +632,7 @@ func TestRemoveBundleOnlyTxs_OnlyFiltersTxIfFeatureIsEnabled(t *testing.T) {
 			}
 
 			upgrades := opera.Upgrades{
-				TransactionBundles: enabled,
+				Brio: enabled,
 			}
 
 			removeBundleOnlyTxs(upgrades, pendingTxs)
@@ -762,7 +762,7 @@ func TestRemoveBundleOnlyTxs_ErasesMultipleBundleMarkedTransactions(t *testing.T
 	}
 
 	removeBundleOnlyTxs(opera.Upgrades{
-		TransactionBundles: true,
+		Brio: true,
 	}, pendingTxs)
 
 	require.Len(t, pendingTxs, 1)

--- a/tests/bundles/feature_flag_test.go
+++ b/tests/bundles/feature_flag_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package bundles
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundle_EnvelopeAndBundleOnly_SemanticsEnabledByBrio_ExecutionEnabledByBundleFlag(t *testing.T) {
+	cases := map[string]struct {
+		sendEnvelope          bool // mutually exclusive with sendBundleOnly
+		sendBundleOnly        bool // mutually exclusive with sendEnvelope
+		brio                  bool
+		transactionBundles    bool
+		expectEnvelopeReceipt bool
+		expectInnerReceipt    bool
+	}{
+		"Envelope/PreBrio/WithoutBundles": {
+			sendEnvelope:          true,
+			brio:                  false,
+			transactionBundles:    false,
+			expectEnvelopeReceipt: true, // envelope interpreted as normal transaction
+		},
+		"Envelope/PreBrio/WithBundles": {
+			sendEnvelope:          true,
+			brio:                  false,
+			transactionBundles:    true,
+			expectEnvelopeReceipt: true, // envelope interpreted as normal transaction
+		},
+		"Envelope/PostBrio/WithoutBundles": {
+			sendEnvelope:       true,
+			brio:               true,
+			transactionBundles: false,
+			expectInnerReceipt: false, // bundles disabled, so envelope should not be executed
+		},
+		"Envelope/PostBrio/WithBundles": {
+			sendEnvelope:       true,
+			brio:               true,
+			transactionBundles: true,
+			expectInnerReceipt: true, // envelope interpreted as bundle, inner transaction executed
+		},
+		"BundleOnly/PreBrio/WithoutBundles": {
+			sendBundleOnly:     true,
+			brio:               false,
+			transactionBundles: false,
+			expectInnerReceipt: true, // bundle-only marker ignored and executed as normal transaction
+		},
+		"BundleOnly/PreBrio/WithBundles": {
+			sendBundleOnly:     true,
+			brio:               false,
+			transactionBundles: true,
+			expectInnerReceipt: true, // bundle-only marker ignored and executed as normal transaction
+		},
+		"BundleOnly/PostBrio/WithoutBundles": {
+			sendBundleOnly:     true,
+			brio:               true,
+			transactionBundles: false,
+			expectInnerReceipt: false, // bundle-only transaction not executed
+		},
+		"BundleOnly/PostBrio/WithBundles": {
+			sendBundleOnly:     true,
+			brio:               true,
+			transactionBundles: true,
+			expectInnerReceipt: false, // bundle-only transaction not executed
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			upgrades := opera.GetAllegroUpgrades()
+			upgrades.Brio = tc.brio
+			upgrades.TransactionBundles = tc.transactionBundles
+
+			net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+				Upgrades: &upgrades,
+				ClientExtraArguments: []string{
+					"--disable-txPool-validation",
+				},
+			})
+			client, err := net.GetClient()
+			require.NoError(t, err)
+			defer client.Close()
+
+			signer := types.LatestSignerForChainID(net.GetChainId())
+
+			sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+
+			txBundle := bundle.NewBuilder().
+				WithSigner(signer).
+				AllOf(Step(t, net, sender, &types.AccessListTx{})).
+				BuildBundle()
+			gasPrice, err := client.SuggestGasPrice(t.Context())
+			require.NoError(t, err)
+			envelope := bundle.NewEnvelope(signer, sender.PrivateKey, 0, gasPrice, &txBundle)
+			innerTx := txBundle.GetTransactionsInReferencedOrder()[0]
+
+			// Submit the transaction.
+			if tc.sendEnvelope {
+				_, err = net.Send(envelope)
+			} else if tc.sendBundleOnly {
+				_, err = net.Send(innerTx)
+			}
+			require.NoError(t, err)
+
+			time.Sleep(1 * time.Second)
+
+			envelopeReceipt, err := client.TransactionReceipt(t.Context(), envelope.Hash())
+			if tc.expectEnvelopeReceipt {
+				require.NoError(t, err)
+				require.Equal(t, types.ReceiptStatusSuccessful, envelopeReceipt.Status)
+			} else {
+				require.ErrorContains(t, err, "not found")
+			}
+
+			innerReceipt, err := client.TransactionReceipt(t.Context(), innerTx.Hash())
+			if tc.expectInnerReceipt {
+				require.NoError(t, err)
+				require.Equal(t, types.ReceiptStatusSuccessful, innerReceipt.Status)
+			} else {
+				require.ErrorContains(t, err, "not found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds integration tests that ensure that bundle semantics are interpreted starting with brio and their execution is controlled by the bundle feature flag.

The tests also uncovered that the emitter was checking for the wrong flag, and the pool was not checking for the flag at all. This has been fixed and is also included in this PR.