### PR TITLE
Introduce shared cache between tx pool and emitter to reuse bundle evaluations within the same block number

### DIFF
--- a/config/make_node.go
+++ b/config/make_node.go
@@ -145,12 +145,15 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 	}
 	signer := valkeystore.NewSignerAuthority(valKeystore, cfg.Emitter.Validator.PubKey)
 
+	// shared resource between the tx pool and the emitter
+	bundleEvaluationCache := evmcore.NewBundleEvaluationCache()
+
 	// Create and register a gossip network service.
 	newTxPool := func(reader evmcore.StateReader) gossip.TxPool {
 		if cfg.TxPool.Journal != "" {
 			cfg.TxPool.Journal = path.Join(cfg.Node.DataDir, cfg.TxPool.Journal)
 		}
-		pool := evmcore.NewTxPool(cfg.TxPool, reader.CurrentConfig(), reader)
+		pool := evmcore.NewTxPool(cfg.TxPool, reader.CurrentConfig(), reader, bundleEvaluationCache)
 		cleanup = append(cleanup, pool.Stop)
 		return pool
 	}
@@ -191,6 +194,7 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 			svc.EmitterWorld(signer),
 			gdb.AsBaseFeeSource(),
 			errorLock,
+			bundleEvaluationCache,
 		))
 	}
 

--- a/evmcore/bundle_integration.go
+++ b/evmcore/bundle_integration.go
@@ -32,17 +32,19 @@ import (
 type bundlePoolStatus int
 
 const (
-	// bundlePending, the bundle hasn't yet been executed and trial-run is positive
+	// bundlePending, the bundle is executable with the current state
 	bundlePending bundlePoolStatus = iota
-	// bundleQueued, the bundle hasn't yet been executed but trial-run is negative
+	// bundleQueued, the bundle is temporarily non-executable
 	bundleQueued
-	// bundleRejected, the bundle has been executed, or is not valid
+	// bundleRejected, the bundle is permanently non-executable
 	bundleRejected
 )
 
-// newBundlesChecker constructs a checker with the available state to determine
-// if a bundle transaction is pending.
+// newBundlesChecker creates a function that checks the status of a bundle in
+// the transaction pool. This function translates BundleState into bundlePoolStatus,
+// for use in promotion/demotion/eviction of bundles in the transaction pool.
 func newBundlesChecker(
+	cache BundleEvaluator,
 	chain StateReader,
 	stateDB state.StateDB,
 ) func(*types.Transaction) bundlePoolStatus {
@@ -52,7 +54,7 @@ func newBundlesChecker(
 		stateDb: stateDB,
 	}
 	return func(tx *types.Transaction) bundlePoolStatus {
-		bundleState := GetBundleState(adapter, stateDB, tx)
+		bundleState := cache.GetBundleState(adapter, stateDB, tx)
 		if bundleState.Executable {
 			return bundlePending
 		} else if bundleState.TemporarilyBlocked {

--- a/evmcore/bundle_precheck_mock.go
+++ b/evmcore/bundle_precheck_mock.go
@@ -213,3 +213,41 @@ func (mr *MocktransactionProcessorMockRecorder) Run(arg0, arg1 any) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MocktransactionProcessor)(nil).Run), arg0, arg1)
 }
+
+// MockBundleEvaluator is a mock of BundleEvaluator interface.
+type MockBundleEvaluator struct {
+	ctrl     *gomock.Controller
+	recorder *MockBundleEvaluatorMockRecorder
+	isgomock struct{}
+}
+
+// MockBundleEvaluatorMockRecorder is the mock recorder for MockBundleEvaluator.
+type MockBundleEvaluatorMockRecorder struct {
+	mock *MockBundleEvaluator
+}
+
+// NewMockBundleEvaluator creates a new mock instance.
+func NewMockBundleEvaluator(ctrl *gomock.Controller) *MockBundleEvaluator {
+	mock := &MockBundleEvaluator{ctrl: ctrl}
+	mock.recorder = &MockBundleEvaluatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBundleEvaluator) EXPECT() *MockBundleEvaluatorMockRecorder {
+	return m.recorder
+}
+
+// GetBundleState mocks base method.
+func (m *MockBundleEvaluator) GetBundleState(chain ChainStateForBundleEval, stateDb state.StateDB, envelope *types.Transaction) BundleState {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBundleState", chain, stateDb, envelope)
+	ret0, _ := ret[0].(BundleState)
+	return ret0
+}
+
+// GetBundleState indicates an expected call of GetBundleState.
+func (mr *MockBundleEvaluatorMockRecorder) GetBundleState(chain, stateDb, envelope any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleState", reflect.TypeOf((*MockBundleEvaluator)(nil).GetBundleState), chain, stateDb, envelope)
+}

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -197,12 +197,6 @@ type subsidiesCheckFuncFactory func(
 	signer types.Signer,
 ) utils.TransactionCheckFunc
 
-// bundleCheckerFuncFactory is a factory method to create a bundle checker instance.
-type bundleCheckerFuncFactory func(
-	chain StateReader,
-	state state.StateDB,
-) func(*types.Transaction) bundlePoolStatus
-
 // TxPoolConfig are the configuration parameters of the transaction pool.
 type TxPoolConfig struct {
 	Locals    []common.Address // Addresses that should be treated by default as local
@@ -347,7 +341,7 @@ type TxPool struct {
 	subsidiesCheckerFactory subsidiesCheckFuncFactory    // Factory to create a subsidies checker instance
 	subsidiesCheckerCache   *utils.TransactionCheckCache // Cache for heavy subsidies check results
 
-	bundleCheckerFactory bundleCheckerFuncFactory // Factory to create a bundle checker instance
+	bundleEvaluationCache BundleEvaluator // Cache for bundle evaluation results
 }
 
 type txpoolResetRequest struct {
@@ -359,13 +353,15 @@ type txpoolResetRequest struct {
 func NewTxPool(
 	config TxPoolConfig,
 	chainconfig *params.ChainConfig,
-	chain StateReader) *TxPool {
+	chain StateReader,
+	bundlesCache BundleEvaluator,
+) *TxPool {
 	return newTxPool(
 		config,
 		chainconfig,
 		chain,
 		newSubsidiesChecker,
-		newBundlesChecker,
+		nil,
 	)
 }
 
@@ -374,7 +370,7 @@ func newTxPool(
 	chainconfig *params.ChainConfig,
 	chain StateReader,
 	subsidiesCheckerFactory subsidiesCheckFuncFactory,
-	bundleCheckerFactory bundleCheckerFuncFactory,
+	bundlesCache BundleEvaluator,
 ) *TxPool {
 	// Sanitize the input to ensure no vulnerable gas prices are set
 	config = (&config).sanitize()
@@ -403,7 +399,7 @@ func newTxPool(
 		subsidiesCheckerFactory: subsidiesCheckerFactory,
 		subsidiesCheckerCache:   utils.NewCheckerCache(-1), // use default size
 
-		bundleCheckerFactory: bundleCheckerFactory,
+		bundleEvaluationCache: bundlesCache,
 	}
 	pool.locals = newAccountSet(pool.signer)
 	for _, addr := range config.Locals {
@@ -760,6 +756,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		pool.chain,
 		pool.currentState,
 		subsidiesChecker,
+		pool.bundleEvaluationCache.GetBundleState,
 		pool.signer,
 	)
 	if err != nil {
@@ -1527,7 +1524,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 	var promoted []*types.Transaction
 
 	isSponsored := pool.getSubsidiesCheckerForReorg()
-	evaluateBundleStatus := pool.getBundlesCheckerForPromotion()
+	evaluateBundleStatus := newBundlesChecker(pool.bundleEvaluationCache, pool.chain, pool.currentState)
 	canPromote := func(tx *types.Transaction) bool {
 		if pool.chain.CurrentRules().Upgrades.Brio {
 			if bundle.IsEnvelope(tx) {
@@ -1617,14 +1614,6 @@ func (pool *TxPool) getSubsidiesCheckerForReorg() utils.TransactionCheckFunc {
 			pool.currentState,
 			pool.signer,
 		))
-}
-
-func (pool *TxPool) getBundlesCheckerForPromotion() func(*types.Transaction) bundlePoolStatus {
-	// TODO: cache?
-	return pool.bundleCheckerFactory(
-		pool.chain,
-		pool.currentState,
-	)
 }
 
 // truncatePending removes transactions from the pending queue if the pool is above the
@@ -1767,7 +1756,7 @@ func (pool *TxPool) truncateQueue() {
 func (pool *TxPool) demoteUnexecutables() {
 
 	isSponsored := pool.getSubsidiesCheckerForReorg()
-	isBundlePending := pool.getBundlesCheckerForPromotion()
+	evaluateBundle := newBundlesChecker(pool.bundleEvaluationCache, pool.chain, pool.currentState)
 
 	// Iterate over all accounts and demote any non-executable transactions
 	for addr, list := range pool.pending {
@@ -1793,7 +1782,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			utils.Uint256ToBigInt(pool.currentState.GetBalance(addr)),
 			pool.currentMaxGas,
 			isSponsored,
-			isBundlePending,
+			evaluateBundle,
 			pool.chain.CurrentRules().Upgrades,
 		)
 		for _, tx := range drops {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -756,7 +756,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		pool.chain,
 		pool.currentState,
 		subsidiesChecker,
-		pool.bundleEvaluationCache.GetBundleState,
+		pool.bundleEvaluationCache,
 		pool.signer,
 	)
 	if err != nil {

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -361,7 +361,7 @@ func NewTxPool(
 		chainconfig,
 		chain,
 		newSubsidiesChecker,
-		nil,
+		bundlesCache,
 	)
 }
 

--- a/evmcore/tx_pool_bundles_test.go
+++ b/evmcore/tx_pool_bundles_test.go
@@ -124,7 +124,9 @@ func TestTxPool_TransactionsAreQueuedAccordingToTheirExecutionStatus(t *testing.
 				return nil
 			}
 
-			pool := newTxPool(poolConfig, chainConfig, chain, subsidiesCheckFactory, newBundlesChecker)
+			bundleEvaluationCache := NewBundleEvaluationCache()
+
+			pool := newTxPool(poolConfig, chainConfig, chain, subsidiesCheckFactory, bundleEvaluationCache)
 
 			pending, queued := pool.Content()
 			expectContents(t, pending, queued, 0, 0)

--- a/evmcore/tx_pool_subsidies_test.go
+++ b/evmcore/tx_pool_subsidies_test.go
@@ -65,7 +65,7 @@ func TestTxPool_SponsoredTransactionsAreIncludedInThePendingSet(t *testing.T) {
 	}
 
 	// Instantiate the pool
-	pool := newTxPool(poolConfig, chainConfig, chain, subsidiesCheckFactory, testBundleCheckerFactory)
+	pool := newTxPool(poolConfig, chainConfig, chain, subsidiesCheckFactory, nil)
 
 	// transactions per sender
 	const transactionsPerSender = 5

--- a/evmcore/tx_pool_subsidies_test.go
+++ b/evmcore/tx_pool_subsidies_test.go
@@ -64,8 +64,10 @@ func TestTxPool_SponsoredTransactionsAreIncludedInThePendingSet(t *testing.T) {
 		}
 	}
 
+	bundlesEvaluator := NewMockBundleEvaluator(ctrl)
+
 	// Instantiate the pool
-	pool := newTxPool(poolConfig, chainConfig, chain, subsidiesCheckFactory, nil)
+	pool := newTxPool(poolConfig, chainConfig, chain, subsidiesCheckFactory, bundlesEvaluator)
 
 	// transactions per sender
 	const transactionsPerSender = 5

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -352,7 +352,7 @@ func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateK
 		config,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 
 	return pool, key
@@ -468,7 +468,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	tx0 := transaction(0, 100000, key)
 	tx1 := transaction(1, 100000, key)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, nil)
 	defer pool.Stop()
 
 	nonce := pool.Nonce(address)
@@ -944,7 +944,7 @@ func TestSetCodeTransactions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			// initialize the pool
-			pool := newTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory, testBundleCheckerFactory)
+			pool := newTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory, nil)
 			defer pool.Stop()
 
 			test.test(t, pool)
@@ -974,7 +974,7 @@ func TestSetCodeTransactionsReorg(t *testing.T) {
 		pragueConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -1031,7 +1031,7 @@ func TestSetCodeTransaction_RemoveAuthorityWhenSetCodeTxIsRemoved(t *testing.T) 
 	blockchain := NewTestBlockChain(db)
 
 	// initialize the pool
-	pool := newTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory, testBundleCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, pragueConfig, blockchain, testSubsidiesCheckerFactory, nil)
 	defer pool.Stop()
 
 	// Create the test accounts
@@ -1480,7 +1480,7 @@ func TestTransactionPostponing(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -1702,7 +1702,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -1800,7 +1800,7 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals bool) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -1944,7 +1944,7 @@ func TestTransactionQueueTruncating(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2055,7 +2055,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2165,7 +2165,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2203,7 +2203,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2249,7 +2249,7 @@ func TestTransactionPool_CanReadMinTipFromPool(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2281,7 +2281,7 @@ func TestTransactionPool_RejectsUnderTippedTransactions(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2325,7 +2325,7 @@ func TestTransactionPool_AcceptsUnderTippedLocals(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2371,7 +2371,7 @@ func TestTransactionPool_DropUnderpricedTransactionsWhenPoolIsFull(t *testing.T)
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2492,7 +2492,7 @@ func TestTransactionPool_DroppingUnderpricedTransactionsDoesNotCreateNonceGaps(t
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2734,7 +2734,7 @@ func TestTransactionDeduplication(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -2806,7 +2806,7 @@ func TestTransactionReplacement(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -3004,7 +3004,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 
 	// Create two test accounts to ensure remotes expire but locals do not
@@ -3047,7 +3047,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 
 	pending, queued = pool.Stats()
@@ -3079,7 +3079,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 
 	pending, queued = pool.Stats()
@@ -3115,7 +3115,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -3190,7 +3190,7 @@ func TestSampleHashes_AllExpectedTransactionsAreReturned(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -3271,7 +3271,7 @@ func TestSampleHashesManySenders(t *testing.T) {
 	statedb := newTestTxPoolStateDb()
 	blockchain := NewTestBlockChain(statedb)
 
-	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory, testBundleCheckerFactory)
+	pool := newTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, testSubsidiesCheckerFactory, nil)
 	defer pool.Stop()
 
 	expectedTxs := make(map[common.Hash]int)
@@ -3334,7 +3334,7 @@ func TestTxPool_ActivatingOsakaDropsTransactionsWithHighGas(t *testing.T) {
 		params.TestChainConfig,
 		blockchain,
 		testSubsidiesCheckerFactory,
-		testBundleCheckerFactory,
+		nil,
 	)
 	defer pool.Stop()
 
@@ -3544,12 +3544,5 @@ func testSubsidiesCheckerFactory(
 	state state.StateDB,
 	signer types.Signer,
 ) utils.TransactionCheckFunc {
-	return nil
-}
-
-func testBundleCheckerFactory(
-	chain StateReader,
-	state state.StateDB,
-) func(tx *types.Transaction) bundlePoolStatus {
 	return nil
 }

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -81,6 +81,7 @@ func validateTx(
 	chain StateReader,
 	state state.StateDB, // Although this can be retrieved from chain, it's passed explicitly to avoid extra db-pool accesses
 	isSponsored utils.TransactionCheckFunc,
+	getBundleState func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState,
 	signer types.Signer,
 ) error {
 
@@ -111,7 +112,7 @@ func validateTx(
 		return err
 	}
 
-	if err := validateBundleTransactions(tx, netRules, chain, state, signer); err != nil {
+	if err := validateBundleTransactions(tx, netRules, chain, getBundleState, state, signer); err != nil {
 		return err
 	}
 
@@ -394,11 +395,19 @@ func validateBundleTransactions(
 	tx *types.Transaction,
 	netRules NetworkRules,
 	chainState StateReader,
+	getBundleState func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState,
 	// Although state can be retrieved from chain, it is passed explicitly to avoid extra db-pool accesses
 	stateDb state.StateDB,
 	signer types.Signer,
 ) error {
-	return validateBundleTransactionsInternal(tx, netRules, chainState, stateDb, signer, GetBundleState)
+	return validateBundleTransactionsInternal(
+		tx,
+		netRules,
+		chainState,
+		stateDb,
+		signer,
+		getBundleState,
+	)
 }
 
 func validateBundleTransactionsInternal(

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -81,7 +81,7 @@ func validateTx(
 	chain StateReader,
 	state state.StateDB, // Although this can be retrieved from chain, it's passed explicitly to avoid extra db-pool accesses
 	isSponsored utils.TransactionCheckFunc,
-	getBundleState func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState,
+	bundleEvaluator BundleEvaluator,
 	signer types.Signer,
 ) error {
 
@@ -112,7 +112,7 @@ func validateTx(
 		return err
 	}
 
-	if err := validateBundleTransactions(tx, netRules, chain, getBundleState, state, signer); err != nil {
+	if err := validateBundleTransactions(tx, netRules, chain, bundleEvaluator, state, signer); err != nil {
 		return err
 	}
 
@@ -395,7 +395,7 @@ func validateBundleTransactions(
 	tx *types.Transaction,
 	netRules NetworkRules,
 	chainState StateReader,
-	getBundleState func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState,
+	bundleEvaluator BundleEvaluator,
 	// Although state can be retrieved from chain, it is passed explicitly to avoid extra db-pool accesses
 	stateDb state.StateDB,
 	signer types.Signer,
@@ -406,7 +406,7 @@ func validateBundleTransactions(
 		chainState,
 		stateDb,
 		signer,
-		getBundleState,
+		bundleEvaluator,
 	)
 }
 
@@ -416,7 +416,7 @@ func validateBundleTransactionsInternal(
 	chainState StateReader,
 	stateDb state.StateDB,
 	signer types.Signer,
-	getBundleState func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState,
+	bundleEvaluator BundleEvaluator,
 ) error {
 
 	// This check only covers bundle transactions, ignore the rest.
@@ -446,7 +446,7 @@ func validateBundleTransactionsInternal(
 	}
 
 	// Check that the bundle is executable.
-	state := getBundleState(getBundleStateAdaptor{chainState}, stateDb, tx)
+	state := bundleEvaluator.GetBundleState(getBundleStateAdaptor{chainState}, stateDb, tx)
 	if !state.Executable && !state.TemporarilyBlocked {
 		err := ErrBundleNonExecutable
 		for _, reason := range state.Reasons {

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -264,7 +264,7 @@ func FuzzValidateTransaction(f *testing.F) {
 		validateErr := validateTx(
 			signedTx, opt, netRules, chain, state,
 			acceptAnySponsorshipRequest,
-			acceptAnyBundleTransaction,
+			acceptAnyBundleTransaction(ctrl),
 			signer)
 
 		// create evm to check validateTx is consistent with processor.

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -263,7 +263,9 @@ func FuzzValidateTransaction(f *testing.F) {
 		// Validate the transaction
 		validateErr := validateTx(
 			signedTx, opt, netRules, chain, state,
-			acceptAnySponsorshipRequest, signer)
+			acceptAnySponsorshipRequest,
+			acceptAnyBundleTransaction,
+			signer)
 
 		// create evm to check validateTx is consistent with processor.
 		evm := makeTestEvm(blockNum, int64(baseFee), uint64(baseFee), state, revision, chainId)

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1221,7 +1221,7 @@ func TestValidateTx_RejectsTx_WhenStaticValidationFails(t *testing.T) {
 				chain,
 				state,
 				expectNoSubsidies(t),
-				expectNoBundleTransaction(t),
+				expectNoBundleTransaction(ctrl),
 				signer)
 			require.Error(t, err)
 		})
@@ -1280,7 +1280,7 @@ func TestValidateTx_RejectsTx_WhenBlockValidationFails(t *testing.T) {
 				chain,
 				state,
 				expectNoSubsidies(t),
-				expectNoBundleTransaction(t),
+				expectNoBundleTransaction(ctrl),
 				signer,
 			)
 			require.Error(t, err)
@@ -1345,7 +1345,7 @@ func TestValidateTx_RejectsTx_WhenPoolValidationFails(t *testing.T) {
 				chain,
 				state,
 				expectNoSubsidies(t),
-				expectNoBundleTransaction(t),
+				expectNoBundleTransaction(ctrl),
 				signer)
 			require.Error(t, err)
 		})
@@ -1411,7 +1411,7 @@ func TestValidateTx_RejectsTx_WhenStateValidationFails(t *testing.T) {
 				chain,
 				state,
 				expectNoSubsidies(t),
-				expectNoBundleTransaction(t),
+				expectNoBundleTransaction(ctrl),
 				signer,
 			)
 			require.Error(t, err)
@@ -1529,7 +1529,7 @@ func TestValidateTx_AcceptsZeroGasPriceTransactions_WhenSubsidiesAreEnabled(t *t
 				chain,
 				state,
 				acceptAnySponsorshipRequest,
-				acceptAnyBundleTransaction,
+				acceptAnyBundleTransaction(ctrl),
 				signer,
 			)
 			require.NoError(t, err)
@@ -1543,7 +1543,7 @@ func TestValidateTx_AcceptsZeroGasPriceTransactions_WhenSubsidiesAreEnabled(t *t
 				chain,
 				state,
 				acceptAnySponsorshipRequest,
-				acceptAnyBundleTransaction,
+				acceptAnyBundleTransaction(ctrl),
 				signer,
 			)
 			require.Error(t, err)
@@ -1811,10 +1811,13 @@ func Test_validateBundleTransactionsInternal_EvaluatesBundleUsingGetBundleState(
 				With(bundle.Step(key, &types.AccessListTx{})).
 				Build()
 
-			err = validateBundleTransactionsInternal(envelope, bundlesEnabled, reader, stateDb, signer,
-				func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
-					return test.bundleState
-				})
+			err = validateBundleTransactionsInternal(envelope,
+				bundlesEnabled,
+				reader,
+				stateDb,
+				signer,
+				returnBundleState(ctrl, test.bundleState),
+			)
 
 			if test.expectedErr != nil {
 				require.ErrorIs(t, err, test.expectedErr)
@@ -1846,12 +1849,13 @@ func Test_validateBundleTransactionsInternal_AccumulatesRejectionReasons(t *test
 
 	reasons := []string{"reason1", "reason2"}
 
-	err = validateBundleTransactionsInternal(envelope, bundlesEnabled, reader, stateDb, signer,
-		func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
-			return BundleState{
-				Reasons: reasons,
-			}
-		})
+	err = validateBundleTransactionsInternal(envelope,
+		bundlesEnabled,
+		reader,
+		stateDb,
+		signer,
+		returnBundleState(ctrl, BundleState{Reasons: reasons}),
+	)
 	require.ErrorIs(t, err, ErrBundleNonExecutable)
 	for _, reason := range reasons {
 		require.ErrorContains(t, err, reason)
@@ -1923,7 +1927,7 @@ func TestValidateTx_AllowsSponsoredZeroGasPriceTransactions_WhenSubsidiesAreFund
 				chain,
 				state,
 				subsidiesChecker,
-				acceptAnyBundleTransaction,
+				acceptAnyBundleTransaction(ctrl),
 				signer,
 			)
 			if test.isSponsored {
@@ -1999,7 +2003,7 @@ func TestValidateTx_Success(t *testing.T) {
 				chain,
 				state,
 				expectNoSubsidies(t),
-				acceptAnyBundleTransaction,
+				acceptAnyBundleTransaction(ctrl),
 				signer,
 			)
 			require.NoError(t, err)
@@ -2103,15 +2107,23 @@ func acceptAnySponsorshipRequest(*types.Transaction) bool {
 	return true
 }
 
-func expectNoBundleTransaction(t *testing.T) func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
-	return func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
-		t.Fatal("unexpected bundle transaction in this test")
-		return BundleState{}
-	}
+func expectNoBundleTransaction(ctrl *gomock.Controller) BundleEvaluator {
+	mock := NewMockBundleEvaluator(ctrl)
+	return mock
 }
 
-func acceptAnyBundleTransaction(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
-	return BundleState{
-		Executable: true,
-	}
+func acceptAnyBundleTransaction(ctrl *gomock.Controller) BundleEvaluator {
+	mock := NewMockBundleEvaluator(ctrl)
+	mock.EXPECT().GetBundleState(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(BundleState{Executable: true}).
+		AnyTimes()
+	return mock
+}
+
+func returnBundleState(ctrl *gomock.Controller, state BundleState) BundleEvaluator {
+	mock := NewMockBundleEvaluator(ctrl)
+	mock.EXPECT().GetBundleState(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(state).
+		AnyTimes()
+	return mock
 }

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -1165,7 +1165,7 @@ func TestValidateTx_RejectsTx_whenNetworkValidationFails(t *testing.T) {
 
 			rules := NetworkRules{}
 
-			err := validateTx(types.NewTx(tx), opts, rules, nil, nil, nil, nil)
+			err := validateTx(types.NewTx(tx), opts, rules, nil, nil, nil, nil, nil)
 			require.Error(t, err)
 		})
 	}
@@ -1221,6 +1221,7 @@ func TestValidateTx_RejectsTx_WhenStaticValidationFails(t *testing.T) {
 				chain,
 				state,
 				expectNoSubsidies(t),
+				expectNoBundleTransaction(t),
 				signer)
 			require.Error(t, err)
 		})
@@ -1279,6 +1280,7 @@ func TestValidateTx_RejectsTx_WhenBlockValidationFails(t *testing.T) {
 				chain,
 				state,
 				expectNoSubsidies(t),
+				expectNoBundleTransaction(t),
 				signer,
 			)
 			require.Error(t, err)
@@ -1336,7 +1338,15 @@ func TestValidateTx_RejectsTx_WhenPoolValidationFails(t *testing.T) {
 				locals: newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, expectNoSubsidies(t), signer)
+			err := validateTx(
+				types.NewTx(tx),
+				opts,
+				rules,
+				chain,
+				state,
+				expectNoSubsidies(t),
+				expectNoBundleTransaction(t),
+				signer)
 			require.Error(t, err)
 		})
 	}
@@ -1394,7 +1404,16 @@ func TestValidateTx_RejectsTx_WhenStateValidationFails(t *testing.T) {
 				locals:  newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, expectNoSubsidies(t), signer)
+			err := validateTx(
+				types.NewTx(tx),
+				opts,
+				rules,
+				chain,
+				state,
+				expectNoSubsidies(t),
+				expectNoBundleTransaction(t),
+				signer,
+			)
 			require.Error(t, err)
 		})
 	}
@@ -1433,6 +1452,7 @@ func TestValidateTx_RejectsTx_WhenBundleTransactionValidationFails(t *testing.T)
 		},
 		chain,
 		state,
+		nil,
 		nil,
 		signer,
 	), ErrBundleTransactionInvalid)
@@ -1502,12 +1522,30 @@ func TestValidateTx_AcceptsZeroGasPriceTransactions_WhenSubsidiesAreEnabled(t *t
 				locals:  newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, acceptAnySponsorshipRequest, signer)
+			err := validateTx(
+				types.NewTx(tx),
+				opts,
+				rules,
+				chain,
+				state,
+				acceptAnySponsorshipRequest,
+				acceptAnyBundleTransaction,
+				signer,
+			)
 			require.NoError(t, err)
 
 			//Check that the same transaction is rejected when gas subsidies are disabled
 			rules.gasSubsidies = false
-			err = validateTx(types.NewTx(tx), opts, rules, chain, state, acceptAnySponsorshipRequest, signer)
+			err = validateTx(
+				types.NewTx(tx),
+				opts,
+				rules,
+				chain,
+				state,
+				acceptAnySponsorshipRequest,
+				acceptAnyBundleTransaction,
+				signer,
+			)
 			require.Error(t, err)
 		})
 	}
@@ -1637,7 +1675,7 @@ func Test_validateBundleTransactions_AcceptNonBundleTransactions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 			require.False(bundle.IsEnvelope(tx))
-			require.NoError(validateBundleTransactions(tx, NetworkRules{}, nil, nil, nil))
+			require.NoError(validateBundleTransactions(tx, NetworkRules{}, nil, nil, nil, nil))
 		})
 	}
 }
@@ -1676,7 +1714,7 @@ func Test_validateBundleTransactions_RespectNetworkRules(t *testing.T) {
 			state := state.NewMockStateDB(ctrl)
 			state.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()).Return(true).AnyTimes()
 
-			err := validateBundleTransactions(bundle, test.rules, nil, state, signer)
+			err := validateBundleTransactions(bundle, test.rules, nil, nil, state, signer)
 			require.ErrorIs(err, test.expectedError)
 		})
 	}
@@ -1696,7 +1734,7 @@ func Test_validateBundleTransactions_ReturnsErrorWithMalformedEnvelope(t *testin
 		transactionBundles: true,
 	}
 
-	err := validateBundleTransactions(malformedBundle, bundlesEnabled, nil, nil, nil)
+	err := validateBundleTransactions(malformedBundle, bundlesEnabled, nil, nil, nil, nil)
 	require.ErrorIs(err, ErrBundleTransactionInvalid)
 }
 
@@ -1722,7 +1760,7 @@ func Test_validateBundleTransactions_RejectsRecentlyProcessedBundles(t *testing.
 
 	state.EXPECT().HasBundleRecentlyBeenProcessed(plan.Hash()).Return(true)
 
-	err = validateBundleTransactions(envelope, bundlesEnabled, nil, state, signer)
+	err = validateBundleTransactions(envelope, bundlesEnabled, nil, nil, state, signer)
 	require.ErrorIs(err, ErrBundleAlreadyProcessed)
 }
 
@@ -1878,7 +1916,16 @@ func TestValidateTx_AllowsSponsoredZeroGasPriceTransactions_WhenSubsidiesAreFund
 				locals:  newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(test.tx), opts, rules, chain, state, subsidiesChecker, signer)
+			err := validateTx(
+				types.NewTx(test.tx),
+				opts,
+				rules,
+				chain,
+				state,
+				subsidiesChecker,
+				acceptAnyBundleTransaction,
+				signer,
+			)
 			if test.isSponsored {
 				require.NoError(t, err)
 			} else {
@@ -1945,7 +1992,16 @@ func TestValidateTx_Success(t *testing.T) {
 				locals:  newAccountSet(signer),
 			}
 
-			err := validateTx(types.NewTx(tx), opts, rules, chain, state, expectNoSubsidies(t), signer)
+			err := validateTx(
+				types.NewTx(tx),
+				opts,
+				rules,
+				chain,
+				state,
+				expectNoSubsidies(t),
+				acceptAnyBundleTransaction,
+				signer,
+			)
 			require.NoError(t, err)
 		})
 	}
@@ -2045,4 +2101,17 @@ func expectNoSubsidies(t *testing.T) func(*types.Transaction) bool {
 // acceptAnySponsorshipRequest returns a subsidies checker that accepts any sponsorship request.
 func acceptAnySponsorshipRequest(*types.Transaction) bool {
 	return true
+}
+
+func expectNoBundleTransaction(t *testing.T) func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
+	return func(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
+		t.Fatal("unexpected bundle transaction in this test")
+		return BundleState{}
+	}
+}
+
+func acceptAnyBundleTransaction(ChainStateForBundleEval, state.StateDB, *types.Transaction) BundleState {
+	return BundleState{
+		Executable: true,
+	}
 }

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -211,7 +211,7 @@ func newTestEnvWithUpgrades(
 		signer := valkeystore.NewSignerAuthority(keyStore, pubkey)
 		world := env.EmitterWorld(signer)
 		world.External = testEmitterWorldExternal{world.External, env}
-		em := emitter.NewEmitter(cfg, world, store.AsBaseFeeSource(), nil)
+		em := emitter.NewEmitter(cfg, world, store.AsBaseFeeSource(), nil, nil)
 		env.RegisterEmitter(em)
 		env.pubkeys = append(env.pubkeys, pubkey)
 		em.Start()

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/txtime"
@@ -159,6 +160,8 @@ type Emitter struct {
 	proposalTracker inter.ProposalTracker
 
 	eventEmissionThrottler throttler.ThrottlingState
+
+	bundleCache evmcore.BundleEvaluator
 }
 
 type BaseFeeSource interface {
@@ -190,6 +193,7 @@ func NewEmitter(
 	world World,
 	baseFeeSource BaseFeeSource,
 	errorLock *errlock.ErrorLock,
+	bundleCache evmcore.BundleEvaluator,
 ) *Emitter {
 	// Randomize event time to decrease chance of 2 parallel instances emitting event at the same time
 	// It increases the chance of detecting parallel instances
@@ -203,6 +207,7 @@ func NewEmitter(
 		Periodic:      logger.Periodic{Instance: logger.New()},
 		baseFeeSource: baseFeeSource,
 		errorLock:     errorLock,
+		bundleCache:   bundleCache,
 	}
 	res.eventEmissionThrottler = throttler.NewThrottlingState(
 		config.Validator.ID,

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -79,7 +79,7 @@ func TestEmitter(t *testing.T) {
 		TxPool:            txPool,
 		EventsSigner:      signer,
 		TransactionSigner: txSigner,
-	}, fixedPriceBaseFeeSource{}, nil)
+	}, fixedPriceBaseFeeSource{}, nil, nil)
 
 	t.Run("init", func(t *testing.T) {
 		external.EXPECT().GetRules().

--- a/gossip/emitter/parents_test.go
+++ b/gossip/emitter/parents_test.go
@@ -37,6 +37,7 @@ func TestChooseParents_NoParentsForGenesisEvent(t *testing.T) {
 		World{External: external},
 		fixedPriceBaseFeeSource{},
 		nil,
+		nil,
 	)
 
 	epoch := idx.Epoch(1)
@@ -63,6 +64,7 @@ func TestChooseParents_NonGenesisEventMustHaveOneSelfParent(t *testing.T) {
 		config.DefaultConfig(),
 		World{External: external},
 		fixedPriceBaseFeeSource{},
+		nil,
 		nil,
 	)
 	em.maxParents = 3

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -236,7 +236,7 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 // isValidBundleTx checks whether the given transaction is a valid bundle that
 // could be emitted by this emitter.
 func (em *Emitter) isValidBundleTx(tx *types.Transaction) bool {
-	return em.isRunnableBundleTxInternal(tx, evmcore.GetBundleState)
+	return em.isRunnableBundleTxInternal(tx, em.bundleCache.GetBundleState)
 }
 
 func (em *Emitter) isRunnableBundleTxInternal(

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -32,7 +32,6 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter"
-	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/txtime"
@@ -236,12 +235,12 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 // isValidBundleTx checks whether the given transaction is a valid bundle that
 // could be emitted by this emitter.
 func (em *Emitter) isValidBundleTx(tx *types.Transaction) bool {
-	return em.isRunnableBundleTxInternal(tx, em.bundleCache.GetBundleState)
+	return em.isRunnableBundleTxInternal(tx, em.bundleCache)
 }
 
 func (em *Emitter) isRunnableBundleTxInternal(
 	tx *types.Transaction,
-	getBundleState func(evmcore.ChainStateForBundleEval, state.StateDB, *types.Transaction) evmcore.BundleState,
+	evalBundle evmcore.BundleEvaluator,
 ) bool {
 	// Ignore if bundled transactions are not enabled.
 	if !em.world.GetRules().Upgrades.TransactionBundles {
@@ -276,7 +275,7 @@ func (em *Emitter) isRunnableBundleTxInternal(
 
 	// Skip bundles that are not runnable in the current state.
 	adapter := &preCheckChainStateAdapter{external: em.world}
-	return getBundleState(adapter, stateDb, tx).Executable
+	return evalBundle.GetBundleState(adapter, stateDb, tx).Executable
 }
 
 type preCheckChainStateAdapter struct {

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -80,11 +80,14 @@ func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testi
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(err)
 
-			allBundlesRunnable := func(evmcore.ChainStateForBundleEval, state.StateDB, *types.Transaction) evmcore.BundleState {
-				return evmcore.BundleState{Executable: true}
+			bundleEvaluator := evmcore.NewMockBundleEvaluator(ctrl)
+			if bundlesEnabled {
+				// if bundles are enabled, it will be evaluated
+				bundleEvaluator.EXPECT().GetBundleState(gomock.Any(), gomock.Any(), tx).
+					Return(evmcore.BundleState{Executable: true})
 			}
 
-			require.Equal(bundlesEnabled, emitter.isRunnableBundleTxInternal(tx, allBundlesRunnable))
+			require.Equal(bundlesEnabled, emitter.isRunnableBundleTxInternal(tx, bundleEvaluator))
 		})
 	}
 }
@@ -163,11 +166,14 @@ func Test_Emitter_isValidBundleTx_RejectsAlreadyProcessedBundle(t *testing.T) {
 			_, _, err := bundle.ValidateEnvelope(signer, tx)
 			require.NoError(t, err)
 
-			getBundleState := func(evmcore.ChainStateForBundleEval, state.StateDB, *types.Transaction) evmcore.BundleState {
-				return evmcore.BundleState{Executable: true}
+			bundleEvaluator := evmcore.NewMockBundleEvaluator(ctrl)
+			if !processed {
+				// if not processed already, it will be evaluated
+				bundleEvaluator.EXPECT().GetBundleState(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(evmcore.BundleState{Executable: true})
 			}
 
-			require.Equal(t, !processed, emitter.isRunnableBundleTxInternal(tx, getBundleState))
+			require.Equal(t, !processed, emitter.isRunnableBundleTxInternal(tx, bundleEvaluator))
 		})
 	}
 }

--- a/gossip/handler_fuzz_test.go
+++ b/gossip/handler_fuzz_test.go
@@ -124,7 +124,7 @@ func makeFuzzedHandler(t *testing.T) (*handler, error) {
 		&EvmStateReader{
 			ServiceFeed: feed,
 			store:       store,
-		})
+		}, nil)
 	t.Cleanup(txpool.Stop)
 
 	h, err := newHandler(


### PR DESCRIPTION
This PR adds a cache shared between the emitter and the transaction pool to cache evaluations of bundles, whenever they can be executed, are blocked or can be discarded. 

The cache is initialized in [config/make_node.go](https://github.com/0xsoniclabs/sonic/compare/luis/tx_pool_bundles_performance?expand=1#diff-e4d4a10709e3b24b15ee28d75652f62379009629d0824f4b170b5be75c22ae60) and then shared with the instances of the pool and the emitter. 

The pool uses this facility in the following locations:
- to validate envelopes as they arrive in the pool for the first time.
- to evaluate if envelopes are dropped from the queued/pending lists. 
- to promote envelopes from queued into pending and vice-versa. 

The emitter uses the facility when evaluating transactions for inclusion in the next event.


Test using `TestBundle_StressWithExpensiveInternalRollback/ComputeHeavy`, this test can emit one envelope per event, therefore creating congestion in the pending list, which forces evaluations for both demoting envelopes to queued and to attempt to emit them again. This test benefits from caching evaluations.

**before** 
<img width="1246" height="1204" alt="image" src="https://github.com/user-attachments/assets/c584d41e-9ef0-42d5-9dfa-efa7d6c35e95" />


**after** 
<img width="1246" height="1204" alt="image" src="https://github.com/user-attachments/assets/3997a21a-4d41-4c35-883f-d2f1dd949039" />

