### PR TITLE
Update Carmen version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ module github.com/0xsoniclabs/sonic
 go 1.25.7
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427
+	github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4
 	github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427 h1:sMPNQv8eWqDb/lfdBZV591WO4E6yqhHFD7wmS4KyKlg=
-github.com/0xsoniclabs/carmen/go v0.0.0-20260427113009-ed285bc2e427/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4 h1:HF2gKas3kyQx28LDcN4jn1yafxa4+gsy+UXUEnli2Kc=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe h1:JPiyJPZ1oBzRwsRW0BER76wChPg7rOxKwk1W5YUkKlE=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=


### PR DESCRIPTION
This PR updates the Carmen version to the head of the `sonic_2.2` branch https://github.com/0xsoniclabs/carmen/commit/2d892af38ce4a293b0b19105a405ceffded5b903.
It includes a fix for a Carmen test and CI updates.

List:
- https://github.com/0xsoniclabs/carmen/commit/44c66875b6c62a04629c351e2916360a0a7592ca
- https://github.com/0xsoniclabs/carmen/commit/2d892af38ce4a293b0b19105a405ceffded5b903
- https://github.com/0xsoniclabs/carmen/commit/d1348c9e9899e8759c1c8d34ada49eccdd9a70e9
