### PR TITLE
Use `Fprintf` instead of `WriteString`

### DIFF
--- a/gossip/emitter/single_proposer_protocol_test.go
+++ b/gossip/emitter/single_proposer_protocol_test.go
@@ -545,7 +545,7 @@ func (mask NodeMask) String() string {
 			if builder.Len() > 1 {
 				builder.WriteString(",")
 			}
-			builder.WriteString(fmt.Sprintf("%d", i))
+			fmt.Fprintf(&builder, "%d", i)
 		}
 	}
 	builder.WriteString("}")

--- a/scc/cert/bitset.go
+++ b/scc/cert/bitset.go
@@ -70,7 +70,7 @@ func (b BitSet[T]) String() string {
 		if i > 0 {
 			builder.WriteString(", ")
 		}
-		builder.WriteString(fmt.Sprintf("%v", entry))
+		fmt.Fprintf(&builder, "%v", entry)
 	}
 	builder.WriteString("}")
 	return builder.String()

--- a/scc/committee.go
+++ b/scc/committee.go
@@ -148,15 +148,13 @@ func (c Committee) String() string {
 	result.WriteString("Committee{")
 	for i, m := range c.Members() {
 		key := m.PublicKey.Serialize()
-		result.WriteString(
-			fmt.Sprintf(
-				"%d: 0x%x..%x -> %d, ",
-				i, key[:2], key[len(key)-2:],
-				m.VotingPower,
-			),
+		fmt.Fprintf(&result,
+			"%d: 0x%x..%x -> %d, ",
+			i, key[:2], key[len(key)-2:],
+			m.VotingPower,
 		)
 	}
-	result.WriteString(fmt.Sprintf("Valid: %t}", c.Validate() == nil))
+	fmt.Fprintf(&result, "Valid: %t}", c.Validate() == nil)
 	return result.String()
 }
 

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -171,7 +171,7 @@ func (nm namespaceMap) String() string {
 	var sb strings.Builder
 	sb.WriteString("{\n")
 	for key, innerMap := range nm {
-		sb.WriteString(fmt.Sprintf("  \"%s\": [", key))
+		fmt.Fprintf(&sb, "  \"%s\": [", key)
 		funcs := []string{}
 		for innerKey := range innerMap {
 			funcs = append(funcs, fmt.Sprintf("\"%s\"", innerKey))


### PR DESCRIPTION
The new rule [QF1012](https://staticcheck.dev/docs/checks/#QF1012) has been added to `staticcheck`. In order to update the linter this has to be fixed before.