### PR TITLE
Add bundle efficiency filter

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -31,6 +31,11 @@ import (
 
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
 
+// MinBundleEfficiency is the minimum efficiency threshold for accepting
+// bundles. The efficiency of a bundle is defined as:
+// sum of usedGas of receipts / total execution cost.
+const MinBundleEfficiency = 0.2
+
 // BundleState represents the current evaluation state of a transaction bundle.
 // It indicates whether the bundle is executable as is, may become executable
 // at a later point or will never be executable. If the bundle is not executable
@@ -403,6 +408,17 @@ func trialRunBundleInternal(
 
 	transactionProcessor := factory.newTransactionProcessor(chain, stateDb, nextBlock)
 	summary := transactionProcessor.Run(0, envelope)
+
+	usedGas := uint64(0)
+	for _, tx := range summary.ProcessedTransactions {
+		if tx.Receipt != nil {
+			usedGas += tx.Receipt.GasUsed
+		}
+	}
+
+	if summary.ExecutionCost == 0 || float64(usedGas)/float64(summary.ExecutionCost) < MinBundleEfficiency {
+		return false
+	}
 
 	// Check if the bundle lead to any accepted transactions. If so, it is
 	// a success, otherwise it is a failure.

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -768,6 +768,11 @@ func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t
 		execCost     core_types.ExecutionCost
 		expectAccept bool
 	}{
+		"below threshold with empty bundle": {
+			processedTxs: []ProcessedTransaction{},
+			execCost:     core_types.ExecutionCost(0),
+			expectAccept: false,
+		},
 		"below threshold with no receipts": {
 			processedTxs: []ProcessedTransaction{},
 			execCost:     core_types.ExecutionCost(100),

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -762,6 +762,79 @@ func Test_trialRunBundle_DoesRunTransactionsThroughEVMAndReturnsIfTransactionsGo
 	}
 }
 
+func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t *testing.T) {
+	tests := map[string]struct {
+		processedTxs []ProcessedTransaction
+		execCost     core_types.ExecutionCost
+		expectAccept bool
+	}{
+		"below threshold with no receipts": {
+			processedTxs: []ProcessedTransaction{},
+			execCost:     core_types.ExecutionCost(100),
+			expectAccept: false,
+		},
+		"below threshold with single receipt": {
+			processedTxs: []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 19}}},
+			execCost:     core_types.ExecutionCost(100),
+			expectAccept: false,
+		},
+		"below threshold with multiple receipts": {
+			processedTxs: []ProcessedTransaction{
+				{Receipt: &types.Receipt{GasUsed: 9}},
+				{Receipt: &types.Receipt{GasUsed: 10}},
+			},
+			execCost:     core_types.ExecutionCost(100),
+			expectAccept: false,
+		},
+		"above threshold with single receipt": {
+			processedTxs: []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 21}}},
+			execCost:     core_types.ExecutionCost(100),
+			expectAccept: true,
+		},
+		"above threshold with multiple receipts": {
+			processedTxs: []ProcessedTransaction{
+				{Receipt: &types.Receipt{GasUsed: 10}},
+				{Receipt: &types.Receipt{GasUsed: 11}},
+			},
+			execCost:     core_types.ExecutionCost(100),
+			expectAccept: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			envelope := types.NewTx(&types.LegacyTx{})
+
+			chainState := NewMockChainStateForBundleEval(ctrl)
+			chainState.EXPECT().GetLatestHeader().Return(&EvmHeader{
+				Number: big.NewInt(0),
+			})
+
+			any := gomock.Any()
+
+			processor := NewMocktransactionProcessor(ctrl)
+			processor.EXPECT().Run(any, any).Return(
+				ProcessSummary{
+					ProcessedTransactions: tc.processedTxs,
+					ExecutionCost:         tc.execCost,
+				},
+			)
+
+			factory := NewMocktransactionProcessorFactory(ctrl)
+			factory.EXPECT().newTransactionProcessor(any, any, any).Return(processor)
+
+			db := state.NewMockStateDB(ctrl)
+			db.EXPECT().InterTxSnapshot()
+			db.EXPECT().RevertToInterTxSnapshot(any)
+
+			got := trialRunBundleInternal(envelope, chainState, db, factory, rand.Read)
+			require.Equal(t, tc.expectAccept, got)
+		})
+	}
+}
+
 func Test_trialRunBundle_UsesRandomPrevRandaoValue(t *testing.T) {
 	// This test verifies that the trialRunBundle function indeed uses a random
 	// source for determining PrevRandao values. It does so by running code
@@ -1045,7 +1118,7 @@ func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.
 			expectedResult: false,
 		},
 		"single result with receipt": {
-			processedTxs:   []ProcessedTransaction{{Receipt: &types.Receipt{}}},
+			processedTxs:   []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 1}}},
 			expectedResult: true,
 		},
 		"multiple results without receipt": {
@@ -1053,7 +1126,7 @@ func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.
 			expectedResult: false,
 		},
 		"multiple results with some receipt": {
-			processedTxs:   []ProcessedTransaction{{}, {Receipt: &types.Receipt{}}, {}},
+			processedTxs:   []ProcessedTransaction{{}, {Receipt: &types.Receipt{GasUsed: 1}}, {}},
 			expectedResult: true,
 		},
 	}
@@ -1075,6 +1148,7 @@ func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.
 			processor := NewMocktransactionProcessor(ctrl)
 			processor.EXPECT().Run(any, any).Return(ProcessSummary{
 				ProcessedTransactions: tc.processedTxs,
+				ExecutionCost:         1,
 			})
 
 			factory := NewMocktransactionProcessorFactory(ctrl)

--- a/tests/bundles/bundle_efficiency_test.go
+++ b/tests/bundles/bundle_efficiency_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package bundles
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundle_BundlesWithTooLowEfficiencyAreRejected(t *testing.T) {
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	signer := types.LatestSignerForChainID(net.GetChainId())
+
+	// Bundle structure: OneOf(AllOf(invalidTx1, ..., invalidTxN), validTx))
+	// The invalid transactions are wrapped in an AllOf step, so their state
+	// changes are reverted and there are no receipts for them, but their gas
+	// cost is still counted toward the bundle execution cost.
+	// The outer OneOf keeps executing the steps because they are all invalid,
+	// until the last step with the valid transaction is executed, which
+	// produces a successful receipt. The bundle is then accepted or rejected
+	// based on the overall efficiency, which depends on the number of invalid
+	// transactions.
+	cases := map[string]struct {
+		InvalidTxCount       int
+		ExpectBelowThreshold bool
+	}{
+		"Bundle with too low efficiency": {
+			InvalidTxCount:       10,
+			ExpectBelowThreshold: true,
+		},
+		"Bundle with efficiency above threshold": {
+			InvalidTxCount:       1,
+			ExpectBelowThreshold: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			senders := tests.MakeAccountsWithBalance(t, net, tc.InvalidTxCount+1, big.NewInt(1e18))
+
+			blockNumber, err := client.BlockNumber(t.Context())
+			require.NoError(t, err)
+
+			steps := make([]bundle.BuilderStep, 0, tc.InvalidTxCount+1)
+			for i := range tc.InvalidTxCount {
+				// The invalid transactions need to pass the pre-execution
+				// checks, in order to count towards the execution cost.
+				steps = append(steps, bundle.AllOf(Step(t, net, senders[i], &types.AccessListTx{
+					Data: []byte{0xfe}, // INVALID opcode as init code
+					Gas:  60_000,
+				})))
+			}
+			// The valid transaction.
+			steps = append(steps, Step(t, net, senders[tc.InvalidTxCount], &types.AccessListTx{}))
+
+			envelope, bundle, _ := bundle.NewBuilder().
+				WithSigner(signer).
+				SetEarliest(blockNumber).
+				With(bundle.OneOf(steps...)).
+				BuildEnvelopeBundleAndPlan()
+
+			execGas := uint64(0)
+			for _, tx := range bundle.GetTransactionsInReferencedOrder() {
+				execGas += tx.Gas()
+			}
+			usedGas := bundle.GetTransactionsInReferencedOrder()[tc.InvalidTxCount].Gas()
+
+			if tc.ExpectBelowThreshold {
+				require.Less(t, float64(usedGas)/float64(execGas), evmcore.MinBundleEfficiency)
+				_, err = net.Send(envelope)
+				require.ErrorContains(t, err, "bundle trial-run failed")
+			} else {
+				require.GreaterOrEqual(t, float64(usedGas)/float64(execGas), evmcore.MinBundleEfficiency)
+				_, err = net.Send(envelope)
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/bundles/bundle_efficiency_test.go
+++ b/tests/bundles/bundle_efficiency_test.go
@@ -78,7 +78,7 @@ func TestBundle_BundlesWithTooLowEfficiencyAreRejected(t *testing.T) {
 			// The valid transaction.
 			steps = append(steps, Step(t, net, senders[tc.InvalidTxCount], &types.AccessListTx{}))
 
-			envelope, bundle, _ := bundle.NewBuilder().
+			envelope, bundle, plan := bundle.NewBuilder().
 				WithSigner(signer).
 				SetEarliest(blockNumber).
 				With(bundle.OneOf(steps...)).
@@ -98,6 +98,21 @@ func TestBundle_BundlesWithTooLowEfficiencyAreRejected(t *testing.T) {
 				require.GreaterOrEqual(t, float64(usedGas)/float64(execGas), evmcore.MinBundleEfficiency)
 				_, err = net.Send(envelope)
 				require.NoError(t, err)
+
+				// Wait for the bundle to be processed.
+				info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
+				require.NoError(t, err)
+
+				bundleTxs := bundle.GetTransactionsInReferencedOrder()
+				blockTxsHashes := getBlockTxsHashes(t, client, big.NewInt(info.Block.Int64()))
+
+				successfulTxHash := bundleTxs[tc.InvalidTxCount].Hash()
+				require.EqualValues(t, info.Count, 1)
+				require.Contains(t, blockTxsHashes, successfulTxHash)
+
+				receipt, err := client.TransactionReceipt(t.Context(), successfulTxHash)
+				require.NoError(t, err)
+				require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
 			}
 		})
 	}

--- a/tests/bundles/bundle_execution_flags_test.go
+++ b/tests/bundles/bundle_execution_flags_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/tests/contracts/add"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
@@ -209,8 +210,18 @@ func TestBundle_AllOfGroupSucceedsIfAllStepsTolerated(t *testing.T) {
 	senders := tests.MakeAccountsWithBalance(t, net, 4, big.NewInt(1e18))
 
 	revertAddress, revertInput := tests.MustDeployRevertContractAndGetMethodCallParameters(t, net)
+	addContractAddr := tests.MustDeployContract(t, net, add.DeployAdd)
+	addContractInput := tests.MustGetMethodParameters(
+		t, add.AddMetaData, "add", big.NewInt(10_000),
+	)
 
 	successfulTx := types.AccessListTx{}
+	// The last successful transaction needs to be expensive enough for the
+	// bundle to pass the efficiency check.
+	successfulExpensiveTx := types.AccessListTx{
+		To:   &addContractAddr,
+		Data: addContractInput,
+	}
 	failingTx := types.AccessListTx{
 		To:   &revertAddress,
 		Gas:  1_000_000,
@@ -283,7 +294,7 @@ func TestBundle_AllOfGroupSucceedsIfAllStepsTolerated(t *testing.T) {
 						).WithFlags(bundle.EF_TolerateFailed),
 						// This tx is needed to produce observable results
 						// in case the group under test was not tolerated
-						Step(t, net, senders[3], &successfulTx),
+						Step(t, net, senders[3], &successfulExpensiveTx),
 					),
 				).
 				BuildEnvelopeBundleAndPlan()
@@ -332,8 +343,19 @@ func TestBundle_OneOfGroupSucceedsOnFirstToleratedStep(t *testing.T) {
 	senders := tests.MakeAccountsWithBalance(t, net, 3, big.NewInt(1e18))
 
 	revertAddress, revertInput := tests.MustDeployRevertContractAndGetMethodCallParameters(t, net)
+	addContractAddr := tests.MustDeployContract(t, net, add.DeployAdd)
+	addContractInput := tests.MustGetMethodParameters(
+		t, add.AddMetaData, "add", big.NewInt(10_000),
+	)
 
 	successfulTx := types.AccessListTx{}
+	// The last successful transaction needs to be expensive enough for the
+	// bundle to pass the efficiency check.
+	successfulExpensiveTx := types.AccessListTx{
+		To:   &addContractAddr,
+		Data: addContractInput,
+	}
+
 	failingTx := types.AccessListTx{
 		To:   &revertAddress,
 		Gas:  1_000_000,
@@ -409,7 +431,7 @@ func TestBundle_OneOfGroupSucceedsOnFirstToleratedStep(t *testing.T) {
 						Step(t, net, senders[0], &c.firstTx),
 						Step(t, net, senders[1], &c.secondTx),
 					).WithFlags(flags),
-					Step(t, net, senders[2], &successfulTx),
+					Step(t, net, senders[2], &successfulExpensiveTx),
 				).
 				BuildEnvelopeBundleAndPlan()
 

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -108,27 +108,42 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 	accounts := tests.MakeAccountsWithBalance(t, net, B*3, big.NewInt(1e18))
 
 	cases := map[string]struct {
-		contractAddr  common.Address
-		contractInput []byte
+		contractAddr       common.Address
+		contractInputLarge []byte
+		contractInputSmall []byte
 	}{
 		"ComputeHeavy": {
 			contractAddr: tests.MustDeployContract(t, net, add.DeployAdd),
-			contractInput: tests.MustGetMethodParameters(
+			// 128_000 iterations is about the maximum number of iterations
+			// that can be executed within the block gas limit. They have to be
+			// split between the rolled back and the successful transaction to
+			// pass the efficiency check.
+			contractInputLarge: tests.MustGetMethodParameters(
 				t, add.AddMetaData, "add",
-				// arguments: iter (128_000 iterations is about the maximum
-				// number of iterations that can be executed within the
-				// block gas limit)
-				big.NewInt(128_000),
+				// arguments: iter
+				big.NewInt(100_000),
+			),
+			contractInputSmall: tests.MustGetMethodParameters(
+				t, add.AddMetaData, "add",
+				// arguments: iter
+				big.NewInt(28_000),
 			),
 		},
 		"DbHeavy": {
 			contractAddr: tests.MustDeployContract(t, net, store.DeployStore),
-			contractInput: tests.MustGetMethodParameters(
+			// 1100 slots is about the maximum number of slots that can be
+			// filled within the block gas limit. They have to be split between
+			// the rolled back and the successful transaction to pass the
+			// efficiency check.
+			contractInputLarge: tests.MustGetMethodParameters(
 				t, store.StoreMetaData, "fill",
-				// arguments: from, until, value (1100 slots is about the
-				// maximum number of slots that can be filled within the
-				// block gas limit)
-				big.NewInt(0), big.NewInt(1100), big.NewInt(1),
+				// arguments: from, until, value
+				big.NewInt(0), big.NewInt(800), big.NewInt(1),
+			),
+			contractInputSmall: tests.MustGetMethodParameters(
+				t, store.StoreMetaData, "fill",
+				// arguments: from, until, value
+				big.NewInt(0), big.NewInt(300), big.NewInt(1),
 			),
 		},
 	}
@@ -146,11 +161,14 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 						bundle.AllOf(
 							Step(t, net, accounts[i*3], &types.AccessListTx{
 								To:   &tc.contractAddr,
-								Data: tc.contractInput,
+								Data: tc.contractInputLarge,
 							}),
 							Step(t, net, accounts[i*3+1], &types.AccessListTx{Gas: 1}),
 						).WithFlags(bundle.EF_TolerateFailed),
-						Step(t, net, accounts[i*3+2], &types.AccessListTx{}),
+						Step(t, net, accounts[i*3+2], &types.AccessListTx{
+							To:   &tc.contractAddr,
+							Data: tc.contractInputSmall,
+						}),
 					).
 					BuildEnvelopeBundleAndPlan()
 


### PR DESCRIPTION
This PR implements a bundle efficiency filter, to reject bundles which consume a lot of gas in the state processor, but only little gas in the transactions that make it into the block. This is needed as a protection against DoS attacks, because the gas pool is captured in the snapshots of the state processor, and therefore rolled back parts of a bundle are not captured by it.

Depends on https://github.com/0xsoniclabs/sonic/pull/940