### PR TITLE
Fix flaky tests: receipt retrieval timeout.

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -416,6 +416,12 @@ func StartIntegrationTestNetWithJsonGenesis(
 	// Speed up the block generation time to reduce test time.
 	jsonGenesis.Rules.Emitter.Interval = inter.Timestamp(time.Millisecond)
 
+	// Set a long stall threshold to avoid the network switching into stall
+	// mode during tests. On slow machines or under heavy load each node may
+	// start stalling if the bootstrap phase takes longer than StallThreshold,
+	// this can prevent consensus from being formed.
+	jsonGenesis.Rules.Emitter.StallThreshold = inter.Timestamp(1 * time.Hour)
+
 	encoded, err := json.MarshalIndent(jsonGenesis, "", "  ")
 	require.NoError(t, err, "failed to marshal genesis json")
 


### PR DESCRIPTION
Some flaky tests suffered time-outs while retrieving the receipt from the first transaction executed. This could be caused in multi-node scenarios by having a lack of consensus. 

This PR adds a very large tolerance to consensus delays to avoid stalling during integration test bootstrap. 
Scenarios where bootstrapping the test network is slow and larger than the `StallThresshold` are penalized by stalling, and consensus formation is delayed even more. Default  `StallThresshold` is 30 s and `StallInterval` 60 s. together they approximate the 100 s timeout. 
