### PR TITLE
Add integration tests for transaction fee accounting

### DIFF
--- a/tests/gas_fee/gas_fee_accounting_test.go
+++ b/tests/gas_fee/gas_fee_accounting_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gasfee
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/drivermodule"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/opera/contracts/driver/drivercall"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxFeeAccounting_EpochSealingReportsAggregatedFees(t *testing.T) {
+	testCases := map[string]bool{
+		"distributed_block_formation": false,
+		"single_proposer":             true,
+	}
+
+	for name, mode := range testCases {
+		t.Run(name, func(t *testing.T) {
+			upgrades := opera.GetBrioUpgrades()
+			upgrades.GasSubsidies = true
+			upgrades.TransactionBundles = true
+			upgrades.SingleProposerBlockFormation = mode
+			testTxFeeAccounting_EpochSealingReportsAggregatedFees(t, tests.IntegrationTestNetOptions{
+				Upgrades: &upgrades,
+				NumNodes: 3,
+			})
+		})
+	}
+}
+
+func testTxFeeAccounting_EpochSealingReportsAggregatedFees(
+	t *testing.T,
+	options tests.IntegrationTestNetOptions,
+) {
+	net := tests.StartIntegrationTestNet(t, options)
+
+	const numEpochs = 3
+	const numTransactions = 100
+	const submissionDelay = 10 * time.Millisecond
+
+	// Create a slice of transactions to create background load on the net.
+	txs := createTransactionMix(t, net, numTransactions)
+	backgroundLoadDone := make(chan struct{})
+	go func() {
+		defer close(backgroundLoadDone)
+
+		// Gradually submit transactions in the background.
+		for _, tx := range txs {
+			_, err := net.Send(tx)
+			require.NoError(t, err)
+			time.Sleep(submissionDelay)
+		}
+
+		// Wait for all of those to complete.
+		waitForTransactionMixToBeComplete(t, net, txs)
+	}()
+
+	// Advance epochs every now and then.
+	interEpochDelay := numTransactions * submissionDelay / (numEpochs + 1)
+	for range numEpochs {
+		net.AdvanceEpoch(t, 1)
+		time.Sleep(interEpochDelay)
+	}
+
+	<-backgroundLoadDone
+
+	// create a final epoch to cover all remaining transactions and a few
+	// empty blocks.
+	net.AdvanceEpoch(t, 1)
+
+	// --- verification ---
+
+	// Fetch all blocks with their transactions and receipts.
+	blocks, err := net.GetBlocks(t.Context())
+	require.NoError(t, err)
+
+	totalFees := big.NewInt(0)
+	for _, b := range blocks {
+		for _, tx := range b.Transactions() {
+
+			receipt, err := net.GetReceipt(tx.Hash())
+			require.NoError(t, err)
+
+			// --- mitigation for reporting bug ---
+			// see https://github.com/0xsoniclabs/sonic-admin/issues/743
+
+			// There is a bug in the system causing the effective gas price for
+			// internal transactions to be non-zero. Until fixed, those prices
+			// need to be corrected here.
+			if internaltx.IsInternal(tx) {
+				receipt.EffectiveGasPrice = big.NewInt(0)
+			}
+			// Same problem for sponsored transactions.
+			if subsidies.IsSponsorshipRequest(tx) {
+				receipt.EffectiveGasPrice = big.NewInt(0)
+			}
+			// --- end of reporting issue mitigation ---
+
+			// Compute the effect fees charged for this transaction.
+			txFees, err := drivermodule.ComputeEffectiveFee(tx, receipt)
+			require.NoError(t, err)
+
+			// Keep a running total.
+			totalFees = new(big.Int).Add(totalFees, txFees)
+
+			// Check if the current transaction is sealing an epoch. If so, the
+			// reported gas fees should match the running total.
+			metrics, err := drivercall.ParseSealEpochArgs(tx)
+			if err != nil {
+				continue
+			}
+
+			sumReportedFees := big.NewInt(0)
+			for _, cur := range metrics {
+				sumReportedFees.Add(sumReportedFees, cur.OriginatedTxFee)
+			}
+
+			// Check that the reported and total fees match.
+			diff := new(big.Int).Sub(sumReportedFees, totalFees)
+			require.Zero(t, diff.Sign(), "Difference in reported fees: %v", diff)
+		}
+	}
+}

--- a/tests/gas_fee/gas_fee_charging_test.go
+++ b/tests/gas_fee/gas_fee_charging_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gasfee
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxFeeAccounting_TransactionFeesAreChargedAsStatedInReceipts(t *testing.T) {
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.GasSubsidies = true
+	upgrades.TransactionBundles = true
+
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
+
+	// run a mix of transactions
+	txs := createTransactionMix(t, net, 100)
+	_, err := net.SendAll(txs)
+	require.NoError(t, err)
+	waitForTransactionMixToBeComplete(t, net, txs)
+
+	// Test for each transaction that fees have been deducted correctly. This
+	// check exploits the fact that all transactions in the mix use independent
+	// accounts and that there are no balances increased on those accounts.
+	blocks, err := net.GetBlocks(t.Context())
+	require.NoError(t, err)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	signer := types.LatestSignerForChainID(net.GetChainId())
+	for _, b := range blocks {
+
+		// Collect all balance changes of senders in this block.
+		expectedDiffs := map[common.Address]*big.Int{}
+		for _, tx := range b.Transactions() {
+
+			receipt, err := net.GetReceipt(tx.Hash())
+			require.NoError(t, err)
+
+			expectedCharges := new(big.Int).Mul(
+				receipt.EffectiveGasPrice,
+				big.NewInt(int64(receipt.GasUsed)),
+			)
+			// --- mitigation for reporting bug ---
+			// see https://github.com/0xsoniclabs/sonic-admin/issues/743
+			if internaltx.IsInternal(tx) || subsidies.IsSponsorshipRequest(tx) {
+				expectedCharges = big.NewInt(0)
+			}
+			// --- end of reporting issue mitigation ---
+
+			// The expected change is the sum of the fee charges and the
+			// transferred value.
+			expectedChange := new(big.Int).Add(expectedCharges, tx.Value())
+
+			// Internal transactions should have zero changes.
+			if internaltx.IsInternal(tx) {
+				require.Equal(t, big.NewInt(0), expectedChange)
+				continue
+			}
+
+			// Keep track of the expected change in the balance.
+			sender, err := types.Sender(signer, tx)
+			require.NoError(t, err)
+			if old, found := expectedDiffs[sender]; found {
+				expectedDiffs[sender] = new(big.Int).Add(old, expectedChange)
+			} else {
+				expectedDiffs[sender] = expectedChange
+			}
+		}
+
+		// Check the aggregated changes of the full block.
+		for sender, expectedChange := range expectedDiffs {
+			before := new(big.Int).Sub(b.Number(), big.NewInt(1))
+			balanceBefore, err := client.BalanceAt(t.Context(), sender, before)
+			require.NoError(t, err)
+
+			balanceAfter, err := client.BalanceAt(t.Context(), sender, b.Number())
+			require.NoError(t, err)
+
+			seenDiff := new(big.Int).Sub(balanceBefore, balanceAfter)
+			require.True(t, expectedChange.Cmp(seenDiff) == 0,
+				"expected: %v, seen: %v for account %v", expectedChange, seenDiff, sender,
+			)
+		}
+	}
+}

--- a/tests/gas_fee/gas_fee_test_utils.go
+++ b/tests/gas_fee/gas_fee_test_utils.go
@@ -1,0 +1,301 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gasfee
+
+import (
+	"math/big"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func createTransactionMix(
+	t testing.TB,
+	session tests.IntegrationTestNetSession,
+	numTransactions int,
+) []*types.Transaction {
+
+	perPart := numTransactions / 3
+	firstPart := numTransactions - 2*perPart
+
+	regularTxs := createRegularTransactions(t, session, firstPart)
+	sponsoredTxs := createSponsoredTransactions(t, session, perPart)
+	bundledTxs := createBundledTransactions(t, session, perPart)
+
+	res := make([]*types.Transaction, 0, numTransactions)
+	res = append(res, regularTxs...)
+	res = append(res, sponsoredTxs...)
+	res = append(res, bundledTxs...)
+	require.Len(t, res, numTransactions)
+
+	rand.Shuffle(len(res), func(i, j int) {
+		res[i], res[j] = res[j], res[i]
+	})
+
+	return res
+}
+
+func createRegularTransactions(
+	t testing.TB,
+	session tests.IntegrationTestNetSession,
+	numTransactions int,
+) []*types.Transaction {
+
+	accounts := tests.MakeAccountsWithBalance(t, session, numTransactions, big.NewInt(1e18))
+	gasPrice := getGasPrice(t, session)
+	signer := types.LatestSignerForChainID(session.GetChainId())
+
+	res := make([]*types.Transaction, 0, numTransactions)
+
+	parts := numTransactions / 3
+	firstPart := numTransactions - 2*parts
+
+	// do a few legacy transactions
+	for range firstPart {
+		tx := types.MustSignNewTx(
+			accounts[0].PrivateKey, signer, &types.LegacyTx{
+				To:       &common.Address{}, // send to the zero address
+				Gas:      21_000,
+				GasPrice: gasPrice,
+			},
+		)
+		res = append(res, tx)
+		accounts = accounts[1:]
+	}
+
+	// followed by a few access list transactions
+	for range parts {
+		tx := types.MustSignNewTx(
+			accounts[0].PrivateKey, signer, &types.AccessListTx{
+				To:       &common.Address{}, // send to the zero address
+				Gas:      21_000,
+				GasPrice: gasPrice,
+			},
+		)
+		res = append(res, tx)
+		accounts = accounts[1:]
+	}
+
+	// followed by a few dynamic fee transactions
+	for range parts {
+		tx := types.MustSignNewTx(
+			accounts[0].PrivateKey, signer, &types.DynamicFeeTx{
+				To:        &common.Address{}, // send to the zero address
+				Gas:       21_000,
+				GasFeeCap: new(big.Int).Mul(gasPrice, big.NewInt(2)),
+				GasTipCap: big.NewInt(1000),
+			},
+		)
+		res = append(res, tx)
+		accounts = accounts[1:]
+	}
+
+	return res
+}
+
+func createSponsoredTransactions(
+	t testing.TB,
+	session tests.IntegrationTestNetSession,
+	numTransactions int,
+) []*types.Transaction {
+
+	client, err := session.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Install a target contract for sponsorships.
+	counterContract, receipt, err := tests.DeployContract(session, counter.DeployCounter)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	// Fund all calls to the counter contract.
+	registry, err := registry.NewRegistry(registry.GetAddress(), client)
+	require.NoError(t, err)
+
+	ok, fundId, err := registry.ContractSponsorshipFundId(nil, receipt.ContractAddress)
+	require.NoError(t, err)
+	require.True(t, ok, "counter contract is not eligible for sponsorship")
+
+	donation := big.NewInt(1e18)
+	receipt, err = session.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		opts.Value = donation
+		require.NoError(t, err)
+		return registry.Sponsor(opts, fundId)
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	// Create sponsored transactions calling the counter contract.
+	accounts := tests.NewAccounts(numTransactions) // no need for endowment
+	signer := types.LatestSignerForChainID(session.GetChainId())
+	res := make([]*types.Transaction, 0, numTransactions)
+	for _, a := range accounts {
+		tx, err := counterContract.IncrementCounter(&bind.TransactOpts{
+			From: a.Address(),
+			Signer: func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
+				require.Equal(t, a.Address(), address)
+				return types.SignTx(tx, signer, a.PrivateKey)
+			},
+			GasPrice: big.NewInt(0), // sponsored: zero gas price
+			NoSend:   true,
+		})
+		require.NoError(t, err)
+		require.True(t, subsidies.IsSponsorshipRequest(tx))
+		require.Zero(t, tx.GasPrice().Sign())
+		res = append(res, tx)
+	}
+
+	return res
+}
+
+func createBundledTransactions(
+	t testing.TB,
+	session tests.IntegrationTestNetSession,
+	numTransactions int,
+) []*types.Transaction {
+
+	// We create three types of bundled transactions:
+	// - bundles where everything is accepted
+	// - bundles where the some transactions are rolled back
+	// - bundles with nested bundles
+	// For all bundles created here, the last referenced transaction is to be
+	// accepted.
+
+	parts := numTransactions / 3
+	firstPart := numTransactions - 2*parts
+
+	accounts := tests.MakeAccountsWithBalance(t, session, 3*numTransactions, big.NewInt(1e18))
+	gasPrice := getGasPrice(t, session)
+	signer := types.LatestSignerForChainID(session.GetChainId())
+
+	success := &types.AccessListTx{
+		To:       &common.Address{}, // send to the zero address
+		GasPrice: gasPrice,
+		Gas:      21_000,
+	}
+
+	fail := &types.AccessListTx{
+		To:       &common.Address{}, // send to the zero address
+		GasPrice: gasPrice,
+		Gas:      10_000, // below minimum gas
+	}
+
+	// Create bundles with all-succeeding transactions.
+	// Each of those bundles is a AllOf(A, B, C) with three steps, each signed
+	// by a different account.
+	res := make([]*types.Transaction, 0, numTransactions)
+	for range firstPart {
+		res = append(res,
+			bundle.NewBuilder().
+				AllOf(
+					bundle.Step(accounts[0].PrivateKey, success),
+					bundle.Step(accounts[1].PrivateKey, success),
+					bundle.Step(accounts[2].PrivateKey, success),
+				).
+				WithSigner(signer).
+				Build(),
+		)
+		accounts = accounts[3:]
+	}
+
+	// Create bundles with some rolled back transactions.
+	// Each of those bundles is a OneOf(AllOf(success, fail), success) with
+	// three different signers for each step.
+	for range parts {
+		res = append(res,
+			bundle.NewBuilder().
+				OneOf(
+					bundle.AllOf(
+						bundle.Step(accounts[0].PrivateKey, success),
+						bundle.Step(accounts[1].PrivateKey, fail),
+					),
+					bundle.Step(accounts[2].PrivateKey, success),
+				).
+				WithSigner(signer).
+				Build(),
+		)
+		accounts = accounts[3:]
+	}
+
+	// Create nested bundles of the form
+	//            AllOf(Envelope(AllOf(success)), success)
+	// where the both success steps and the envelope are signed by different
+	// accounts.
+	for range parts {
+		inner := bundle.NewBuilder().
+			AllOf(bundle.Step(accounts[0].PrivateKey, success)).
+			WithSigner(signer).
+			Build()
+
+		res = append(res,
+			bundle.NewBuilder().
+				AllOf(
+					bundle.Step(accounts[2].PrivateKey, inner),
+					bundle.Step(accounts[1].PrivateKey, success),
+				).
+				WithSigner(signer).
+				Build(),
+		)
+		accounts = accounts[3:]
+	}
+
+	return res
+}
+
+func getGasPrice(
+	t testing.TB,
+	session tests.IntegrationTestNetSession,
+) *big.Int {
+	client, err := session.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	gasPrice, err := client.SuggestGasPrice(t.Context())
+	require.NoError(t, err)
+	gasPrice = new(big.Int).Mul(gasPrice, big.NewInt(5))
+	return gasPrice
+}
+
+func waitForTransactionMixToBeComplete(
+	t testing.TB,
+	session tests.IntegrationTestNetSession,
+	txs []*types.Transaction,
+) {
+	// In the end, wait for all transactions to be included and successful.
+	signer := types.LatestSignerForChainID(session.GetChainId())
+	for _, tx := range txs {
+		represent := tx
+		if bundle.IsEnvelope(tx) {
+			txBundle, err := bundle.OpenEnvelope(signer, tx)
+			require.NoError(t, err)
+			txs := txBundle.GetTransactionsInReferencedOrder()
+			represent = txs[len(txs)-1]
+		}
+		receipt, err := session.GetReceipt(represent.Hash())
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	}
+}

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -55,7 +55,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	geth_crypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -373,6 +373,23 @@ func StartIntegrationTestNetWithJsonGenesis(
 	)
 
 	jsonGenesis.Accounts = append(jsonGenesis.Accounts, effectiveOptions.Accounts...)
+
+	// Give extra balance to the first validator, being the account used to
+	// sponsor transactions and endow accounts in tests.
+	sponsorAddress := crypto.PubkeyToAddress(evmcore.FakeKey(1).PublicKey)
+	found := false
+	for i := range jsonGenesis.Accounts {
+		cur := &jsonGenesis.Accounts[i]
+		if cur.Address == sponsorAddress {
+			// enough tokens to endow plenty of accounts
+			extraBalanceForSponsor := new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9))
+			balance := cur.Balance
+			cur.Balance = new(big.Int).Add(balance, extraBalanceForSponsor)
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "sponsor account not found in genesis accounts")
 
 	// Speed up the block generation time to reduce test time.
 	jsonGenesis.Rules.Emitter.Interval = inter.Timestamp(time.Millisecond)
@@ -852,6 +869,32 @@ func (n *IntegrationTestNet) GetHeaders() ([]*types.Header, error) {
 	return headers, nil
 }
 
+// GetBlocks returns all blocks on the network from block 0 to the latest block,
+// as reported by node zero.
+func (n *IntegrationTestNet) GetBlocks(ctxt context.Context) ([]*types.Block, error) {
+	client, err := n.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to the Ethereum client: %w", err)
+	}
+	defer client.Close()
+
+	lastBlock, err := client.BlockByNumber(context.Background(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last block: %w", err)
+	}
+
+	blocks := []*types.Block{}
+	for i := range lastBlock.NumberU64() {
+		block, err := client.BlockByNumber(ctxt, big.NewInt(int64(i)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get block: %w", err)
+		}
+		blocks = append(blocks, block)
+	}
+
+	return blocks, nil
+}
+
 // SpawnSession creates a new test session on the network.
 // The session is backed by an account which will be used to sign and pay for
 // transactions. By using this function, multiple test sessions can be run in
@@ -871,7 +914,7 @@ func (n *IntegrationTestNet) SpawnSession(t *testing.T) IntegrationTestNetSessio
 	n.sessionsMutex.Lock()
 	defer n.sessionsMutex.Unlock()
 
-	key, _ := geth_crypto.GenerateKey()
+	key, _ := crypto.GenerateKey()
 	nextSessionAccount := Account{
 		PrivateKey: key,
 	}
@@ -1043,6 +1086,19 @@ func (s *Session) EndowAccounts(
 		return nil, fmt.Errorf("failed to connect to the network: %w", err)
 	}
 	defer client.Close()
+
+	// Check that there are enough funds in the account to endow the requested accounts.
+	balance, err := client.BalanceAt(context.Background(), s.account.Address(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get balance: %w", err)
+	}
+	totalValue := new(big.Int).Mul(value, big.NewInt(int64(len(addresses))))
+	if balance.Cmp(totalValue) < 0 {
+		return nil, fmt.Errorf("not enough funds to endow accounts: balance %s, required %s",
+			new(big.Float).SetInt(balance).String(), // scientific notation for large numbers
+			new(big.Float).SetInt(totalValue).String(),
+		)
+	}
 
 	chainId, err := client.ChainID(context.Background())
 	if err != nil {

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -302,7 +302,7 @@ func MakeAccountWithBalance(t *testing.T, net IntegrationTestNetSession, balance
 
 // MakeAccountsWithBalance creates multiple new accounts and endows them with the given balance.
 // Creating the accounts this way allows to get access to the private keys to sign transactions.
-func MakeAccountsWithBalance(t *testing.T, net IntegrationTestNetSession, count int, balance *big.Int) []*Account {
+func MakeAccountsWithBalance(t testing.TB, net IntegrationTestNetSession, count int, balance *big.Int) []*Account {
 	t.Helper()
 
 	accounts := make([]*Account, count)


### PR DESCRIPTION
This PR adds two integration tests verifying fee charges and accounting:
- `TestTxFeeAccounting_EpochSealingReportsAggregatedFees` runs a network with a stream of mixed transactions (regular, sponsored, bundled) and epoch changes. After the run, the sum of charged fees are summed up and compared to the fees reported during epoch sealing to verify consistency
- `TestTxFeeAccounting_TransactionFeesAreChargedAsStatedInReceipts` checks that the fees reported in receipts match the actual fees deducted from the signer's account

Both tests share a common utility to generate a mix of independent transactions to be processed on the network.