### PR TITLE
Verify bundle history hash integrity on genesis import

### DIFF
--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -242,44 +242,54 @@ func TestSonicTool_genesis_ExportImport_WithBundles(t *testing.T) {
 	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
 	})
-
-	bundleHash, originalInfo := runBundle(t, net)
-
 	client, err := net.GetClient()
 	require.NoError(t, err)
 
-	// check that the bundle is still there after the export-import process
-	infoBeforeRestart, err := bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash)
+	// run a bundle and check it can be queried
+	bundleHash1, originalInfo1 := runBundle(t, net)
+	info1, err := bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash1)
 	require.NoError(t, err)
-	require.Equal(t, originalInfo, infoBeforeRestart,
+	require.Equal(t, originalInfo1, info1,
 		"bundle info mismatch after genesis export-import")
 
-	// close client before restarting the net
+	// restart the net
 	client.Close()
-
 	require.NoError(t, net.RestartWithExportImport())
-
 	client, err = net.GetClient()
 	require.NoError(t, err)
 
 	// check that the bundle is still there after the export-import process
-	infoAfterRestart, err := bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash)
+	info1, err = bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash1)
 	require.NoError(t, err)
-	require.Equal(t, originalInfo, infoAfterRestart,
+	require.Equal(t, originalInfo1, info1,
 		"bundle info mismatch after genesis export-import")
-	client.Close()
 
-	// run enough blocks to make sure that if the history hash is pruned.
+	// run enough blocks to make sure that the history hash is pruned.
 	generateNBlocks(t, net, int(bundle.MaxBlockRange)+10)
 
-	require.NoError(t, net.RestartWithExportImport())
+	// run another bundle
+	bundleHash2, originalInfo2 := runBundle(t, net)
 
+	// check that the first bundle is pruned and the second bundle is still there after pruning
+	_, err = bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash1)
+	require.ErrorContains(t, err, "not found")
+	info2, err := bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash2)
+	require.NoError(t, err)
+	require.Equal(t, originalInfo2, info2)
+
+	// restart the net
+	client.Close()
+	require.NoError(t, net.RestartWithExportImport())
 	client, err = net.GetClient()
 	require.NoError(t, err)
 
-	// check that the bundle is still there after the export-import process
-	_, err = bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash)
+	// check that the second bundle is available, but the first bundle is not, after the export-import process
+	_, err = bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash1)
 	require.ErrorContains(t, err, "not found")
+	info2, err = bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash2)
+	require.NoError(t, err)
+	require.Equal(t, originalInfo2, info2)
+
 	client.Close()
 }
 
@@ -647,8 +657,13 @@ func runBundle(t *testing.T, net *tests.IntegrationTestNet) (
 	defer client.Close()
 
 	signer := types.LatestSignerForChainID(net.GetChainId())
+
+	block, err := client.BlockNumber(t.Context())
+	require.NoError(t, err)
+
 	envelope, plan := bundle.NewBuilder().
 		WithSigner(signer).
+		SetEarliest(block).
 		AllOf(
 			bundle.Step(
 				net.GetSessionSponsor().PrivateKey,

--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -261,13 +261,26 @@ func TestSonicTool_genesis_ExportImport_WithBundles(t *testing.T) {
 
 	client, err = net.GetClient()
 	require.NoError(t, err)
-	defer client.Close()
 
 	// check that the bundle is still there after the export-import process
 	infoAfterRestart, err := bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash)
 	require.NoError(t, err)
 	require.Equal(t, originalInfo, infoAfterRestart,
 		"bundle info mismatch after genesis export-import")
+	client.Close()
+
+	// run enough blocks to make sure that if the history hash is pruned.
+	generateNBlocks(t, net, int(bundle.MaxBlockRange)+10)
+
+	require.NoError(t, net.RestartWithExportImport())
+
+	client, err = net.GetClient()
+	require.NoError(t, err)
+
+	// check that the bundle is still there after the export-import process
+	_, err = bundles.GetBundleInfo(t.Context(), client.Client(), bundleHash)
+	require.ErrorContains(t, err, "not found")
+	client.Close()
 }
 
 func TestSonicTool_heal_ExecutesWithoutErrors(t *testing.T) {

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -297,12 +297,25 @@ func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter
 func exportBundlesHash(ctx context.Context, gdb *gossip.Store, writer *unitWriter, lastBlock idx.Block) error {
 	log.Info("Exporting processed bundles history hash")
 
-	// write the history hash as the first item.
-	blockNum, histHash := gdb.GetLatestProcessedBundleHistoryHash()
-	b := MustRlpEncodeToByte(bundle.HistoryHash{
-		BlockNumber: blockNum,
-		Hash:        histHash,
-	})
+	latestBlockNum, latestHash := gdb.GetLatestProcessedBundleHistoryHash()
+	oldestBlockNum, oldestHash, ok := gdb.GetEarliestBundleHistoryHash()
+
+	if !ok {
+		log.Info("No processed bundles history hash found in genesis, skipping export")
+		return nil
+	}
+
+	hh := bundle.BundleGenesisHistoryHashes{
+		Latest: bundle.HistoryHash{
+			BlockNumber: latestBlockNum,
+			Hash:        latestHash,
+		},
+		Oldest: bundle.HistoryHash{
+			BlockNumber: oldestBlockNum,
+			Hash:        oldestHash,
+		},
+	}
+	b := MustRlpEncodeToByte(hh)
 	if _, err := writer.Write(b); err != nil {
 		return err
 	}
@@ -310,7 +323,9 @@ func exportBundlesHash(ctx context.Context, gdb *gossip.Store, writer *unitWrite
 	if err != nil {
 		return err
 	}
-	log.Info("Exported processed bundles history hash", "blockNum", blockNum, "hash", histHash)
+	log.Info("Exported processed bundles history hash",
+		"latestBlockNum", latestBlockNum, "latestHash", latestHash,
+		"oldestBlockNum", oldestBlockNum, "oldestHash", oldestHash)
 	fmt.Printf("- Processed bundles history hash: %v \n", hash.String())
 	return nil
 }

--- a/cmd/sonictool/genesis/export_test.go
+++ b/cmd/sonictool/genesis/export_test.go
@@ -111,13 +111,27 @@ func TestBundles_WriteError(t *testing.T) {
 func TestBundles_RoundTrip(t *testing.T) {
 	store := setupBundleStore(t)
 
-	wantBundles := map[common.Hash]bundle.PositionInBlock{
-		{0xaa}: {Offset: 0, Count: 2},
-		{0xbb}: {Offset: 2, Count: 1},
+	wantBundles := map[uint64]map[common.Hash]bundle.PositionInBlock{
+		1: {
+			{0xaa}: {Offset: 0, Count: 2},
+			{0xbb}: {Offset: 2, Count: 1},
+		},
+		2: {
+			{0xcc}: {Offset: 0, Count: 1},
+		},
 	}
-	store.AddProcessedBundles(1, wantBundles)
-	wantHistoryHash := common.Hash{0xff}
-	store.SetProcessedBundlesHistoryHash(1, wantHistoryHash)
+	// Execute bundles at two different blocks so there is an oldest retained hash.
+	store.AddProcessedBundles(1, wantBundles[1])
+	store.AddProcessedBundles(2, wantBundles[2])
+	wantNewestHistoryHash, ok := store.GetProcessedBundleHistoryHash(2)
+	require.True(t, ok, "newest history hash should be present")
+	wantEarliestBlock, wantEarliestHistoryHash, hasEarliest := store.GetEarliestBundleHistoryHash()
+
+	require.True(t, hasEarliest, "oldest retained hash should be present")
+	require.Equal(t, uint64(1), wantEarliestBlock)
+	require.NotEqual(t, wantEarliestHistoryHash, wantNewestHistoryHash,
+		"oldest and newest history hashes should differ")
+	require.NotZero(t, wantEarliestHistoryHash)
 
 	// Export to a real file.
 	tmpDir := t.TempDir()
@@ -145,11 +159,13 @@ func TestBundles_RoundTrip(t *testing.T) {
 	gs, _, err := genesisstore.OpenGenesisStore(outFile)
 	require.NoError(t, err)
 
-	// Verify history hash roundtrips correctly.
-	gotHist, ok := gs.ProcessedBundles().GetHistoryHash()
-	require.True(t, ok, "history hash should be present")
-	require.Equal(t, uint64(1), gotHist.BlockNumber)
-	require.Equal(t, wantHistoryHash, gotHist.Hash)
+	// Verify history hashes roundtrip correctly via the new GetHistoryHashes method.
+	gotHHs, ok := gs.ProcessedBundles().GetHistoryHashes()
+	require.True(t, ok, "history hashes should be present")
+	require.Equal(t, wantEarliestHistoryHash, gotHHs.Oldest.Hash)
+	require.Equal(t, wantEarliestBlock, gotHHs.Oldest.BlockNumber)
+	require.Equal(t, wantNewestHistoryHash, gotHHs.Latest.Hash)
+	require.Equal(t, uint64(2), gotHHs.Latest.BlockNumber)
 
 	// Verify bundle execution infos roundtrip correctly.
 	wantInfos := store.EnumerateProcessedBundles()
@@ -209,6 +225,10 @@ func TestMustRlpEncodeToByte_CanEncodeHistoryHashAndExecutionInfo(t *testing.T) 
 			BlockNumber:       123,
 			ExecutionPlanHash: common.Hash{0x42},
 			Position:          bundle.PositionInBlock{Offset: 1, Count: 2},
+		},
+		"bundle genesis history hashes": bundle.BundleGenesisHistoryHashes{
+			Latest: bundle.HistoryHash{BlockNumber: 100, Hash: common.HexToHash("0xaabbcc")},
+			Oldest: bundle.HistoryHash{BlockNumber: 1, Hash: common.HexToHash("0x112233")},
 		},
 	}
 

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -174,13 +174,15 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 			"oldestBlockNum", hh.Oldest.BlockNumber, "oldestHash", hh.Oldest.Hash,
 			"latestBlockNum", hh.Latest.BlockNumber, "latestHash", hh.Latest.Hash)
 
-		// When the oldest block has bundle entries, the hash chain was
-		// never pruned for that block, so we can replay from it with the
-		// hash starting at zero. When the oldest block has no entries,
-		// pruning occurred and the oldest hash is a predecessor: seed the
-		// chain with it and start replaying from the next block.
+		// When the block range is less than 1024, there have been less than
+		// 1024 blocks since the first block which contains processed bundles.
+		// Therefore, we know the previous history hash is zero and we can
+		// start from the oldest block. Otherwise, there have been at least
+		// 1024 blocks since the first block with processed bundles, so we use
+		// the oldest hash as the starting point and start replay from the next
+		// block. Because the block range is inclusive, we check for 1023.
 		startBlock := hh.Oldest.BlockNumber
-		if _, oldestHasBundles := bundlesByBlock[hh.Oldest.BlockNumber]; !oldestHasBundles {
+		if hh.Latest.BlockNumber-hh.Oldest.BlockNumber >= 1023 {
 			s.SetProcessedBundlesHistoryHash(hh.Oldest.BlockNumber, hh.Oldest.Hash)
 			startBlock = hh.Oldest.BlockNumber + 1
 		}

--- a/gossip/apply_genesis.go
+++ b/gossip/apply_genesis.go
@@ -19,8 +19,6 @@ package gossip
 import (
 	"errors"
 	"fmt"
-	"maps"
-	"slices"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
@@ -160,29 +158,64 @@ func (s *Store) ApplyGenesis(g genesis.Genesis) (err error) {
 			return true
 		})
 
-		// Import bundles grouped by block number in ascending order.
-		for _, bn := range slices.Sorted(maps.Keys(bundlesByBlock)) {
+		if len(bundlesByBlock) == 0 {
+			s.Log.Info("No processed bundles in genesis, skipping import")
+			return nil
+		}
+		s.Log.Info("Importing processed bundles from genesis", "count", len(bundlesByBlock))
+
+		// get history hashes from genesis so that the predecessor can be used
+		// as the starting point and both oldest and latest can be verified.
+		hh, found := g.ProcessedBundles.GetHistoryHashes()
+		if !found {
+			s.Log.Crit("Bundles were processed but no history hash was found in genesis")
+		}
+		s.Log.Info("found bundle history hashes in genesis",
+			"oldestBlockNum", hh.Oldest.BlockNumber, "oldestHash", hh.Oldest.Hash,
+			"latestBlockNum", hh.Latest.BlockNumber, "latestHash", hh.Latest.Hash)
+
+		// When the oldest block has bundle entries, the hash chain was
+		// never pruned for that block, so we can replay from it with the
+		// hash starting at zero. When the oldest block has no entries,
+		// pruning occurred and the oldest hash is a predecessor: seed the
+		// chain with it and start replaying from the next block.
+		startBlock := hh.Oldest.BlockNumber
+		if _, oldestHasBundles := bundlesByBlock[hh.Oldest.BlockNumber]; !oldestHasBundles {
+			s.SetProcessedBundlesHistoryHash(hh.Oldest.BlockNumber, hh.Oldest.Hash)
+			startBlock = hh.Oldest.BlockNumber + 1
+		}
+
+		// Replay all blocks to latest, adding bundles
+		// where present and nil otherwise, so the hash chain is correctly
+		// computed for every block.
+		for block := startBlock; block <= hh.Latest.BlockNumber; block++ {
 			bundlesPerBlock := map[common.Hash]bundle.PositionInBlock{}
-			for _, info := range bundlesByBlock[bn] {
+			for _, info := range bundlesByBlock[block] {
 				if _, exists := bundlesPerBlock[info.ExecutionPlanHash]; exists {
 					s.Log.Crit("Duplicate execution plan hash in genesis",
-						"blockNumber", bn,
+						"block", block,
 						"hash", info.ExecutionPlanHash)
 					return fmt.Errorf(
 						"duplicate execution plan hash in genesis: block %d, hash %s",
-						bn, info.ExecutionPlanHash)
+						block, info.ExecutionPlanHash)
 				}
 				bundlesPerBlock[info.ExecutionPlanHash] = info.Position
 			}
-			s.AddProcessedBundles(bn, bundlesPerBlock)
+			s.AddProcessedBundles(block, bundlesPerBlock)
 		}
 
-		// last overwrite of the history hash, to ensure it is consistent with
-		// the exported hash. This is needed because the history hash is affected
-		// by bundles that could have been deleted from the store out of old age.
-		if h, found := g.ProcessedBundles.GetHistoryHash(); found {
-			s.SetProcessedBundlesHistoryHash(h.BlockNumber, h.Hash)
+		// Verify that the cumulative history hash for the latest block matches
+		// the expected hash from the genesis file, confirming that the imported
+		// entries are correct and complete.
+		latestHash, ok := s.GetProcessedBundleHistoryHash(hh.Latest.BlockNumber)
+		if !ok || latestHash != hh.Latest.Hash {
+			return fmt.Errorf(
+				"reproduced latest bundle history hash does not match genesis: "+
+					"got block %d hash %s, want block %d hash %s",
+				hh.Latest.BlockNumber, latestHash, hh.Latest.BlockNumber, hh.Latest.Hash)
 		}
+		s.Log.Info("Processed bundles imported successfully, all history hashes verified",
+			"latestBlockNum", hh.Latest.BlockNumber, "latestHash", latestHash)
 	}
 
 	return nil

--- a/gossip/blockproc/bundle/execution_info.go
+++ b/gossip/blockproc/bundle/execution_info.go
@@ -40,3 +40,13 @@ type HistoryHash struct {
 	BlockNumber uint64
 	Hash        common.Hash
 }
+
+// BundleGenesisHistoryHashes carries both the latest and the oldest
+// cumulative history hashes for genesis export and import. The latest field
+// allows importers to verify that replayed bundle entries produce the correct
+// history hash for the oldest block still in the retention window, catching
+// any mismatch between the exported entries and the expected history.
+type BundleGenesisHistoryHashes struct {
+	Latest HistoryHash
+	Oldest HistoryHash
+}

--- a/opera/genesis/types.go
+++ b/opera/genesis/types.go
@@ -51,7 +51,7 @@ type (
 	}
 	ProcessedBundles interface {
 		ForEach(fn func(bundle.ExecutionInfo) bool)
-		GetHistoryHash() (bundle.HistoryHash, bool)
+		GetHistoryHashes() (bundle.BundleGenesisHistoryHashes, bool)
 	}
 	FwsLiveSection interface {
 		GetReader() (io.Reader, error)

--- a/opera/genesisstore/store_genesis.go
+++ b/opera/genesisstore/store_genesis.go
@@ -225,24 +225,24 @@ func (s *Store) ProcessedBundles() genesis.ProcessedBundles {
 	return RawProcessedBundles{s.fMap}
 }
 
-func (s RawProcessedBundles) GetHistoryHash() (bundle.HistoryHash, bool) {
+func (s RawProcessedBundles) GetHistoryHashes() (bundle.BundleGenesisHistoryHashes, bool) {
 	for i := range 1000 {
 		f, err := s.fMap(BundleHashSection(i))
 		if err != nil {
 			continue
 		}
 		stream := rlp.NewStream(f, 0)
-		var h bundle.HistoryHash
-		err = stream.Decode(&h)
+		var hh bundle.BundleGenesisHistoryHashes
+		err = stream.Decode(&hh)
 		if err == io.EOF {
-			return bundle.HistoryHash{}, false
+			return bundle.BundleGenesisHistoryHashes{}, false
 		}
 		if err != nil {
 			log.Crit("Failed to decode Processed Bundles history hash", "err", err)
 		}
-		return h, true
+		return hh, true
 	}
-	return bundle.HistoryHash{}, false
+	return bundle.BundleGenesisHistoryHashes{}, false
 }
 
 func (s RawProcessedBundles) ForEach(fn func(bundle.ExecutionInfo) bool) {


### PR DESCRIPTION
This PR depends on https://github.com/0xsoniclabs/sonic/pull/893

**Problem**
Previously, genesis export stored only the latest bundle history hash, and import blindly overwrote it after replaying entries. This meant a corrupted or incomplete export could be imported without detection — the hash was simply force-set rather than independently reproduced and verified.

**Solution**
Export now includes two history hash checkpoints — earliest and latest — and import verifies the hash chain by replaying it from scratch:
- Export: Serializes a `BundleGenesisHistoryHashes` struct containing both checkpoints instead of just the last `HistoryHash`.
- Import: Seeds the hash chain with the _earliest hash_ (the entry just before the retention window).
Replays every block through latest, calling `AddProcessedBundles` with the exported entries (or nil for blocks without bundles).
Verifies the reproduced hash matches the latest checkpoint after all blocks.

This PR finishes https://github.com/0xsoniclabs/sonic-admin/issues/706