### PR TITLE
Fix flaky TestBundle_StressWithExpensiveInternalRollback

### DIFF
--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -162,12 +162,14 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 							Step(t, net, accounts[i*3], &types.AccessListTx{
 								To:   &tc.contractAddr,
 								Data: tc.contractInputLarge,
+								Gas:  19_321_848,
 							}),
 							Step(t, net, accounts[i*3+1], &types.AccessListTx{Gas: 1}),
 						).WithFlags(bundle.EF_TolerateFailed),
 						Step(t, net, accounts[i*3+2], &types.AccessListTx{
 							To:   &tc.contractAddr,
 							Data: tc.contractInputSmall,
+							Gas:  5_425_836,
 						}),
 					).
 					BuildEnvelopeBundleAndPlan()

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -111,6 +111,8 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 		contractAddr       common.Address
 		contractInputLarge []byte
 		contractInputSmall []byte
+		GasLarge           uint64
+		GasSmall           uint64
 	}{
 		"ComputeHeavy": {
 			contractAddr: tests.MustDeployContract(t, net, add.DeployAdd),
@@ -128,6 +130,8 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 				// arguments: iter
 				big.NewInt(28_000),
 			),
+			GasLarge: 19_321_848,
+			GasSmall: 5_425_836,
 		},
 		"DbHeavy": {
 			contractAddr: tests.MustDeployContract(t, net, store.DeployStore),
@@ -145,6 +149,8 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 				// arguments: from, until, value
 				big.NewInt(0), big.NewInt(300), big.NewInt(1),
 			),
+			GasLarge: 17910958,
+			GasSmall: 6744458,
 		},
 	}
 
@@ -162,14 +168,14 @@ func TestBundle_StressWithExpensiveInternalRollback(t *testing.T) {
 							Step(t, net, accounts[i*3], &types.AccessListTx{
 								To:   &tc.contractAddr,
 								Data: tc.contractInputLarge,
-								Gas:  19_321_848,
+								Gas:  tc.GasLarge,
 							}),
 							Step(t, net, accounts[i*3+1], &types.AccessListTx{Gas: 1}),
 						).WithFlags(bundle.EF_TolerateFailed),
 						Step(t, net, accounts[i*3+2], &types.AccessListTx{
 							To:   &tc.contractAddr,
 							Data: tc.contractInputSmall,
-							Gas:  5_425_836,
+							Gas:  tc.GasSmall,
 						}),
 					).
 					BuildEnvelopeBundleAndPlan()


### PR DESCRIPTION
This PR fixes https://github.com/0xsoniclabs/sonic-admin/issues/760

**The Problem**
The test `TestBundle_StressWithExpensiveInternalRollback/ComputeHeavy` fails flakily with ` execution aborted (timeout = 0s)`.

**Root Cause**
The [`Step()`](https://github.com/0xsoniclabs/sonic/blob/main/tests/bundles/bundle_test_utils.go#L107) calls `SetTransactionDefaults`, which when called without a `Gas == 0` then calls `EstimateGas`. `EstimateGas` performs a binary search trying to find an acceptable `Gas` value for the transaction, and because the transaction being submitted is too large, this means many iterations of the binary search are needed. 

When running this tests with `-race` this iterations are slow enough that a timeout is triggered. 

**The Fix**
Take the estimated values of a successful run (without `-race`), and set the `Gas` for the transactions explicitly.
