### PR TITLE
Restrict data returned by OnNewLog call

### DIFF
--- a/evmcore/core_types/log.go
+++ b/evmcore/core_types/log.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package core_types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Log is a reduced version of types.Log that only includes the fields covered
+// by the consensus. In particular, it does not include the transaction index,
+// block hash, block number, or log index.
+type Log struct {
+	// address of the contract that generated the event
+	Address common.Address
+	// list of topics provided by the contract.
+	Topics []common.Hash
+	// supplied by the contract, usually ABI-encoded
+	Data []byte
+}
+
+// CoreLogFromGethLog converts a types.Log from the go-ethereum library to a
+// core_types.Log used internally in Sonic.
+func CoreLogFromGethLog(l *types.Log) *Log {
+	if l == nil {
+		return nil
+	}
+	return &Log{
+		Address: l.Address,
+		Topics:  l.Topics,
+		Data:    l.Data,
+	}
+}

--- a/evmcore/core_types/log_test.go
+++ b/evmcore/core_types/log_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package core_types
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoreLogFromGethLog_NilRemainsNil(t *testing.T) {
+	require.Nil(t, CoreLogFromGethLog(nil))
+}
+
+func TestCoreLogFromGethLog_CoversAddress(t *testing.T) {
+	addresses := []common.Address{
+		{},
+		{1, 2, 3},
+	}
+
+	for _, address := range addresses {
+		gethLog := &types.Log{
+			Address: address,
+		}
+		coreLog := CoreLogFromGethLog(gethLog)
+		require.Equal(t, address, coreLog.Address)
+	}
+}
+
+func TestCoreLogFromGethLog_CoversTopics(t *testing.T) {
+	topics := [][]common.Hash{
+		{},
+		{{1, 2, 3}},
+		{{4, 5}, {6, 7, 8}},
+	}
+
+	for _, topicList := range topics {
+		gethLog := &types.Log{
+			Topics: topicList,
+		}
+		coreLog := CoreLogFromGethLog(gethLog)
+		require.Equal(t, topicList, coreLog.Topics)
+	}
+}
+
+func TestCoreLogFromGethLog_CoversData(t *testing.T) {
+	datas := [][]byte{
+		{},
+		{0x00},
+		{0x01, 0x02, 0x03},
+	}
+
+	for _, data := range datas {
+		gethLog := &types.Log{
+			Data: data,
+		}
+		coreLog := CoreLogFromGethLog(gethLog)
+		require.Equal(t, data, coreLog.Data)
+	}
+}

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -121,7 +121,7 @@ type ProcessedTransaction struct {
 // consistent.
 func (p *StateProcessor) Process(
 	block *EvmBlock, statedb state.StateDB, cfg vm.Config, gasLimit uint64,
-	usedGas *uint64, trueTxOffset int, onNewLog func(*types.Log),
+	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log),
 ) ProcessSummary {
 	sonicDifficulty := big.NewInt(1)
 	return p.ProcessWithDifficulty(block, statedb, cfg, gasLimit, usedGas, trueTxOffset, onNewLog, sonicDifficulty)
@@ -133,7 +133,7 @@ func (p *StateProcessor) Process(
 // difficulty values than Sonic's constant difficulty of 1.
 func (p *StateProcessor) ProcessWithDifficulty(
 	block *EvmBlock, statedb state.StateDB, cfg vm.Config, gasLimit uint64,
-	usedGas *uint64, trueTxOffset int, onNewLog func(*types.Log),
+	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log),
 	difficulty *big.Int,
 ) ProcessSummary {
 	var (
@@ -169,7 +169,7 @@ type runContext struct {
 	blockNumber *big.Int
 	blockTime   inter.Timestamp
 	usedGas     *uint64
-	onNewLog    func(*types.Log)
+	onNewLog    func(*core_types.Log)
 	upgrades    opera.Upgrades
 	runner      _transactionRunner
 	forReplay   bool // Whether the context is used for replaying transactions or for head state processing.
@@ -187,7 +187,7 @@ func newRunContext(
 	blockNumber *big.Int,
 	blockTime inter.Timestamp,
 	usedGas *uint64,
-	onNewLog func(*types.Log),
+	onNewLog func(*core_types.Log),
 	upgrades opera.Upgrades,
 	runner _transactionRunner,
 	isReplay bool,
@@ -694,7 +694,7 @@ func NewTransactionProcessorForBlock(
 // probe individual transactions to determine their applicability and gas usage.
 func (p *StateProcessor) BeginBlock(
 	block *EvmBlock, stateDb state.StateDB, cfg vm.Config, gasLimit uint64,
-	onNewLog func(*types.Log),
+	onNewLog func(*core_types.Log),
 ) *TransactionProcessor {
 	var (
 		gp            = core.NewGasPool(gasLimit)
@@ -731,7 +731,7 @@ type TransactionProcessor struct {
 	blockTime     inter.Timestamp
 	gp            *core.GasPool
 	header        *EvmHeader
-	onNewLog      func(*types.Log)
+	onNewLog      func(*core_types.Log)
 	signer        types.Signer
 	stateDb       state.StateDB
 	usedGas       uint64
@@ -854,7 +854,7 @@ func applyTransaction(
 	tx *types.Transaction,
 	usedGas *uint64,
 	evm *vm.EVM,
-	onNewLog func(*types.Log),
+	onNewLog func(*core_types.Log),
 ) (
 	*types.Receipt,
 	uint64,
@@ -899,7 +899,7 @@ func applyTransaction(
 	logs := statedb.GetLogs(tx.Hash(), common.Hash{})
 	if onNewLog != nil {
 		for _, l := range logs {
-			onNewLog(l)
+			onNewLog(core_types.CoreLogFromGethLog(l))
 		}
 	}
 

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -51,7 +51,7 @@ import (
 // Process method.
 func (p *StateProcessor) process_iteratively(
 	block *EvmBlock, stateDb state.StateDB, cfg vm.Config, gasLimit uint64,
-	usedGas *uint64, trueTxOffset int, onNewLog func(*types.Log),
+	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log),
 ) ProcessSummary {
 	// This implementation is a wrapper around the BeginBlock function, which
 	// handles the actual transaction processing.
@@ -113,8 +113,8 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 				Transactions: transactions,
 			}
 
-			reportedLogs := []*types.Log{}
-			onLog := func(log *types.Log) {
+			reportedLogs := []*core_types.Log{}
+			onLog := func(log *core_types.Log) {
 				reportedLogs = append(reportedLogs, log)
 			}
 
@@ -169,7 +169,9 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 
 			require.Nil(processed[3].Receipt)
 
-			require.Equal([]*types.Log{logMsg0, logMsg2}, reportedLogs)
+			coreLogMsg0 := core_types.CoreLogFromGethLog(logMsg0)
+			coreLogMsg2 := core_types.CoreLogFromGethLog(logMsg2)
+			require.Equal([]*core_types.Log{coreLogMsg0, coreLogMsg2}, reportedLogs)
 
 			require.Equal(uint64(21_000+21_000), *usedGas)
 		})
@@ -871,7 +873,7 @@ type processFunction = func(
 	gasLimit uint64,
 	usedGas *uint64,
 	trueTxOffset int,
-	onNewLog func(*types.Log),
+	onNewLog func(*core_types.Log),
 ) ProcessSummary
 
 func getStateDbMockForTransactions(

--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice"
@@ -293,7 +294,7 @@ func ComputeEffectiveFee(
 	return new(big.Int).Add(gasFee, blobGasFee), nil
 }
 
-func decodeDataBytes(l *types.Log) ([]byte, error) {
+func decodeDataBytes(l *core_types.Log) ([]byte, error) {
 	if len(l.Data) < 32 {
 		return nil, io.ErrUnexpectedEOF
 	}
@@ -308,7 +309,7 @@ func decodeDataBytes(l *types.Log) ([]byte, error) {
 	return l.Data[start+32 : start+32+size], nil
 }
 
-func (p *DriverTxListener) OnNewLog(l *types.Log) {
+func (p *DriverTxListener) OnNewLog(l *core_types.Log) {
 	if l.Address != driver.ContractAddress {
 		return
 	}

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
@@ -46,7 +47,7 @@ func (p *EVMModule) Start(
 	block iblockproc.BlockCtx,
 	statedb state.StateDB,
 	reader evmcore.DummyChain,
-	onNewLog func(*types.Log),
+	onNewLog func(*core_types.Log),
 	rules opera.Rules,
 	evmCfg *params.ChainConfig,
 	prevrandao common.Hash,
@@ -87,7 +88,7 @@ type OperaEVMProcessor struct {
 	block    iblockproc.BlockCtx
 	reader   evmcore.DummyChain
 	statedb  state.StateDB
-	onNewLog func(*types.Log)
+	onNewLog func(*core_types.Log)
 	rules    opera.Rules
 	evmCfg   *params.ChainConfig
 
@@ -155,11 +156,7 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) evm
 
 	// Process txs
 	evmBlock := p.evmBlockWith(txs)
-	summary := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, trueTxsOffset, func(l *types.Log) {
-		// Note: l.Index is properly set before
-		l.TxIndex += legacyTxsOffset
-		p.onNewLog(l)
-	})
+	summary := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, trueTxsOffset, p.onNewLog)
 
 	if legacyTxsOffset > 0 {
 		for _, p := range summary.ProcessedTransactions {
@@ -234,7 +231,7 @@ type _stateProcessor interface {
 		gasLimit uint64,
 		gasUsed *uint64,
 		trueTxOffset int,
-		onNewLog func(*types.Log),
+		onNewLog func(*core_types.Log),
 	) evmcore.ProcessSummary
 }
 

--- a/gossip/blockproc/evmmodule/evm_mock.go
+++ b/gossip/blockproc/evmmodule/evm_mock.go
@@ -13,9 +13,9 @@ import (
 	reflect "reflect"
 
 	evmcore "github.com/0xsoniclabs/sonic/evmcore"
+	core_types "github.com/0xsoniclabs/sonic/evmcore/core_types"
 	state "github.com/0xsoniclabs/sonic/inter/state"
 	opera "github.com/0xsoniclabs/sonic/opera"
-	types "github.com/ethereum/go-ethereum/core/types"
 	vm "github.com/ethereum/go-ethereum/core/vm"
 	params "github.com/ethereum/go-ethereum/params"
 	gomock "go.uber.org/mock/gomock"
@@ -98,7 +98,7 @@ func (m *Mock_stateProcessor) EXPECT() *Mock_stateProcessorMockRecorder {
 }
 
 // Process mocks base method.
-func (m *Mock_stateProcessor) Process(block *evmcore.EvmBlock, statedb state.StateDB, vmCfg vm.Config, gasLimit uint64, gasUsed *uint64, trueTxOffset int, onNewLog func(*types.Log)) evmcore.ProcessSummary {
+func (m *Mock_stateProcessor) Process(block *evmcore.EvmBlock, statedb state.StateDB, vmCfg vm.Config, gasLimit uint64, gasUsed *uint64, trueTxOffset int, onNewLog func(*core_types.Log)) evmcore.ProcessSummary {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Process", block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog)
 	ret0, _ := ret[0].(evmcore.ProcessSummary)

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -17,7 +17,6 @@
 package evmmodule
 
 import (
-	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -25,6 +24,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
@@ -112,7 +112,7 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 	}
 }
 
-func TestOperaEVMProcessor_Execute_ProducesContinuousTxIndexesInLogsAndReceipts(t *testing.T) {
+func TestOperaEVMProcessor_Execute_ProducesContinuousTxIndexesInReceipts(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	stateDb := state.NewMockStateDB(ctrl)
@@ -144,19 +144,11 @@ func TestOperaEVMProcessor_Execute_ProducesContinuousTxIndexesInLogsAndReceipts(
 			return currentTxIndex
 		},
 	)
-	stateDb.EXPECT().GetLogs(any, any).AnyTimes().DoAndReturn(
-		func(_, _ common.Hash) []*types.Log {
-			return []*types.Log{{
-				TxIndex: uint(currentTxIndex),
-			}}
-		},
-	)
+	stateDb.EXPECT().GetLogs(any, any).AnyTimes().Return([]*types.Log{{}})
 
 	// Logs should be reported in consecutive order, one per transaction.
 	const N = 5
-	for i := range N * 3 {
-		logConsumer.EXPECT().OnNewLog(LogWithTxIndex(uint(i)))
-	}
+	logConsumer.EXPECT().OnNewLog(gomock.Any()).Times(N * 3)
 
 	evmModule := New()
 	processor := evmModule.Start(
@@ -554,34 +546,9 @@ func TestOperaEVMProcessor_Finalize_BlockOnSyncChannel_WhenBlockIsYoungerThanOne
 // onNewLog is a helper interface to allow mocking the onNewLog function
 // passed to the EVM processor.
 type _onNewLog interface {
-	OnNewLog(*types.Log)
+	OnNewLog(*core_types.Log)
 }
 
 // Added to avoid unused warning of onNewLog interface which is only used for
 // generating the mock.
 var _ _onNewLog = (*Mock_onNewLog)(nil)
-
-// LogWithTxIndex creates a gomock matcher that matches a log message with the
-// given transaction index.
-func LogWithTxIndex(id any) gomock.Matcher {
-	if matcher, ok := id.(gomock.Matcher); ok {
-		return logWithTxIndex{txIndex: matcher}
-	}
-	return LogWithTxIndex(gomock.Eq(id))
-}
-
-type logWithTxIndex struct {
-	txIndex gomock.Matcher
-}
-
-func (i logWithTxIndex) Matches(arg any) bool {
-	log, ok := arg.(*types.Log)
-	if !ok || log == nil {
-		return false
-	}
-	return i.txIndex.Matches(log.TxIndex)
-}
-
-func (i logWithTxIndex) String() string {
-	return fmt.Sprintf("Log with TxIndex: %s", i.txIndex.String())
-}

--- a/gossip/blockproc/evmmodule/evm_test_mock.go
+++ b/gossip/blockproc/evmmodule/evm_test_mock.go
@@ -12,7 +12,7 @@ package evmmodule
 import (
 	reflect "reflect"
 
-	types "github.com/ethereum/go-ethereum/core/types"
+	core_types "github.com/0xsoniclabs/sonic/evmcore/core_types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +41,7 @@ func (m *Mock_onNewLog) EXPECT() *Mock_onNewLogMockRecorder {
 }
 
 // OnNewLog mocks base method.
-func (m *Mock_onNewLog) OnNewLog(arg0 *types.Log) {
+func (m *Mock_onNewLog) OnNewLog(arg0 *core_types.Log) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnNewLog", arg0)
 }

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
@@ -35,7 +36,7 @@ import (
 //go:generate mockgen -source=interface.go -package=blockproc -destination=interface_mock.go
 
 type TxListener interface {
-	OnNewLog(*types.Log)
+	OnNewLog(*core_types.Log)
 	OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int)
 	Finalize() iblockproc.BlockState
 	Update(bs iblockproc.BlockState, es iblockproc.EpochState)
@@ -82,7 +83,7 @@ type EVM interface {
 		block iblockproc.BlockCtx,
 		statedb state.StateDB,
 		reader evmcore.DummyChain,
-		onNewLog func(*types.Log),
+		onNewLog func(*core_types.Log),
 		net opera.Rules,
 		evmCfg *params.ChainConfig,
 		prevrandao common.Hash,

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	evmcore "github.com/0xsoniclabs/sonic/evmcore"
+	core_types "github.com/0xsoniclabs/sonic/evmcore/core_types"
 	inter "github.com/0xsoniclabs/sonic/inter"
 	iblockproc "github.com/0xsoniclabs/sonic/inter/iblockproc"
 	state "github.com/0xsoniclabs/sonic/inter/state"
@@ -65,7 +66,7 @@ func (mr *MockTxListenerMockRecorder) Finalize() *gomock.Call {
 }
 
 // OnNewLog mocks base method.
-func (m *MockTxListener) OnNewLog(arg0 *types.Log) {
+func (m *MockTxListener) OnNewLog(arg0 *core_types.Log) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnNewLog", arg0)
 }
@@ -446,7 +447,7 @@ func (m *MockEVM) EXPECT() *MockEVMMockRecorder {
 }
 
 // Start mocks base method.
-func (m *MockEVM) Start(block iblockproc.BlockCtx, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*types.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash) EVMProcessor {
+func (m *MockEVM) Start(block iblockproc.BlockCtx, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*core_types.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash) EVMProcessor {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", block, statedb, reader, onNewLog, net, evmCfg, prevrandao)
 	ret0, _ := ret[0].(EVMProcessor)

--- a/gossip/blockproc/verwatcher/version_watcher.go
+++ b/gossip/blockproc/verwatcher/version_watcher.go
@@ -22,8 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
-
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/logger"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driver"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driver/driverpos"
@@ -62,7 +61,7 @@ func (w *VersionWatcher) Pause() error {
 	return nil
 }
 
-func (w *VersionWatcher) OnNewLog(l *types.Log) {
+func (w *VersionWatcher) OnNewLog(l *core_types.Log) {
 	if l.Address != driver.ContractAddress {
 		return
 	}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	scc_node "github.com/0xsoniclabs/sonic/scc/node"
 
@@ -315,7 +316,7 @@ func consensusCallbackBeginBlockFn(
 				sealer := blockProc.SealerModule.Start(blockCtx, bs, es)
 				sealing := sealer.EpochSealing()
 				txListener := blockProc.TxListenerModule.Start(blockCtx, bs, es, statedb)
-				onNewLogAll := func(l *types.Log) {
+				onNewLogAll := func(l *core_types.Log) {
 					txListener.OnNewLog(l)
 					// Note: it's possible for logs to get indexed twice by BR and block processing
 					if verWatcher != nil {

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -43,6 +43,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/evmmodule"
@@ -1203,7 +1204,7 @@ func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransa
 		iblockproc.BlockCtx{},
 		statedb,
 		&EvmStateReader{},
-		func(l *types.Log) {},
+		func(l *core_types.Log) {},
 		opera.Rules{},
 		&params.ChainConfig{},
 		common.Hash{},

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/0xsoniclabs/sonic/utils/objstream"
@@ -261,7 +262,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	)
 	evmProcessor := blockProc.EVMModule.Start(
 		blockCtx, b.tmpStateDB, dummyHeaderReturner{b.blocks},
-		func(l *types.Log) { txListener.OnNewLog(l) },
+		func(l *core_types.Log) { txListener.OnNewLog(l) },
 		es.Rules,
 		chainConfig,
 		common.Hash{0x01}, // non-zero PrevRandao necessary to enable Cancun


### PR DESCRIPTION
This PR eliminates the in-flight adjustment of the transaction index of log messages reported by the state processor [here](https://github.com/0xsoniclabs/sonic/blob/c847f4bb9ba7c3d1c9ae38cf89e8b5bdbe5cd841/gossip/blockproc/evmmodule/evm.go#L158-L162).

It turns out that no consumer of the log message requires the transaction index to be set. To make sure this remains like this, a new internal log type (`core_types.Log`) is introduced not covering this field.

The rest of the changes are mere adjustments to the type switch.