### PR TITLE
Process sponsored transactions as regular transactions during replay

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -273,7 +273,7 @@ func runTransaction(
 			return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid
 		}
 	}
-	if context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
+	if !context.forReplay && context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
 		res, result := context.runner.runSponsoredTransaction(context, tx, legacyTxIndexOffset, trueTxIndexOffset)
 		return res, result
 	} else {

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -1125,6 +1125,26 @@ func TestRunTransaction_GasSubsidiesEnabled_RunsSponsorshipRequestWithSponsorshi
 	require.Nil(t, processed[0].Receipt)
 }
 
+func TestRunTransaction_GasSubsidiesEnabled_ForReplay_RunsSponsorshipRequestAsRegularTransaction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	runner := NewMock_transactionRunner(ctrl)
+
+	tx := getSponsorshipRequest(t)
+	processed := ProcessedTransaction{
+		Transaction: tx,
+	}
+
+	context := &runContext{
+		runner:    runner,
+		upgrades:  opera.Upgrades{GasSubsidies: true},
+		forReplay: true,
+	}
+	runner.EXPECT().runRegularTransaction(context, tx, 0, 123).Return(processed, core_types.TransactionResultSuccessful)
+	got, status := runTransaction(context, tx, 0, 123)
+	require.Equal(t, []ProcessedTransaction{processed}, got)
+	require.Equal(t, core_types.TransactionResultSuccessful, status)
+}
+
 func TestRunTransactions_GasSubsidiesDisabled_BundlesDisabled_ProcessesAsRegularTransaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	runner := NewMock_transactionRunner(ctrl)

--- a/tests/block_verifiability_utils.go
+++ b/tests/block_verifiability_utils.go
@@ -220,15 +220,10 @@ func (s *State) ApplyBlock(
 		idx.Block(block.NumberU64()),
 	)
 
-	// In verification mode, gas subsidies are disabled to avoid introducing
-	// a second charge for sponsored transactions.
-	upgrades := rules.Upgrades
-	upgrades.GasSubsidies = false
-
 	processor := evmcore.NewStateProcessorForReplay(
 		chainConfig,
 		historyAdapter{history: s.blockHashHistory},
-		upgrades,
+		rules.Upgrades,
 	)
 
 	evmBlock := &evmcore.EvmBlock{
@@ -262,20 +257,6 @@ func (s *State) ApplyBlock(
 		0, // tx index offset
 		nil,
 	).ProcessedTransactions
-
-	if false { // Debug
-		fmt.Printf("block %d: used gas %d / %d\n", block.NumberU64(), usedGas, block.GasUsed())
-		signer := types.LatestSignerForChainID(big.NewInt(int64(rules.NetworkID)))
-		for _, cur := range processed {
-			from, _ := signer.Sender(cur.Transaction)
-			to := cur.Transaction.To()
-			if cur.Receipt != nil {
-				fmt.Printf("  tx %v -> %v, nonce %d (gas used %d)\n", from.Hex(), to.Hex(), cur.Transaction.Nonce(), cur.Receipt.GasUsed)
-			} else {
-				fmt.Printf("  tx %v -> %v, nonce %d (skipped)\n", from.Hex(), to.Hex(), cur.Transaction.Nonce())
-			}
-		}
-	}
 
 	receipts := types.Receipts{}
 	for i, cur := range processed {


### PR DESCRIPTION
Now that the state processor is replay-aware, this information can be used to process sponsored transactions as normal transactions during replay, so that the processing of the sponsored transactions does not introduce a second payment transaction. This then allows to not modify the rules during replay.