### PR TITLE
Add fail-fast flag to CI tests to reduce waiting time for failed CI runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,12 @@ sonic-image:
 
 .PHONY: test
 test:
-	go test --timeout 30m ./...
+	go test --timeout 30m -failfast ./...
 
 .PHONY: coverage
 coverage:
 	@mkdir -p build ;\
-	go test -coverpkg=./... --timeout=30m -coverprofile=build/coverage.cov ./... && \
+	go test -coverpkg=./... --timeout=30m -failfast -coverprofile=build/coverage.cov ./... && \
 	go tool cover -html build/coverage.cov -o build/coverage.html &&\
 	echo "Coverage report generated in build/coverage.html"
 


### PR DESCRIPTION
I would like to add the [--failfast](https://go.dev/doc/go1.10#test) option to the CI tests such that if a test fails for some reason (flaky or not) the CI is not running all other tests before reporting an issue.