### PR TITLE
Update transaction fee tracking to cover bundles

### DIFF
--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -229,11 +229,15 @@ func (p *DriverTxListener) onNewReceiptPostBrioInternal(
 	if err != nil {
 		// If there is an error in the fee computation, the safe default
 		// is to avoid attributing it to any validator, so no fees are paid out.
-		log.Warn("error in fee computation", "tx", tx.Hash(),
-			"usedGas", r.GasUsed, "gasPrice", r.EffectiveGasPrice,
-			"blobGasUsed", r.BlobGasUsed, "blobGasPrice", r.BlobGasPrice,
-			"err", err,
-		)
+		if r == nil {
+			log.Warn("error in fee computation", "tx", tx.Hash(), "err", err)
+		} else {
+			log.Warn("error in fee computation", "tx", tx.Hash(),
+				"usedGas", r.GasUsed, "gasPrice", r.EffectiveGasPrice,
+				"blobGasUsed", r.BlobGasUsed, "blobGasPrice", r.BlobGasPrice,
+				"err", err,
+			)
+		}
 		return
 	}
 

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -204,7 +204,7 @@ func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 // onNewReceiptPostBrio is called for every transaction accepted in a block,
 // providing the ID of the validator that has proposed the transaction in one of
 // its events, the accepted transaction, and its receipt. It is used to keep
-// track on the consumed gas on the network.
+// track of validator-originated transaction fees.
 //
 // This function is an updated version of the `onNewReceiptPreBrio` function
 // above, which is getting enabled with the Brio flag. Unlike the previous

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -150,6 +150,14 @@ func (p *DriverTxTransactor) PopInternalTxs(_ iblockproc.BlockCtx, _ iblockproc.
 }
 
 func (p *DriverTxListener) OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int) {
+	if p.es.Rules.Upgrades.Brio {
+		p.onNewReceiptPostBrio(originator, tx, r)
+	} else {
+		p.onNewReceiptPreBrio(tx, r, originator, baseFee, blobBaseFee)
+	}
+}
+
+func (p *DriverTxListener) onNewReceiptPreBrio(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int) {
 	if originator == 0 {
 		return
 	}
@@ -191,6 +199,52 @@ func effectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 	// function for backward compatibility with previous client versions.
 	gasTip, _ := gasprice.EffectiveGasTip(tx, baseFee)
 	return new(big.Int).Add(baseFee, gasTip)
+}
+
+// onNewReceiptPostBrio is called for every transaction accepted in a block,
+// providing the ID of the validator that has proposed the transaction in one of
+// its events, the accepted transaction, and its receipt. It is used to keep
+// track on the consumed gas on the network.
+//
+// This function is an updated version of the `onNewReceiptPreBrio` function
+// above, which is getting enabled with the Brio flag. Unlike the previous
+// version, this function correctly accounts for fees of sponsored and bundled
+// transactions. The old code is preserved for backward compatibility until the
+// Brio hard-fork and to support full-history syncs.
+func (p *DriverTxListener) onNewReceiptPostBrio(
+	originator idx.ValidatorID,
+	tx *types.Transaction,
+	r *types.Receipt,
+) {
+	p.onNewReceiptPostBrioInternal(originator, tx, r, log.Root())
+}
+
+func (p *DriverTxListener) onNewReceiptPostBrioInternal(
+	originator idx.ValidatorID,
+	tx *types.Transaction,
+	r *types.Receipt,
+	log log.Logger,
+) {
+	fee, err := ComputeEffectiveFee(tx, r)
+	if err != nil {
+		// If there is an error in the fee computation, the safe default
+		// is to avoid attributing it to any validator, so no fees are paid out.
+		log.Warn("error in fee computation", "tx", tx.Hash(),
+			"usedGas", r.GasUsed, "gasPrice", r.EffectiveGasPrice,
+			"blobGasUsed", r.BlobGasUsed, "blobGasPrice", r.BlobGasPrice,
+			"err", err,
+		)
+		return
+	}
+
+	if originator == 0 {
+		log.Warn("failed to attribute transaction to validator, fees got burned", "tx", tx.Hash(), "fees", fee)
+		return
+	}
+
+	originatorIdx := p.es.Validators.GetIdx(originator)
+	originated := p.bs.ValidatorStates[originatorIdx].Originated
+	originated.Add(originated, fee)
 }
 
 // ComputeEffectiveFee returns the effective fee charged for the given

--- a/gossip/blockproc/drivermodule/driver_txs_test.go
+++ b/gossip/blockproc/drivermodule/driver_txs_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/0xsoniclabs/sonic/logger"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
@@ -170,6 +171,181 @@ func TestReceiptRewardWithBlobsAndFixEnabled(t *testing.T) {
 		t.Errorf("Originated increment not GasUsed*EffectiveGasPrice+BlobGasUsed*BlobBaseFee: expected %d, actual %d",
 			OrigOriginated+GasUsed*EffectiveGasPrice+BlobGasUsed*BlobBaseFee, originated)
 	}
+}
+
+func TestDriverTxListener_OnNewReceipt_SwitchesOnBrio(t *testing.T) {
+	// To detect whether the listener correctly switches on Brio, we can test
+	// whether fee charge transactions are processed correctly.
+	tests := map[string]struct {
+		Upgrades                         opera.Upgrades
+		ShouldCoverFeeChargeTransactions bool
+	}{
+		"sonic": {
+			Upgrades:                         opera.GetSonicUpgrades(),
+			ShouldCoverFeeChargeTransactions: false,
+		},
+		"allegro": {
+			Upgrades:                         opera.GetAllegroUpgrades(),
+			ShouldCoverFeeChargeTransactions: false,
+		},
+		"brio": {
+			Upgrades:                         opera.GetBrioUpgrades(),
+			ShouldCoverFeeChargeTransactions: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			nonceSource := subsidies.NewMockNonceSource(ctrl)
+			nonceSource.EXPECT().GetNonce(gomock.Any()).AnyTimes()
+
+			tx, err := subsidies.GetFeeChargeTransaction(
+				nonceSource,
+				subsidies.FundId{},
+				subsidies.GasConfig{},
+				123,
+				big.NewInt(456),
+			)
+			require.NoError(t, err)
+
+			fees, err := ComputeEffectiveFee(tx, nil)
+			require.NoError(t, err)
+			require.Equal(t, uint64(123*456), fees.Uint64())
+
+			validatorId := idx.ValidatorID(12)
+			valsBuilder := pos.NewBuilder()
+			valsBuilder.Set(validatorId, 100)
+			validators := valsBuilder.Build()
+
+			receipt := &types.Receipt{}
+
+			listener := &DriverTxListener{
+				es: iblockproc.EpochState{
+					Validators: validators,
+					Rules: opera.Rules{
+						Upgrades: tc.Upgrades,
+					},
+				},
+				bs: iblockproc.BlockState{
+					ValidatorStates: []iblockproc.ValidatorBlockState{{
+						Originated: big.NewInt(0),
+					}},
+				},
+			}
+
+			listener.OnNewReceipt(tx, receipt, validatorId, big.NewInt(123), nil)
+
+			// Before Brio, fee charge transactions should not be processed, so the
+			// receipt should not be attributed to the validator.
+			validatorIndex := listener.es.Validators.GetIdx(validatorId)
+			originated := listener.bs.ValidatorStates[validatorIndex].Originated.Uint64()
+
+			if tc.ShouldCoverFeeChargeTransactions {
+				require.Equal(t, fees.Uint64(), originated)
+			} else {
+				require.Zero(t, originated)
+			}
+		})
+	}
+}
+
+func TestDriverTxListener_onNewReceiptPostBrio_AddsFeesToRespectiveValidator(t *testing.T) {
+	receipt := &types.Receipt{
+		EffectiveGasPrice: big.NewInt(100),
+		GasUsed:           50,
+	}
+
+	creator := idx.ValidatorID(12)
+	other := idx.ValidatorID(14)
+
+	// build two validators with different stake
+	validatorBuilder := pos.NewBuilder()
+	validatorBuilder.Set(creator, 200)
+	validatorBuilder.Set(other, 100)
+	validators := validatorBuilder.Build()
+
+	creatorIndex := validators.GetIdx(creator)
+	otherIndex := validators.GetIdx(other)
+
+	initialFees := []*big.Int{
+		big.NewInt(1234), big.NewInt(4321),
+	}
+	state := make([]iblockproc.ValidatorBlockState, 2)
+	state[creatorIndex].Originated = new(big.Int).SetBytes(initialFees[0].Bytes())
+	state[otherIndex].Originated = new(big.Int).SetBytes(initialFees[1].Bytes())
+
+	listener := &DriverTxListener{
+		es: iblockproc.EpochState{
+			Validators: validators,
+		},
+		bs: iblockproc.BlockState{
+			ValidatorStates: state,
+		},
+	}
+
+	listener.onNewReceiptPostBrio(creator, nil, receipt)
+
+	fee, err := ComputeEffectiveFee(nil, receipt)
+	require.NoError(t, err)
+	require.Equal(t, 1, fee.Sign())
+
+	// The creator's originated fees should have been increased.
+	want := new(big.Int).Add(initialFees[0], fee)
+	got := listener.bs.ValidatorStates[creatorIndex].Originated
+	require.True(t, got.Cmp(want) == 0,
+		"want: %v, got %v", want, got,
+	)
+
+	// the other validator's originated fees should remain as they were.
+	want = initialFees[1]
+	got = listener.bs.ValidatorStates[otherIndex].Originated
+	require.True(t, got.Cmp(want) == 0,
+		"want: %v, got %v", want, got,
+	)
+}
+
+func TestDriverTxListener_onNewReceiptPostBrioInternal_OnFeeComputationError_WarnsAndBurnsFees(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	log := logger.NewMockLogger(ctrl)
+
+	tx := types.NewTx(&types.LegacyTx{})
+
+	receipt := &types.Receipt{}
+
+	log.EXPECT().Warn(
+		"error in fee computation",
+		"tx", tx.Hash(),
+		"usedGas", receipt.GasUsed,
+		"gasPrice", receipt.EffectiveGasPrice,
+		"blobGasUsed", receipt.BlobGasUsed,
+		"blobGasPrice", receipt.BlobGasPrice,
+		"err", gomock.Any(),
+	)
+
+	listener := &DriverTxListener{}
+	listener.onNewReceiptPostBrioInternal(0, tx, receipt, log)
+}
+
+func TestDriverTxListener_onNewReceiptPostBrioInternal_WarnsOnOriginatorZero(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	log := logger.NewMockLogger(ctrl)
+
+	tx := types.NewTx(&types.LegacyTx{})
+
+	receipt := &types.Receipt{
+		EffectiveGasPrice: big.NewInt(100),
+		GasUsed:           50,
+	}
+
+	log.EXPECT().Warn(
+		"failed to attribute transaction to validator, fees got burned",
+		"tx", tx.Hash(),
+		"fees", big.NewInt(100*50),
+	)
+
+	listener := &DriverTxListener{}
+	listener.onNewReceiptPostBrioInternal(0, tx, receipt, log)
 }
 
 func TestComputeEffectiveFee_ComputesFeesBySummingGasAndBlobFees(t *testing.T) {

--- a/gossip/blockproc/drivermodule/driver_txs_test.go
+++ b/gossip/blockproc/drivermodule/driver_txs_test.go
@@ -305,6 +305,22 @@ func TestDriverTxListener_onNewReceiptPostBrio_AddsFeesToRespectiveValidator(t *
 	)
 }
 
+func TestDriverTxListener_onNewReceiptPostBrioInternal_OnMissingReceipt_WarnsAndBurnsFees(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	log := logger.NewMockLogger(ctrl)
+
+	tx := types.NewTx(&types.LegacyTx{})
+
+	log.EXPECT().Warn(
+		"error in fee computation",
+		"tx", tx.Hash(),
+		"err", gomock.Any(),
+	)
+
+	listener := &DriverTxListener{}
+	listener.onNewReceiptPostBrioInternal(0, tx, nil, log)
+}
+
 func TestDriverTxListener_onNewReceiptPostBrioInternal_OnFeeComputationError_WarnsAndBurnsFees(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	log := logger.NewMockLogger(ctrl)

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -422,9 +422,10 @@ func consensusCallbackBeginBlockFn(
 
 					orderedTxs := proposal.Transactions
 					numSkippedDueToBlockLimits := 0
+					var txCausedBy map[common.Hash]common.Hash
 					if es.Rules.Upgrades.Brio {
 						// Limit block size and gas while adding user transactions
-						numSkippedDueToBlockLimits =
+						numSkippedDueToBlockLimits, txCausedBy =
 							processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit)
 					} else {
 						// Pre brio there were no limits on user transactions
@@ -482,7 +483,11 @@ func consensusCallbackBeginBlockFn(
 
 					// call OnNewReceipt
 					for i, r := range allReceipts {
-						creator := txPositions[r.TxHash].EventCreator
+						originTx := r.TxHash
+						if origin, found := txCausedBy[r.TxHash]; found {
+							originTx = origin
+						}
+						creator := txPositions[originTx].EventCreator
 						if creator != 0 && es.Validators.Get(creator) == 0 {
 							creator = 0
 						}
@@ -616,13 +621,20 @@ func processUserTransactionsNoLimits(
 // used for block size calculations.
 const rlpEncodedMaxHeaderSizeInBytes = 1024
 
-// processUserTransactions executes user transactions in order, adding them to the block
-// until all transactions are processed or the gas/block size limit is reached.
+// processUserTransactions executes user transactions in order, adding them to
+// the block until all transactions are processed or the gas/block size limit is
+// reached. The function returns the number of input transactions skipped due
+// to capacity limitations as well as a map linking the hashes of accepted
+// transactions to the transaction they are derived from in the given list.
 func processUserTransactions(
 	evmProcessor blockproc.EVMProcessor,
 	blockBuilder *inter.BlockBuilder,
 	orderedTxs []*types.Transaction,
-	userTransactionGasLimit uint64) int {
+	userTransactionGasLimit uint64,
+) (
+	skippedCount int,
+	causedBy map[common.Hash]common.Hash,
+) {
 	remainingGas := userTransactionGasLimit
 	remainingSize := uint64(params.MaxBlockSize - rlpEncodedMaxHeaderSizeInBytes)
 	internalTxs := blockBuilder.GetTransactions()
@@ -630,11 +642,12 @@ func processUserTransactions(
 		txSize := tx.Size()
 		if txSize > remainingSize {
 			log.Warn("block filled with only internal transactions")
-			return len(orderedTxs)
+			return len(orderedTxs), nil
 		}
 		remainingSize -= txSize
 	}
 
+	causedBy = make(map[common.Hash]common.Hash)
 	skippedCounter := 0
 	for _, tx := range orderedTxs {
 		neededSpace := txSizeIncludingSubsidies(tx)
@@ -647,13 +660,14 @@ func processUserTransactions(
 					)
 					remainingGas -= processed.Receipt.GasUsed
 					remainingSize -= processed.Transaction.Size()
+					causedBy[processed.Transaction.Hash()] = tx.Hash()
 				}
 			}
 		} else {
 			skippedCounter++
 		}
 	}
-	return skippedCounter
+	return skippedCounter, causedBy
 }
 
 // txSizeIncludingSubsidies returns the size of the transaction,

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1125,7 +1125,7 @@ func TestProcessUserTransactions_TransactionsWithNoReceiptAreNotIncluded(t *test
 		Execute([]*types.Transaction{tx}, gomock.Any()).
 		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx, Receipt: nil}}})
 
-	skippedCount :=
+	skippedCount, _ :=
 		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx}, 10000)
 
 	require.Equal(t, 0, skippedCount,
@@ -1147,7 +1147,7 @@ func TestProcessUserTransactions_DeductsInternalTxsSize(t *testing.T) {
 
 	// Create a user tx that would only fit without the internal tx
 	userTx := types.NewTx(&types.LegacyTx{Data: make([]byte, params.MaxBlockSize/2)})
-	skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
+	skippedCount, _ := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
 
 	// Both internal and user tx should be present
 	gotTxs := blockBuilder.GetTransactions()
@@ -1174,7 +1174,7 @@ func TestProcessUserTransactions_SkipsTxsExceedingSizeLimit(t *testing.T) {
 		Execute([]*types.Transaction{tx1}, gomock.Any()).
 		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx1, Receipt: &types.Receipt{}}}})
 
-	skippedCount :=
+	skippedCount, _ :=
 		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{largeTx, tx0, tx1}, 10000)
 
 	require.Equal(t, 1, skippedCount)
@@ -1231,7 +1231,7 @@ func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransa
 	// the user transaction only fits into the user transaction gas limit if
 	// the internal transaction gas is not counted towards it
 	userTransactionGasLimit := uint64(30_000)
-	skippedCount :=
+	skippedCount, _ :=
 		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx0, skippedTx}, userTransactionGasLimit)
 
 	// the skipped transaction is counted by the evm processor
@@ -1304,7 +1304,7 @@ func TestProcessUserTransactions_SponsoredTxSizeIsAccountedCorrectly(t *testing.
 					ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx2, Receipt: &types.Receipt{}}},
 				}).AnyTimes()
 
-			skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx0, tx1, tx2}, 10000)
+			skippedCount, _ := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx0, tx1, tx2}, 10000)
 
 			gotTxs := blockBuilder.GetTransactions()
 			require.Contains(t, gotTxs, tx0)
@@ -1351,7 +1351,7 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 
 			// Create a user tx that would only fit without the internal tx
 			userTx := types.NewTx(&types.LegacyTx{})
-			skippedCount := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
+			skippedCount, _ := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
 
 			// Only internal tx should be present
 			gotTxs := blockBuilder.GetTransactions()
@@ -1359,6 +1359,62 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 			require.Equal(t, 1, skippedCount)
 		})
 	}
+}
+
+func TestProcessUserTransactions_RecordsOriginTransactionForAcceptedProcessedTransactions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+
+	transactions := []*types.Transaction{
+		types.NewTx(&types.LegacyTx{Nonce: 0}),
+		types.NewTx(&types.LegacyTx{Nonce: 1}),
+		types.NewTx(&types.LegacyTx{Nonce: 2}),
+	}
+
+	extras := []*types.Transaction{
+		types.NewTx(&types.LegacyTx{Nonce: 11}),
+		types.NewTx(&types.LegacyTx{Nonce: 21}),
+		types.NewTx(&types.LegacyTx{Nonce: 22}),
+		types.NewTx(&types.LegacyTx{Nonce: 23}),
+	}
+
+	results := []evmcore.ProcessSummary{
+		{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: transactions[0], Receipt: &types.Receipt{}},
+		}},
+		{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: transactions[1], Receipt: &types.Receipt{}},
+			{Transaction: extras[0], Receipt: &types.Receipt{}},
+		}},
+		{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: extras[1], Receipt: &types.Receipt{}},
+			{Transaction: extras[2], Receipt: &types.Receipt{}},
+			{Transaction: extras[3], Receipt: nil},
+		}},
+	}
+
+	for i, tx := range transactions {
+		evmProcessor.EXPECT().
+			Execute([]*types.Transaction{tx}, gomock.Any()).
+			Return(results[i])
+	}
+
+	wantCausedBy := map[common.Hash]common.Hash{
+		transactions[0].Hash(): transactions[0].Hash(),
+		transactions[1].Hash(): transactions[1].Hash(),
+		extras[0].Hash():       transactions[1].Hash(),
+		extras[1].Hash():       transactions[2].Hash(),
+		extras[2].Hash():       transactions[2].Hash(),
+		// no entry for extras[3] since it has no receipt
+	}
+
+	_, gotCausedBy := processUserTransactions(
+		evmProcessor,
+		inter.NewBlockBuilder(),
+		transactions,
+		math.MaxUint64,
+	)
+	require.Equal(t, wantCausedBy, gotCausedBy)
 }
 
 func TestTransactionSize_ConsidersSponsoredTxs(t *testing.T) {


### PR DESCRIPTION
This PR adds support for the correct aggregation of transaction fees when processing bundles.

In order to facilitate the distribution of transaction fees among validators, a record of charged fees needs to be maintained by the sonic client. This book-keeping is conducted by the [DriverTxListener](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/blockproc/drivermodule/driver_txs.go#L62).

### Old Behavior
A record of the collected gas fees is kept as follows:
- after each block is completed, a call back to the `OnNewReceipt` function for each included transaction is conducted ([here](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/c_block_callbacks.go#L489)). One of the parameters is the ID of the validator that proposed the accepted transaction in one of its events. 
- the fees  charged for the respective transaction are then added to the validator's originated transaction fees ([here](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/blockproc/drivermodule/driver_txs.go#L170-L171))
- when sealing an epoch, the total sum of originated fees is reported to the SFC to handle the fee distribution ([here](https://github.com/0xsoniclabs/sonic/blob/8d1f49c73de18510c1950c0503c75ff46146758a/gossip/blockproc/drivermodule/driver_txs.go#L112-L132))

With the introduction of features like sponsored transactions and bundles, this mechanism is no longer sufficient. Sponsored transactions are payed indirectly, not derivable from the transactions receipt, and transactions ending up in blocks are not directly included in events but encoded in envelopes carried by events. Thus, the fee aggregation mechanism needs to updated.

### New Changes
The following changes are enabled with the Brio flag:
- indirect causes are tracked in the `c_block_callback.go`, such that transactions introduced in blocks via subsidies or bundles are correctly associated to the respective validator
- in the [OnNewReceipt](https://github.com/0xsoniclabs/sonic/blob/80d3fa1a6bf4d995058ac825e36a81396958020a/gossip/blockproc/drivermodule/driver_txs.go#L152) callback, the computation rules are adapted post-Brio; the effective fees are [computed](https://github.com/0xsoniclabs/sonic/blob/80d3fa1a6bf4d995058ac825e36a81396958020a/gossip/blockproc/drivermodule/driver_txs.go#L228) for each accepted transaction using a new [ComputeEffectiveFee](https://github.com/0xsoniclabs/sonic/blob/80d3fa1a6bf4d995058ac825e36a81396958020a/gossip/blockproc/drivermodule/driver_txs.go#L257) function; this function identifies fee-payment transactions for sponsored transactions and extracts the amount of fees charged

The result should be a accurate fee tracking for bundled and sponsored transactions and the preservation of the backward compatibility with pre-Brio handling.

### Gas Refunds for Validators
The new implementation of the gas-fee tracking in `driver_tx.go` does not refunds for excessive gas. The computation of that value for bundles is beyond the scope of this task, and the impact of dropping this feature is considered low, but under investigation. See https://github.com/0xsoniclabs/sonic-admin/issues/748.
