### PR TITLE
Add check for out-of-bound gas prices in EVM context creation

### DIFF
--- a/api/ethapi/tx_trace.go
+++ b/api/ethapi/tx_trace.go
@@ -241,7 +241,11 @@ func (s *PublicTxTraceAPI) traceCallExec(
 	}
 
 	// Set tx context in EVM
-	tracedEVM.vmenv.SetTxContext(evmcore.NewEVMTxContext(msg))
+	vmContext, err := evmcore.NewEVMTxContext(msg)
+	if err != nil {
+		return nil, err
+	}
+	tracedEVM.vmenv.SetTxContext(vmContext)
 
 	// Execute the transaction using core.ApplyMessage to capture raw return data.
 	result, applyErr := core.ApplyMessage(tracedEVM.vmenv, msg, core.NewGasPool(msg.GasLimit))
@@ -427,7 +431,7 @@ func (s *PublicTxTraceAPI) replayBlock(ctx context.Context, block *evmcore.EvmBl
 
 			vmenv, _, err := s.b.GetEVM(ctx, state, block.Header(), &vmConfig, nil)
 			if err != nil {
-				return nil, fmt.Errorf("cannot initialize vm for transaction %s, error: %s", tx.Hash().String(), err.Error())
+				return nil, fmt.Errorf("cannot initialize vm for transaction %s, error: %w", tx.Hash().String(), err)
 			}
 
 			if vmenv.ChainConfig().IsPrague(block.Number, uint64(block.Time.Unix())) {

--- a/api/ethapi/tx_trace.go
+++ b/api/ethapi/tx_trace.go
@@ -431,7 +431,7 @@ func (s *PublicTxTraceAPI) replayBlock(ctx context.Context, block *evmcore.EvmBl
 
 			vmenv, _, err := s.b.GetEVM(ctx, state, block.Header(), &vmConfig, nil)
 			if err != nil {
-				return nil, fmt.Errorf("cannot initialize vm for transaction %s, error: %w", tx.Hash().String(), err)
+				return nil, fmt.Errorf("cannot initialize vm for transaction %s, error: %s", tx.Hash().String(), err.Error())
 			}
 
 			if vmenv.ChainConfig().IsPrague(block.Number, uint64(block.Time.Unix())) {

--- a/api/ethapi/tx_trace_test.go
+++ b/api/ethapi/tx_trace_test.go
@@ -383,6 +383,42 @@ func TestTraceCallExec_BothTypes(t *testing.T) {
 	require.NotNil(t, result.StateDiff, "stateDiff must be non-nil when requested")
 }
 
+func TestTraceCallExec_InvalidGasPrice_ReturnsError(t *testing.T) {
+	tests := map[string]*core.Message{
+		"negative gas price": {
+			GasPrice: big.NewInt(-1),
+		},
+		"excessively large gas price": {
+			GasPrice: new(big.Int).Lsh(big.NewInt(1), 256),
+		},
+	}
+
+	for name, msg := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockState := state.NewMockStateDB(ctrl)
+			backend := setupBackendForTracing(ctrl, mockState)
+
+			mockState.EXPECT().SetTxContext(gomock.Any(), gomock.Any())
+
+			api := &PublicTxTraceAPI{b: backend}
+			result, err := api.traceCallExec(
+				t.Context(),
+				traceTestBlock(),
+				msg,
+				mockState,
+				traceTestTx(),
+				0,
+				true,
+				false,
+			)
+
+			require.ErrorContains(t, err, "invalid gas price")
+			require.Nil(t, result, "result must be nil on error")
+		})
+	}
+}
+
 // setupBackendForCallMany returns a MockBackend pre-configured with all expectations
 // needed by CallMany: BlockByNumber, StateAndBlockByNumberOrHash, RPCGasCap, and
 // everything required by setupTracedEVM (GetNetworkRules, RPCEVMTimeout, GetEVM).

--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -19,6 +19,7 @@ package evmcore
 //go:generate mockgen -source=evm.go -destination=evm_mock.go -package=evmcore
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/core"
@@ -91,11 +92,28 @@ func NewEVMBlockContextWithDifficulty(
 }
 
 // NewEVMTxContext creates a new transaction context for a single transaction.
-func NewEVMTxContext(msg *core.Message) vm.TxContext {
-	return vm.TxContext{
-		Origin:   msg.From,
-		GasPrice: uint256.MustFromBig(msg.GasPrice),
+// This is a wrapper around core.NewEVMTxContext to ensure that the gas price is
+// valid. If the gas price is invalid, an error is returned.
+func NewEVMTxContext(msg *core.Message) (vm.TxContext, error) {
+	if msg == nil {
+		return vm.TxContext{}, fmt.Errorf("message cannot be nil")
 	}
+	_, overflow := uint256.FromBig(msg.GasPrice)
+	if msg.GasPrice.Sign() < 0 || overflow {
+		return vm.TxContext{}, fmt.Errorf("invalid gas price %v", msg.GasPrice)
+	}
+	return core.NewEVMTxContext(msg), nil
+}
+
+// MustNewEVMTxContext is a helper function that wraps NewEVMTxContext and
+// panics if an error occurs. Use this with care, when you are sure that the
+// input message is valid.
+func MustNewEVMTxContext(msg *core.Message) vm.TxContext {
+	txContext, err := NewEVMTxContext(msg)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create EVM transaction context: %v", err))
+	}
+	return txContext
 }
 
 // GetHashFn returns a GetHashFunc which retrieves header hashes by number

--- a/evmcore/evm_test.go
+++ b/evmcore/evm_test.go
@@ -20,6 +20,11 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,4 +45,91 @@ func TestNewEVMBlockContextWithDifficulty_UsesProvidedDifficulty(t *testing.T) {
 		context := NewEVMBlockContextWithDifficulty(header, nil, nil, difficulty)
 		require.Equal(t, difficulty, context.Difficulty)
 	}
+}
+
+func TestNewEVMTxContext_ReturnsErrorForNilMessage(t *testing.T) {
+	_, err := NewEVMTxContext(nil)
+	require.ErrorContains(t, err, "message cannot be nil")
+}
+
+func TestNewEVMTxContext_ReturnsErrorForInvalidGasPrice(t *testing.T) {
+	tests := map[string]*big.Int{
+		"negative":  big.NewInt(-1),
+		"too large": new(big.Int).Lsh(big.NewInt(1), 256),
+	}
+	for name, gasPrice := range tests {
+		t.Run(name, func(t *testing.T) {
+			msg := &core.Message{
+				GasPrice: gasPrice,
+			}
+			_, err := NewEVMTxContext(msg)
+			require.ErrorContains(t, err, "invalid gas price")
+		})
+	}
+}
+
+func TestNewEVMTxContext_UsesEthereumCoreConversion(t *testing.T) {
+	msg := &core.Message{
+		From:     common.Address{1, 2, 3},
+		GasPrice: big.NewInt(100),
+		BlobHashes: []common.Hash{
+			{4, 5, 6},
+			{7, 8},
+		},
+	}
+	txContext, err := NewEVMTxContext(msg)
+	require.NoError(t, err)
+	expected := core.NewEVMTxContext(msg)
+	require.Equal(t, expected, txContext)
+}
+
+func TestNewEVMTxContext_OnlyCoversKnownFields(t *testing.T) {
+	// This test should detect if the implementation in go-ethereum changes in a
+	// way that requires us to update our wrapper.
+
+	msg := &core.Message{
+		From:      common.Address{1, 2, 3},
+		To:        &common.Address{4, 5, 6},
+		Value:     big.NewInt(1000),
+		GasLimit:  21000,
+		GasPrice:  big.NewInt(100),
+		GasFeeCap: big.NewInt(200),
+		GasTipCap: big.NewInt(50),
+		Data:      []byte{0x1, 0x2},
+		AccessList: types.AccessList{
+			{
+				Address:     common.Address{9, 10},
+				StorageKeys: []common.Hash{{11}, {12}},
+			},
+		},
+		BlobGasFeeCap: big.NewInt(300),
+		BlobHashes: []common.Hash{
+			{4, 5, 6},
+			{7, 8},
+		},
+		SetCodeAuthorizations: []types.SetCodeAuthorization{
+			{Address: common.Address{13, 14}},
+		},
+	}
+
+	txContext, err := NewEVMTxContext(msg)
+	require.NoError(t, err)
+
+	expected := vm.TxContext{
+		Origin:     msg.From,
+		GasPrice:   uint256.MustFromBig(msg.GasPrice),
+		BlobHashes: msg.BlobHashes,
+	}
+	require.Equal(t, expected, txContext)
+}
+
+func TestMustNewEVMTxContext_PanicsOnInvalidGasPrice(t *testing.T) {
+	msg := &core.Message{
+		GasPrice: big.NewInt(-1),
+	}
+	require.PanicsWithValue(
+		t,
+		"failed to create EVM transaction context: invalid gas price -1",
+		func() { MustNewEVMTxContext(msg) },
+	)
 }

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -729,7 +729,11 @@ func ApplyTransactionWithEVM(msg *core.Message, config *params.ChainConfig, gp *
 		}
 	}
 	// Create a new context to be used in the EVM environment.
-	txContext := NewEVMTxContext(msg)
+	txContext, err := NewEVMTxContext(msg)
+	if err != nil {
+		statedb.EndTransaction()
+		return nil, fmt.Errorf("failed to create EVM transaction context: %w", err)
+	}
 	evm.SetTxContext(txContext)
 
 	// For now, Sonic only supports Blob transactions without blob data.
@@ -745,6 +749,7 @@ func ApplyTransactionWithEVM(msg *core.Message, config *params.ChainConfig, gp *
 	// Apply the transaction to the current state (included in the env).
 	result, err := core.ApplyMessage(evm, msg, gp)
 	if err != nil {
+		statedb.EndTransaction()
 		return nil, err
 	}
 
@@ -798,8 +803,8 @@ func ProcessParentBlockHash(prevHash common.Hash, evm *vm.EVM, stateDb state.Sta
 		Data:      prevHash.Bytes(),
 	}
 
-	txContext := NewEVMTxContext(msg)
-	evm.SetTxContext(txContext)
+	// Must is fine, since all inputs are practically hardcoded above.
+	evm.SetTxContext(MustNewEVMTxContext(msg))
 
 	stateDb.AddAddressToAccessList(params.HistoryStorageAddress)
 	_, _, _ = evm.Call(msg.From, *msg.To, msg.Data, 30_000_000, common.U2560)
@@ -826,7 +831,11 @@ func applyTransaction(
 	error,
 ) {
 	// Create a new context to be used in the EVM environment.
-	txContext := NewEVMTxContext(msg)
+	txContext, err := NewEVMTxContext(msg)
+	if err != nil {
+		statedb.EndTransaction()
+		return nil, 0, fmt.Errorf("failed to create EVM transaction context: %w", err)
+	}
 	evm.SetTxContext(txContext)
 
 	// Skip checking of base fee limits for internal transactions.

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -703,6 +703,18 @@ func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {
 	}
 }
 
+func TestApplyTransaction_FailsForTransactionWithInvalidGasPrice(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().EndTransaction()
+
+	msg := &core.Message{
+		GasPrice: big.NewInt(-1),
+	}
+	_, _, err := applyTransaction(msg, nil, stateDb, nil, nil, nil, nil, nil)
+	require.ErrorContains(t, err, "failed to create EVM transaction context")
+}
+
 func TestApplyTransaction_BlobHashesNotSupportedAndSkipped(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	state := state.NewMockStateDB(ctrl)

--- a/tests/regressions/gas_fee_overflow_test.go
+++ b/tests/regressions/gas_fee_overflow_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package regressions
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/config"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file reproduce a bug that was reported by an external code
+// audit, identifying an overflow of the gas fee field beyond the 256-bit limit
+// as a potential attack vector for panicking the client.
+//
+// While such transactions are filtered by the TxPool and the RPC, a modified
+// validator could still attempt to include them in a block, causing the block
+// processor to panic when processing the transaction.
+//
+// This bug never reached a release, but these tests are kept as a regression
+// test to ensure that the issue is properly fixed and does not regress in the
+// future.
+
+func TestGasFeeOverflow_TransactionsWithOverflowingFeeCapsAreIgnoredByBlockProcessor(t *testing.T) {
+	net := tests.StartIntegrationTestNet(t)
+
+	account := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+
+	// Create and sign a transaction with excessive gas fees (beyond 256 bits).
+	signer := types.LatestSignerForChainID(net.GetChainId())
+	tx := types.MustSignNewTx(account.PrivateKey, signer, &types.DynamicFeeTx{
+		To:        &common.Address{},
+		Gas:       21000,
+		GasFeeCap: new(big.Int).Lsh(big.NewInt(1), 256),
+		GasTipCap: new(big.Int).Lsh(big.NewInt(1), 256),
+	})
+
+	// Send the transaction to the network, by-passing the transaction pool.
+	_, err := net.ForceEmit(t.Context(), tx)
+	require.NoError(t, err)
+
+	// Let the network progress. The bug to be reproduced by this test causes
+	// the client to panic when processing the invalid transaction.
+	net.AdvanceEpoch(t, 1)
+
+	// The transaction did not get accepted in any block.
+	_, err = net.TryGetReceipt(10*time.Second, tx.Hash())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestGasFeeOverflow_TransactionsAreRejected(t *testing.T) {
+	// This test makes sure that transactions with gas fees exceeding the
+	// 256-bit limit are rejected by both the RPC and the TxPool when using
+	// the default configuration.
+
+	cases := map[string]struct {
+		options                 tests.IntegrationTestNetOptions
+		expectedRejectionReason string
+	}{
+		"rejected by RPC": {
+			options:                 tests.IntegrationTestNetOptions{},
+			expectedRejectionReason: "exceeds the configured cap (100.00 FTM)",
+		},
+		"rejected by TxPool": {
+			options: tests.IntegrationTestNetOptions{
+				// Disable the fee-cap check in the RPC
+				ModifyConfig: func(config *config.Config) {
+					config.Opera.RPCTxFeeCap = math.Pow(2, 256) // (FTM)
+				},
+			},
+			expectedRejectionReason: "max fee per gas higher than 2^256-1",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			net := tests.StartIntegrationTestNet(t, tc.options)
+
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err)
+
+			// Create and sign a transaction with excessive gas fees (beyond 256 bits).
+			signer := types.LatestSignerForChainID(net.GetChainId())
+			tx := types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
+				To:        &common.Address{},
+				Gas:       21000,
+				GasFeeCap: new(big.Int).Lsh(big.NewInt(1), 256),
+				GasTipCap: new(big.Int).Lsh(big.NewInt(1), 256),
+			})
+
+			// Send the transaction to the network. This should be rejected
+			// either by the RPC or the TxPool, depending on the test case.
+			_, err = net.Send(tx)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedRejectionReason)
+		})
+	}
+}
+
+func TestGasFeeOverflow_TransactionWithFeeOverflowInBundleAreIgnoredByBlockProcessor(t *testing.T) {
+
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+
+	// In this setup, all TxPool and RPC checks are enabled.
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+		ClientExtraArguments: []string{
+			"--disable-txPool-validation",
+		},
+	})
+
+	account := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+
+	// Create a bundle with a transaction exceeding gas fee limits (beyond 256 bits).
+	signer := types.LatestSignerForChainID(net.GetChainId())
+	envelope, bundle, _ := bundle.NewBuilder().AllOf(
+		bundle.Step(account.PrivateKey, &types.DynamicFeeTx{
+			To:        &common.Address{},
+			Gas:       21000,
+			GasFeeCap: new(big.Int).Lsh(big.NewInt(1), 256),
+			GasTipCap: new(big.Int).Lsh(big.NewInt(1), 256),
+		}),
+	).WithSigner(signer).BuildEnvelopeBundleAndPlan()
+
+	// Send the transaction to the network. Since checks in the pool are
+	// disabled, this should be accepted.
+	_, err := net.ForceEmit(t.Context(), envelope)
+	require.NoError(t, err)
+
+	// Let the network progress. The bug to be reproduced by this test causes
+	// the client to panic when processing the invalid transaction.
+	net.AdvanceEpoch(t, 1)
+
+	// The transaction did not get accepted in any block.
+	inner := bundle.GetTransactionsInReferencedOrder()[0]
+	_, err = net.TryGetReceipt(10*time.Second, inner.Hash())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestGasFeeOverflow_TransactionWithFeeOverflowInBundleIsRejectedByThePool(t *testing.T) {
+
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+
+	// In this setup, all TxPool and RPC checks are enabled.
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
+
+	account := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+
+	// Create a bundle with a transaction exceeding gas fee limits (beyond 256 bits).
+	signer := types.LatestSignerForChainID(net.GetChainId())
+	envelope := bundle.NewBuilder().AllOf(
+		bundle.Step(account.PrivateKey, &types.DynamicFeeTx{
+			To:        &common.Address{},
+			Gas:       21000,
+			GasFeeCap: new(big.Int).Lsh(big.NewInt(1), 256),
+			GasTipCap: new(big.Int).Lsh(big.NewInt(1), 256),
+		}),
+	).WithSigner(signer).Build()
+
+	// Send the transaction to the network. This should be rejected by the
+	// TxPool, with a proper error message.
+	_, err := net.Send(envelope)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "trial-run failed")
+}


### PR DESCRIPTION
This PR introduces an integration test reproducing an vulnerability that was detected by an external code reviewer that causes nodes to crash if transactions with gas prices exceeding the 256-bit limit are processed. The PR also includes a corresponding fix for the vulnerability.

Follow-up work will add further safeguards against similar issues.