### PR TITLE
Simplify dry runner and fix missclassification

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -183,79 +183,32 @@ func checkForNonceConflicts(
 	signer types.Signer,
 	nonceSource NonceSource,
 ) BundleState {
-	// We start by collecting the lowest nonces referenced for each sender in
-	// the bundle.
-	lowest, err := getLowestReferencedNonces(txBundle, signer)
-	if err != nil {
-		// If we fail to derive the lowest referenced nonces, it means that the
-		// bundle is malformed (e.g., contains invalid transactions) and we can
-		// consider it as non-executable.
-		return makePermanentlyBlockedState(
-			fmt.Sprintf("could not get lowest nonce for all accounts: %v", err))
+
+	// Step 1: run with current nonces to check whether the bundle is ready to
+	// run right now. The runner does not allow nonce-gaps.
+	strictRunner := &dryRunner{
+		signer:       signer,
+		nonceTracker: &nonceTracker{source: nonceSource},
+	}
+	if bundle.RunBundle(txBundle, strictRunner) {
+		return makeRunnableState()
 	}
 
-	// We correct the lowest nonces to be at least as high as the current nonces
-	// for each sender. Lower nonces are no longer available.
-	for sender, lowestNonce := range lowest {
-		lowest[sender] = max(lowestNonce, nonceSource.GetNonce(sender))
+	// Step 2: check with future nonces, to check whether the bundle may become
+	// executable in the future. The runner allows nonce-gaps.
+	looseRunner := &dryRunner{
+		signer:       signer,
+		nonceTracker: &nonceTracker{source: nonceSource},
+		allowGaps:    true, // for each account, a future nonce may be chosen once
+	}
+	if bundle.RunBundle(txBundle, looseRunner) {
+		return makeTemporaryBlockedState("gapped nonce")
 	}
 
-	// With those lowest nonces as a start, we attempt to run the bundle.
-	runner := &dryRunner{
-		signer:         signer,
-		nonceTracker:   &nonceTracker{nonces: maps.Clone(lowest)},
-		acceptedSender: make(map[common.Address]struct{}),
-	}
-
-	// If this execution failed, the bundle is non-executable.
-	if success := bundle.RunBundle(txBundle, runner); !success {
-		return makePermanentlyBlockedState("bundle nonce check execution failed")
-	}
-
-	// If it succeeded, it depends on whether there is a gap between the lowest
-	// and the current nonces for any sender of an accepted transaction.
-	for sender := range runner.acceptedSender {
-		if nonceSource.GetNonce(sender) < lowest[sender] {
-			return makeTemporaryBlockedState("gapped nonce")
-		}
-	}
-	return makeRunnableState()
-}
-
-// getLowestReferencedNonces returns the lowest nonce referenced for each sender
-// in the bundle. If the bundle is malformed (e.g., contains invalid signatures)
-// an error is returned.
-func getLowestReferencedNonces(
-	txBundle *bundle.TransactionBundle,
-	signer types.Signer,
-) (map[common.Address]uint64, error) {
-	res := make(map[common.Address]uint64)
-	for _, tx := range txBundle.Transactions {
-		if bundle.IsEnvelope(tx) {
-			bundle, err := bundle.OpenEnvelope(signer, tx)
-			if err != nil {
-				return nil, fmt.Errorf("invalid nested bundle: %w", err)
-			}
-			innerRes, err := getLowestReferencedNonces(&bundle, signer)
-			if err != nil {
-				return nil, err
-			}
-			for addr, nonce := range innerRes {
-				if existingNonce, ok := res[addr]; !ok || nonce < existingNonce {
-					res[addr] = nonce
-				}
-			}
-		} else {
-			sender, err := types.Sender(signer, tx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to derive sender: %w", err)
-			}
-			if nonce, ok := res[sender]; !ok || tx.Nonce() < nonce {
-				res[sender] = tx.Nonce()
-			}
-		}
-	}
-	return res, nil
+	// Step 3: if it is still not successful, it means that there are nonce
+	// conflicts that can not be resolved by waiting for other transactions to
+	// be executed, and we can consider the bundle as non-executable.
+	return makePermanentlyBlockedState("bundle nonce check execution failed")
 }
 
 // dryRunner is an implementation of the TransactionRunner interface enabling
@@ -266,14 +219,14 @@ func getLowestReferencedNonces(
 // It is only to be used by the checkForNonceConflicts function, which performs
 // the proper lifecycle management of the dryRunner.
 type dryRunner struct {
-	signer         types.Signer
-	nonceTracker   *nonceTracker
-	acceptedSender map[common.Address]struct{}
-	undo           []func()
+	signer       types.Signer
+	nonceTracker *nonceTracker
+	allowGaps    bool
+	nonceUsed    map[common.Address]struct{}
+	undo         []func()
 }
 
 func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
-
 	// if the transaction is a nested bundle, process it as such
 	if bundle.IsEnvelope(tx) {
 		txBundle, err := bundle.OpenEnvelope(r.signer, tx)
@@ -293,27 +246,41 @@ func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
 	if err != nil {
 		return core_types.TransactionResultInvalid
 	}
+	if r.allowGaps && r.nonceUsed == nil {
+		r.nonceUsed = make(map[common.Address]struct{})
+	}
+
+	got := tx.Nonce()
 	want := r.nonceTracker.getNonce(sender)
-	if tx.Nonce() < want {
+	if got != want {
+		// If gaps are allowed, we can skip over one nonce gap for each account.
+		if got > want && r.allowGaps {
+			if _, found := r.nonceUsed[sender]; !found {
+				r.nonceUsed[sender] = struct{}{}
+				r.nonceTracker.setNonce(sender, got+1)
+				return core_types.TransactionResultSuccessful
+			}
+		}
 		return core_types.TransactionResultInvalid
 	}
-	if tx.Nonce() > want {
-		return core_types.TransactionResultInvalid
+
+	// This account has used the first nonce now, no more gaps allowed for it.
+	if r.allowGaps {
+		r.nonceUsed[sender] = struct{}{}
 	}
 
 	// if there are no nonce conflicts, consume the nonce for the sender and
 	// continue with the next transaction in the bundle
-	r.nonceTracker.consumeNonce(sender)
-	r.acceptedSender[sender] = struct{}{}
+	r.nonceTracker.setNonce(sender, got+1)
 	return core_types.TransactionResultSuccessful
 }
 
 func (r *dryRunner) CreateSnapshot() int {
-	acceptedBackup := maps.Clone(r.acceptedSender)
 	nonceBackup := r.nonceTracker.backup()
+	nonceUsedBackup := maps.Clone(r.nonceUsed)
 	r.undo = append(r.undo, func() {
 		r.nonceTracker.restore(nonceBackup)
-		r.acceptedSender = acceptedBackup
+		r.nonceUsed = nonceUsedBackup
 	})
 	return len(r.undo) - 1
 }
@@ -328,26 +295,36 @@ func (r *dryRunner) RevertToSnapshot(id int) {
 }
 
 // nonceTracker is keeping track of consumed nonces during the execution of a
-// bundle, recording the lowest required nonce per account.
+// bundle in dry-run mode. It allows to check for nonce conflicts without having
+// to trial-run the bundle on the EVM.
 type nonceTracker struct {
-	nonces map[common.Address]uint64
+	source NonceSource
+	nonces map[common.Address]uint64 // overrides
 }
 
 func (t *nonceTracker) getNonce(addr common.Address) uint64 {
-	return t.nonces[addr]
+	if nonce, ok := t.nonces[addr]; ok {
+		return nonce
+	}
+	return t.source.GetNonce(addr)
 }
 
-func (t *nonceTracker) consumeNonce(addr common.Address) {
-	t.nonces[addr]++
+func (t *nonceTracker) setNonce(addr common.Address, nonce uint64) {
+	if t.nonces == nil {
+		t.nonces = make(map[common.Address]uint64)
+	}
+	t.nonces[addr] = nonce
 }
 
 func (t *nonceTracker) backup() *nonceTracker {
 	return &nonceTracker{
+		source: t.source,
 		nonces: maps.Clone(t.nonces),
 	}
 }
 
 func (t *nonceTracker) restore(backup *nonceTracker) {
+	t.source = backup.source
 	t.nonces = backup.nonces
 }
 

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -206,7 +206,7 @@ func checkForNonceConflicts(
 	}
 
 	// Step 3: if it is still not successful, it means that there are nonce
-	// conflicts that can not be resolved by waiting for other transactions to
+	// conflicts that cannot be resolved by waiting for other transactions to
 	// be executed, and we can consider the bundle as non-executable.
 	return makePermanentlyBlockedState("bundle nonce check execution failed")
 }
@@ -222,7 +222,7 @@ type dryRunner struct {
 	signer       types.Signer
 	nonceTracker *nonceTracker
 	allowGaps    bool
-	nonceUsed    map[common.Address]struct{}
+	nonceLocked  map[common.Address]struct{}
 	undo         []func()
 }
 
@@ -246,8 +246,8 @@ func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
 	if err != nil {
 		return core_types.TransactionResultInvalid
 	}
-	if r.allowGaps && r.nonceUsed == nil {
-		r.nonceUsed = make(map[common.Address]struct{})
+	if r.allowGaps && r.nonceLocked == nil {
+		r.nonceLocked = make(map[common.Address]struct{})
 	}
 
 	got := tx.Nonce()
@@ -255,8 +255,8 @@ func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
 	if got != want {
 		// If gaps are allowed, we can skip over one nonce gap for each account.
 		if got > want && r.allowGaps {
-			if _, found := r.nonceUsed[sender]; !found {
-				r.nonceUsed[sender] = struct{}{}
+			if _, found := r.nonceLocked[sender]; !found {
+				r.nonceLocked[sender] = struct{}{}
 				r.nonceTracker.setNonce(sender, got+1)
 				return core_types.TransactionResultSuccessful
 			}
@@ -266,7 +266,7 @@ func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
 
 	// This account has used the first nonce now, no more gaps allowed for it.
 	if r.allowGaps {
-		r.nonceUsed[sender] = struct{}{}
+		r.nonceLocked[sender] = struct{}{}
 	}
 
 	// if there are no nonce conflicts, consume the nonce for the sender and
@@ -277,10 +277,10 @@ func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
 
 func (r *dryRunner) CreateSnapshot() int {
 	nonceBackup := r.nonceTracker.backup()
-	nonceUsedBackup := maps.Clone(r.nonceUsed)
+	nonceLockedBackup := maps.Clone(r.nonceLocked)
 	r.undo = append(r.undo, func() {
 		r.nonceTracker.restore(nonceBackup)
-		r.nonceUsed = nonceUsedBackup
+		r.nonceLocked = nonceLockedBackup
 	})
 	return len(r.undo) - 1
 }
@@ -306,7 +306,9 @@ func (t *nonceTracker) getNonce(addr common.Address) uint64 {
 	if nonce, ok := t.nonces[addr]; ok {
 		return nonce
 	}
-	return t.source.GetNonce(addr)
+	nonce := t.source.GetNonce(addr)
+	t.setNonce(addr, nonce)
+	return nonce
 }
 
 func (t *nonceTracker) setNonce(addr common.Address, nonce uint64) {

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"slices"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
@@ -410,9 +409,17 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 			bundle: allOf(0, 1, 2),
 			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
 		},
+		"multiple all-of with too old and too new nonces": {
+			bundle: allOf(0, 2),
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
+		},
 		"multiple one-of with old nonce": {
 			bundle: oneOf(0, 1, 2),
 			result: makeRunnableState(),
+		},
+		"multiple one-of with too old and too new nonces": {
+			bundle: oneOf(0, 2),
+			result: makeTemporaryBlockedState("gapped nonce"),
 		},
 		"all-of with nonce gap": {
 			bundle: allOf(1, 3),
@@ -463,6 +470,14 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 			bundle: oneOf(0xA0, 0xB1),
 			result: makeRunnableState(),
 		},
+		"one-of with distinct future nonce options": {
+			bundle: oneOf(allOf(2, 3), allOf(4, 5)),
+			result: makeTemporaryBlockedState("gapped nonce"),
+		},
+		"one-of with distinct future nonce gaps": {
+			bundle: oneOf(allOf(2, 4), allOf(4, 6)),
+			result: makePermanentlyBlockedState("bundle nonce check execution failed"),
+		},
 	}
 
 	keys, senders := createKeys(t)
@@ -475,7 +490,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 
 			source := NewMockNonceSource(ctrl)
 			for _, sender := range senders {
-				source.EXPECT().GetNonce(sender).Return(uint64(initialNonce)).MaxTimes(2)
+				source.EXPECT().GetNonce(sender).Return(uint64(initialNonce)).AnyTimes()
 			}
 
 			envelope := test.bundle.toBundle(keys)
@@ -488,133 +503,13 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 	}
 }
 
-func Test_checkForNonceConflicts_LowestReferencedNoncesCannotBeDerived_ReturnsNonExecutable(t *testing.T) {
-	invalidTx := types.NewTx(&types.LegacyTx{})
-	bundle := &bundle.TransactionBundle{
-		Transactions: map[bundle.TxReference]*types.Transaction{
-			{}: invalidTx,
-		},
-	}
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-	_, err := getLowestReferencedNonces(bundle, signer)
-	require.Error(t, err)
-
-	got := checkForNonceConflicts(bundle, signer, nil)
-	require.Equal(t, got, makePermanentlyBlockedState("could not get lowest nonce for all accounts: failed to derive sender: invalid transaction v, r, s values"))
-}
-
-func Test_getLowestReferencedNonces_ReturnsLowestNoncesInBundle(t *testing.T) {
-
-	tests := map[string]struct {
-		bundle   pattern
-		expected map[int]uint64
-	}{
-		"empty bundle": {
-			bundle:   allOf(),
-			expected: map[int]uint64{},
-		},
-		"single transaction": {
-			bundle:   allOf(0xA1),
-			expected: map[int]uint64{0xA: 1},
-		},
-		"multiple transactions from same sender": {
-			bundle:   allOf(0xA2, 0xA1, 0xA3),
-			expected: map[int]uint64{0xA: 1},
-		},
-		"multiple transactions from different senders": {
-			bundle:   allOf(0xA2, 0xB3, 0xA1, 0xB4),
-			expected: map[int]uint64{0xA: 1, 0xB: 3},
-		},
-		"nested bundles": {
-			bundle:   allOf(0xA2, oneOf(0xB3, 0xB4), allOf(0xA1, 0xA3)),
-			expected: map[int]uint64{0xA: 1, 0xB: 3},
-		},
-	}
-
-	keys, senders := createKeys(t)
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			chainId := big.NewInt(1)
-			signer := types.LatestSignerForChainID(chainId)
-
-			envelope := test.bundle.toBundle(keys)
-			bundle, _, err := bundle.ValidateEnvelope(signer, envelope)
-			require.NoError(t, err)
-
-			lowest, err := getLowestReferencedNonces(bundle, signer)
-			require.NoError(t, err)
-
-			got := make(map[int]uint64)
-			for addr, nonce := range lowest {
-				got[slices.Index(senders, addr)] = nonce
-			}
-			require.Equal(t, test.expected, got)
-		})
-	}
-}
-
-func Test_getLowestReferencedNonces_ReturnsIfSenderCannotBeDerived(t *testing.T) {
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-	bundle := bundle.TransactionBundle{
-		// Add a transaction with a missing signature.
-		Transactions: map[bundle.TxReference]*types.Transaction{
-			{}: types.NewTx(&types.LegacyTx{}),
-		},
-	}
-	_, err := getLowestReferencedNonces(&bundle, signer)
-	require.ErrorContains(t, err, "failed to derive sender")
-}
-
-func Test_getLowestReferencedNonces_DetectsInvalidNestedBundle(t *testing.T) {
-	require := require.New(t)
-	invalidBundle := types.NewTx(&types.LegacyTx{To: &bundle.BundleProcessor})
-	require.True(bundle.IsEnvelope(invalidBundle))
-
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-	_, _, err := bundle.ValidateEnvelope(signer, invalidBundle)
-	require.Error(err)
-
-	bundle := bundle.TransactionBundle{
-		Transactions: map[bundle.TxReference]*types.Transaction{
-			{}: invalidBundle,
-		},
-	}
-	_, err = getLowestReferencedNonces(&bundle, signer)
-	require.ErrorContains(err, "invalid nested bundle")
-}
-
-func Test_getLowestReferencedNonces_ReportsErrorWhileObtainingNoncesOfNestedBundles(t *testing.T) {
-	require := require.New(t)
-	invalidInner := types.NewTx(&types.LegacyTx{To: &bundle.BundleProcessor})
-	require.True(bundle.IsEnvelope(invalidInner))
-
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-	_, _, err := bundle.ValidateEnvelope(signer, invalidInner)
-	require.Error(err)
-
-	key, err := crypto.GenerateKey()
-	require.NoError(err)
-
-	middle := bundle.NewBuilder().
-		With(bundle.Step(key, invalidInner)).
-		Build()
-
-	outer, _ := bundle.NewBuilder().
-		With(bundle.Step(key, middle)).
-		BuildBundleAndPlan()
-
-	_, err = getLowestReferencedNonces(outer, signer)
-	require.ErrorContains(err, "invalid nested bundle")
-}
-
 func Test_runner_Run_ReturnsErrorForInvalidNestedBundle(t *testing.T) {
 	require := require.New(t)
 	invalidBundle := types.NewTx(&types.LegacyTx{To: &bundle.BundleProcessor})
 	require.True(bundle.IsEnvelope(invalidBundle))
 
 	runner := &dryRunner{
-		signer:         types.LatestSignerForChainID(big.NewInt(1)),
-		acceptedSender: make(map[common.Address]struct{}),
+		signer: types.LatestSignerForChainID(big.NewInt(1)),
 	}
 
 	result := runner.Run(invalidBundle)
@@ -624,8 +519,7 @@ func Test_runner_Run_ReturnsErrorForInvalidNestedBundle(t *testing.T) {
 func Test_runner_Run_ReturnsInvalidForTransactionsWithoutSignature(t *testing.T) {
 	tx := types.NewTx(&types.LegacyTx{})
 	runner := &dryRunner{
-		signer:         types.LatestSignerForChainID(big.NewInt(1)),
-		acceptedSender: make(map[common.Address]struct{}),
+		signer: types.LatestSignerForChainID(big.NewInt(1)),
 	}
 
 	result := runner.Run(tx)


### PR DESCRIPTION
This PR simplifies the implementation of the dry-runner by performing two dry-run iterations instead of one:
- the first checks whether the current nonces would be fine for the bundle
- the second checks whether any future nonces would be fine for the bundle

This simplifies the overall code structure, removes complexity, and fixes https://github.com/0xsoniclabs/sonic-admin/issues/742