### PR TITLE
Removing panicking cast from big to uint256 in favour of error-returning version.

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -489,7 +489,10 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args *Transacti
 		return nil, err
 	}
 	// Assemble the transaction and sign with the wallet
-	tx := args.ToTransaction()
+	tx, err := args.ToTransaction()
+	if err != nil {
+		return nil, err
+	}
 
 	chainID := s.b.ChainConfig(s.b.Progress().CurrentBlock).ChainID
 	return wallet.SignTxWithPassphrase(account, passwd, tx, chainID)
@@ -533,7 +536,10 @@ func (s *PrivateAccountAPI) SignTransaction(ctx context.Context, args Transactio
 		return nil, fmt.Errorf("nonce not specified")
 	}
 	// Before actually signing the transaction, ensure the transaction fee is reasonable.
-	tx := args.ToTransaction()
+	tx, err := args.ToTransaction()
+	if err != nil {
+		return nil, err
+	}
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), s.b.RPCTxFeeCap()); err != nil {
 		return nil, err
 	}
@@ -1785,7 +1791,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		res, err := core.ApplyMessage(vmenv, msg, core.NewGasPool(msg.GasLimit))
 		statedb.Release()
 		if err != nil {
-			return nil, 0, nil, fmt.Errorf("failed to apply transaction: %v err: %v", args.ToTransaction().Hash(), err)
+			return nil, 0, nil, fmt.Errorf("failed to apply transaction: %w", err)
 		}
 		if tracer.Equal(prevTracer) {
 			return accessList, res.UsedGas, res.Err, nil
@@ -2156,7 +2162,10 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Tra
 		return common.Hash{}, err
 	}
 	// Assemble the transaction and sign with the wallet
-	tx := args.ToTransaction()
+	tx, err := args.ToTransaction()
+	if err != nil {
+		return common.Hash{}, err
+	}
 
 	chainID := s.b.ChainID()
 	signed, err := wallet.SignTx(account, tx, chainID)
@@ -2175,7 +2184,10 @@ func (s *PublicTransactionPoolAPI) FillTransaction(ctx context.Context, args Tra
 		return nil, err
 	}
 	// Assemble the transaction and obtain rlp
-	tx := args.ToTransaction()
+	tx, err := args.ToTransaction()
+	if err != nil {
+		return nil, err
+	}
 	data, err := tx.MarshalBinary()
 	if err != nil {
 		return nil, err
@@ -2241,7 +2253,10 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Tra
 		return nil, err
 	}
 	// Before actually sign the transaction, ensure the transaction fee is reasonable.
-	tx := args.ToTransaction()
+	tx, err := args.ToTransaction()
+	if err != nil {
+		return nil, err
+	}
 	if err := checkTxFee(tx.GasPrice(), tx.Gas(), s.b.RPCTxFeeCap()); err != nil {
 		return nil, err
 	}
@@ -2288,7 +2303,10 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs Transact
 	if err := sendArgs.setDefaults(ctx, s.b); err != nil {
 		return common.Hash{}, err
 	}
-	matchTx := sendArgs.ToTransaction()
+	matchTx, err := sendArgs.ToTransaction()
+	if err != nil {
+		return common.Hash{}, err
+	}
 
 	// Before replacing the old transaction, ensure the _new_ transaction fee is reasonable.
 	var price = matchTx.GasPrice()
@@ -2319,7 +2337,11 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs Transact
 			if gasLimit != nil && *gasLimit != 0 {
 				sendArgs.Gas = gasLimit
 			}
-			signedTx, err := s.sign(sendArgs.from(), sendArgs.ToTransaction())
+			resendTx, err := sendArgs.ToTransaction()
+			if err != nil {
+				return common.Hash{}, err
+			}
+			signedTx, err := s.sign(sendArgs.from(), resendTx)
 			if err != nil {
 				return common.Hash{}, err
 			}

--- a/api/ethapi/simulate.go
+++ b/api/ethapi/simulate.go
@@ -350,7 +350,10 @@ func (sim *simulator) processBlock(
 			return nil, nil, nil, nil, err
 		}
 
-		tx := call.ToTransaction()
+		tx, err := call.ToTransaction()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
 		txHash := tx.Hash()
 		txes[i] = tx
 		senders[txHash] = call.from()

--- a/api/ethapi/transaction_args.go
+++ b/api/ethapi/transaction_args.go
@@ -291,7 +291,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, lo
 
 // ToTransaction converts the arguments to an unsigned `types.transaction`.
 // This assumes that setDefaults has been called.
-func (args *TransactionArgs) ToTransaction() *types.Transaction {
+func (args *TransactionArgs) ToTransaction() (*types.Transaction, error) {
 	var data types.TxData
 
 	switch {
@@ -300,13 +300,21 @@ func (args *TransactionArgs) ToTransaction() *types.Transaction {
 		if args.AccessList != nil {
 			al = *args.AccessList
 		}
+		gasFeeCap, err := utils.BigIntToUint256((*big.Int)(args.MaxFeePerGas))
+		if err != nil {
+			return nil, fmt.Errorf("invalid MaxFeePerGas: %w", err)
+		}
+		gasTipCap, err := utils.BigIntToUint256((*big.Int)(args.MaxPriorityFeePerGas))
+		if err != nil {
+			return nil, fmt.Errorf("invalid MaxPriorityFeePerGas: %w", err)
+		}
 		data = &types.SetCodeTx{
 			To:         *args.To,
 			ChainID:    uint256.MustFromBig((*big.Int)(args.ChainID)),
 			Nonce:      uint64(*args.Nonce),
 			Gas:        uint64(*args.Gas),
-			GasFeeCap:  utils.BigIntToUint256((*big.Int)(args.MaxFeePerGas)),
-			GasTipCap:  utils.BigIntToUint256((*big.Int)(args.MaxPriorityFeePerGas)),
+			GasFeeCap:  gasFeeCap,
+			GasTipCap:  gasTipCap,
 			Value:      uint256.MustFromBig((*big.Int)(args.Value)),
 			Data:       args.data(),
 			AccessList: al,
@@ -318,17 +326,29 @@ func (args *TransactionArgs) ToTransaction() *types.Transaction {
 		if args.AccessList != nil {
 			al = *args.AccessList
 		}
+		gasFeeCap, err := utils.BigIntToUint256((*big.Int)(args.MaxFeePerGas))
+		if err != nil {
+			return nil, fmt.Errorf("invalid MaxFeePerGas: %w", err)
+		}
+		gasTipCap, err := utils.BigIntToUint256((*big.Int)(args.MaxPriorityFeePerGas))
+		if err != nil {
+			return nil, fmt.Errorf("invalid MaxPriorityFeePerGas: %w", err)
+		}
+		blobFeeCap, err := utils.BigIntToUint256((*big.Int)(args.BlobFeeCap))
+		if err != nil {
+			return nil, fmt.Errorf("invalid BlobFeeCap: %w", err)
+		}
 		data = &types.BlobTx{
 			To:         *args.To,
 			ChainID:    uint256.MustFromBig((*big.Int)(args.ChainID)),
 			Nonce:      uint64(*args.Nonce),
 			Gas:        uint64(*args.Gas),
-			GasFeeCap:  utils.BigIntToUint256((*big.Int)(args.MaxFeePerGas)),
-			GasTipCap:  utils.BigIntToUint256((*big.Int)(args.MaxPriorityFeePerGas)),
+			GasFeeCap:  gasFeeCap,
+			GasTipCap:  gasTipCap,
 			Value:      uint256.MustFromBig((*big.Int)(args.Value)),
 			Data:       args.data(),
 			AccessList: al,
-			BlobFeeCap: utils.BigIntToUint256((*big.Int)(args.BlobFeeCap)),
+			BlobFeeCap: blobFeeCap,
 			BlobHashes: args.BlobHashes,
 		}
 
@@ -369,5 +389,5 @@ func (args *TransactionArgs) ToTransaction() *types.Transaction {
 			Data:     args.data(),
 		}
 	}
-	return types.NewTx(data)
+	return types.NewTx(data), nil
 }

--- a/api/ethapi/transaction_args_test.go
+++ b/api/ethapi/transaction_args_test.go
@@ -622,7 +622,8 @@ func TestTransactionArgs_ToTransaction(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			converted := test.args.ToTransaction()
+			converted, err := test.args.ToTransaction()
+			require.NoError(t, err)
 
 			// expected type must match
 			require.Equal(t, test.expected.Type(), converted.Type())
@@ -648,6 +649,160 @@ func TestTransactionArgs_ToTransaction(t *testing.T) {
 
 			// set code authorizations
 			require.Equal(t, test.expected.SetCodeAuthorizations(), converted.SetCodeAuthorizations())
+		})
+	}
+}
+
+func TestToTransaction_ReturnsErrors(t *testing.T) {
+	addr := common.Address{1}
+	nonce := hexutil.Uint64(1)
+	gas := hexutil.Uint64(21000)
+	validFee := (*hexutil.Big)(big.NewInt(1000))
+
+	negative := (*hexutil.Big)(big.NewInt(-1))
+	overflow := (*hexutil.Big)(new(big.Int).Lsh(big.NewInt(1), 257))
+
+	tests := map[string]struct {
+		args        TransactionArgs
+		expectedErr string
+	}{
+		// --- SetCodeTx errors (triggered by AuthorizationList) ---
+		"SetCodeTx: negative MaxFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         negative,
+				MaxPriorityFeePerGas: validFee,
+				AuthorizationList:    []types.SetCodeAuthorization{{}},
+			},
+			expectedErr: "invalid MaxFeePerGas",
+		},
+		"SetCodeTx: overflowing MaxFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         overflow,
+				MaxPriorityFeePerGas: validFee,
+				AuthorizationList:    []types.SetCodeAuthorization{{}},
+			},
+			expectedErr: "invalid MaxFeePerGas",
+		},
+		"SetCodeTx: negative MaxPriorityFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         validFee,
+				MaxPriorityFeePerGas: negative,
+				AuthorizationList:    []types.SetCodeAuthorization{{}},
+			},
+			expectedErr: "invalid MaxPriorityFeePerGas",
+		},
+		"SetCodeTx: overflowing MaxPriorityFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         validFee,
+				MaxPriorityFeePerGas: overflow,
+				AuthorizationList:    []types.SetCodeAuthorization{{}},
+			},
+			expectedErr: "invalid MaxPriorityFeePerGas",
+		},
+
+		// --- BlobTx errors (triggered by BlobFeeCap or BlobHashes) ---
+		"BlobTx: negative MaxFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         negative,
+				MaxPriorityFeePerGas: validFee,
+				BlobFeeCap:           validFee,
+				BlobHashes:           []common.Hash{{1}},
+			},
+			expectedErr: "invalid MaxFeePerGas",
+		},
+		"BlobTx: overflowing MaxFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         overflow,
+				MaxPriorityFeePerGas: validFee,
+				BlobFeeCap:           validFee,
+				BlobHashes:           []common.Hash{{1}},
+			},
+			expectedErr: "invalid MaxFeePerGas",
+		},
+		"BlobTx: negative MaxPriorityFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         validFee,
+				MaxPriorityFeePerGas: negative,
+				BlobFeeCap:           validFee,
+				BlobHashes:           []common.Hash{{1}},
+			},
+			expectedErr: "invalid MaxPriorityFeePerGas",
+		},
+		"BlobTx: overflowing MaxPriorityFeePerGas": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         validFee,
+				MaxPriorityFeePerGas: overflow,
+				BlobFeeCap:           validFee,
+				BlobHashes:           []common.Hash{{1}},
+			},
+			expectedErr: "invalid MaxPriorityFeePerGas",
+		},
+		"BlobTx: negative BlobFeeCap": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         validFee,
+				MaxPriorityFeePerGas: validFee,
+				BlobFeeCap:           negative,
+				BlobHashes:           []common.Hash{{1}},
+			},
+			expectedErr: "invalid BlobFeeCap",
+		},
+		"BlobTx: overflowing BlobFeeCap": {
+			args: TransactionArgs{
+				From:                 &addr,
+				To:                   &addr,
+				Nonce:                &nonce,
+				Gas:                  &gas,
+				MaxFeePerGas:         validFee,
+				MaxPriorityFeePerGas: validFee,
+				BlobFeeCap:           overflow,
+				BlobHashes:           []common.Hash{{1}},
+			},
+			expectedErr: "invalid BlobFeeCap",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx, err := tt.args.ToTransaction()
+			require.Error(t, err)
+			require.Nil(t, tx)
+			require.ErrorContains(t, err, tt.expectedErr)
 		})
 	}
 }

--- a/api/sonicapi/bundles_api_integration_test.go
+++ b/api/sonicapi/bundles_api_integration_test.go
@@ -235,7 +235,9 @@ func Test_bundlesRPC_PrepareAndSubmit_PoolsValidBundles(t *testing.T) {
 			for i, tx := range prepared.Transactions {
 				// Note: all transactions at this stage have access list, therefore
 				// toTransactionForBundles is not needed.
-				signedTx, err := types.SignTx(tx.ToTransaction(), signer, addrToKey[*tx.From])
+				txToSign, err := tx.ToTransaction()
+				require.NoError(t, err)
+				signedTx, err := types.SignTx(txToSign, signer, addrToKey[*tx.From])
 				require.NoError(t, err)
 
 				encodedTx, err := signedTx.MarshalBinary()

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -338,7 +338,10 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 			return empty, fmt.Errorf("transaction in bundle must include from")
 		}
 
-		tx := toTransactionForBundles(step.TransactionArgs)
+		tx, err := toTransactionForBundles(step.TransactionArgs)
+		if err != nil {
+			return empty, fmt.Errorf("invalid transaction in bundle: %w", err)
+		}
 		hash := signer.Hash(tx)
 
 		return bundle.NewTxStep(bundle.TxReference{
@@ -395,8 +398,11 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 // toTransactionForBundles converts ethapi.TransactionArgs to types.Transaction
 // for computing execution plan transaction reference hashes. Legacy transactions
 // are promoted to AccessList transactions to prevent poisoning the plan hash.
-func toTransactionForBundles(step ethapi.TransactionArgs) *types.Transaction {
-	tx := step.ToTransaction()
+func toTransactionForBundles(step ethapi.TransactionArgs) (*types.Transaction, error) {
+	tx, err := step.ToTransaction()
+	if err != nil {
+		return nil, err
+	}
 
 	// legacy transactions cannot be included in a bundle.
 	// if the transaction arguments correspond to a legacy transaction,
@@ -411,7 +417,7 @@ func toTransactionForBundles(step ethapi.TransactionArgs) *types.Transaction {
 			GasPrice: tx.GasPrice(),
 		})
 	}
-	return tx
+	return tx, nil
 }
 
 func transform(

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -28,6 +28,7 @@ import (
 	rpctest "github.com/0xsoniclabs/sonic/api/rpc_test"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
@@ -1050,8 +1051,197 @@ func Test_convertProposalToPlan(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.plan, plan)
 			require.Equal(t, tt.plan.Hash(), plan.Hash())
+		})
+	}
+}
 
-			t.Log("plan", plan.Root.String())
+func Test_convertProposalToPlan_ReturnsErrors(t *testing.T) {
+
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	address := common.Address{1}
+
+	validRange := &RPCRange{
+		First:  *rpctest.ToHexUint64(0),
+		Length: *rpctest.ToHexUint64(1023),
+	}
+
+	validStep := RPCExecutionStepProposal{
+		TransactionArgs: ethapi.TransactionArgs{
+			From:  &address,
+			To:    &common.Address{2},
+			Nonce: rpctest.ToHexUint64(1),
+			Gas:   rpctest.ToHexUint64(21000),
+		},
+	}
+
+	// a value that overflows uint256
+	overflowingValue := new(big.Int).Lsh(big.NewInt(1), 257)
+
+	tests := map[string]struct {
+		proposal    RPCExecutionProposal
+		expectedErr string
+	}{
+		// --- missing fields ---
+		"missing block range": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{validStep},
+				},
+			},
+			expectedErr: "execution proposal must include block range",
+		},
+		"missing from in step": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								To:    &common.Address{2},
+								Nonce: rpctest.ToHexUint64(1),
+								Gas:   rpctest.ToHexUint64(21000),
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "transaction in bundle must include from",
+		},
+
+		// --- empty / wrong structure ---
+		"empty steps": {
+			proposal: RPCExecutionProposal{
+				BlockRange:            validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{Steps: []any{}},
+			},
+			expectedErr: "proposed group must include at least one step",
+		},
+		"empty nested group": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{Steps: []any{}},
+					},
+				},
+			},
+			expectedErr: "proposed group must include at least one step",
+		},
+		"nil step element in group": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{nil},
+				},
+			},
+			expectedErr: "invalid execution proposal level",
+		},
+		"wrong type in steps slice": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{"not a step"},
+				},
+			},
+			expectedErr: "invalid execution proposal level",
+		},
+
+		// --- wrong transactions (overflow in gas fee fields) ---
+		"SetCodeTx with overflowing MaxFeePerGas": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:              &address,
+								To:                &common.Address{2},
+								Nonce:             rpctest.ToHexUint64(1),
+								Gas:               rpctest.ToHexUint64(21000),
+								MaxFeePerGas:      (*hexutil.Big)(overflowingValue),
+								AuthorizationList: []types.SetCodeAuthorization{{}},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "invalid MaxFeePerGas",
+		},
+		"SetCodeTx with negative MaxPriorityFeePerGas": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:                 &address,
+								To:                   &common.Address{2},
+								Nonce:                rpctest.ToHexUint64(1),
+								Gas:                  rpctest.ToHexUint64(21000),
+								MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1)),
+								MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(-1)),
+								AuthorizationList:    []types.SetCodeAuthorization{{}},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "invalid MaxPriorityFeePerGas",
+		},
+		"BlobTx with overflowing BlobFeeCap": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{
+								From:                 &address,
+								To:                   &common.Address{2},
+								Nonce:                rpctest.ToHexUint64(1),
+								Gas:                  rpctest.ToHexUint64(21000),
+								MaxFeePerGas:         (*hexutil.Big)(big.NewInt(1)),
+								MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(1)),
+								BlobFeeCap:           (*hexutil.Big)(overflowingValue),
+								BlobHashes:           []common.Hash{{1}},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "invalid BlobFeeCap",
+		},
+
+		// --- wrong transaction nested in group ---
+		"error propagates from nested group step": {
+			proposal: RPCExecutionProposal{
+				BlockRange: validRange,
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							OneOf: true,
+							Steps: []any{
+								RPCExecutionStepProposal{
+									TransactionArgs: ethapi.TransactionArgs{
+										// missing From
+										To:    &common.Address{2},
+										Nonce: rpctest.ToHexUint64(1),
+										Gas:   rpctest.ToHexUint64(21000),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: "transaction in bundle must include from",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := convertProposalToPlan(signer, tt.proposal)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.expectedErr)
 		})
 	}
 }

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -991,7 +991,9 @@ func Test_PrepareBundle_PlanHashesMatchTransactions(t *testing.T) {
 				planHashes := collectLeafHashes(result.ExecutionPlan.Steps)
 				// For EIP-1559 (type 2), the access list is part of the signing hash.
 				// Without stripping the marker the hash must differ from the plan hash.
-				withMarker := signer.Hash(result.Transactions[0].ToTransaction())
+				markerTx, err := result.Transactions[0].ToTransaction()
+				require.NoError(t, err)
+				withMarker := signer.Hash(markerTx)
 				require.NotEqual(t, planHashes[0], withMarker, "stripping bundle marker must be necessary for EIP-1559 txs")
 			},
 		},
@@ -1029,7 +1031,8 @@ func Test_PrepareBundle_PlanHashesMatchTransactions(t *testing.T) {
 			expectedHashes := make([]common.Hash, len(result.Transactions))
 			for i, txArgs := range result.Transactions {
 				clean := stripBundleMarker(txArgs)
-				tx := toTransactionForBundles(clean)
+				tx, err := toTransactionForBundles(clean)
+				require.NoError(t, err)
 				expectedHashes[i] = signer.Hash(tx)
 			}
 			planHashes := collectLeafHashes(result.ExecutionPlan.Steps)

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -501,14 +501,14 @@ func testAddBalance(pool *TxPool, addr common.Address, amount *big.Int) {
 	pool.mu.Lock()
 	original := pool.currentState.(*testTxPoolStateDb).balances[addr]
 	if original == nil {
-		amountU256 := utils.BigIntToUint256(amount)
+		amountU256 := utils.BigIntToUint256Clamped(amount)
 		pool.currentState.(*testTxPoolStateDb).balances[addr] = amountU256
 	} else {
 		if amount.Sign() >= 0 {
-			amountU256 := utils.BigIntToUint256(amount)
+			amountU256 := utils.BigIntToUint256Clamped(amount)
 			pool.currentState.(*testTxPoolStateDb).balances[addr] = original.Add(original, amountU256)
 		} else {
-			amountU256 := utils.BigIntToUint256(new(big.Int).Mul(amount, big.NewInt(-1)))
+			amountU256 := utils.BigIntToUint256Clamped(new(big.Int).Mul(amount, big.NewInt(-1)))
 			pool.currentState.(*testTxPoolStateDb).balances[addr] = original.Sub(original, amountU256)
 		}
 	}

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -111,7 +111,7 @@ func testConsensusCallback(t *testing.T, upgrades opera.Upgrades) {
 		require.NoError(err)
 		// subtract fees
 		for i, r := range rr {
-			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256(txs[i].GasPrice()))
+			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256Clamped(txs[i].GasPrice()))
 			balances[i] = uint256.NewInt(0).Sub(balances[i], fee)
 		}
 		// balance movements

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -334,22 +334,37 @@ func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
 			pendingTxs[from] = txs[:em.config.MaxTxsPerAddress]
 		}
 	}
+
 	// Convert to lists of LazyTransactions
 	txs := make(map[common.Address][]*txpool.LazyTransaction, len(pendingTxs))
 	for from, list := range pendingTxs {
 		lazyTxs := make([]*txpool.LazyTransaction, 0, len(list))
 		for _, tx := range list {
+
+			gasFee, err := utils.BigIntToUint256(tx.GasFeeCap())
+			if err != nil {
+				em.Log.Warn("Failed to convert tx fee cap to uint256", "hash", tx.Hash(), "gasFeeCap", tx.GasFeeCap(), "err", err)
+				continue
+			}
+			gasTip, err := utils.BigIntToUint256(tx.GasTipCap())
+			if err != nil {
+				em.Log.Warn("Failed to convert tx tip cap to uint256", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap(), "err", err)
+				continue
+			}
+
 			lazyTxs = append(lazyTxs, &txpool.LazyTransaction{
 				Hash:      tx.Hash(),
 				Tx:        tx,
 				Time:      tx.Time(),
-				GasFeeCap: utils.BigIntToUint256(tx.GasFeeCap()),
-				GasTipCap: utils.BigIntToUint256(tx.GasTipCap()),
+				GasFeeCap: gasFee,
+				GasTipCap: gasTip,
 				Gas:       tx.Gas(),
 				BlobGas:   tx.BlobGas(),
 			})
 		}
-		txs[from] = lazyTxs
+		if len(lazyTxs) != 0 {
+			txs[from] = lazyTxs
+		}
 	}
 
 	sortedTxs := newTransactionsByPriceAndNonce(em.world.TransactionSigner, txs, baseFee)

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -482,6 +482,109 @@ func TestEmitter_EmitEvent(t *testing.T) {
 	require.NotNil(t, e)
 }
 
+func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
+	any := gomock.Any()
+
+	validator := idx.ValidatorID(1)
+	builder := pos.NewBuilder()
+	builder.Set(validator, pos.Weight(1))
+	validators := builder.Build()
+
+	tests := map[string]struct {
+		tx               *types.Transaction
+		expectedLog      string
+		expectedArgument string
+	}{
+
+		"overflow GasPrice": {
+			tx: types.NewTx(&types.LegacyTx{
+				GasPrice: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"overflow GasFeeCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"overflow GasTipCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: big.NewInt(1),
+				GasTipCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx tip cap to uint256",
+			expectedArgument: "gasTipCap",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			ctrl := gomock.NewController(t)
+
+			world := NewMockExternal(ctrl)
+			world.EXPECT().GetRules().AnyTimes()
+			world.EXPECT().GetLastEvent(any, any).AnyTimes()
+			world.EXPECT().Build(any, any).AnyTimes()
+			world.EXPECT().Check(any, any).Return(nil).AnyTimes()
+			world.EXPECT().GetLatestBlock().Return(&inter.Block{}).AnyTimes()
+			world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
+			world.EXPECT().IsBusy().AnyTimes()
+			world.EXPECT().Lock()
+			world.EXPECT().Unlock()
+			world.EXPECT().Process(any)
+			world.EXPECT().Broadcast(any)
+
+			log := logger.NewMockLogger(ctrl)
+
+			txPool := NewMockTxPool(ctrl)
+			txPool.EXPECT().Count().Return(1)
+
+			transactions := map[common.Address]types.Transactions{
+				{1}: {tt.tx},
+			}
+
+			txPool.EXPECT().Pending(gomock.Any()).Return(transactions, nil)
+
+			signer := valkeystore.NewMockSignerAuthority(ctrl)
+			signer.EXPECT().Sign(gomock.Any()).AnyTimes()
+
+			baseFeeSource := NewMockBaseFeeSource(ctrl)
+			baseFeeSource.EXPECT().GetCurrentBaseFee()
+
+			em := &Emitter{
+				baseFeeSource: baseFeeSource,
+				Periodic: logger.Periodic{
+					Instance: logger.Instance{
+						Log: log,
+					},
+				},
+				config: config.Config{
+					MaxTxsPerAddress: 1,
+					Validator: config.ValidatorConfig{
+						ID: validator,
+					},
+				},
+				world: World{
+					External:     world,
+					TxPool:       txPool,
+					EventsSigner: signer,
+				},
+			}
+			em.validators.Store(validators)
+
+			log.EXPECT().Warn(tt.expectedLog, "hash", gomock.Any(), tt.expectedArgument, gomock.Any(), "err", gomock.Any())
+
+			e, err := em.EmitEvent()
+			require.NoError(t, err)
+			require.NotNil(t, e)
+		})
+	}
+}
+
 func TestEmitter_ThrottlerWorldAdapter_ReturnsNilIfNoEventIsFound(t *testing.T) {
 	validator := idx.ValidatorID(1)
 

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -267,8 +267,8 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 				Hash:      test.tx.Hash(),
 				Tx:        test.tx,
 				Time:      test.tx.Time(),
-				GasFeeCap: utils.BigIntToUint256(test.tx.GasFeeCap()),
-				GasTipCap: utils.BigIntToUint256(test.tx.GasTipCap()),
+				GasFeeCap: utils.BigIntToUint256Clamped(test.tx.GasFeeCap()),
+				GasTipCap: utils.BigIntToUint256Clamped(test.tx.GasTipCap()),
 				Gas:       test.tx.Gas(),
 				BlobGas:   test.tx.BlobGas(),
 			}

--- a/gossip/sfc_test.go
+++ b/gossip/sfc_test.go
@@ -217,7 +217,7 @@ func circleTransfers(t *testing.T, env *testEnv, count uint64) {
 		rr, err := env.ApplyTxs(sameEpoch, txs...)
 		require.NoError(err)
 		for i, r := range rr {
-			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256(txs[i].GasPrice()))
+			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256Clamped(txs[i].GasPrice()))
 			balances[i] = uint256.NewInt(0).Sub(balances[i], fee)
 		}
 	}

--- a/utils/int.go
+++ b/utils/int.go
@@ -17,20 +17,21 @@
 package utils
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/holiman/uint256"
 )
 
-func BigIntToUint256(value *big.Int) *uint256.Int {
+func BigIntToUint256(value *big.Int) (*uint256.Int, error) {
 	if value.Sign() < 0 {
-		panic("unable to convert negative big.Int to uint256")
+		return nil, fmt.Errorf("unable to convert negative big.Int to uint256")
 	}
-	bytes := value.Bytes()
-	if len(bytes) > 32 {
-		panic("unable to convert big.Int exceeding 32 bytes to uint256")
+	res, overflow := uint256.FromBig(value)
+	if overflow {
+		return nil, fmt.Errorf("unable to convert big.Int exceeding 32 bytes to uint256")
 	}
-	return new(uint256.Int).SetBytes(bytes)
+	return res, nil
 }
 
 // BigIntToUint256Clamped converts a big.Int to a uint256.Int. If the value is

--- a/utils/int_test.go
+++ b/utils/int_test.go
@@ -79,3 +79,161 @@ func TestBigIntToU256_Clamps_Inputs(t *testing.T) {
 		})
 	}
 }
+
+func TestBigIntToUint256_ValidConversions(t *testing.T) {
+	tests := map[string]struct {
+		input    *big.Int
+		expected *uint256.Int
+	}{
+		"zero": {
+			input:    big.NewInt(0),
+			expected: uint256.NewInt(0),
+		},
+		"one": {
+			input:    big.NewInt(1),
+			expected: uint256.NewInt(1),
+		},
+		"small value": {
+			input:    big.NewInt(42),
+			expected: uint256.NewInt(42),
+		},
+		"max uint64": {
+			input: new(big.Int).SetUint64(^uint64(0)),
+			expected: func() *uint256.Int {
+				return new(uint256.Int).SetUint64(^uint64(0))
+			}(),
+		},
+		"max uint64 + 1": {
+			input: new(big.Int).Add(
+				new(big.Int).SetUint64(^uint64(0)),
+				big.NewInt(1),
+			),
+			expected: func() *uint256.Int {
+				u := new(uint256.Int).SetUint64(^uint64(0))
+				u.AddUint64(u, 1)
+				return u
+			}(),
+		},
+		"max uint128": {
+			input: func() *big.Int {
+				b := new(big.Int).Lsh(big.NewInt(1), 128)
+				b.Sub(b, big.NewInt(1))
+				return b
+			}(),
+			expected: func() *uint256.Int {
+				u, _ := uint256.FromBig(new(big.Int).Sub(
+					new(big.Int).Lsh(big.NewInt(1), 128),
+					big.NewInt(1),
+				))
+				return u
+			}(),
+		},
+		"exactly 32 bytes (max uint256)": {
+			input: func() *big.Int {
+				b := new(big.Int).Lsh(big.NewInt(1), 256)
+				b.Sub(b, big.NewInt(1))
+				return b
+			}(),
+			expected: func() *uint256.Int {
+				u := new(uint256.Int)
+				u.SetAllOne()
+				return u
+			}(),
+		},
+		"1 wei": {
+			input:    big.NewInt(1),
+			expected: uint256.NewInt(1),
+		},
+		"1 ether in wei": {
+			input: new(big.Int).Mul(big.NewInt(1), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
+			expected: func() *uint256.Int {
+				u, _ := uint256.FromBig(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+				return u
+			}(),
+		},
+		"power of 2 boundary (2^255)": {
+			input: new(big.Int).Lsh(big.NewInt(1), 255),
+			expected: func() *uint256.Int {
+				u, _ := uint256.FromBig(new(big.Int).Lsh(big.NewInt(1), 255))
+				return u
+			}(),
+		},
+		"2^256 - 2 (one below max)": {
+			input: new(big.Int).Sub(
+				new(big.Int).Lsh(big.NewInt(1), 256),
+				big.NewInt(2),
+			),
+			expected: func() *uint256.Int {
+				u := new(uint256.Int)
+				u.SetAllOne()
+				one := uint256.NewInt(1)
+				u.Sub(u, one)
+				return u
+			}(),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := BigIntToUint256(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+
+			// verify round-trip: converting back should yield the original
+			roundTrip := Uint256ToBigInt(result)
+			require.Equal(t, 0, tt.input.Cmp(roundTrip),
+				"round-trip failed: input=%v got=%v", tt.input, roundTrip)
+		})
+	}
+}
+
+func TestBigIntToUint256_ErrorCases(t *testing.T) {
+	tests := map[string]struct {
+		input       *big.Int
+		expectedErr string
+	}{
+		"negative one": {
+			input:       big.NewInt(-1),
+			expectedErr: "negative",
+		},
+		"large negative": {
+			input:       big.NewInt(-1_000_000_000),
+			expectedErr: "negative",
+		},
+		"min int64": {
+			input:       new(big.Int).SetInt64(-(1 << 63)),
+			expectedErr: "negative",
+		},
+		"2^256 (one above max)": {
+			input:       new(big.Int).Lsh(big.NewInt(1), 256),
+			expectedErr: "exceeding 32 bytes",
+		},
+		"2^257": {
+			input:       new(big.Int).Lsh(big.NewInt(1), 257),
+			expectedErr: "exceeding 32 bytes",
+		},
+		"2^512": {
+			input:       new(big.Int).Lsh(big.NewInt(1), 512),
+			expectedErr: "exceeding 32 bytes",
+		},
+		"max uint256 + 1": {
+			input: new(big.Int).Add(
+				new(big.Int).Sub(
+					new(big.Int).Lsh(big.NewInt(1), 256),
+					big.NewInt(1),
+				),
+				big.NewInt(1),
+			),
+			expectedErr: "exceeding 32 bytes",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := BigIntToUint256(tt.input)
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.ErrorContains(t, err, tt.expectedErr)
+		})
+	}
+}

--- a/utils/to_ftm.go
+++ b/utils/to_ftm.go
@@ -29,5 +29,5 @@ func ToFtm(ftm uint64) *big.Int {
 
 // ToFtmU256 number of FTM to Wei using the uint256 type
 func ToFtmU256(ftm uint64) *uint256.Int {
-	return BigIntToUint256(ToFtm(ftm))
+	return BigIntToUint256Clamped(ToFtm(ftm))
 }


### PR DESCRIPTION
This PR is rather large, but I think it is beneficial to have it atomically to avoid having multiple versions of the function `BigIntToUint256` in use. This PR entirely removes uses of the panicking version. 

To facilitate review, different commits have been separated. 
- The change to the library itself and testing
- changes to the emitter
- changes to the RPC tools and testing. 
- changes to the RPC
- use clamp version in other tests 


