### PR TITLE
Upgrade go version to 1.26

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Golang dependency
         uses: actions/setup-go@v3
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Static lints
         run: make lint

--- a/CI/Dockerfile.jenkins
+++ b/CI/Dockerfile.jenkins
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 
 # Install dependencies and keep image small as described in best practices
 # https://docs.docker.com/build/building/best-practices/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker run --name sonic1 --entrypoint sonictool sonic --datadir=/var/sonic genesis fake 1
 # docker run --volumes-from sonic1 -p 5050:5050 -p 5050:5050/udp -p 18545:18545 sonic --fakenet 1/1 --http --http.addr=0.0.0.0
 
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 RUN apt-get update && apt-get install -y git musl-dev make
 
@@ -17,7 +17,7 @@ RUN go mod download
 RUN make all
 
 
-FROM golang:1.25
+FROM golang:1.26
 
 COPY --from=builder /go/Sonic/build/sonicd /usr/local/bin/
 COPY --from=builder /go/Sonic/build/sonictool /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ EVM-compatible chain secured by the Lachesis consensus algorithm.
 
 ## Building the source
 
-Building Sonic requires both a Go (version 1.25 or later) and a C compiler. You can install
+Building Sonic requires both a Go (version 1.26 or later) and a C compiler. You can install
 them using your favourite package manager. Once the dependencies are installed, run:
 
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@
 
 module github.com/0xsoniclabs/sonic
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4


### PR DESCRIPTION
This PR upgrades go version to 1.26 in:

- github workflows test
- CI Dockerfile
- Docker file
- go mod of the repo
- readme required version. 