### PR TITLE
Add bundle evaluation cache

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -20,13 +20,15 @@ import (
 	"crypto/rand"
 	"fmt"
 	"maps"
-	big "math/big"
+	"math/big"
 
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	state "github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
@@ -440,4 +442,76 @@ func makeTemporaryBlockedState(reason string) BundleState {
 
 func makePermanentlyBlockedState(reason string) BundleState {
 	return BundleState{Reasons: []string{reason}}
+}
+
+// BundleEvaluator is an interface which exposes the GetBundleState function,
+// The signature of GetBundleState is identical to the free standing function
+// GetBundleState, this allows to inject caches in functions using the function.
+type BundleEvaluator interface {
+	GetBundleState(
+		chain ChainStateForBundleEval,
+		stateDb state.StateDB,
+		envelope *types.Transaction,
+	) BundleState
+}
+
+type bundleEvaluationCache struct {
+	cache *lru.Cache
+}
+
+// NewBundleEvaluationCache creates a new instance of bundleEvaluationCache,
+// which is an LRU cache for storing bundle evaluation results.
+//
+// Bundles are cached by their execution plan hash and the block number at
+// which they were evaluated, to ensure that further evaluations in the same
+// block can hit the cache, sparing the need to re-run the same bundle
+// multiple times within the same block.
+func NewBundleEvaluationCache() *bundleEvaluationCache {
+
+	// The cache size of 100k entries is chosen arbitrarily and can be tuned
+	// Evaluation of block current-1 are never used again, so we can consider
+	// that the cache is only useful for the current block. This means that the
+	//  cache contains evaluations for up to 100k envelopes pending of execution.
+	//
+	// Maximum memory consumption is a constant factor of the following formula:
+	// number of bundles in the cache * (size of bundle plan hash + size of block number + size of BundleState)
+	// 32  + 8 + ( 1+1 + 24, aligned to 32) = 72 bytes per entry, so ~7.2MiB for 100k entries.
+	// Notice that the reasons in the bundle state point to static strings,
+	// so they do not contribute to the memory consumption of each entry.
+	cache, _ := lru.New(100_000)
+	return &bundleEvaluationCache{cache: cache}
+}
+
+func (c *bundleEvaluationCache) GetBundleState(
+	chain ChainStateForBundleEval,
+	stateDb state.StateDB,
+	envelope *types.Transaction,
+) BundleState {
+	chainId := big.NewInt(int64(chain.GetCurrentNetworkRules().NetworkID))
+	signer := types.LatestSignerForChainID(chainId)
+
+	// Does this even pay off? cache envelope vs cache plan
+	txBundle, err := bundle.OpenEnvelope(signer, envelope)
+	if err != nil {
+		return makeRunnableState()
+	}
+	planHash := txBundle.Plan.Hash()
+
+	// get current block number
+	blockNumber := uint64(0)
+	if block := chain.GetLatestHeader(); block != nil {
+		blockNumber = block.Number.Uint64()
+	}
+
+	key := string(append(
+		bigendian.Uint64ToBytes(blockNumber),
+		planHash.Bytes()...,
+	))
+	if state, ok := c.cache.Get(key); ok {
+		return state.(BundleState)
+	}
+
+	state := GetBundleState(chain, stateDb, envelope)
+	c.cache.Add(key, state)
+	return state
 }

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -491,13 +491,18 @@ func (c *bundleEvaluationCache) GetBundleState(
 	stateDb state.StateDB,
 	envelope *types.Transaction,
 ) BundleState {
+
+	if !bundle.IsEnvelope(envelope) {
+		return makeRunnableState()
+	}
+
 	chainId := big.NewInt(int64(chain.GetCurrentNetworkRules().NetworkID))
 	signer := types.LatestSignerForChainID(chainId)
 
 	// Does this even pay off? cache envelope vs cache plan
 	txBundle, err := bundle.OpenEnvelope(signer, envelope)
 	if err != nil {
-		return makeRunnableState()
+		return makePermanentlyBlockedState(err.Error())
 	}
 	planHash := txBundle.Plan.Hash()
 

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -499,14 +499,17 @@ func (c *bundleEvaluationCache) GetBundleState(
 	chainId := big.NewInt(int64(chain.GetCurrentNetworkRules().NetworkID))
 	signer := types.LatestSignerForChainID(chainId)
 
-	// Does this even pay off? cache envelope vs cache plan
+	// Caching evaluations by plan hash instead of envelope hash allows to
+	// maximize cache hits, covering cases where different envelopes share
+	// the same execution plan.
+	// OpenEnvelope may be an expensive operation, this step relies on optimizations
+	// done in OpenEnvelope itself to be efficient.
 	txBundle, err := bundle.OpenEnvelope(signer, envelope)
 	if err != nil {
 		return makePermanentlyBlockedState(err.Error())
 	}
 	planHash := txBundle.Plan.Hash()
 
-	// get current block number
 	blockNumber := uint64(0)
 	if block := chain.GetLatestHeader(); block != nil {
 		blockNumber = block.Number.Uint64()

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -471,7 +471,11 @@ func NewBundleEvaluationCache() *bundleEvaluationCache {
 	// The cache size of 100k entries is chosen arbitrarily and can be tuned
 	// Evaluation of block current-1 are never used again, so we can consider
 	// that the cache is only useful for the current block. This means that the
-	//  cache contains evaluations for up to 100k envelopes pending of execution.
+	// cache contains evaluations for up to 100k envelopes pending of execution.
+	//
+	// The cache does not proactively purge entries from previous blocks, instead
+	// it relies on its LRU eviction policy to evict old entries when the cache
+	// is full, older block evaluations are expected to be evicted first.
 	//
 	// Maximum memory consumption is a constant factor of the following formula:
 	// number of bundles in the cache * (size of bundle plan hash + size of block number + size of BundleState)

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -1278,3 +1278,25 @@ func Test_BundleEvaluationCache_IgnoresNonEnvelopes(t *testing.T) {
 	result := cache.GetBundleState(chainState, stateDb, tx)
 	require.Equal(t, makeRunnableState(), result)
 }
+
+func Test_BundleEvaluationCache_ReturnsErrorForInvalidEnvelope(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	chainState := NewMockChainStateForBundleEval(ctrl)
+	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
+		NetworkID: 1,
+		Upgrades:  opera.Upgrades{TransactionBundles: true},
+	}).AnyTimes()
+	chainState.EXPECT().GetLatestHeader().Return(&EvmHeader{
+		Number: big.NewInt(100),
+	}).AnyTimes()
+
+	stateDb := state.NewMockStateDB(ctrl)
+
+	tx := types.NewTx(&types.LegacyTx{
+		To: &bundle.BundleProcessor,
+	})
+	cache := NewBundleEvaluationCache()
+
+	result := cache.GetBundleState(chainState, stateDb, tx)
+	require.Equal(t, makePermanentlyBlockedState("failed to decode transaction bundle: unexpected EOF"), result)
+}

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
@@ -1126,4 +1127,154 @@ func createKeys(t *testing.T) ([]*ecdsa.PrivateKey, []common.Address) {
 		senders[i] = crypto.PubkeyToAddress(key.PublicKey)
 	}
 	return keys, senders
+}
+
+var _ BundleEvaluator = (*bundleEvaluationCache)(nil)
+
+// evaluationSignature is used to static assert that the free standing
+// function and the cache method are interchangeable
+type evaluationSignature func(
+	chain ChainStateForBundleEval,
+	stateDb state.StateDB,
+	envelope *types.Transaction,
+) BundleState
+
+var _ evaluationSignature = GetBundleState
+var _ evaluationSignature = (*bundleEvaluationCache)(nil).GetBundleState
+
+func Test_BundleEvaluationCache_IsThreadSafe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	chainState := NewMockChainStateForBundleEval(ctrl)
+	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
+		NetworkID: 1,
+		Upgrades:  opera.Upgrades{TransactionBundles: true},
+	}).AnyTimes()
+	chainState.EXPECT().GetLatestHeader().Return(&EvmHeader{
+		Number: big.NewInt(100),
+	}).AnyTimes()
+
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(true).AnyTimes()
+
+	envelope := bundle.NewBuilder().Build()
+	cache := NewBundleEvaluationCache()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			cache.GetBundleState(chainState, stateDb, envelope)
+		}()
+	}
+	wg.Wait()
+}
+
+func Test_BundleEvaluationCache_CachesWithinSameBlock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	chainState := NewMockChainStateForBundleEval(ctrl)
+	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
+		NetworkID: 1,
+		Upgrades:  opera.Upgrades{TransactionBundles: true},
+	}).AnyTimes()
+	chainState.EXPECT().GetLatestHeader().Return(&EvmHeader{
+		Number: big.NewInt(100),
+	}).AnyTimes()
+
+	stateDb := state.NewMockStateDB(ctrl)
+	// HasBundleRecentlyBeenProcessed is only called by GetBundleState.
+	// If caching works, the second call should not reach GetBundleState.
+	stateDb.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(true).Times(1)
+
+	envelope := bundle.NewBuilder().Build()
+	cache := NewBundleEvaluationCache()
+
+	result1 := cache.GetBundleState(chainState, stateDb, envelope)
+	result2 := cache.GetBundleState(chainState, stateDb, envelope)
+	require.Equal(t, result1, result2)
+	require.Equal(t, makePermanentlyBlockedState("bundle already processed"), result1)
+}
+
+func Test_BundleEvaluationCache_ReEvaluatesOnBlockChange(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	chainState := NewMockChainStateForBundleEval(ctrl)
+	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
+		NetworkID: 1,
+		Upgrades:  opera.Upgrades{TransactionBundles: true},
+	}).AnyTimes()
+
+	blockNum := uint64(100)
+	chainState.EXPECT().GetLatestHeader().DoAndReturn(func() *EvmHeader {
+		return &EvmHeader{Number: big.NewInt(int64(blockNum))}
+	}).AnyTimes()
+
+	stateDb := state.NewMockStateDB(ctrl)
+	// Expect two evaluations: one for block 100 and one for block 101.
+	stateDb.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(true).Times(2)
+
+	envelope := bundle.NewBuilder().Build()
+	cache := NewBundleEvaluationCache()
+
+	result1 := cache.GetBundleState(chainState, stateDb, envelope)
+	blockNum = 101
+	result2 := cache.GetBundleState(chainState, stateDb, envelope)
+
+	require.Equal(t, makePermanentlyBlockedState("bundle already processed"), result1)
+	require.Equal(t, makePermanentlyBlockedState("bundle already processed"), result2)
+}
+
+func Test_BundleEvaluationCache_AssumesBlock0IfNoHeaderAvailable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	chainState := NewMockChainStateForBundleEval(ctrl)
+	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
+		NetworkID: 1,
+		Upgrades:  opera.Upgrades{TransactionBundles: true},
+	}).AnyTimes()
+
+	// The first cache call triggers GetBundleState internally, which calls
+	// GetLatestHeader multiple times. All of those must return a valid header.
+	// The second cache call (key computation only) returns nil, which should
+	// resolve to block 0 and produce a cache hit.
+	headerCallCount := 0
+	chainState.EXPECT().GetLatestHeader().DoAndReturn(func() *EvmHeader {
+		headerCallCount++
+		if headerCallCount <= 3 {
+			return &EvmHeader{Number: big.NewInt(0)}
+		}
+		return nil
+	}).AnyTimes()
+
+	stateDb := state.NewMockStateDB(ctrl)
+	// Only one evaluation: the second call should use the cached value.
+	stateDb.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(true).Times(1)
+
+	envelope := bundle.NewBuilder().Build()
+	cache := NewBundleEvaluationCache()
+
+	result1 := cache.GetBundleState(chainState, stateDb, envelope)
+	result2 := cache.GetBundleState(chainState, stateDb, envelope)
+
+	require.Equal(t, result1, result2)
+	require.Equal(t, makePermanentlyBlockedState("bundle already processed"), result1)
+}
+
+func Test_BundleEvaluationCache_IgnoresNonEnvelopes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	chainState := NewMockChainStateForBundleEval(ctrl)
+	chainState.EXPECT().GetCurrentNetworkRules().Return(opera.Rules{
+		NetworkID: 1,
+		Upgrades:  opera.Upgrades{TransactionBundles: true},
+	}).AnyTimes()
+	chainState.EXPECT().GetLatestHeader().Return(&EvmHeader{
+		Number: big.NewInt(100),
+	}).AnyTimes()
+
+	stateDb := state.NewMockStateDB(ctrl)
+
+	tx := types.NewTx(&types.LegacyTx{})
+	cache := NewBundleEvaluationCache()
+
+	result := cache.GetBundleState(chainState, stateDb, tx)
+	require.Equal(t, makeRunnableState(), result)
 }


### PR DESCRIPTION
This PR adds a cache to prevent re-evaluating bundles within the same block number. This resource is to be used by the pool and emitter, as recently promoted transactions may be emitted within the same state context. 

```
	// The cache size of 100k entries is chosen arbitrarily and can be tuned
	// Evaluation of block current-1 are never used again, so we can consider
	// that the cache is only useful for the current block. This means that the
	//  cache contains evaluations for up to 100k envelopes pending of execution.
	//
	// Maximum memory consumption is a constant factor of the following formula:
	// number of bundles in the cache * (size of bundle plan hash + size of block number + size of BundleState)
	// 32  + 8 + ( 1+1 + 24, aligned to 32) = 72 bytes per entry, so ~7.2MiB for 100k entries.
	// Notice that the reasons in the bundle state point to static strings,
	// so they do not contribute to the memory consumption of each entry.
```