### PR TITLE
Update golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean:
 
 .PHONY: lint
 lint: 
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1
 	@golangci-lint run ./...
 
 .PHONY: license-check

--- a/gossip/config_test.go
+++ b/gossip/config_test.go
@@ -37,7 +37,7 @@ func TestConfigInstancesAreIndependent(t *testing.T) {
 func checkNoSharedReferences(t *testing.T, a, b interface{}, path string) {
 	va := reflect.ValueOf(a)
 	vb := reflect.ValueOf(b)
-	if va.Kind() == reflect.Ptr || va.Kind() == reflect.Interface {
+	if va.Kind() == reflect.Pointer || va.Kind() == reflect.Interface {
 		if va.IsNil() || vb.IsNil() {
 			return
 		}

--- a/valkeystore/signer_test.go
+++ b/valkeystore/signer_test.go
@@ -80,6 +80,7 @@ func TestSignerAuthority_SignatureMayFail(t *testing.T) {
 	t.Run("with corrupted key", func(t *testing.T) {
 		key, err := crypto.GenerateKey()
 		require.NoError(t, err)
+		//nolint:staticcheck // SA1019: key.D has been deprecated but remains the only way to corrupt the key for testing
 		key.D = big.NewInt(0) // corrupt the key by setting D to zero
 		corruptedKey := encryption.PrivateKey{Decoded: key}
 


### PR DESCRIPTION
This PR updates golangci-lint to version 2.12.1 (the current latest). 
This PR also fixes 2 single occurrence issues (an alias rename and a `nolint` for a test)