### PR TITLE
Revert access list fix

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -1787,14 +1787,6 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 			return nil, 0, nil, fmt.Errorf("failed to apply transaction: %v err: %v", args.toTransaction().Hash(), err)
 		}
 		if tracer.Equal(prevTracer) {
-			// In case an address with no storage keys is in the list,
-			// it has to be ensured that the storage keys are not nil,
-			// but an empty slice instead. Otherwise the JSON unmarshalling fails.
-			for i := range accessList {
-				if accessList[i].StorageKeys == nil {
-					accessList[i].StorageKeys = []common.Hash{}
-				}
-			}
 			return accessList, res.UsedGas, res.Err, nil
 		}
 		prevTracer = tracer


### PR DESCRIPTION
Geth version 1.17.1 had a bug related to an empty access list, this has been fixed in [#33976](https://github.com/ethereum/go-ethereum/pull/33976) which is part of version 1.17.2. Therefore, the fix is no longer required.
Fixes [#668](https://github.com/0xsoniclabs/sonic-admin/issues/668).