### PR TITLE
Use standard maps/slices instead of experimental.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tyler-smith/go-bip39 v1.1.0
 	go.uber.org/mock v0.6.0
-	golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d
 	golang.org/x/sys v0.40.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/urfave/cli.v1 v1.20.0
@@ -140,6 +139,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	golang.org/x/crypto v0.44.0 // indirect
+	golang.org/x/exp v0.0.0-20241204233417-43b7b7cde48d // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/scc/cert/bitset_test.go
+++ b/scc/cert/bitset_test.go
@@ -18,11 +18,12 @@ package cert
 
 import (
 	"encoding/json"
+	"maps"
 	"math/rand/v2"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 func TestBitSet_Default_IsEmpty(t *testing.T) {
@@ -72,7 +73,7 @@ func TestBitSet_ContainsAndEntriesAreConsistent(t *testing.T) {
 			require.Equal(t, found, b.Contains(i))
 		}
 
-		require.ElementsMatch(t, maps.Keys(ref), b.Entries())
+		require.ElementsMatch(t, slices.Collect(maps.Keys(ref)), b.Entries())
 	}
 }
 

--- a/tests/max_block_size/max_block_size_test.go
+++ b/tests/max_block_size/max_block_size_test.go
@@ -19,6 +19,7 @@ package max_block_size
 import (
 	"fmt"
 	"math/big"
+	"slices"
 	"testing"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 // This test ensures that the maximum block size introduced in EIP-7934 is

--- a/tests/rpc_replay_test.go
+++ b/tests/rpc_replay_test.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"math/big"
+	"slices"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/api/ethapi"
@@ -25,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestRpcReplay_IsConsistentWithUpgradesAtBlockHeight(t *testing.T) {


### PR DESCRIPTION
Origin: https://github.com/0xsoniclabs/sonic/pull/943#discussion_r3201771114

This PR removes usages of `golang.org/x/exp/` maps and slices, and uses the standard `"maps"` and `"slices"` equivalents. 

The package is moved as `indirect` because:
```bash
~/sonic$ go mod why -m golang.org/x/exp
# golang.org/x/exp
github.com/0xsoniclabs/sonic/api/ethapi
github.com/0xsoniclabs/carmen/go/common
golang.org/x/exp/constraints
~/sonic$
```
This means that `carmen/go/common` uses `exp/constraints`, and that is why it is needed.