### PR TITLE
Refactor block range format

### DIFF
--- a/api/sonicapi/bundle_api.go
+++ b/api/sonicapi/bundle_api.go
@@ -29,42 +29,33 @@ func sanitizeBlockRange(currentBlock uint64, blockRange *RPCRange) (RPCRange, er
 	if blockRange == nil {
 		maxRange := bundle.MakeMaxRangeStartingAt(currentBlock + 1)
 		return RPCRange{
-			Earliest: hexutil.Uint64(maxRange.Earliest),
-			Latest:   hexutil.Uint64(maxRange.Latest),
+			First:  hexutil.Uint64(maxRange.First),
+			Length: hexutil.Uint64(maxRange.Length),
 		}, nil
 	}
 
-	if blockRange.Latest == 0 && blockRange.Earliest != 0 {
-		blockRange.Latest = hexutil.Uint64(uint64(blockRange.Earliest) + bundle.MaxBlockRange - 1)
-		return RPCRange{
-			Earliest: blockRange.Earliest,
-			Latest:   blockRange.Latest,
-		}, nil
+	// If first is not specified, set it to currentBlock + 1.
+	first := uint64(blockRange.First)
+	if first == 0 {
+		first = currentBlock + 1
 	}
 
-	// earliest not specified but latest is specified, set earliest to latest - maxRange + 1, but not less than currentBlock + 1 and check overflow
-	if blockRange.Earliest == 0 && blockRange.Latest != 0 {
-		if blockRange.Latest < hexutil.Uint64(currentBlock+bundle.MaxBlockRange) {
-			blockRange.Earliest = hexutil.Uint64(currentBlock + 1)
-		} else {
-			return RPCRange{}, fmt.Errorf("invalid block range: latest block %d is too far in the future; earliest block must be at least %d", blockRange.Latest, currentBlock+1)
-		}
+	// Sanitize the length of the range.
+	limit := uint64(blockRange.Length)
+	if limit == 0 { // < user did not specify, use maximum allowed range
+		limit = bundle.MaxBlockRangeLength
+	} else if limit > bundle.MaxBlockRangeLength {
+		return RPCRange{}, fmt.Errorf("invalid block range: length %d is too large; must be at most %d blocks", limit, bundle.MaxBlockRangeLength)
 	}
 
-	if blockRange.Latest < hexutil.Uint64(currentBlock) {
-		return RPCRange{}, fmt.Errorf("invalid block range: latest block %d is earlier than current block %d", blockRange.Latest, currentBlock)
-	}
-
-	if uint64(blockRange.Latest) < uint64(blockRange.Earliest) {
-		return RPCRange{}, fmt.Errorf("invalid block range: latest block %d is earlier than earliest block %d", blockRange.Latest, blockRange.Earliest)
-	}
-
-	if uint64(blockRange.Latest-blockRange.Earliest+1) > bundle.MaxBlockRange {
-		return RPCRange{}, fmt.Errorf("invalid block range: range %d is too large; must be at most %d blocks", blockRange.Latest-blockRange.Earliest+1, bundle.MaxBlockRange)
+	// Check whether the user given limit is already in the past
+	r := bundle.BlockRange{First: first, Length: limit}
+	if r.IsAfterRange(currentBlock) {
+		return RPCRange{}, fmt.Errorf("invalid block range: the specified range (first: %d, length: %d) is not in the future relative to current block %d", first, limit, currentBlock)
 	}
 
 	return RPCRange{
-		Earliest: blockRange.Earliest,
-		Latest:   blockRange.Latest,
+		First:  hexutil.Uint64(first),
+		Length: hexutil.Uint64(limit),
 	}, nil
 }

--- a/api/sonicapi/bundle_api.go
+++ b/api/sonicapi/bundle_api.go
@@ -26,8 +26,9 @@ import (
 // sanitizeBlockRange checks that the provided block range is valid and within
 // allowed limits, defaulting to a sensible range if not provided.
 func sanitizeBlockRange(currentBlock uint64, blockRange *RPCRange) (RPCRange, error) {
+	nextBlock := max(currentBlock+1, currentBlock)
 	if blockRange == nil {
-		maxRange := bundle.MakeMaxRangeStartingAt(currentBlock + 1)
+		maxRange := bundle.MakeMaxRangeStartingAt(nextBlock)
 		return RPCRange{
 			First:  hexutil.Uint64(maxRange.First),
 			Length: hexutil.Uint64(maxRange.Length),
@@ -37,7 +38,7 @@ func sanitizeBlockRange(currentBlock uint64, blockRange *RPCRange) (RPCRange, er
 	// If first is not specified, set it to currentBlock + 1.
 	first := uint64(blockRange.First)
 	if first == 0 {
-		first = currentBlock + 1
+		first = nextBlock
 	}
 
 	// Sanitize the length of the range.

--- a/api/sonicapi/bundle_api_test.go
+++ b/api/sonicapi/bundle_api_test.go
@@ -30,57 +30,42 @@ func Test_sanitizeBlockRange(t *testing.T) {
 	tests := map[string]struct {
 		currentBlock  uint64
 		blockRange    *RPCRange
-		wantEarliest  uint64
-		wantLatest    uint64
+		wantFirst     uint64
+		wantLength    uint64
 		errorContains string
 	}{
 		"nil both defaults from current block": {
 			currentBlock: 10,
-			wantEarliest: 11,
-			wantLatest:   10 + bundle.MaxBlockRange,
+			wantFirst:    11,
+			wantLength:   bundle.MaxBlockRangeLength,
 		},
-		"only earliest": {
+		"only first": {
 			currentBlock: 10,
-			blockRange:   &RPCRange{Earliest: hexN(50)},
-			wantEarliest: 50,
-			wantLatest:   50 + bundle.MaxBlockRange - 1,
+			blockRange:   &RPCRange{First: hexN(50)},
+			wantFirst:    50,
+			wantLength:   bundle.MaxBlockRangeLength,
 		},
-		"explicit latest": {
+		"explicit length": {
 			currentBlock: 10,
-			blockRange:   &RPCRange{Latest: hexN(200)},
-			wantEarliest: 11,
-			wantLatest:   200,
+			blockRange:   &RPCRange{Length: hexN(200)},
+			wantFirst:    11,
+			wantLength:   200,
 		},
-		"range exceeds MaxBlockRange when only latest set": {
+		"length exceeds MaxBlockRange": {
 			currentBlock:  10,
-			blockRange:    &RPCRange{Latest: hexN(10 + bundle.MaxBlockRange + 100)},
+			blockRange:    &RPCRange{Length: hexN(bundle.MaxBlockRangeLength + 1)},
 			errorContains: "invalid block range",
 		},
 		"both explicit": {
 			currentBlock: 10,
-			blockRange:   &RPCRange{Earliest: hexN(5), Latest: hexN(20)},
-			wantEarliest: 5,
-			wantLatest:   20,
+			blockRange:   &RPCRange{First: hexN(5), Length: hexN(20)},
+			wantFirst:    5,
+			wantLength:   20,
 		},
 		"current block zero earliest is one": {
 			currentBlock: 0,
-			wantEarliest: 1,
-			wantLatest:   bundle.MaxBlockRange,
-		},
-		"latest is less than earliest": {
-			currentBlock:  100,
-			blockRange:    &RPCRange{Earliest: hexN(50), Latest: hexN(40)},
-			errorContains: "invalid block range",
-		},
-		"latest before implicit earliest from current block": {
-			currentBlock:  10,
-			blockRange:    &RPCRange{Latest: hexN(5)},
-			errorContains: "invalid block range",
-		},
-		"greater than Max block range": {
-			currentBlock:  100,
-			blockRange:    &RPCRange{Earliest: hexN(50), Latest: hexN(50 + bundle.MaxBlockRange + 1)},
-			errorContains: "invalid block range",
+			wantFirst:    1,
+			wantLength:   bundle.MaxBlockRangeLength,
 		},
 	}
 
@@ -91,8 +76,8 @@ func Test_sanitizeBlockRange(t *testing.T) {
 				require.ErrorContains(t, err, tc.errorContains)
 			} else {
 				require.NoError(t, err)
-				require.EqualValues(t, tc.wantEarliest, r.Earliest)
-				require.EqualValues(t, tc.wantLatest, r.Latest)
+				require.EqualValues(t, tc.wantFirst, r.First)
+				require.EqualValues(t, tc.wantLength, r.Length)
 			}
 		})
 	}

--- a/api/sonicapi/bundle_api_test.go
+++ b/api/sonicapi/bundle_api_test.go
@@ -73,6 +73,11 @@ func Test_sanitizeBlockRange(t *testing.T) {
 			wantFirst:    math.MaxUint64,
 			wantLength:   bundle.MaxBlockRangeLength,
 		},
+		"specified range is in the past": {
+			currentBlock:  10,
+			blockRange:    &RPCRange{First: hexN(5), Length: hexN(3)},
+			errorContains: "invalid block range",
+		},
 	}
 
 	for name, tc := range tests {

--- a/api/sonicapi/bundle_api_test.go
+++ b/api/sonicapi/bundle_api_test.go
@@ -17,6 +17,7 @@
 package sonicapi
 
 import (
+	"math"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
@@ -65,6 +66,11 @@ func Test_sanitizeBlockRange(t *testing.T) {
 		"current block zero earliest is one": {
 			currentBlock: 0,
 			wantFirst:    1,
+			wantLength:   bundle.MaxBlockRangeLength,
+		},
+		"no overflow of first": {
+			currentBlock: math.MaxUint64,
+			wantFirst:    math.MaxUint64,
 			wantLength:   bundle.MaxBlockRangeLength,
 		},
 	}

--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -33,8 +33,8 @@ import (
 //
 //	{
 //	  "blockRange": {
-//	    "earliest": 12345678,
-//	    "latest": 12345778
+//	    "first": 12345678,
+//	    "length": 100
 //	  },
 //	  "steps": [
 //	    {

--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -78,8 +78,8 @@ type RPCExecutionStepComposable struct {
 
 // RPCRange represents the block range for which the execution plan is valid.
 type RPCRange struct {
-	Earliest hexutil.Uint64 `json:"earliest"`
-	Latest   hexutil.Uint64 `json:"latest"`
+	First  hexutil.Uint64 `json:"first"`
+	Length hexutil.Uint64 `json:"length"`
 }
 
 // NewRPCExecutionPlanComposable converts a bundle.ExecutionPlan to an RPCExecutionPlan that can be returned by the API.
@@ -100,10 +100,7 @@ func NewRPCExecutionPlanComposable(plan bundle.ExecutionPlan) (RPCExecutionPlanC
 	}
 
 	return RPCExecutionPlanComposable{
-		BlockRange: RPCRange{
-			Earliest: hexutil.Uint64(plan.Range.Earliest),
-			Latest:   hexutil.Uint64(plan.Range.Latest),
-		},
+		BlockRange:            fromBundleRange(plan.Range),
 		RPCExecutionPlanGroup: visitor.result,
 	}, nil
 }
@@ -115,11 +112,8 @@ func ToBundleExecutionPlan(rpcPlan RPCExecutionPlanComposable) (bundle.Execution
 	}
 
 	return bundle.ExecutionPlan{
-		Range: bundle.BlockRange{
-			Earliest: uint64(rpcPlan.BlockRange.Earliest),
-			Latest:   uint64(rpcPlan.BlockRange.Latest),
-		},
-		Root: root,
+		Range: rpcPlan.BlockRange.toBundleBlockRange(),
+		Root:  root,
 	}, nil
 }
 
@@ -251,7 +245,14 @@ func (v *toJsonExecutionPlanVisitor) EndGroup() {
 
 func (r RPCRange) toBundleBlockRange() bundle.BlockRange {
 	return bundle.BlockRange{
-		Earliest: uint64(r.Earliest),
-		Latest:   uint64(r.Latest),
+		First:  uint64(r.First),
+		Length: uint64(r.Length),
+	}
+}
+
+func fromBundleRange(r bundle.BlockRange) RPCRange {
+	return RPCRange{
+		First:  hexutil.Uint64(r.First),
+		Length: hexutil.Uint64(r.Length),
 	}
 }

--- a/api/sonicapi/execution_plan_test.go
+++ b/api/sonicapi/execution_plan_test.go
@@ -302,9 +302,9 @@ func Test_NewRPCExecutionPlanComposable_FromBundleExecutionPlan(t *testing.T) {
 			}`,
 		},
 		"plan with block range": {
-			plan: bundle.ExecutionPlan{Root: step1, Range: bundle.BlockRange{Earliest: 10, Latest: 20}},
+			plan: bundle.ExecutionPlan{Root: step1, Range: bundle.BlockRange{First: 10, Length: 20}},
 			expectedJson: `{
-				"blockRange":{"earliest":"0xa","latest":"0x14"},
+				"blockRange":{"first":"0xa","length":"0x14"},
 				"steps":[
 					{
 						"from":"0x0100000000000000000000000000000000000000",
@@ -314,9 +314,9 @@ func Test_NewRPCExecutionPlanComposable_FromBundleExecutionPlan(t *testing.T) {
 			}`,
 		},
 		"plan with different start": {
-			plan: bundle.ExecutionPlan{Root: step1, Range: bundle.BlockRange{Earliest: 11, Latest: 20}},
+			plan: bundle.ExecutionPlan{Root: step1, Range: bundle.BlockRange{First: 11, Length: 20}},
 			expectedJson: `{
-				"blockRange":{"earliest":"0xb","latest":"0x14"},
+				"blockRange":{"first":"0xb","length":"0x14"},
 				"steps":[
 					{
 						"from":"0x0100000000000000000000000000000000000000",
@@ -326,9 +326,9 @@ func Test_NewRPCExecutionPlanComposable_FromBundleExecutionPlan(t *testing.T) {
 			}`,
 		},
 		"plan with different end": {
-			plan: bundle.ExecutionPlan{Root: step1, Range: bundle.BlockRange{Earliest: 10, Latest: 21}},
+			plan: bundle.ExecutionPlan{Root: step1, Range: bundle.BlockRange{First: 10, Length: 21}},
 			expectedJson: `{
-				"blockRange":{"earliest":"0xa","latest":"0x15"},
+				"blockRange":{"first":"0xa","length":"0x15"},
 				"steps":[
 					{
 						"from":"0x0100000000000000000000000000000000000000",
@@ -346,10 +346,10 @@ func Test_NewRPCExecutionPlanComposable_FromBundleExecutionPlan(t *testing.T) {
 						bundle.NewTxStep(ref2).WithFlags(bundle.EF_TolerateInvalid),
 					),
 				),
-				Range: bundle.BlockRange{Earliest: 12345678, Latest: 12345778},
+				Range: bundle.BlockRange{First: 12345678, Length: 12345778},
 			},
 			expectedJson: `{
-				"blockRange":{"earliest":"0xbc614e","latest":"0xbc61b2"},
+				"blockRange":{"first":"0xbc614e","length":"0xbc61b2"},
 				"steps":[
 					{
 						"oneOf":true,
@@ -419,7 +419,7 @@ func Test_toBundleExecutionPlan_CanReturnErrors(t *testing.T) {
 	}
 
 	rpcPlan := RPCExecutionPlanComposable{
-		BlockRange: RPCRange{Earliest: 10, Latest: 20},
+		BlockRange: RPCRange{First: 10, Length: 20},
 		RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 			Steps: []any{invalidStep},
 		},

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -190,11 +190,9 @@ func createProposalRequestFromBundle(signer types.Signer, txBundle *bundle.Trans
 		return nil, fmt.Errorf("failed to create execution proposal: %w", err)
 	}
 
+	blockRange := fromBundleRange(plan.Range)
 	proposal := &RPCExecutionProposal{
-		BlockRange: &RPCRange{
-			Earliest: hexutil.Uint64(plan.Range.Earliest),
-			Latest:   hexutil.Uint64(plan.Range.Latest),
-		},
+		BlockRange:            &blockRange,
 		RPCExecutionPlanGroup: visitor.result,
 	}
 

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -42,8 +42,8 @@ import (
 //
 //	{
 //	  "blockRange": {
-//	    "earliest": "0xbc614e",
-//	    "latest": "0xbc61b2"
+//	    "first": "0xbc614e",
+//	    "length": "0x64"
 //	  },
 //	  "steps": [
 //	    {

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -84,7 +84,7 @@ func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
 				With(bundle.Step(key, &types.AccessListTx{})).
 				BuildBundle(),
 			json: fmt.Sprintf(`{
-				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"blockRange":{"first":"0x0","length":"0x400"},
 				"steps":[%s]
 			}`, s),
 		},
@@ -99,7 +99,7 @@ func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
 				).
 				BuildBundle(),
 			json: fmt.Sprintf(`{
-				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"blockRange":{"first":"0x0","length":"0x400"},
 				"steps":[{"steps":[%s,%s]}]
 			}`, s, s),
 		},
@@ -115,7 +115,7 @@ func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
 				).
 				BuildBundle(),
 			json: fmt.Sprintf(`{
-				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"blockRange":{"first":"0x0","length":"0x400"},
 				"steps":[{"oneOf":true,"steps":[{"steps":[%s]}]}]
 			}`, s),
 		},
@@ -134,7 +134,7 @@ func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
 				).
 				BuildBundle(),
 			json: fmt.Sprintf(`{
-				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"blockRange":{"first":"0x0","length":"0x400"},
 				"steps":[{"steps":[%s,%s,%s]}]
 			}`, sTF, sTI, sTFI),
 		},
@@ -159,7 +159,7 @@ func Test_ExecutionProposal_canBeConstructedFromBuilderBundle(t *testing.T) {
 				).
 				BuildBundle(),
 			json: fmt.Sprintf(`{
-				"blockRange":{"earliest":"0x0","latest":"0x3ff"},
+				"blockRange":{"first":"0x0","length":"0x400"},
 				"steps":[{"steps":[
 					{"oneOf":true,"steps":[%s]},
 					{"tolerateFailures":true,"oneOf":true,"steps":[%s]},
@@ -534,8 +534,8 @@ func TestCreateProposalRequestFromBundle(t *testing.T) {
 	require.NotNil(t, proposal)
 
 	// Check that the proposal contains the expected block range and steps
-	require.EqualValues(t, *rpctest.ToHexUint64(0), proposal.BlockRange.Earliest)
-	require.EqualValues(t, *rpctest.ToHexUint64(1023), proposal.BlockRange.Latest)
+	require.EqualValues(t, *rpctest.ToHexUint64(0), proposal.BlockRange.First)
+	require.EqualValues(t, *rpctest.ToHexUint64(1024), proposal.BlockRange.Length)
 	require.Len(t, proposal.Steps, 1)
 
 	// Nested bundle (AllOf with two steps)
@@ -820,8 +820,8 @@ func Test_convertProposalToPlan(t *testing.T) {
 		"simple proposal with one step": {
 			proposal: RPCExecutionProposal{
 				BlockRange: &RPCRange{
-					Earliest: *rpctest.ToHexUint64(0),
-					Latest:   *rpctest.ToHexUint64(1023),
+					First:  *rpctest.ToHexUint64(0),
+					Length: *rpctest.ToHexUint64(1023),
 				},
 				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 					Steps: []any{
@@ -837,7 +837,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 				},
 			},
 			plan: bundle.NewBuilder().
-				SetEarliest(0).SetLatest(1023).
+				SetEarliest(0).SetRangeLength(1023).
 				WithSigner(signer).
 				With(
 					bundle.Step(key1, &types.AccessListTx{
@@ -851,8 +851,8 @@ func Test_convertProposalToPlan(t *testing.T) {
 		"two steps in one group": {
 			proposal: RPCExecutionProposal{
 				BlockRange: &RPCRange{
-					Earliest: *rpctest.ToHexUint64(0),
-					Latest:   *rpctest.ToHexUint64(1023),
+					First:  *rpctest.ToHexUint64(0),
+					Length: *rpctest.ToHexUint64(1023),
 				},
 				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 					Steps: []any{
@@ -876,7 +876,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 				},
 			},
 			plan: bundle.NewBuilder().
-				SetEarliest(0).SetLatest(1023).
+				SetEarliest(0).SetRangeLength(1023).
 				WithSigner(signer).
 				AllOf(
 					bundle.Step(key1, &types.AccessListTx{
@@ -895,8 +895,8 @@ func Test_convertProposalToPlan(t *testing.T) {
 		"different execution flags in steps": {
 			proposal: RPCExecutionProposal{
 				BlockRange: &RPCRange{
-					Earliest: *rpctest.ToHexUint64(0),
-					Latest:   *rpctest.ToHexUint64(1023),
+					First:  *rpctest.ToHexUint64(0),
+					Length: *rpctest.ToHexUint64(1023),
 				},
 				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 					Steps: []any{
@@ -924,7 +924,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 				},
 			},
 			plan: bundle.NewBuilder().
-				SetEarliest(0).SetLatest(1023).
+				SetEarliest(0).SetRangeLength(1023).
 				WithSigner(signer).
 				AllOf(
 					bundle.Step(key1, &types.AccessListTx{
@@ -944,8 +944,8 @@ func Test_convertProposalToPlan(t *testing.T) {
 
 			proposal: RPCExecutionProposal{
 				BlockRange: &RPCRange{
-					Earliest: *rpctest.ToHexUint64(0),
-					Latest:   *rpctest.ToHexUint64(1023),
+					First:  *rpctest.ToHexUint64(0),
+					Length: *rpctest.ToHexUint64(1023),
 				},
 				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 					Steps: []any{
@@ -975,7 +975,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 			},
 
 			plan: bundle.NewBuilder().
-				SetEarliest(0).SetLatest(1023).
+				SetEarliest(0).SetRangeLength(1023).
 				WithSigner(signer).
 				OneOf(
 					bundle.Step(key1, &types.AccessListTx{
@@ -994,8 +994,8 @@ func Test_convertProposalToPlan(t *testing.T) {
 		"OneOf group with different execution flags in steps": {
 			proposal: RPCExecutionProposal{
 				BlockRange: &RPCRange{
-					Earliest: *rpctest.ToHexUint64(0),
-					Latest:   *rpctest.ToHexUint64(1023),
+					First:  *rpctest.ToHexUint64(0),
+					Length: *rpctest.ToHexUint64(1023),
 				},
 				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 					Steps: []any{
@@ -1026,7 +1026,7 @@ func Test_convertProposalToPlan(t *testing.T) {
 				},
 			},
 			plan: bundle.NewBuilder().
-				SetEarliest(0).SetLatest(1023).
+				SetEarliest(0).SetRangeLength(1023).
 				WithSigner(signer).
 				OneOf(
 					bundle.Step(key1, &types.AccessListTx{

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -405,15 +405,15 @@ func Test_PrepareBundle_DefaultBlockRange_IsCurrentBlockPlusOne(t *testing.T) {
 	result, err := api.PrepareBundle(t.Context(), args)
 	require.NoError(t, err)
 
-	require.EqualValues(t, currentBlock+1, result.ExecutionPlan.BlockRange.Earliest)
-	require.EqualValues(t, currentBlock+bundle.MaxBlockRange, result.ExecutionPlan.BlockRange.Latest)
+	require.EqualValues(t, currentBlock+1, result.ExecutionPlan.BlockRange.First)
+	require.EqualValues(t, bundle.MaxBlockRangeLength, result.ExecutionPlan.BlockRange.Length)
 }
 
 func Test_PrepareBundle_ExplicitBlockRange_IsRespected(t *testing.T) {
 	addr1 := common.Address{1}
 	addr2 := common.Address{2}
-	earliest := hexutil.Uint64(10)
-	latest := hexutil.Uint64(20)
+	first := hexutil.Uint64(10)
+	length := hexutil.Uint64(20)
 
 	be := rpctest.NewBackendBuilder(t).
 		WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
@@ -432,16 +432,16 @@ func Test_PrepareBundle_ExplicitBlockRange_IsRespected(t *testing.T) {
 			},
 		},
 		BlockRange: &RPCRange{
-			Earliest: earliest,
-			Latest:   latest,
+			First:  first,
+			Length: length,
 		},
 	}
 
 	result, err := api.PrepareBundle(t.Context(), args)
 	require.NoError(t, err)
 
-	require.EqualValues(t, earliest, result.ExecutionPlan.BlockRange.Earliest)
-	require.EqualValues(t, latest, result.ExecutionPlan.BlockRange.Latest)
+	require.EqualValues(t, first, result.ExecutionPlan.BlockRange.First)
+	require.EqualValues(t, length, result.ExecutionPlan.BlockRange.Length)
 }
 
 func Test_PrepareBundle_MissingNonce_ReturnsError(t *testing.T) {

--- a/api/sonicapi/submit_bundle_test.go
+++ b/api/sonicapi/submit_bundle_test.go
@@ -424,7 +424,7 @@ func Test_SubmitBundle_StepCountMismatch_ReturnsError(t *testing.T) {
 func buildSubmitBundleArgs(
 	signer types.Signer,
 	flags bundle.ExecutionFlags,
-	earliest, latest uint64,
+	first, length uint64,
 	steps ...bundle.BuilderStep,
 ) SubmitBundleArgs {
 	stepsWithFlags := make([]bundle.BuilderStep, len(steps))
@@ -441,8 +441,8 @@ func buildSubmitBundleArgs(
 
 	tb, plan := bundle.NewBuilder().
 		WithSigner(signer).
-		SetEarliest(earliest).
-		SetRangeLength(latest).
+		SetEarliest(first).
+		SetRangeLength(length).
 		With(root).
 		BuildBundleAndPlan()
 

--- a/api/sonicapi/submit_bundle_test.go
+++ b/api/sonicapi/submit_bundle_test.go
@@ -84,8 +84,8 @@ func Test_SubmitBundle_ValidBundle_ReturnsExecutionPlanHash(t *testing.T) {
 			require.Equal(t, submittedPlan.Hash(), hash)
 
 			// Block range must be preserved.
-			require.EqualValues(t, 1, submittedPlan.Range.Earliest)
-			require.EqualValues(t, 100, submittedPlan.Range.Latest)
+			require.EqualValues(t, 1, submittedPlan.Range.First)
+			require.EqualValues(t, 100, submittedPlan.Range.Length)
 		})
 	}
 }
@@ -181,8 +181,8 @@ func Test_SubmitBundle_SubmittedEnvelopeMatchesBundleContents(t *testing.T) {
 	decoded, err := bundle.OpenEnvelope(signer, submitted)
 	require.NoError(t, err)
 	require.Len(t, decoded.Transactions, 2)
-	require.EqualValues(t, 10, decoded.Plan.Range.Earliest)
-	require.EqualValues(t, 20, decoded.Plan.Range.Latest)
+	require.EqualValues(t, 10, decoded.Plan.Range.First)
+	require.EqualValues(t, 20, decoded.Plan.Range.Length)
 }
 
 func Test_SubmitBundle_EnvelopeGasCoversAllBundledTxs(t *testing.T) {
@@ -229,12 +229,12 @@ func Test_SubmitBundle_EnvelopeGasCoversAllBundledTxs(t *testing.T) {
 
 func Test_SubmitBundle_BlockRangeIsPreservedInPool(t *testing.T) {
 	tests := map[string]struct {
-		earliest uint64
-		latest   uint64
+		first  uint64
+		length uint64
 	}{
-		"range [1,1]":   {1, 1},
-		"range [1,100]": {1, 100},
-		"range [50,50]": {50, 50},
+		"range [1,+1)":   {1, 1},
+		"range [1,+100)": {1, 100},
+		"range [50,+50)": {50, 50},
 	}
 
 	for name, tt := range tests {
@@ -255,7 +255,7 @@ func Test_SubmitBundle_BlockRangeIsPreservedInPool(t *testing.T) {
 			require.NoError(t, err)
 			addr := common.Address{2}
 
-			args := buildSubmitBundleArgs(signer, bundle.EF_Default, tt.earliest, tt.latest,
+			args := buildSubmitBundleArgs(signer, bundle.EF_Default, tt.first, tt.length,
 				bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas}),
 			)
 
@@ -265,27 +265,22 @@ func Test_SubmitBundle_BlockRangeIsPreservedInPool(t *testing.T) {
 
 			decoded, err := bundle.OpenEnvelope(signer, submitted)
 			require.NoError(t, err)
-			require.Equal(t, tt.earliest, decoded.Plan.Range.Earliest)
-			require.Equal(t, tt.latest, decoded.Plan.Range.Latest)
+			require.Equal(t, tt.first, decoded.Plan.Range.First)
+			require.Equal(t, tt.length, decoded.Plan.Range.Length)
 		})
 	}
 }
 
 func Test_SubmitBundle_InvalidBlockRange_ReturnsError(t *testing.T) {
 	tests := map[string]struct {
-		earliest uint64
-		latest   uint64
-		errMsg   string
+		first  uint64
+		length uint64
+		errMsg string
 	}{
-		"earliest > latest": {
-			earliest: 10,
-			latest:   5,
-			errMsg:   "invalid block range",
-		},
 		"range too large": {
-			earliest: 0,
-			latest:   bundle.MaxBlockRange + 1,
-			errMsg:   "invalid block range",
+			first:  15,
+			length: bundle.MaxBlockRangeLength + 1,
+			errMsg: "invalid block range",
 		},
 	}
 
@@ -306,7 +301,7 @@ func Test_SubmitBundle_InvalidBlockRange_ReturnsError(t *testing.T) {
 			tb, plan := bundle.NewBuilder().
 				WithSigner(signer).
 				SetEarliest(1).
-				SetLatest(10).
+				SetRangeLength(10).
 				With(bundle.Step(key, &types.DynamicFeeTx{To: &addr, Gas: params.TxGas})).
 				BuildBundleAndPlan()
 
@@ -320,8 +315,8 @@ func Test_SubmitBundle_InvalidBlockRange_ReturnsError(t *testing.T) {
 
 			rpcPlan, err := NewRPCExecutionPlanComposable(plan)
 			require.NoError(t, err)
-			rpcPlan.BlockRange.Earliest = hexutil.Uint64(tt.earliest)
-			rpcPlan.BlockRange.Latest = hexutil.Uint64(tt.latest)
+			rpcPlan.BlockRange.First = hexutil.Uint64(tt.first)
+			rpcPlan.BlockRange.Length = hexutil.Uint64(tt.length)
 
 			args := SubmitBundleArgs{
 				SignedTransactions: signedTxs,
@@ -447,7 +442,7 @@ func buildSubmitBundleArgs(
 	tb, plan := bundle.NewBuilder().
 		WithSigner(signer).
 		SetEarliest(earliest).
-		SetLatest(latest).
+		SetRangeLength(latest).
 		With(root).
 		BuildBundleAndPlan()
 

--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -265,7 +265,7 @@ func TestSonicTool_genesis_ExportImport_WithBundles(t *testing.T) {
 		"bundle info mismatch after genesis export-import")
 
 	// run enough blocks to make sure that the history hash is pruned.
-	generateNBlocks(t, net, int(bundle.MaxBlockRange)+10)
+	generateNBlocks(t, net, int(bundle.MaxBlockRangeLength)+10)
 
 	// run another bundle
 	bundleHash2, originalInfo2 := runBundle(t, net)

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -102,10 +102,10 @@ func getBundleState(
 
 	// Quickest filter: check if the bundle is in the valid block range.
 	currentBlock := chain.GetLatestHeader().Number.Uint64()
-	if bundle.Plan.Range.Latest < currentBlock {
+	if bundle.Plan.Range.IsAfterRange(currentBlock) {
 		return makePermanentlyBlockedState("bundle has expired")
 	}
-	if bundle.Plan.Range.Earliest > currentBlock {
+	if bundle.Plan.Range.IsBeforeRange(currentBlock) {
 		return makeTemporaryBlockedState("bundle targets future blocks")
 	}
 

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -88,7 +88,7 @@ func Test_GetBundleState_OutdatedBundle_ReturnsNonExecutable(t *testing.T) {
 
 	// Build an outdated bundle.
 	signer := types.LatestSignerForChainID(big.NewInt(1))
-	envelope := bundle.NewBuilder().SetLatest(currentBlock - 1).Build()
+	envelope := bundle.NewBuilder().SetEarliest(currentBlock - 1).SetRangeLength(1).Build()
 
 	_, _, err := bundle.ValidateEnvelope(signer, envelope)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func Test_GetBundleState_FutureBundle_ReturnsTemporaryBlocked(t *testing.T) {
 	signer := types.LatestSignerForChainID(big.NewInt(1))
 	envelop := bundle.NewBuilder().
 		SetEarliest(currentBlock + 1).
-		SetLatest(currentBlock + 10).
+		SetRangeLength(10).
 		Build()
 
 	_, _, err := bundle.ValidateEnvelope(signer, envelop)
@@ -145,7 +145,7 @@ func Test_GetBundleState_FailedTrialRun_ReturnsNonExecutable(t *testing.T) {
 
 	envelope := bundle.NewBuilder().
 		SetEarliest(currentBlock - 5).
-		SetLatest(currentBlock + 5).
+		SetRangeLength(10).
 		Build()
 
 	rejectEverything := func(*types.Transaction, ChainStateForBundleEval, state.StateDB) bool {
@@ -176,7 +176,7 @@ func Test_GetBundleState_ValidBundle_ReturnsRunnable(t *testing.T) {
 	// Build a bundle with a valid block window.
 	envelope := bundle.NewBuilder().
 		SetEarliest(currentBlock - 5).
-		SetLatest(currentBlock + 5).
+		SetRangeLength(10).
 		Build()
 
 	acceptEverything := func(*types.Transaction, ChainStateForBundleEval, state.StateDB) bool {

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -448,7 +448,7 @@ func (r *transactionRunner) runTransactionBundleInternal(
 	}
 
 	if !plan.Range.IsInRange(ctxt.blockNumber.Uint64()) {
-		log.Warn("Bundle skipped due to out-of-range execution plan", "tx", tx.Hash().Hex(), "planRange", fmt.Sprintf("[%d,%d]", plan.Range.Earliest, plan.Range.Latest), "blockNumber", ctxt.blockNumber.Uint64())
+		log.Warn("Bundle skipped due to out-of-range execution plan", "tx", tx.Hash().Hex(), "planRange", plan.Range, "blockNumber", ctxt.blockNumber.Uint64())
 		return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid
 	}
 

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2190,7 +2190,7 @@ func TestRunTransactionBundle_BundleOutOfRange_ReturnsEnvelopeAndResultInvalid(t
 			Nonce: 0, To: &common.Address{1}, Gas: 21_000, GasPrice: big.NewInt(1),
 		})).
 		SetEarliest(11). // not ready for execution yet
-		SetLatest(12).
+		SetRangeLength(2).
 		Build()
 
 	_, _, err = bundle.ValidateEnvelope(signer, tx)

--- a/gossip/blockproc/bundle/block_range.go
+++ b/gossip/blockproc/bundle/block_range.go
@@ -53,8 +53,11 @@ func MakeMaxRangeStartingAt(blockNum uint64) BlockRange {
 }
 
 // IsInRange checks if the given block number is within this block range.
-// The range is a closed interval [Earliest, Latest], meaning that blocks with
-// numbers from Earliest through Latest (inclusive) are considered in range.
+// The range is the half-open interval [First, First+Length): a block number
+// is in range if First <= blockNum and blockNum is strictly less than the end
+// of the range. If Length is 0, the range is empty and no block number is in
+// range. The implementation avoids computing First+Length directly, so the
+// result remains correct even if that sum would overflow uint64.
 func (r BlockRange) IsInRange(blockNum uint64) bool {
 	return !r.IsBeforeRange(blockNum) && !r.IsAfterRange(blockNum)
 }

--- a/gossip/blockproc/bundle/block_range.go
+++ b/gossip/blockproc/bundle/block_range.go
@@ -43,11 +43,13 @@ type BlockRange struct {
 	Length uint64
 }
 
-// MakeMaxRangeStartingAt creates a block range of maximum allowed size, starting
-// at the given block number.
-func MakeMaxRangeStartingAt(blockNum uint64) BlockRange {
+// MakeMaxRangeStartingAt creates a block range of maximum allowed size,
+// starting at the given block number. The resulting range may implicitly cover
+// blocks beyond math.MaxUint64 if the start block is high enough. The length
+// is not adjusted to cap block ranges at math.MaxUint64.
+func MakeMaxRangeStartingAt(first uint64) BlockRange {
 	return BlockRange{
-		First:  blockNum,
+		First:  first,
 		Length: MaxBlockRangeLength,
 	}
 }
@@ -71,7 +73,7 @@ func (r BlockRange) IsBeforeRange(blockNum uint64) bool {
 // IsAfterRange checks if the given block number is after this block range.
 func (r BlockRange) IsAfterRange(blockNum uint64) bool {
 	// r.First + r.Length may overflow, so we subtract the first
-	return blockNum > r.First && blockNum-r.First >= r.Length
+	return blockNum >= r.First && blockNum-r.First >= r.Length
 }
 
 func (r BlockRange) String() string {

--- a/gossip/blockproc/bundle/block_range.go
+++ b/gossip/blockproc/bundle/block_range.go
@@ -17,64 +17,62 @@
 package bundle
 
 import (
+	"fmt"
 	"io"
-	"math"
 
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
 const (
-	// MaxBlockRange is the maximum allowed block range (Latest - Earliest) for
-	// allowed for the validity period of a bundle.
-	MaxBlockRange = uint64(1024)
+	// MaxBlockRangeLength is the maximum allowed block range length being
+	// specified in execution plans of bundles. The limit is needed to limit
+	// the state information required to be maintained by validators for
+	// tracking processed execution plans.
+	MaxBlockRangeLength = uint64(1024)
 )
 
-// BlockRange represents a range of blocks, defined by an earliest and latest
-// block number. The covered block range is a closed interval [Earliest, Latest],
-// meaning that the earliest and latest blocks are included in the range.
-// For instance, [0,0] is a valid block range that only includes the block
-// number 0, while [0,1] includes both blocks 0 and 1. An interval where Latest
-// is smaller than Earliest, such as [1,0], is a valid empty range.
+// BlockRange defines a range of blocks. The range is defined by a first block
+// and the length of the range. All block numbers that satisfy
+//
+//	First <= blockNum < First + Length
+//
+// are included in the range. If Length is 0, the range is empty and does not
+// include any block numbers.
 type BlockRange struct {
-	Earliest uint64
-	Latest   uint64
+	First  uint64
+	Length uint64
 }
 
 // MakeMaxRangeStartingAt creates a block range of maximum allowed size, starting
 // at the given block number.
 func MakeMaxRangeStartingAt(blockNum uint64) BlockRange {
-	latest := blockNum + MaxBlockRange - 1
-	if blockNum > math.MaxUint64-MaxBlockRange {
-		// if the starting block number is too close to maxUint64,
-		// we cannot create a full range of MaxBlockRange blocks without overflowing.
-		// In this case, we create the largest possible range starting at blockNum,
-		// which ends at the maximum uint64 value.
-		latest = math.MaxUint64
-	}
 	return BlockRange{
-		Earliest: blockNum,
-		Latest:   latest,
+		First:  blockNum,
+		Length: MaxBlockRangeLength,
 	}
-}
-
-// Size returns the size of the block range, which is the number of blocks
-// included in the range.
-func (r BlockRange) Size() uint64 {
-	if r.Latest < r.Earliest {
-		return 0
-	}
-	// overflow check
-	if r.Earliest == 0 && r.Latest == math.MaxUint64 {
-		return math.MaxUint64
-	}
-	return r.Latest - r.Earliest + 1
 }
 
 // IsInRange checks if the given block number is within this block range.
 // The range is a closed interval [Earliest, Latest], meaning that blocks with
 // numbers from Earliest through Latest (inclusive) are considered in range.
 func (r BlockRange) IsInRange(blockNum uint64) bool {
-	return blockNum >= r.Earliest && blockNum <= r.Latest
+	return !r.IsBeforeRange(blockNum) && !r.IsAfterRange(blockNum)
+}
+
+// IsBeforeRange checks if the given block number is before this block range,
+// meaning that it is less than the first block number of the range.
+func (r BlockRange) IsBeforeRange(blockNum uint64) bool {
+	return blockNum < r.First
+}
+
+// IsAfterRange checks if the given block number is after this block range.
+func (r BlockRange) IsAfterRange(blockNum uint64) bool {
+	// r.First + r.Length may overflow, so we subtract the first
+	return blockNum > r.First && blockNum-r.First >= r.Length
+}
+
+func (r BlockRange) String() string {
+	return fmt.Sprintf("[%d,+%d)", r.First, r.Length)
 }
 
 func (r BlockRange) encode(writer io.Writer) error {

--- a/gossip/blockproc/bundle/block_range_test.go
+++ b/gossip/blockproc/bundle/block_range_test.go
@@ -24,152 +24,16 @@ import (
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 func TestMakeMaxRangeStartingAt_CreatesMaxRangeStartingAtGivenBlock(t *testing.T) {
-	cases := map[string]struct {
-		start          uint64
-		expectedLatest uint64
-		expectedSize   uint64
-	}{
-		"start at 0": {
-			start:          0,
-			expectedLatest: MaxBlockRange - 1,
-			expectedSize:   MaxBlockRange,
-		},
-		"start at 1": {
-			start:          1,
-			expectedLatest: MaxBlockRange,
-			expectedSize:   MaxBlockRange,
-		},
-		"start at 100": {
-			start:          100,
-			expectedLatest: 100 + MaxBlockRange - 1,
-			expectedSize:   MaxBlockRange,
-		},
-		"start with max plus one blocks": {
-			start:          math.MaxUint64 - MaxBlockRange - 1,
-			expectedLatest: math.MaxUint64 - 2,
-			expectedSize:   MaxBlockRange,
-		},
-		"start with max blocks": {
-			start:          math.MaxUint64 - MaxBlockRange,
-			expectedLatest: math.MaxUint64 - 1,
-			expectedSize:   MaxBlockRange,
-		},
-		"start with exact left blocks": {
-			start:          math.MaxUint64 - MaxBlockRange + 1,
-			expectedLatest: math.MaxUint64,
-			expectedSize:   MaxBlockRange,
-		},
-		"start with not enough blocks": {
-			start:          math.MaxUint64 - MaxBlockRange + 2,
-			expectedLatest: math.MaxUint64,
-			expectedSize:   MaxBlockRange - 1,
-		},
-		"start with two blocks left": {
-			start:          math.MaxUint64 - 1,
-			expectedLatest: math.MaxUint64,
-			expectedSize:   2,
-		},
-		"start with one block left": {
-			start:          math.MaxUint64,
-			expectedLatest: math.MaxUint64,
-			expectedSize:   1,
-		},
-	}
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			r := MakeMaxRangeStartingAt(c.start)
-			require.Equal(t, c.start, r.Earliest)
-			require.Equal(t, c.expectedLatest, r.Latest)
-			require.Equal(t, c.expectedSize, r.Size())
-		})
-	}
-}
+	starts := []uint64{0, 1, 100, math.MaxUint64}
 
-func TestBlockRange_Size_ReturnsCorrectSize(t *testing.T) {
-	tests := map[string]struct {
-		blockRange BlockRange
-		want       uint64
-	}{
-		"empty range": {
-			blockRange: BlockRange{
-				Earliest: 10,
-				Latest:   9,
-			},
-			want: 0,
-		},
-		"single range": {
-			blockRange: BlockRange{
-				Earliest: 10,
-				Latest:   10,
-			},
-			want: 1,
-		},
-		"two blocks range": {
-			blockRange: BlockRange{
-				Earliest: 10,
-				Latest:   11,
-			},
-			want: 2,
-		},
-		"multiple blocks range": {
-			blockRange: BlockRange{
-				Earliest: 10,
-				Latest:   20,
-			},
-			want: 11,
-		},
-		"large range": {
-			blockRange: BlockRange{
-				Earliest: 0,
-				Latest:   10_000_000,
-			},
-			want: 10_000_001,
-		},
-		"large range with latest near max uint64": {
-			blockRange: BlockRange{
-				Earliest: 0,
-				Latest:   math.MaxUint64 - 1,
-			},
-			want: math.MaxUint64,
-		},
-		"too large range is capped to prevent overflow": {
-			blockRange: BlockRange{
-				Earliest: 0,
-				Latest:   math.MaxUint64,
-			},
-			want: math.MaxUint64,
-		},
-		"small range start near max uint64": {
-			blockRange: BlockRange{
-				Earliest: math.MaxUint64 - 10,
-				Latest:   math.MaxUint64,
-			},
-			want: 11,
-		},
-		"small range with the last two blocks": {
-			blockRange: BlockRange{
-				Earliest: math.MaxUint64 - 1,
-				Latest:   math.MaxUint64,
-			},
-			want: 2,
-		},
-		"single block range at max uint64": {
-			blockRange: BlockRange{
-				Earliest: math.MaxUint64,
-				Latest:   math.MaxUint64,
-			},
-			want: 1,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			require.EqualValues(t, test.want, test.blockRange.Size())
-		})
+	for _, start := range starts {
+		r := MakeMaxRangeStartingAt(start)
+		require.Equal(t, start, r.First)
+		require.Equal(t, MaxBlockRangeLength, r.Length)
 	}
 }
 
@@ -180,47 +44,47 @@ func TestBlockRange_IsInRange_ReturnsTrueIfBlockNumberIsWithinRange(t *testing.T
 		want       bool
 	}{
 		"within range": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 20},
+			BlockRange: BlockRange{First: 10, Length: 10},
 			current:    15,
 			want:       true,
 		},
 		"at earliest": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 20},
+			BlockRange: BlockRange{First: 10, Length: 20},
 			current:    10,
 			want:       true,
 		},
 		"at latest": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 20},
-			current:    20,
+			BlockRange: BlockRange{First: 10, Length: 20},
+			current:    29,
 			want:       true,
 		},
 		"below range": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 20},
+			BlockRange: BlockRange{First: 10, Length: 20},
 			current:    9,
 			want:       false,
 		},
 		"above range": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 20},
-			current:    21,
+			BlockRange: BlockRange{First: 10, Length: 20},
+			current:    30,
 			want:       false,
 		},
 		"at lower end": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 20},
+			BlockRange: BlockRange{First: 10, Length: 20},
 			current:    10,
 			want:       true,
 		},
 		"at upper end": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 20},
-			current:    20,
+			BlockRange: BlockRange{First: 10, Length: 20},
+			current:    29,
 			want:       true,
 		},
 		"single block range": {
-			BlockRange: BlockRange{Earliest: 10, Latest: 10},
+			BlockRange: BlockRange{First: 10, Length: 1},
 			current:    10,
 			want:       true,
 		},
 		"invalid range": {
-			BlockRange: BlockRange{Earliest: 20, Latest: 10},
+			BlockRange: BlockRange{First: 20, Length: 0},
 			current:    15,
 			want:       false,
 		},
@@ -234,12 +98,65 @@ func TestBlockRange_IsInRange_ReturnsTrueIfBlockNumberIsWithinRange(t *testing.T
 	}
 }
 
+func TestBlockRange_IsBeforeRange_ReturnsTrueIfBlockNumberIsBeforeRange(t *testing.T) {
+	for first := range uint64(10) {
+		for cur := range uint64(10) {
+			r := BlockRange{First: first, Length: 10}
+			want := cur < first
+			got := r.IsBeforeRange(cur)
+			require.Equal(t, want, got)
+		}
+	}
+}
+
+func TestBlockRange_IsAfterRange_ReturnsTrueIfBlockNumberIsAfterRange(t *testing.T) {
+	for first := range uint64(10) {
+		for cur := range uint64(10) {
+			r := BlockRange{First: first, Length: 2}
+			want := cur >= first+2
+			got := r.IsAfterRange(cur)
+			require.Equal(t, want, got)
+		}
+	}
+}
+
+func TestBlockRange_IsAfterRange_HandlesOverflow(t *testing.T) {
+	r := BlockRange{First: math.MaxUint64 - 1, Length: 2}
+	require.Zero(t, r.First+uint64(r.Length)) // overflow occurs
+	require.False(t, r.IsAfterRange(math.MaxUint64))
+	require.False(t, r.IsAfterRange(math.MaxUint64-1))
+	require.False(t, r.IsAfterRange(0))
+}
+
+func TestBlockRange_String_ReturnsFormattedString(t *testing.T) {
+	tests := map[string]struct {
+		BlockRange BlockRange
+		want       string
+	}{
+		"zero range": {
+			BlockRange: BlockRange{First: 0, Length: 0},
+			want:       "[0,+0)",
+		},
+		"non-zero range": {
+			BlockRange: BlockRange{First: 10, Length: 20},
+			want:       "[10,+20)",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.BlockRange.String()
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
 func TestBlockRange_EncodingAndDecodingIsAligned(t *testing.T) {
 	require := require.New(t)
 	tests := []BlockRange{
 		{0, 0}, {10, 20}, {20, 10},
-		{0, math.MaxUint64}, {math.MaxUint64, 0},
-		{math.MaxUint64, math.MaxUint64},
+		{0, math.MaxUint16}, {math.MaxUint64, 0},
+		{math.MaxUint64, math.MaxUint16},
 	}
 
 	for _, cur := range tests {
@@ -256,8 +173,8 @@ func TestBlockRange_encode_encodesBoundsUsingRlp(t *testing.T) {
 	require := require.New(t)
 	tests := []BlockRange{
 		{0, 0}, {10, 20}, {20, 10},
-		{0, math.MaxUint64}, {math.MaxUint64, 0},
-		{math.MaxUint64, math.MaxUint64},
+		{0, math.MaxUint16}, {math.MaxUint64, 0},
+		{math.MaxUint64, math.MaxUint16},
 	}
 
 	for _, cur := range tests {
@@ -268,7 +185,7 @@ func TestBlockRange_encode_encodesBoundsUsingRlp(t *testing.T) {
 			A, B uint64
 		}
 
-		want, err := rlp.EncodeToBytes(pair{cur.Earliest, cur.Latest})
+		want, err := rlp.EncodeToBytes(pair{cur.First, cur.Length})
 		require.NoError(err)
 
 		require.Equal(want[:], buf.Bytes())
@@ -282,7 +199,7 @@ func TestBlockRange_encode_FailingWriter_ReturnsIssue(t *testing.T) {
 	issue := fmt.Errorf("injected issue")
 	writer.EXPECT().Write(gomock.Any()).Return(0, issue)
 
-	r := BlockRange{Earliest: 10, Latest: 20}
+	r := BlockRange{First: 10, Length: 20}
 	err := r.encode(writer)
 	require.ErrorIs(t, err, issue)
 }
@@ -291,8 +208,8 @@ func TestBlockRange_decode_ReadsRlpEncodedUint64Values(t *testing.T) {
 	require := require.New(t)
 	tests := []BlockRange{
 		{0, 0}, {10, 20}, {20, 10},
-		{0, math.MaxUint64}, {math.MaxUint64, 0},
-		{math.MaxUint64, math.MaxUint64},
+		{0, math.MaxUint16}, {math.MaxUint64, 0},
+		{math.MaxUint64, math.MaxUint16},
 	}
 
 	for _, cur := range tests {
@@ -300,7 +217,7 @@ func TestBlockRange_decode_ReadsRlpEncodedUint64Values(t *testing.T) {
 			A, B uint64
 		}
 
-		data, err := rlp.EncodeToBytes(pair{cur.Earliest, cur.Latest})
+		data, err := rlp.EncodeToBytes(pair{cur.First, cur.Length})
 		require.NoError(err)
 
 		var r BlockRange

--- a/gossip/blockproc/bundle/block_range_test.go
+++ b/gossip/blockproc/bundle/block_range_test.go
@@ -83,9 +83,24 @@ func TestBlockRange_IsInRange_ReturnsTrueIfBlockNumberIsWithinRange(t *testing.T
 			current:    10,
 			want:       true,
 		},
-		"invalid range": {
+		"single block range before": {
+			BlockRange: BlockRange{First: 10, Length: 1},
+			current:    9,
+			want:       false,
+		},
+		"single block range after": {
+			BlockRange: BlockRange{First: 10, Length: 1},
+			current:    11,
+			want:       false,
+		},
+		"empty range before": {
 			BlockRange: BlockRange{First: 20, Length: 0},
-			current:    15,
+			current:    19,
+			want:       false,
+		},
+		"empty range after": {
+			BlockRange: BlockRange{First: 20, Length: 0},
+			current:    20,
 			want:       false,
 		},
 	}
@@ -111,11 +126,13 @@ func TestBlockRange_IsBeforeRange_ReturnsTrueIfBlockNumberIsBeforeRange(t *testi
 
 func TestBlockRange_IsAfterRange_ReturnsTrueIfBlockNumberIsAfterRange(t *testing.T) {
 	for first := range uint64(10) {
-		for cur := range uint64(10) {
-			r := BlockRange{First: first, Length: 2}
-			want := cur >= first+2
-			got := r.IsAfterRange(cur)
-			require.Equal(t, want, got)
+		for length := range uint64(10) {
+			for cur := range uint64(10) {
+				r := BlockRange{First: first, Length: length}
+				want := cur >= first+length
+				got := r.IsAfterRange(cur)
+				require.Equal(t, want, got)
+			}
 		}
 	}
 }

--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -133,7 +133,7 @@ func NewBuilder() *builder {
 type builder struct {
 	signer           types.Signer
 	earliest         *uint64
-	latest           *uint64
+	rangeLength      *uint64
 	root             BuilderStep
 	envelopeKey      *ecdsa.PrivateKey
 	envelopeNonce    uint64
@@ -145,8 +145,8 @@ func (b *builder) SetEarliest(earliest uint64) *builder {
 	return b
 }
 
-func (b *builder) SetLatest(latest uint64) *builder {
-	b.latest = &latest
+func (b *builder) SetRangeLength(length uint64) *builder {
+	b.rangeLength = &length
 	return b
 }
 
@@ -197,13 +197,12 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 
 	// Set up defaults for meta flags.
 	earliest := uint64(0)
-	latest := uint64(MaxBlockRange - 1)
+	rangeLength := MaxBlockRangeLength
 	if b.earliest != nil {
 		earliest = *b.earliest
-		latest = earliest + MaxBlockRange - 1
 	}
-	if b.latest != nil {
-		latest = *b.latest
+	if b.rangeLength != nil {
+		rangeLength = *b.rangeLength
 	}
 
 	signer := b.GetSigner()
@@ -260,8 +259,8 @@ func (b *builder) BuildBundleAndPlan() (*TransactionBundle, ExecutionPlan) {
 	plan := ExecutionPlan{
 		Root: root.toStep(signer),
 		Range: BlockRange{
-			Earliest: earliest,
-			Latest:   latest,
+			First:  earliest,
+			Length: rangeLength,
 		},
 	}
 

--- a/gossip/blockproc/bundle/builder_test.go
+++ b/gossip/blockproc/bundle/builder_test.go
@@ -45,7 +45,7 @@ func TestBundleBuilder_Build_AllowsToBuildBundleAsSpecified(t *testing.T) {
 	tx := NewBuilder().
 		WithSigner(signer).
 		SetEarliest(12).
-		SetLatest(15).
+		SetRangeLength(4).
 		AllOf(
 			Step(key0, &types.AccessListTx{
 				Nonce: 0,
@@ -65,8 +65,8 @@ func TestBundleBuilder_Build_AllowsToBuildBundleAsSpecified(t *testing.T) {
 
 	// Check the block range.
 	require.Equal(bundle.Plan, *plan)
-	require.EqualValues(12, plan.Range.Earliest)
-	require.EqualValues(15, plan.Range.Latest)
+	require.EqualValues(12, plan.Range.First)
+	require.EqualValues(4, plan.Range.Length)
 
 	// check the structure of the execution plan
 	require.Equal(

--- a/gossip/blockproc/bundle/execution_plan_test.go
+++ b/gossip/blockproc/bundle/execution_plan_test.go
@@ -88,15 +88,15 @@ func TestExecutionPlan_Hash_ComputesDeterministicHash(t *testing.T) {
 		},
 		"plan with block range": {
 			Root:  step1,
-			Range: BlockRange{Earliest: 10, Latest: 20},
+			Range: BlockRange{First: 10, Length: 12},
 		},
 		"plan with different start": {
 			Root:  step1,
-			Range: BlockRange{Earliest: 11, Latest: 20},
+			Range: BlockRange{First: 11, Length: 12},
 		},
-		"plan with different end": {
+		"plan with different length": {
 			Root:  step1,
-			Range: BlockRange{Earliest: 10, Latest: 21},
+			Range: BlockRange{First: 10, Length: 14},
 		},
 	}
 

--- a/gossip/blockproc/bundle/validate.go
+++ b/gossip/blockproc/bundle/validate.go
@@ -262,12 +262,12 @@ func validateStepInternal(
 // validateRange checks that the given block range is valid, i.e. that it is not
 // empty and does not exceed the maximum allowed range.
 func validateRange(r BlockRange) error {
-	size := r.Size()
+	size := r.Length
 	if size == 0 {
-		return fmt.Errorf("invalid empty block range [%d,%d]", r.Earliest, r.Latest)
+		return fmt.Errorf("invalid empty block range [%d,+%d)", r.First, r.Length)
 	}
-	if size > MaxBlockRange {
-		return fmt.Errorf("invalid block range, duration %d, limit %d", size, MaxBlockRange)
+	if size > MaxBlockRangeLength {
+		return fmt.Errorf("invalid block range, length %d, limit %d", size, MaxBlockRangeLength)
 	}
 	return nil
 }

--- a/gossip/blockproc/bundle/validate_test.go
+++ b/gossip/blockproc/bundle/validate_test.go
@@ -138,7 +138,7 @@ func TestValidateEnvelope_InvalidBundle_IsRejected(t *testing.T) {
 	tests := map[string]TransactionBundle{
 		"invalid block range": NewBuilder().
 			SetEarliest(20).
-			SetLatest(10).
+			SetRangeLength(MaxBlockRangeLength + 1).
 			BuildBundle(),
 		"missing transactions": func() TransactionBundle {
 			bundle := NewBuilder().AllOf(
@@ -253,8 +253,7 @@ func TestValidateEnvelope_NestedInvalidEnvelope_IsRejected(t *testing.T) {
 	require.NoError(err)
 
 	invalidInner := NewBuilder().
-		SetEarliest(20).
-		SetLatest(10).
+		SetRangeLength(MaxBlockRangeLength + 1).
 		WithSigner(signer).
 		Build()
 
@@ -377,7 +376,7 @@ func TestValidateBundle_NilTransaction_Rejected(t *testing.T) {
 	for name, transactions := range tests {
 		t.Run(name, func(t *testing.T) {
 			validPlan := ExecutionPlan{
-				Range: BlockRange{Earliest: 10, Latest: 20},
+				Range: BlockRange{First: 10, Length: 20},
 				Root:  NewTxStep(TxReference{}),
 			}
 			require.NoError(t, validatePlan(validPlan))
@@ -437,7 +436,7 @@ func TestValidateBundle_InconsistentChainIds_Rejected(t *testing.T) {
 	for name, transactions := range tests {
 		t.Run(name, func(t *testing.T) {
 			validPlan := ExecutionPlan{
-				Range: BlockRange{Earliest: 10, Latest: 20},
+				Range: BlockRange{First: 10, Length: 20},
 				Root:  NewTxStep(TxReference{}),
 			}
 			require.NoError(t, validatePlan(validPlan))
@@ -472,7 +471,7 @@ func TestValidateBundle_InconsistentChainIds_Rejected(t *testing.T) {
 
 func TestValidateBundle_MissingSigner_ProducesAnError(t *testing.T) {
 	validPlan := ExecutionPlan{
-		Range: BlockRange{Earliest: 10, Latest: 20},
+		Range: BlockRange{First: 10, Length: 20},
 		Root:  NewTxStep(TxReference{}),
 	}
 
@@ -527,7 +526,7 @@ func TestValidateBundle_InvalidIndex_Rejected(t *testing.T) {
 
 func TestValidateBundle_UsageOfLegacyTransaction_Rejected(t *testing.T) {
 	validPlan := ExecutionPlan{
-		Range: BlockRange{Earliest: 10, Latest: 20},
+		Range: BlockRange{First: 10, Length: 20},
 		Root:  NewTxStep(TxReference{}),
 	}
 	require.NoError(t, validatePlan(validPlan))
@@ -653,15 +652,15 @@ func TestValidatePlan_AcceptsValidPlans(t *testing.T) {
 	validPlans := []ExecutionPlan{
 		{
 			Root:  NewTxStep(TxReference{}),
-			Range: BlockRange{Earliest: 10, Latest: 10},
+			Range: BlockRange{First: 10, Length: 1},
 		},
 		{
 			Root:  NewAllOfStep(NewTxStep(TxReference{}), NewTxStep(TxReference{})),
-			Range: BlockRange{Earliest: 10, Latest: 20},
+			Range: BlockRange{First: 10, Length: 10},
 		},
 		{
 			Root:  NewOneOfStep(NewTxStep(TxReference{}), NewTxStep(TxReference{})),
-			Range: BlockRange{Earliest: 0, Latest: MaxBlockRange - 1},
+			Range: BlockRange{First: 0, Length: MaxBlockRangeLength},
 		},
 	}
 
@@ -682,14 +681,14 @@ func TestValidatePlan_DetectsInvalidPlans(t *testing.T) {
 		"invalid root step": {
 			plan: ExecutionPlan{
 				Root:  ExecutionStep{}, // invalid step
-				Range: BlockRange{Earliest: 10, Latest: 20},
+				Range: BlockRange{First: 10, Length: 20},
 			},
 			issue: "invalid execution plan",
 		},
 		"invalid block range": {
 			plan: ExecutionPlan{
 				Root:  NewTxStep(TxReference{}),
-				Range: BlockRange{Earliest: 20, Latest: 10}, // invalid range
+				Range: BlockRange{First: 20, Length: MaxBlockRangeLength + 1}, // invalid range
 			},
 			issue: "invalid block range",
 		},
@@ -702,8 +701,8 @@ func TestValidatePlan_DetectsInvalidPlans(t *testing.T) {
 	}
 
 	invalidPlanAndRange := ExecutionPlan{
-		Root:  ExecutionStep{},                      // invalid step
-		Range: BlockRange{Earliest: 20, Latest: 10}, // invalid range
+		Root:  ExecutionStep{},                                        // invalid step
+		Range: BlockRange{First: 20, Length: MaxBlockRangeLength + 1}, // invalid range
 	}
 
 	require.Error(t, validateStep(invalidPlanAndRange.Root))
@@ -860,12 +859,12 @@ func wrapInNested(inner ExecutionStep, depth int) ExecutionStep {
 
 func TestValidateRange_AcceptsValidRanges(t *testing.T) {
 	tests := []BlockRange{
-		{0, 0},
-		{0, 100},
-		{0, MaxBlockRange - 1},
-		{10, 10},
-		{10, 100},
-		{10, MaxBlockRange + 9},
+		{First: 0, Length: 1},
+		{First: 0, Length: 100},
+		{First: 0, Length: MaxBlockRangeLength - 1},
+		{First: 0, Length: MaxBlockRangeLength},
+		{First: 10, Length: 11},
+		{First: 10, Length: 100},
 	}
 
 	for _, tc := range tests {
@@ -883,23 +882,11 @@ func TestValidateRange_DetectsInvalidRanges(t *testing.T) {
 			issue:      "empty block range",
 		},
 		{
-			blockRange: BlockRange{10, 9},
-			issue:      "empty block range",
-		},
-		{
-			blockRange: BlockRange{MaxBlockRange, 0},
-			issue:      "empty block range",
-		},
-		{
-			blockRange: BlockRange{0, MaxBlockRange},
+			blockRange: BlockRange{0, MaxBlockRangeLength + 1},
 			issue:      "invalid block range",
 		},
 		{
-			blockRange: BlockRange{10, MaxBlockRange + 10},
-			issue:      "invalid block range",
-		},
-		{
-			blockRange: BlockRange{10, MaxBlockRange + 100},
+			blockRange: BlockRange{10, MaxBlockRangeLength + 10},
 			issue:      "invalid block range",
 		},
 	}
@@ -910,16 +897,16 @@ func TestValidateRange_DetectsInvalidRanges(t *testing.T) {
 }
 
 func TestValidateRange_ComprehensiveRangeChecks(t *testing.T) {
-	for earliest := range 2 * MaxBlockRange {
-		for latest := range 2 * MaxBlockRange {
-			r := BlockRange{earliest, latest}
-			if size := r.Size(); size > 0 && size <= MaxBlockRange {
+	for first := range 2 * MaxBlockRangeLength {
+		for length := range 2 * MaxBlockRangeLength {
+			r := BlockRange{first, length}
+			if length > 0 && length <= MaxBlockRangeLength {
 				require.NoError(t, validateRange(r),
-					"earliest=%d, latest=%d", earliest, latest,
+					"first=%d, length=%d", first, length,
 				)
 			} else {
 				require.Error(t, validateRange(r),
-					"earliest=%d, latest=%d", earliest, latest,
+					"first=%d, length=%d", first, length,
 				)
 			}
 		}

--- a/gossip/blockproc/bundle/validate_test.go
+++ b/gossip/blockproc/bundle/validate_test.go
@@ -863,6 +863,7 @@ func TestValidateRange_AcceptsValidRanges(t *testing.T) {
 		{First: 0, Length: 100},
 		{First: 0, Length: MaxBlockRangeLength - 1},
 		{First: 0, Length: MaxBlockRangeLength},
+		{First: 10, Length: 1},
 		{First: 10, Length: 11},
 		{First: 10, Length: 100},
 	}

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -75,7 +75,7 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 				},
 			}
 
-			tx := bundle.NewBuilder().SetEarliest(50).SetLatest(150).WithSigner(signer).Build()
+			tx := bundle.NewBuilder().SetEarliest(50).SetRangeLength(100).WithSigner(signer).Build()
 
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(err)
@@ -98,7 +98,7 @@ func Test_Emitter_isValidBundleTx_RejectsInvalidBundle(t *testing.T) {
 		}),
 		"bundle with out-of-range block numbers": bundle.NewBuilder().
 			SetEarliest(150).
-			SetLatest(250).
+			SetRangeLength(100).
 			Build(),
 	}
 
@@ -158,7 +158,7 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 				},
 			}
 
-			tx := bundle.NewBuilder().SetEarliest(50).SetLatest(150).Build()
+			tx := bundle.NewBuilder().SetEarliest(50).SetRangeLength(100).Build()
 
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(t, err)

--- a/gossip/store_processed_bundles.go
+++ b/gossip/store_processed_bundles.go
@@ -135,11 +135,11 @@ func (s *Store) addNewBundles(
 func (s *Store) deleteOutdatedBundles(finishedBlock uint64, batch kvdb.Batch) {
 	nextBlock := finishedBlock + 1
 
-	if nextBlock < bundle.MaxBlockRange {
+	if nextBlock < bundle.MaxBlockRangeLength {
 		return
 	}
 
-	highestOutdatedBlockNumber := nextBlock - bundle.MaxBlockRange
+	highestOutdatedBlockNumber := nextBlock - bundle.MaxBlockRangeLength
 
 	// Prune bundle-index and entries keys ('i', 'e').
 	// key layout for 'i': 1 byte prefix + 8 bytes blockNum + 32 bytes execPlanHash

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -1418,7 +1418,7 @@ func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 	require.NotZero(historyHash)
 
 	entries := store.EnumerateProcessedBundles()
-	// MaxBlockRange-1 entries (oldest was pruned)
+	// MaxBlockRangeLength-1 entries (oldest was pruned)
 	require.Len(entries, int(bundle.MaxBlockRangeLength-1))
 	require.Len(entries, len(expected),
 		"expected number of exported entries does not match expected")

--- a/gossip/store_processed_bundles_test.go
+++ b/gossip/store_processed_bundles_test.go
@@ -69,7 +69,7 @@ func TestStore_GetBundleExecutionInfo_ReturnsInfoForKnownBundles(t *testing.T) {
 	history := map[uint64]map[common.Hash]bundle.PositionInBlock{}
 
 	// construct a history of bundles in boundary block number and boundary positions
-	for i, blockNum := range []uint64{0, 1, bundle.MaxBlockRange / 2, bundle.MaxBlockRange - 2, bundle.MaxBlockRange - 1} {
+	for i, blockNum := range []uint64{0, 1, bundle.MaxBlockRangeLength / 2, bundle.MaxBlockRangeLength - 2, bundle.MaxBlockRangeLength - 1} {
 		history[blockNum] = map[common.Hash]bundle.PositionInBlock{
 			uint64ToHash(uint64(i * 3)): {
 				Offset: 0,
@@ -154,9 +154,9 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 
 	for _, block := range []uint64{
 		0, 1,
-		bundle.MaxBlockRange - 1,
-		bundle.MaxBlockRange,
-		bundle.MaxBlockRange + 1,
+		bundle.MaxBlockRangeLength - 1,
+		bundle.MaxBlockRangeLength,
+		bundle.MaxBlockRangeLength + 1,
 	} {
 		t.Run(fmt.Sprintf("BlockNumber=%d", block), func(t *testing.T) {
 			store, table, _, batch, it := storeTableLogMocks(t)
@@ -181,8 +181,8 @@ func TestStore_AddProcessedBundles_AddsNewBundlesToStorage(t *testing.T) {
 				[]byte{0},
 			)
 			// when the history is large enough, the store starts deleting outdated entries.
-			if block >= bundle.MaxBlockRange-1 {
-				toDelete := block - bundle.MaxBlockRange + 1
+			if block >= bundle.MaxBlockRangeLength-1 {
+				toDelete := block - bundle.MaxBlockRangeLength + 1
 
 				table.EXPECT().NewIterator([]byte{'i'}, nil).Return(it)
 				next := it.EXPECT().Next().Return(true)
@@ -262,8 +262,8 @@ func TestStore_AddProcessedBundles_RemovesOlderHistoryHash_EvenForBlockNumberWit
 	store, err := NewMemStore(t)
 	require.NoError(t, err)
 	// Run enough blocks that some 'h' entries from bundle-less blocks get pruned.
-	const currentBlock = bundle.MaxBlockRange * 2
-	const firstBundle = bundle.MaxBlockRange / 2
+	const currentBlock = bundle.MaxBlockRangeLength * 2
+	const firstBundle = bundle.MaxBlockRangeLength / 2
 	for block := range uint64(currentBlock) + 1 {
 		// add a single block with bundles
 		if block == firstBundle {
@@ -288,8 +288,8 @@ func TestStore_AddProcessedBundles_RemovesOlderHistoryHash_EvenForBlockNumberWit
 			// the boundary is tested by other tests, in particular
 			// TestStore_ProcessedBundles_RetainsAllHashesToVerifyContainedExecutionPlans
 			wantEarliest := firstBundle
-			if block >= bundle.MaxBlockRange+firstBundle {
-				wantEarliest = block - bundle.MaxBlockRange + 1
+			if block >= bundle.MaxBlockRangeLength+firstBundle {
+				wantEarliest = block - bundle.MaxBlockRangeLength + 1
 			}
 			require.Equal(t, wantEarliest, earliestHashBlockNumber)
 		}
@@ -305,7 +305,7 @@ func TestStore_AddProcessedBundles_HistoryHashIsConsistentWithPerBlockHash(t *te
 	require.NoError(t, err)
 
 	var historicHashes []common.Hash
-	for block := range bundle.MaxBlockRange * 2 {
+	for block := range bundle.MaxBlockRangeLength * 2 {
 		// randomly add bundles to some blocks, but not all
 		if rand.Uint64()%2 == 0 {
 			store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{
@@ -340,7 +340,7 @@ func TestStore_GetLatestProcessedBundleHistoryHash_InitiallyZero(t *testing.T) {
 func TestStore_GetLatestProcessedBundleHistoryHash_CorrectlyParsesHash(t *testing.T) {
 	store, table, _, _, _ := storeTableLogMocks(t)
 
-	for i := range 2 * bundle.MaxBlockRange {
+	for i := range 2 * bundle.MaxBlockRangeLength {
 		block := uint64(i)
 		hash := crypto.Keccak256Hash([]byte(fmt.Sprintf("hash for block %d", block)))
 
@@ -487,7 +487,7 @@ func TestStore_GetEarliestBundleHistoryHash_ReturnsZero_WhenNoBundlesExecuted(t 
 	require.NoError(err)
 
 	// add blocks without bundles
-	for block := range bundle.MaxBlockRange + 2 {
+	for block := range bundle.MaxBlockRangeLength + 2 {
 		store.AddProcessedBundles(block, map[common.Hash]bundle.PositionInBlock{})
 		blockNum, hash := store.GetLatestProcessedBundleHistoryHash()
 		require.Zero(blockNum)
@@ -666,101 +666,101 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 		// when current block number is not large enough to have a history to delete
 		{
 			storedBundleBlockNumber: 0,
-			finishingBlock:          bundle.MaxBlockRange - 2,
+			finishingBlock:          bundle.MaxBlockRangeLength - 2,
 			expectDeleted:           false,
 		},
 		{
 			storedBundleBlockNumber: 1,
-			finishingBlock:          bundle.MaxBlockRange - 2,
+			finishingBlock:          bundle.MaxBlockRangeLength - 2,
 			expectDeleted:           false,
 		},
 		{
 			storedBundleBlockNumber: 1,
-			finishingBlock:          bundle.MaxBlockRange - 1,
+			finishingBlock:          bundle.MaxBlockRangeLength - 1,
 			expectDeleted:           false,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange / 2,
-			finishingBlock:          bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength / 2,
+			finishingBlock:          bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange - 1,
-			finishingBlock:          bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength - 1,
+			finishingBlock:          bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange,
-			finishingBlock:          bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength,
+			finishingBlock:          bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 		// Following cases are after the warm up phase, when current block
 		// number is large enough to have a history to delete,
 		{
 			storedBundleBlockNumber: 0,
-			finishingBlock:          bundle.MaxBlockRange - 1,
+			finishingBlock:          bundle.MaxBlockRangeLength - 1,
 			expectDeleted:           true,
 		},
 		{
 			storedBundleBlockNumber: 0,
-			finishingBlock:          bundle.MaxBlockRange,
+			finishingBlock:          bundle.MaxBlockRangeLength,
 			expectDeleted:           true,
 		},
 		{
 			storedBundleBlockNumber: 0,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           true,
 		},
 		{
 			storedBundleBlockNumber: 1,
-			finishingBlock:          bundle.MaxBlockRange,
+			finishingBlock:          bundle.MaxBlockRangeLength,
 			expectDeleted:           true,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange / 2,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength / 2,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           true,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange - 1,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength - 1,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           true,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           true,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange + 1,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength + 1,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           true,
 		},
 		// Following cases are recent enough to not be deleted
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange + 2,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength + 2,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 		{
-			storedBundleBlockNumber: bundle.MaxBlockRange * 3 / 2,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: bundle.MaxBlockRangeLength * 3 / 2,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 		{
-			storedBundleBlockNumber: 2*bundle.MaxBlockRange - 1,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: 2*bundle.MaxBlockRangeLength - 1,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 		{
-			storedBundleBlockNumber: 2 * bundle.MaxBlockRange,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: 2 * bundle.MaxBlockRangeLength,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 		// future block numbers should not cause deletion
 		{
-			storedBundleBlockNumber: 2*bundle.MaxBlockRange + 1,
-			finishingBlock:          2 * bundle.MaxBlockRange,
+			storedBundleBlockNumber: 2*bundle.MaxBlockRangeLength + 1,
+			finishingBlock:          2 * bundle.MaxBlockRangeLength,
 			expectDeleted:           false,
 		},
 	}
@@ -773,7 +773,7 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 			batch := NewMockstoreBatch(ctrl)
 			table := NewMockstoreTable(ctrl)
 			it := NewMockdbIterator(ctrl)
-			if c.finishingBlock >= bundle.MaxBlockRange-1 {
+			if c.finishingBlock >= bundle.MaxBlockRangeLength-1 {
 				it.EXPECT().Release()
 			}
 			store := &Store{}
@@ -783,7 +783,7 @@ func TestStore_deleteOutdatedBundles_RemovesBundles_WhenOld(t *testing.T) {
 
 			// The algorithm would not contemplate any history
 			// when the block number is short enough to not to require any cleanup
-			if c.finishingBlock >= bundle.MaxBlockRange-1 {
+			if c.finishingBlock >= bundle.MaxBlockRangeLength-1 {
 				it2 := NewMockdbIterator(ctrl)
 				it2.EXPECT().Release()
 
@@ -843,7 +843,7 @@ func TestStore_deleteOutdatedBundles_RemovesMultipleEntries_WhenNotCleanedForToo
 	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 	it2.EXPECT().Next().Return(false)
 
-	store.deleteOutdatedBundles(bundle.MaxBlockRange+10, batch)
+	store.deleteOutdatedBundles(bundle.MaxBlockRangeLength+10, batch)
 }
 
 func TestStore_deleteOutdatedBundles_IgnoresIndexKeysOfWrongLength(t *testing.T) {
@@ -868,7 +868,7 @@ func TestStore_deleteOutdatedBundles_IgnoresIndexKeysOfWrongLength(t *testing.T)
 	it2.EXPECT().Release()
 	table.EXPECT().NewIterator([]byte{'h'}, nil).Return(it2)
 
-	store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch)
+	store.deleteOutdatedBundles(bundle.MaxBlockRangeLength+1, batch)
 }
 
 func TestStore_deleteOutdatedBundles_IgnoresHashKeysOfWrongLength(t *testing.T) {
@@ -892,7 +892,7 @@ func TestStore_deleteOutdatedBundles_IgnoresHashKeysOfWrongLength(t *testing.T) 
 		it.EXPECT().Release(),
 	)
 
-	store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch)
+	store.deleteOutdatedBundles(bundle.MaxBlockRangeLength+1, batch)
 }
 
 func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
@@ -918,7 +918,7 @@ func TestStore_deleteOutdatedBundles_LogsOnBatchDeleteError(t *testing.T) {
 	// To prevent the test from exiting, the mock logger is configured to panic instead.
 	require.PanicsWithValue(t,
 		fmt.Sprintf("failed to delete old processed bundle hash: %v", []any{"error", compoundErr}),
-		func() { store.deleteOutdatedBundles(bundle.MaxBlockRange+1, batch) })
+		func() { store.deleteOutdatedBundles(bundle.MaxBlockRangeLength+1, batch) })
 }
 
 func TestStore_deleteOutdatedBundles_LogsOnIterationError(t *testing.T) {
@@ -942,7 +942,7 @@ func TestStore_deleteOutdatedBundles_LogsOnIterationError(t *testing.T) {
 	require.PanicsWithValue(t,
 		"deliberately stopped by unit test",
 		func() {
-			store.deleteOutdatedBundles(bundle.MaxBlockRange+12, batch)
+			store.deleteOutdatedBundles(bundle.MaxBlockRangeLength+12, batch)
 		},
 	)
 }
@@ -976,7 +976,7 @@ func TestStore_deleteOutdatedBundles_LogsOnErrorWhenDeletingHashes(t *testing.T)
 	require.PanicsWithValue(t,
 		"deliberately stopped by unit test",
 		func() {
-			store.deleteOutdatedBundles(bundle.MaxBlockRange+12, batch)
+			store.deleteOutdatedBundles(bundle.MaxBlockRangeLength+12, batch)
 		},
 	)
 }
@@ -1009,7 +1009,7 @@ func TestStore_deleteOutdatedBundles_LogsOnSecondIterationError(t *testing.T) {
 	require.PanicsWithValue(t,
 		"deliberately stopped by unit test",
 		func() {
-			store.deleteOutdatedBundles(bundle.MaxBlockRange+12, batch)
+			store.deleteOutdatedBundles(bundle.MaxBlockRangeLength+12, batch)
 		},
 	)
 }
@@ -1085,9 +1085,9 @@ func TestStore_computeNewBundleStateHash_CorrectlyProcessesEdgeCases(t *testing.
 	}
 	blockNumberDomain := []uint64{
 		0, 1, 512,
-		bundle.MaxBlockRange - 1,
-		bundle.MaxBlockRange,
-		bundle.MaxBlockRange + 1,
+		bundle.MaxBlockRangeLength - 1,
+		bundle.MaxBlockRangeLength,
+		bundle.MaxBlockRangeLength + 1,
 		math.MaxUint64}
 
 	type testCase struct {
@@ -1181,7 +1181,7 @@ func TestStore_ProcessedBundles_ZeroHistoryHashIsPreserved_WhenNoBundlesAreExecu
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
-	for i := range bundle.MaxBlockRange + 2 {
+	for i := range bundle.MaxBlockRangeLength + 2 {
 		// nil bundles executed
 		store.AddProcessedBundles(i, nil)
 		blockNum, hash := store.GetLatestProcessedBundleHistoryHash()
@@ -1272,7 +1272,7 @@ func TestStore_ProcessedBundles_HashIsUpdatedWithNewBlocks(t *testing.T) {
 	// this test relies on the incremental nature uint64ToHash to
 	// generate distinct hashes which also yield different xor values
 	seenHashes := make(map[common.Hash]struct{})
-	for i := range 4 * bundle.MaxBlockRange {
+	for i := range 4 * bundle.MaxBlockRangeLength {
 		store.AddProcessedBundles(i, map[common.Hash]bundle.PositionInBlock{
 			uint64ToHash(uint64(i)): {Offset: 0, Count: 1},
 		})
@@ -1286,7 +1286,7 @@ func TestStore_ProcessedBundles_HashIsUpdatedWithNewBlocks(t *testing.T) {
 
 func TestStore_ProcessedBundles_RetainsAllBundlesRequiredToCoverTheMaximumBlockRange(t *testing.T) {
 	require := require.New(t)
-	numBlocks := 3 * bundle.MaxBlockRange
+	numBlocks := 3 * bundle.MaxBlockRangeLength
 
 	store, err := NewMemStore(t)
 	require.NoError(err)
@@ -1302,8 +1302,8 @@ func TestStore_ProcessedBundles_RetainsAllBundlesRequiredToCoverTheMaximumBlockR
 			want := blockRange.IsInRange(currentBlockNumber)
 			require.Equal(
 				want, store.HasBundleRecentlyBeenProcessed(uint64ToHash(block)),
-				"Current block %d, checking plan with range [%d,%d]",
-				currentBlockNumber, blockRange.Earliest, blockRange.Latest,
+				"Current block %d, checking plan with range %v",
+				currentBlockNumber, blockRange,
 			)
 		}
 
@@ -1317,7 +1317,7 @@ func TestStore_ProcessedBundles_RetainsAllHashesToVerifyContainedExecutionPlans(
 	// This test makes sure that exactly those hashes are retained in the store
 	// that are required to verify the stored execution plan hashes.
 	require := require.New(t)
-	numBlocks := 3 * bundle.MaxBlockRange
+	numBlocks := 3 * bundle.MaxBlockRangeLength
 
 	store, err := NewMemStore(t)
 	require.NoError(err)
@@ -1397,7 +1397,7 @@ func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 
 	expected := map[common.Hash]bundle.ExecutionInfo{}
 	// fill the store with the maximum number of block
-	for i := range bundle.MaxBlockRange + 1 {
+	for i := range bundle.MaxBlockRangeLength + 1 {
 		hash := common.BytesToHash(bigendian.Uint32ToBytes(uint32(i)))
 		position := bundle.PositionInBlock{Offset: uint32(i), Count: 1}
 		executedBundles := map[common.Hash]bundle.PositionInBlock{
@@ -1413,13 +1413,13 @@ func TestStore_EnumerateProcessedBundles_ReturnsAllAddedEntries(t *testing.T) {
 		}
 	}
 	block, historyHash := store.GetLatestProcessedBundleHistoryHash()
-	require.Equal(uint64(bundle.MaxBlockRange), block)
+	require.Equal(uint64(bundle.MaxBlockRangeLength), block)
 	require.NotNil(historyHash)
 	require.NotZero(historyHash)
 
 	entries := store.EnumerateProcessedBundles()
 	// MaxBlockRange-1 entries (oldest was pruned)
-	require.Len(entries, int(bundle.MaxBlockRange-1))
+	require.Len(entries, int(bundle.MaxBlockRangeLength-1))
 	require.Len(entries, len(expected),
 		"expected number of exported entries does not match expected")
 
@@ -1602,7 +1602,7 @@ func TestStore_ProcessedBundles_HistoryHashRemainsZero_WhenNoBundlesAreEverProce
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
-	for block := range 3 * bundle.MaxBlockRange {
+	for block := range 3 * bundle.MaxBlockRangeLength {
 		store.AddProcessedBundles(uint64(block), nil)
 		_, hash := store.GetLatestProcessedBundleHistoryHash()
 		require.Equal(common.Hash{}, hash,
@@ -1635,12 +1635,12 @@ func TestStore_ProcessedBundles_DeletingEntries_DoesNotAffectHistoryHash(t *test
 	// Compute the expected hash by replaying the same updates manually,
 	// independent of any internal pruning.
 	expectedHash := hashAt0
-	for block := uint64(1); block <= bundle.MaxBlockRange; block++ {
+	for block := uint64(1); block <= bundle.MaxBlockRangeLength; block++ {
 		expectedHash = referenceComputeStateHash(expectedHash, common.Hash{}, block)
 	}
 
 	// Advance enough blocks to trigger pruning of the entry at block 0.
-	for block := uint64(1); block <= bundle.MaxBlockRange; block++ {
+	for block := uint64(1); block <= bundle.MaxBlockRangeLength; block++ {
 		store.AddProcessedBundles(block, nil)
 	}
 


### PR DESCRIPTION
This PR updates the block range to be represented by `[First,+Length)` instead of `[Earliest,Latest]`.

This simplifies some code (in particular everything related to size) and makes the `MaxBlockRangeLength` constant  simpler to interpret.