### PR TITLE
Use unit256.Int instead of big.Int in fake genesis tools

### DIFF
--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -43,8 +43,8 @@ func tmpdir(t *testing.T) string {
 func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 	genesisStore := makefakegenesis.FakeGenesisStore(
 		validatorsNum,
-		futils.ToFtm(1000000000),
-		futils.ToFtm(5000000),
+		futils.ToFtmU256(1000000000),
+		futils.ToFtmU256(5000000),
 		opera.GetSonicUpgrades(),
 	)
 	defer func() {

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -180,8 +180,8 @@ func fakeGenesisImport(ctx *cli.Context) (err error) {
 
 	genesisStore := makefakegenesis.FakeGenesisStore(
 		idx.Validator(validatorsNumber),
-		futils.ToFtm(1_000_000_000),
-		futils.ToFtm(5_000_000),
+		futils.ToFtmU256(1_000_000_000),
+		futils.ToFtmU256(5_000_000),
 		upgrades,
 	)
 	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -238,8 +238,8 @@ func newInMemoryStoreWithGenesisData(
 
 	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
 		numValidators,
-		utils.ToFtm(genesisBalance),
-		utils.ToFtm(genesisStake),
+		utils.ToFtmU256(genesisBalance),
+		utils.ToFtmU256(genesisStake),
 		rules,
 		firstEpoch,
 		2,

--- a/gossip/emitter_world_test.go
+++ b/gossip/emitter_world_test.go
@@ -61,8 +61,8 @@ func initStoreForTests(t *testing.T) *Store {
 
 	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
 		2,
-		utils.ToFtm(genesisBalance),
-		utils.ToFtm(genesisStake),
+		utils.ToFtmU256(genesisBalance),
+		utils.ToFtmU256(genesisStake),
 		opera.FakeNetRules(opera.GetSonicUpgrades()),
 		2,
 		2,

--- a/gossip/handler_fuzz_test.go
+++ b/gossip/handler_fuzz_test.go
@@ -80,8 +80,8 @@ func makeFuzzedHandler(t *testing.T) (*handler, error) {
 
 	genStore := makefakegenesis.FakeGenesisStore(
 		genesisStakers,
-		utils.ToFtm(genesisBalance),
-		utils.ToFtm(genesisStake),
+		utils.ToFtmU256(genesisBalance),
+		utils.ToFtmU256(genesisStake),
 		upgrades,
 	)
 	genesis := genStore.Genesis()

--- a/integration/makefakegenesis/genesis.go
+++ b/integration/makefakegenesis/genesis.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/integration/makegenesis"
@@ -62,17 +63,17 @@ func FakeKey(n idx.ValidatorID) *ecdsa.PrivateKey {
 	return evmcore.FakeKey(uint32(n))
 }
 
-func FakeGenesisStore(num idx.Validator, balance, stake *big.Int, upgrades opera.Upgrades) *genesisstore.Store {
+func FakeGenesisStore(num idx.Validator, balance, stake *uint256.Int, upgrades opera.Upgrades) *genesisstore.Store {
 	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules(upgrades))
 }
 
-func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *big.Int, rules opera.Rules) *genesisstore.Store {
+func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *uint256.Int, rules opera.Rules) *genesisstore.Store {
 	return FakeGenesisStoreWithRulesAndStart(num, balance, stake, rules, 2, 1)
 }
 
 func FakeGenesisStoreWithRulesAndStart(
 	num idx.Validator,
-	balance, stake *big.Int,
+	balance, stake *uint256.Int,
 	rules opera.Rules,
 	epoch idx.Epoch,
 	block idx.Block,
@@ -88,7 +89,7 @@ func FakeGenesisStoreWithRulesAndStart(
 		delegations = append(delegations, drivercall.Delegation{
 			Address:            val.Address,
 			ValidatorID:        val.ID,
-			Stake:              stake,
+			Stake:              stake.ToBig(),
 			LockedStake:        new(big.Int),
 			LockupFromEpoch:    0,
 			LockupEndTime:      0,

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -53,6 +53,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 )
 
 type GenesisJson struct {
@@ -66,7 +67,7 @@ type GenesisJson struct {
 type Account struct {
 	Name    string
 	Address common.Address
-	Balance *big.Int                    `json:",omitempty"`
+	Balance *uint256.Int                `json:",omitempty"`
 	Code    VariableLenCode             `json:",omitempty"`
 	Nonce   uint64                      `json:",omitempty"`
 	Storage map[common.Hash]common.Hash `json:",omitempty"`
@@ -177,8 +178,8 @@ func GenerateFakeJsonGenesis(
 	}
 
 	// Create the validator accounts and provide some tokens.
-	tokensPerValidator := utils.ToFtm(1_000_000_000)
-	totalSupply := big.NewInt(0)
+	tokensPerValidator := utils.ToFtmU256(1_000_000_000)
+	totalSupply := uint256.NewInt(0)
 	validatorParameters := GetFakeValidators(idx.Validator(len(validatorsStake)))
 	for _, validator := range validatorParameters {
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
@@ -204,7 +205,7 @@ func GenerateFakeJsonGenesis(
 	}
 
 	// Create the genesis transactions.
-	genesisTxs := GetGenesisTxs(0, validatorParameters, totalSupply, delegations, validatorParameters[0].Address)
+	genesisTxs := GetGenesisTxs(0, validatorParameters, totalSupply.ToBig(), delegations, validatorParameters[0].Address)
 	for _, tx := range genesisTxs {
 		jsonGenesis.Txs = append(jsonGenesis.Txs, Transaction{
 			To:   *tx.To(),

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -31,6 +31,7 @@ import (
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	"github.com/0xsoniclabs/sonic/utils/objstream"
 	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/holiman/uint256"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -53,7 +54,6 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/genesis"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
-	"github.com/0xsoniclabs/sonic/utils"
 
 	mptIo "github.com/0xsoniclabs/carmen/go/database/mpt/io"
 	carmen "github.com/0xsoniclabs/carmen/go/state"
@@ -64,7 +64,7 @@ type GenesisBuilder struct {
 	carmenDir     string
 	carmenStateDb carmen.StateDB
 
-	totalSupply *big.Int
+	totalSupply *uint256.Int
 
 	blocks       []ibr.LlrIdxFullBlockRecord
 	epochs       []ier.LlrIdxFullEpochRecord
@@ -94,11 +94,11 @@ func DefaultBlockProc() BlockProc {
 	}
 }
 
-func (b *GenesisBuilder) AddBalance(acc common.Address, balance *big.Int) {
+func (b *GenesisBuilder) AddBalance(acc common.Address, balance *uint256.Int) {
 	if len(b.blocks) > 0 {
 		panic("cannot add balance after block zero is finalized")
 	}
-	b.tmpStateDB.AddBalance(acc, utils.BigIntToUint256(balance), tracing.BalanceIncreaseGenesisBalance)
+	b.tmpStateDB.AddBalance(acc, balance, tracing.BalanceIncreaseGenesisBalance)
 	b.totalSupply.Add(b.totalSupply, balance)
 }
 
@@ -128,7 +128,7 @@ func (b *GenesisBuilder) SetCurrentEpoch(er ier.LlrIdxFullEpochRecord) {
 }
 
 func (b *GenesisBuilder) TotalSupply() *big.Int {
-	return b.totalSupply
+	return b.totalSupply.ToBig()
 }
 
 func (b *GenesisBuilder) CurrentHash() hash.Hash {
@@ -159,7 +159,7 @@ func NewGenesisBuilder() *GenesisBuilder {
 		tmpStateDB:    tmpStateDB,
 		carmenDir:     carmenDir,
 		carmenStateDb: carmenStateDb,
-		totalSupply:   new(big.Int),
+		totalSupply:   new(uint256.Int),
 	}
 }
 

--- a/integration/makegenesis/genesis_test.go
+++ b/integration/makegenesis/genesis_test.go
@@ -44,7 +44,7 @@ func TestGenesisBuilder_ExecuteGenesisTxs_ExecutesTransactionsAccordingToUpgrade
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 	address := crypto.PubkeyToAddress(key.PublicKey)
-	builder.AddBalance(address, big.NewInt(1e18))
+	builder.AddBalance(address, uint256.NewInt(1e18))
 
 	finalizeBlockZero(t, builder, rules)
 

--- a/tests/block_verifiability_utils.go
+++ b/tests/block_verifiability_utils.go
@@ -191,9 +191,10 @@ func (s *State) ApplyGenesis(genesis *makefakegenesis.GenesisJson) error {
 		if len(account.Code) != 0 {
 			s.db.SetCode(cc.Address(address), account.Code)
 		}
-		balance, err := amount.NewFromBigInt(account.Balance)
-		if err != nil {
-			return fmt.Errorf("invalid balance for account %s: %w", address.Hex(), err)
+
+		var balance amount.Amount
+		if account.Balance != nil {
+			balance = amount.NewFromUint256(account.Balance)
 		}
 		s.db.AddBalance(cc.Address(address), balance)
 		s.db.SetNonce(cc.Address(address), account.Nonce)

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -101,8 +101,8 @@ func getNodeService(t *testing.T) *gossip.Service {
 
 	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
 		1,
-		utils.ToFtm(genesisBalance),
-		utils.ToFtm(genesisStake),
+		utils.ToFtmU256(genesisBalance),
+		utils.ToFtmU256(genesisStake),
 		rules,
 		1,
 		2,

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -39,6 +39,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 
 	sonicd "github.com/0xsoniclabs/sonic/cmd/sonicd/app"
@@ -393,9 +394,9 @@ func StartIntegrationTestNetWithJsonGenesis(
 		cur := &jsonGenesis.Accounts[i]
 		if cur.Address == sponsorAddress {
 			// enough tokens to endow plenty of accounts
-			extraBalanceForSponsor := new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e9))
+			extraBalanceForSponsor := new(uint256.Int).Mul(uint256.NewInt(1e18), uint256.NewInt(1e9))
 			balance := cur.Balance
-			cur.Balance = new(big.Int).Add(balance, extraBalanceForSponsor)
+			cur.Balance = new(uint256.Int).Add(balance, extraBalanceForSponsor)
 			found = true
 			break
 		}

--- a/tests/max_block_size/max_block_size_test.go
+++ b/tests/max_block_size/max_block_size_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,7 +61,7 @@ func TestMaxBlockSizeIsEnforced(t *testing.T) {
 
 		genesisAccount := makefakegenesis.Account{
 			Address: account.Address(),
-			Balance: big.NewInt(1e18),
+			Balance: uint256.NewInt(1e18),
 			Nonce:   0,
 		}
 		genesisAccounts = append(genesisAccounts, genesisAccount)

--- a/tests/rejected_tx/max_nonce_test.go
+++ b/tests/rejected_tx/max_nonce_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,17 +43,17 @@ func TestAccount_RejectTransactions(t *testing.T) {
 	genesisAccounts := []makefakegenesis.Account{
 		{
 			Address: nonceAccount.Address(),
-			Balance: big.NewInt(1e18),
+			Balance: uint256.NewInt(1e18),
 			Nonce:   math.MaxUint64,
 		},
 		{
 			Address: codeAccount.Address(),
-			Balance: big.NewInt(1e18),
+			Balance: uint256.NewInt(1e18),
 			Code:    []byte{0x01},
 		},
 		{
 			Address: nonceAndCodeAccount.Address(),
-			Balance: big.NewInt(1e18),
+			Balance: uint256.NewInt(1e18),
 			Nonce:   math.MaxUint64,
 			Code:    []byte{0x01},
 		},

--- a/tests/set_code_tx_test.go
+++ b/tests/set_code_tx_test.go
@@ -1035,7 +1035,7 @@ func TestSetCode_CannotChangeCode_OfEOA(t *testing.T) {
 		Accounts: []makefakegenesis.Account{
 			{
 				Address: codeAccountAddress,
-				Balance: big.NewInt(1e18),
+				Balance: uint256.NewInt(1e18),
 				Code:    originalCode,
 			},
 		},


### PR DESCRIPTION
This removes the need to cast `big.Int` to `uint256.Int`, facilitates removing function `BigIntToUint256` by reducing its uses.


The tools modified here affect Fake Genesis and Json Genesis only. 