### PR TITLE
Add bundle-only transaction integration test

### DIFF
--- a/tests/bundles/network_rules_test.go
+++ b/tests/bundles/network_rules_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBundles_BundleOnlyTransactionsAreNotExecutedStartingFromBrio(t *testing.T) {
+func TestBundles_BundleOnlyTransactionsAreFilteredOutByTheTxPoolStartingFromBrio(t *testing.T) {
 	brioAndBundlesUpgrades := opera.GetBrioUpgrades()
 	brioAndBundlesUpgrades.TransactionBundles = true
 
@@ -103,7 +103,8 @@ func TestBundles_BundleOnlyTransactionsAreNotExecutedStartingFromBrio(t *testing
 				_, err = net.GetReceipt(normalHash)
 				require.NoError(t, err)
 
-				// After a block advanced, the bundle-only tx should not have been executed.
+				// After a block advanced, the bundle-only tx should not have reached the processor
+				// and should not have been executed.
 				blockNumber, err = client.BlockNumber(t.Context())
 				require.NoError(t, err)
 				balance, err = client.BalanceAt(t.Context(), recipientAddr, big.NewInt(int64(blockNumber)))

--- a/tests/bundles/network_rules_test.go
+++ b/tests/bundles/network_rules_test.go
@@ -23,9 +23,97 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBundles_BundleOnlyTransactionsAreNotExecutedStartingFromBrio(t *testing.T) {
+	brioAndBundlesUpgrades := opera.GetBrioUpgrades()
+	brioAndBundlesUpgrades.TransactionBundles = true
+
+	testCases := map[string]struct {
+		upgrades  opera.Upgrades
+		processed bool
+	}{
+		"pre-Brio": {
+			upgrades:  opera.GetAllegroUpgrades(),
+			processed: true,
+		},
+		"Brio": {
+			upgrades:  opera.GetBrioUpgrades(),
+			processed: false,
+		},
+		"Brio and Bundles": {
+			upgrades:  brioAndBundlesUpgrades,
+			processed: false,
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+				Upgrades: &test.upgrades,
+			})
+			client, err := net.GetClient()
+			require.NoError(t, err)
+			defer client.Close()
+
+			sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+			recipient := tests.NewAccount()
+			recipientAddr := recipient.Address()
+			blockNumber, err := client.BlockNumber(t.Context())
+			require.NoError(t, err)
+			balance, err := client.BalanceAt(t.Context(), recipientAddr, big.NewInt(int64(blockNumber)))
+			require.NoError(t, err)
+			require.Equal(t, uint64(0), balance.Uint64(),
+				"recipient should have 0 balance before transaction")
+
+			// Create a bundle-only transaction (has BundleOnly marker in access list)
+			// which transfers some funds.
+			bundleOnlyTx := tests.CreateTransaction(t, net, &types.AccessListTx{
+				To:    &recipientAddr,
+				Value: big.NewInt(100),
+				AccessList: types.AccessList{{
+					Address:     bundle.BundleOnly,
+					StorageKeys: []common.Hash{},
+				}},
+			}, sender)
+			require.True(t, bundle.IsBundleOnly(bundleOnlyTx))
+
+			txHash, err := net.Send(bundleOnlyTx)
+			require.NoError(t, err)
+			if test.processed {
+				// The transaction should be processed and recipient should receive the funds.
+				receipt, err := net.GetReceipt(txHash)
+				require.NoError(t, err)
+				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status,
+					"transaction should succeed")
+
+				balance, err = client.BalanceAt(t.Context(), recipientAddr, receipt.BlockNumber)
+				require.NoError(t, err)
+				require.Equal(t, uint64(100), balance.Uint64(),
+					"recipient should receive 100")
+			} else {
+				// Submit a normal tx from a different account to advance at least one block.
+				other := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+				normalTx := tests.CreateTransaction(t, net, &types.AccessListTx{}, other)
+				normalHash, err := net.Send(normalTx)
+				require.NoError(t, err)
+				_, err = net.GetReceipt(normalHash)
+				require.NoError(t, err)
+
+				// After a block advanced, the bundle-only tx should not have been executed.
+				blockNumber, err = client.BlockNumber(t.Context())
+				require.NoError(t, err)
+				balance, err = client.BalanceAt(t.Context(), recipientAddr, big.NewInt(int64(blockNumber)))
+				require.NoError(t, err)
+				require.Equal(t, uint64(0), balance.Uint64(),
+					"recipient should still have 0 balance")
+			}
+		})
+	}
+}
 
 func TestBundles_BundlesCanBeEnabledAndDisabledStartingFromBrio(t *testing.T) {
 	// Start with Brio but bundles initially disabled.

--- a/tests/bundles/network_rules_test.go
+++ b/tests/bundles/network_rules_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBundles_BundleOnlyTransactionsAreFilteredOutByTheTxPoolStartingFromBrio(t *testing.T) {
+func TestBundles_BundleOnlyTransactionsAreAcceptedByTxPoolButNeverExecutedStartingFromBrio(t *testing.T) {
 	brioAndBundlesUpgrades := opera.GetBrioUpgrades()
 	brioAndBundlesUpgrades.TransactionBundles = true
 
@@ -81,6 +81,7 @@ func TestBundles_BundleOnlyTransactionsAreFilteredOutByTheTxPoolStartingFromBrio
 			}, sender)
 			require.True(t, bundle.IsBundleOnly(bundleOnlyTx))
 
+			// The pool should accept the bundle-only transaction, even if brio is enabled.
 			txHash, err := net.Send(bundleOnlyTx)
 			require.NoError(t, err)
 			if test.processed {


### PR DESCRIPTION
This PR adds an integration test to ensure bundle only transactions do not have any effect starting from Brio.