### PR TITLE
Cache bundle.OpenEnvelope

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,6 @@ require (
 	pgregory.net/rand v1.0.2 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20260506145648-6b3ddf5db680
+replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe
 
 replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20260429065829-930ae462cd09

--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,6 @@ require (
 	pgregory.net/rand v1.0.2 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20260424113012-971561538c58
+replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20260506145648-6b3ddf5db680
 
 replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20260429065829-930ae462cd09

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427 h1:sMPNQv8eWqDb/lfdBZV591WO4E6yqhHFD7wmS4KyKlg=
 github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20260424113012-971561538c58 h1:FXc86ukHR2flWIFTGanxow99cOagC8ek73GeagYP3wI=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20260424113012-971561538c58/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20260506145648-6b3ddf5db680 h1:q8PpYcDS1Wc2Te91jltdazKJKGndw4uKunTlNX5E7QA=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20260506145648-6b3ddf5db680/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42/go.mod h1:iXtx7i9R25Oc5SD/xGI7aamdnF0nCteBpulZGIOIYJI=
 github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb h1:mb6rPN+DpA/N2QWrQrLQEG2uzrYgy061PPauifstXNM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427 h1:sMPNQv8eWqDb/lfdBZV591WO4E6yqhHFD7wmS4KyKlg=
 github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20260506145648-6b3ddf5db680 h1:q8PpYcDS1Wc2Te91jltdazKJKGndw4uKunTlNX5E7QA=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20260506145648-6b3ddf5db680/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe h1:JPiyJPZ1oBzRwsRW0BER76wChPg7rOxKwk1W5YUkKlE=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42/go.mod h1:iXtx7i9R25Oc5SD/xGI7aamdnF0nCteBpulZGIOIYJI=
 github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb h1:mb6rPN+DpA/N2QWrQrLQEG2uzrYgy061PPauifstXNM=

--- a/gossip/blockproc/bundle/bundle.go
+++ b/gossip/blockproc/bundle/bundle.go
@@ -62,7 +62,7 @@ func OpenEnvelope(
 
 	const openedBundleKey = "openedBundle"
 	if txBundle, cached := types.GetSonicPayload[TransactionBundle](tx, openedBundleKey); cached {
-		return txBundle, nil
+		return txBundle.Clone(), nil
 	}
 
 	txBundle, err := decode(signer, tx.Data())
@@ -70,7 +70,7 @@ func OpenEnvelope(
 		return TransactionBundle{}, err
 	}
 	types.SetSonicPayload(tx, openedBundleKey, txBundle)
-	return txBundle, nil
+	return txBundle.Clone(), nil
 }
 
 var (
@@ -112,6 +112,14 @@ func (tb *TransactionBundle) GetTransactionsInReferencedOrder() []*types.Transac
 // envelope transaction's data field.
 func (tb *TransactionBundle) Encode() ([]byte, error) {
 	return encodeInternal(bundleEncodingVersion, tb)
+}
+
+// Clone creates a deep copy of the transaction bundle by encoding and decoding it.
+func (tb *TransactionBundle) Clone() TransactionBundle {
+	return TransactionBundle{
+		Transactions: maps.Clone(tb.Transactions),
+		Plan:         tb.Plan,
+	}
 }
 
 // --- internal utilities ---

--- a/gossip/blockproc/bundle/bundle.go
+++ b/gossip/blockproc/bundle/bundle.go
@@ -49,6 +49,9 @@ func IsEnvelope(tx *types.Transaction) bool {
 }
 
 // OpenEnvelope extracts the bundle enclosed in the given envelope.
+// Results are cached in the transaction's Sonic payload to avoid redundant decoding of the
+// same bundle, and repeated construction of the same transaction objects for the transactions
+// included in the bundle, as computing the sender of such transactions is an expensive operation.
 func OpenEnvelope(
 	signer types.Signer,
 	tx *types.Transaction,
@@ -56,7 +59,18 @@ func OpenEnvelope(
 	if !IsEnvelope(tx) {
 		return TransactionBundle{}, fmt.Errorf("not an envelope")
 	}
-	return decode(signer, tx.Data())
+
+	const openedBundleKey = "openedBundle"
+	if txBundle, cached := types.GetSonicPayload[TransactionBundle](tx, openedBundleKey); cached {
+		return txBundle, nil
+	}
+
+	txBundle, err := decode(signer, tx.Data())
+	if err != nil {
+		return TransactionBundle{}, err
+	}
+	types.SetSonicPayload(tx, openedBundleKey, txBundle)
+	return txBundle, nil
 }
 
 var (

--- a/gossip/blockproc/bundle/bundle.go
+++ b/gossip/blockproc/bundle/bundle.go
@@ -62,7 +62,7 @@ func OpenEnvelope(
 
 	const openedBundleKey = "openedBundle"
 	if txBundle, cached := types.GetSonicPayload[TransactionBundle](tx, openedBundleKey); cached {
-		return txBundle.Clone(), nil
+		return txBundle.Copy(), nil
 	}
 
 	txBundle, err := decode(signer, tx.Data())
@@ -70,7 +70,7 @@ func OpenEnvelope(
 		return TransactionBundle{}, err
 	}
 	types.SetSonicPayload(tx, openedBundleKey, txBundle)
-	return txBundle.Clone(), nil
+	return txBundle.Copy(), nil
 }
 
 var (
@@ -114,8 +114,9 @@ func (tb *TransactionBundle) Encode() ([]byte, error) {
 	return encodeInternal(bundleEncodingVersion, tb)
 }
 
-// Clone creates a deep copy of the transaction bundle by encoding and decoding it.
-func (tb *TransactionBundle) Clone() TransactionBundle {
+// Copy creates a shallow copy of the transaction bundle. The transaction pointers
+// would remain shared as the types.Transaction objects are immutable.
+func (tb *TransactionBundle) Copy() TransactionBundle {
 	return TransactionBundle{
 		Transactions: maps.Clone(tb.Transactions),
 		Plan:         tb.Plan,

--- a/gossip/blockproc/bundle/bundle_test.go
+++ b/gossip/blockproc/bundle/bundle_test.go
@@ -134,17 +134,9 @@ func TestOpenEnvelope_CachesCalls(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	bundle := NewBuilder().AllOf(
+	envelope := NewBuilder().AllOf(
 		Step(key, &types.AccessListTx{Nonce: 1}),
-	).BuildBundle()
-
-	payload, err := bundle.Encode()
-	require.NoError(t, err)
-
-	envelope := types.NewTx(&types.LegacyTx{
-		To:   &BundleProcessor,
-		Data: payload,
-	})
+	).Build()
 
 	// Expect the signer to be called only during the first OpenEnvelope call.
 	mockSigner.EXPECT().Sender(gomock.Any()).Return(common.Address{}, nil).Times(1)

--- a/gossip/blockproc/bundle/bundle_test.go
+++ b/gossip/blockproc/bundle/bundle_test.go
@@ -786,3 +786,25 @@ func TestDecode_CorruptedExecutionPlanEncoding_DetectedDuringDecoding(t *testing
 	_, err = decode(nil, encoded)
 	require.ErrorContains(t, err, "failed to decode execution plan")
 }
+
+func TestTransactionBundle_Copy_CreatesDistinctCopy(t *testing.T) {
+	bundle := TransactionBundle{
+		Transactions: map[TxReference]*types.Transaction{
+			{From: common.Address{0x1}, Hash: common.Hash{0x1}}: types.NewTx(&types.LegacyTx{Nonce: 1}),
+		},
+		Plan: ExecutionPlan{
+			Root: NewTxStep(TxReference{From: common.Address{0x1}, Hash: common.Hash{0x1}}),
+		},
+	}
+
+	copied := bundle.Copy()
+
+	require.Equal(t, bundle.Transactions, copied.Transactions)
+	require.Equal(t, bundle.Plan, copied.Plan)
+
+	copied.Transactions[TxReference{From: common.Address{0x2}, Hash: common.Hash{0x2}}] = types.NewTx(&types.LegacyTx{Nonce: 2})
+	copied.Plan.Root = NewTxStep(TxReference{From: common.Address{0x2}, Hash: common.Hash{0x2}})
+
+	require.NotContains(t, bundle.Transactions, TxReference{From: common.Address{0x2}, Hash: common.Hash{0x2}})
+	require.Equal(t, NewTxStep(TxReference{From: common.Address{0x1}, Hash: common.Hash{0x1}}), bundle.Plan.Root)
+}

--- a/gossip/blockproc/bundle/bundle_test.go
+++ b/gossip/blockproc/bundle/bundle_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestIsBundledOnly_IdentifiesBundleOnlyTransactions_OfAllTypes(t *testing.T) {
@@ -123,6 +124,45 @@ func TestOpenEnvelope_SuccessfullyDecodesEnvelopes(t *testing.T) {
 
 			require.Equal(t, bundle, unpacked)
 		})
+	}
+}
+
+func TestOpenEnvelope_CachesCalls(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockSigner := NewMockSigner(ctrl)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	bundle := NewBuilder().AllOf(
+		Step(key, &types.AccessListTx{Nonce: 1}),
+	).BuildBundle()
+
+	payload, err := bundle.Encode()
+	require.NoError(t, err)
+
+	envelope := types.NewTx(&types.LegacyTx{
+		To:   &BundleProcessor,
+		Data: payload,
+	})
+
+	// Expect the signer to be called only during the first OpenEnvelope call.
+	mockSigner.EXPECT().Sender(gomock.Any()).Return(common.Address{}, nil).Times(1)
+	mockSigner.EXPECT().Hash(gomock.Any()).Return(common.Hash{}).Times(1)
+
+	// First call: signer is used to decode the bundle.
+	firstValue, err := OpenEnvelope(mockSigner, envelope)
+	require.NoError(t, err)
+
+	// Second call: result is cached, signer must not be called again.
+	secondValue, err := OpenEnvelope(mockSigner, envelope)
+	require.NoError(t, err)
+
+	require.Equal(t, firstValue, secondValue)
+	for i := range firstValue.Transactions {
+		// Ensure that bundled transactions have the same cached sender, they must
+		// be the same instance
+		require.Same(t, firstValue.Transactions[i], secondValue.Transactions[i])
 	}
 }
 

--- a/gossip/blockproc/bundle/bundle_test.go
+++ b/gossip/blockproc/bundle/bundle_test.go
@@ -158,6 +158,36 @@ func TestOpenEnvelope_CachesCalls(t *testing.T) {
 	}
 }
 
+func TestOpenEnvelope_CachedValuesAreImmutable(t *testing.T) {
+
+	ctrl := gomock.NewController(t)
+	mockSigner := NewMockSigner(ctrl)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	envelope := NewBuilder().AllOf(
+		Step(key, &types.AccessListTx{Nonce: 1}),
+	).Build()
+
+	// Expect the signer to be called only during the first OpenEnvelope call.
+	mockSigner.EXPECT().Sender(gomock.Any()).Return(common.Address{0x1}, nil).Times(1)
+	mockSigner.EXPECT().Hash(gomock.Any()).Return(common.Hash{0x1}).Times(1)
+
+	// First call: signer is used to decode the bundle.
+	firstValue, err := OpenEnvelope(mockSigner, envelope)
+	require.NoError(t, err)
+
+	testRef := TxReference{From: common.Address{0x2}, Hash: common.Hash{0x2}}
+	firstValue.Transactions[testRef] = types.NewTx(&types.LegacyTx{Nonce: 999})
+
+	// Second call: result is cached, signer must not be called again.
+	secondValue, err := OpenEnvelope(mockSigner, envelope)
+	require.NoError(t, err)
+
+	require.NotContains(t, secondValue.Transactions, testRef)
+}
+
 func TestOpenEnvelope_FailsIfNotAnEnvelope(t *testing.T) {
 	notEnvelope := types.NewTx(&types.LegacyTx{})
 	require.False(t, IsEnvelope(notEnvelope))


### PR DESCRIPTION
This PR caches OpenBundle results into the transaction instance storage added [here](https://github.com/0xsoniclabs/go-ethereum/pull/15)

This is an impactful performance optimization as opening the bundle implies creating new transaction instances for the bundled transactions. These new instances do not have the sender cached, and the singer needs to be used to recompute every time a bundle is open, which happens a few times along the pipeline. 
 
 
An example of the impact of this operation:
**Before**: 
<img width="1268" height="695" alt="image" src="https://github.com/user-attachments/assets/3774975e-610a-4739-94d8-5126c8e3b37d" />


**After**: 
<img width="1268" height="695" alt="image" src="https://github.com/user-attachments/assets/437f930c-510f-4f51-a0fb-be163edff949" />


