### PR TITLE
DoEstimateGas reports cancelled error reason

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -1204,8 +1204,10 @@ func DoCall(
 	}
 
 	// If the timer caused an abort, return an appropriate error message
-	if evm.Cancelled() {
+	if evm.Cancelled() && timeout > 0 {
 		return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
+	} else if evm.Cancelled() {
+		return nil, fmt.Errorf("execution aborted, (reason: %v)", ctx.Err())
 	}
 	if err != nil {
 		return result, fmt.Errorf("err: %w (supplied gas %d)", err, msg.GasLimit)

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -1204,10 +1204,8 @@ func DoCall(
 	}
 
 	// If the timer caused an abort, return an appropriate error message
-	if evm.Cancelled() && timeout > 0 {
-		return nil, fmt.Errorf("execution aborted (timeout = %v)", timeout)
-	} else if evm.Cancelled() {
-		return nil, fmt.Errorf("execution aborted, (reason: %v)", ctx.Err())
+	if evm.Cancelled() {
+		return nil, fmt.Errorf("execution aborted (reason: %v, timeout: %v)", ctx.Err(), timeout)
 	}
 	if err != nil {
 		return result, fmt.Errorf("err: %w (supplied gas %d)", err, msg.GasLimit)


### PR DESCRIPTION
When `DoCall` is called with `timeout` parameter set to `0`, it uses a context without timeout. In the case of a cancelled context it assumed it was a timeout and printed the timeout parameter, instead of the error. This changes make it so that if the timeout parameters was not zero, then it is printed, otherwise the reason for the context cancellation is printed. 
This change allows for better error reporting in a flaky test.
