### PR TITLE
Remove panicking cast in emitter

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -19,6 +19,7 @@ package emitter
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"math/rand/v2"
 	"os"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/opera"
-	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/txtime"
 	"github.com/Fantom-foundation/lachesis-base/emitter/ancestor"
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -41,6 +41,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/holiman/uint256"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/gossip/emitter/config"
@@ -334,23 +335,41 @@ func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
 			pendingTxs[from] = txs[:em.config.MaxTxsPerAddress]
 		}
 	}
+
 	// Convert to lists of LazyTransactions
 	txs := make(map[common.Address][]*txpool.LazyTransaction, len(pendingTxs))
 	for from, list := range pendingTxs {
 		lazyTxs := make([]*txpool.LazyTransaction, 0, len(list))
 		for _, tx := range list {
+
+			gasFee, overflow := uint256.FromBig(tx.GasFeeCap())
+			if overflow {
+				em.Log.Error("Failed to convert tx fee cap to uint256", "hash", tx.Hash(), "gasFeeCap", tx.GasFeeCap())
+				continue
+			}
+			gasTip, overflow := uint256.FromBig(tx.GasTipCap())
+			if overflow {
+				em.Log.Error("Failed to convert tx tip cap to uint256", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap())
+				continue
+			}
+
 			lazyTxs = append(lazyTxs, &txpool.LazyTransaction{
 				Hash:      tx.Hash(),
 				Tx:        tx,
 				Time:      tx.Time(),
-				GasFeeCap: utils.BigIntToUint256(tx.GasFeeCap()),
-				GasTipCap: utils.BigIntToUint256(tx.GasTipCap()),
+				GasFeeCap: gasFee,
+				GasTipCap: gasTip,
 				Gas:       tx.Gas(),
 				BlobGas:   tx.BlobGas(),
 			})
 		}
 		txs[from] = lazyTxs
 	}
+
+	// clean addresses yielding no transactions
+	maps.DeleteFunc(txs, func(_ common.Address, txs []*txpool.LazyTransaction) bool {
+		return len(txs) == 0
+	})
 
 	sortedTxs := newTransactionsByPriceAndNonce(em.world.TransactionSigner, txs, baseFee)
 	em.cache.sortedTxs = sortedTxs

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -19,7 +19,6 @@ package emitter
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"math/big"
 	"math/rand/v2"
 	"os"
@@ -363,13 +362,10 @@ func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
 				BlobGas:   tx.BlobGas(),
 			})
 		}
-		txs[from] = lazyTxs
+		if len(lazyTxs) != 0 {
+			txs[from] = lazyTxs
+		}
 	}
-
-	// clean addresses yielding no transactions
-	maps.DeleteFunc(txs, func(_ common.Address, txs []*txpool.LazyTransaction) bool {
-		return len(txs) == 0
-	})
 
 	sortedTxs := newTransactionsByPriceAndNonce(em.world.TransactionSigner, txs, baseFee)
 	em.cache.sortedTxs = sortedTxs

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -482,6 +482,108 @@ func TestEmitter_EmitEvent(t *testing.T) {
 	require.NotNil(t, e)
 }
 
+func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
+	any := gomock.Any()
+
+	validator := idx.ValidatorID(1)
+	builder := pos.NewBuilder()
+	builder.Set(validator, pos.Weight(1))
+	validators := builder.Build()
+
+	tests := map[string]struct {
+		tx               *types.Transaction
+		expectedLog      string
+		expectedArgument string
+	}{
+
+		"overflow GasPrice": {
+			tx: types.NewTx(&types.LegacyTx{
+				GasPrice: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"overflow GasFeeCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"overflow GasTipCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasTipCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx tip cap to uint256",
+			expectedArgument: "gasTipCap",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			ctrl := gomock.NewController(t)
+
+			world := NewMockExternal(ctrl)
+			world.EXPECT().GetRules().AnyTimes()
+			world.EXPECT().GetLastEvent(any, any).AnyTimes()
+			world.EXPECT().Build(any, any).AnyTimes()
+			world.EXPECT().Check(any, any).Return(nil).AnyTimes()
+			world.EXPECT().GetLatestBlock().Return(&inter.Block{}).AnyTimes()
+			world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
+			world.EXPECT().IsBusy().AnyTimes()
+			world.EXPECT().Lock()
+			world.EXPECT().Unlock()
+			world.EXPECT().Process(any)
+			world.EXPECT().Broadcast(any)
+
+			log := logger.NewMockLogger(ctrl)
+
+			txPool := NewMockTxPool(ctrl)
+			txPool.EXPECT().Count().Return(1)
+
+			transactions := map[common.Address]types.Transactions{
+				{1}: {tt.tx},
+			}
+
+			txPool.EXPECT().Pending(gomock.Any()).Return(transactions, nil)
+
+			signer := valkeystore.NewMockSignerAuthority(ctrl)
+			signer.EXPECT().Sign(gomock.Any()).AnyTimes()
+
+			baseFeeSource := NewMockBaseFeeSource(ctrl)
+			baseFeeSource.EXPECT().GetCurrentBaseFee()
+
+			em := &Emitter{
+				baseFeeSource: baseFeeSource,
+				Periodic: logger.Periodic{
+					Instance: logger.Instance{
+						Log: log,
+					},
+				},
+				config: config.Config{
+					MaxTxsPerAddress: 1,
+					Validator: config.ValidatorConfig{
+						ID: validator,
+					},
+				},
+				world: World{
+					External:     world,
+					TxPool:       txPool,
+					EventsSigner: signer,
+				},
+			}
+			em.validators.Store(validators)
+
+			log.EXPECT().Error(tt.expectedLog, "hash", gomock.Any(), tt.expectedArgument, gomock.Any())
+
+			e, err := em.EmitEvent()
+			require.NoError(t, err)
+			require.NotNil(t, e)
+		})
+	}
+}
+
 func TestEmitter_ThrottlerWorldAdapter_ReturnsNilIfNoEventIsFound(t *testing.T) {
 	validator := idx.ValidatorID(1)
 

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -512,6 +512,7 @@ func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
 		},
 		"overflow GasTipCap": {
 			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: big.NewInt(1),
 				GasTipCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
 			}),
 			expectedLog:      "Failed to convert tx tip cap to uint256",


### PR DESCRIPTION
This PR implements defensive programming for panicking cast.
If a transaction with overflowing or negative gas fee or tip reaches the emitter, It will be skipped from emission instead of panicking. Log will be prompted. 


Note, previous code used `utils.BigIntToUint256` which would panic on negative values. The new code allows binary conversion of negative `big.Int` to `uint256.Int`, 