### PR TITLE
Add non-panicking version of BigIntToUint256

### DIFF
--- a/utils/int.go
+++ b/utils/int.go
@@ -17,11 +17,15 @@
 package utils
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/holiman/uint256"
 )
 
+// BigIntToUint256 converts a big.Int to a uint256.Int.
+// It panics if the value is negative or too large to fit into a uint256.Int.
+// FIXME: remove in favour of BigIntToUint256Err
 func BigIntToUint256(value *big.Int) *uint256.Int {
 	if value.Sign() < 0 {
 		panic("unable to convert negative big.Int to uint256")
@@ -31,6 +35,24 @@ func BigIntToUint256(value *big.Int) *uint256.Int {
 		panic("unable to convert big.Int exceeding 32 bytes to uint256")
 	}
 	return new(uint256.Int).SetBytes(bytes)
+}
+
+// BigIntToUint256Err converts a big.Int to a uint256.Int.
+// It returns an error if the value is negative or too large to fit into a uint256.Int.
+// If the value is nil, nil is returned.
+// FIXME: rename to BigIntToUint256 once the panicking version is removed
+func BigIntToUint256Err(value *big.Int) (*uint256.Int, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if value.Sign() < 0 {
+		return nil, fmt.Errorf("unable to convert negative big.Int to uint256")
+	}
+	res, overflow := uint256.FromBig(value)
+	if overflow {
+		return nil, fmt.Errorf("unable to convert big.Int exceeding 32 bytes to uint256")
+	}
+	return res, nil
 }
 
 // BigIntToUint256Clamped converts a big.Int to a uint256.Int. If the value is
@@ -50,6 +72,8 @@ func BigIntToUint256Clamped(value *big.Int) *uint256.Int {
 	return res
 }
 
+// Uint256ToBigInt converts a uint256.Int to a big.Int.
+// If the input is nil, nil is returned.
 func Uint256ToBigInt(value *uint256.Int) *big.Int {
-	return new(big.Int).SetBytes(value.Bytes())
+	return value.ToBig()
 }

--- a/utils/int_test.go
+++ b/utils/int_test.go
@@ -129,6 +129,10 @@ func TestBigIntToUint256Err_ValidConversions(t *testing.T) {
 
 			// verify round-trip: converting back should yield the original
 			roundTrip := Uint256ToBigInt(result)
+			if tt.input == nil {
+				require.Nil(t, roundTrip, "round-trip failed: input=%v got=%v", tt.input, roundTrip)
+				return
+			}
 			require.Equal(t, 0, tt.input.Cmp(roundTrip),
 				"round-trip failed: input=%v got=%v", tt.input, roundTrip)
 		})

--- a/utils/int_test.go
+++ b/utils/int_test.go
@@ -24,7 +24,169 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBigIntToU256_Clamps_Inputs(t *testing.T) {
+func TestBigIntToUint256Err_ValidConversions(t *testing.T) {
+	tests := map[string]struct {
+		input    *big.Int
+		expected *uint256.Int
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"zero": {
+			input:    big.NewInt(0),
+			expected: uint256.NewInt(0),
+		},
+		"one": {
+			input:    big.NewInt(1),
+			expected: uint256.NewInt(1),
+		},
+		"small value": {
+			input:    big.NewInt(42),
+			expected: uint256.NewInt(42),
+		},
+		"max uint64": {
+			input: new(big.Int).SetUint64(^uint64(0)),
+			expected: func() *uint256.Int {
+				return new(uint256.Int).SetUint64(^uint64(0))
+			}(),
+		},
+		"max uint64 + 1": {
+			input: new(big.Int).Add(
+				new(big.Int).SetUint64(^uint64(0)),
+				big.NewInt(1),
+			),
+			expected: func() *uint256.Int {
+				u := new(uint256.Int).SetUint64(^uint64(0))
+				u.AddUint64(u, 1)
+				return u
+			}(),
+		},
+		"max uint128": {
+			input: func() *big.Int {
+				b := new(big.Int).Lsh(big.NewInt(1), 128)
+				b.Sub(b, big.NewInt(1))
+				return b
+			}(),
+			expected: func() *uint256.Int {
+				u, _ := uint256.FromBig(new(big.Int).Sub(
+					new(big.Int).Lsh(big.NewInt(1), 128),
+					big.NewInt(1),
+				))
+				return u
+			}(),
+		},
+		"exactly 32 bytes (max uint256)": {
+			input: func() *big.Int {
+				b := new(big.Int).Lsh(big.NewInt(1), 256)
+				b.Sub(b, big.NewInt(1))
+				return b
+			}(),
+			expected: func() *uint256.Int {
+				u := new(uint256.Int)
+				u.SetAllOne()
+				return u
+			}(),
+		},
+		"1 wei": {
+			input:    big.NewInt(1),
+			expected: uint256.NewInt(1),
+		},
+		"1 ether in wei": {
+			input: new(big.Int).Mul(big.NewInt(1), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
+			expected: func() *uint256.Int {
+				u, _ := uint256.FromBig(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+				return u
+			}(),
+		},
+		"power of 2 boundary (2^255)": {
+			input: new(big.Int).Lsh(big.NewInt(1), 255),
+			expected: func() *uint256.Int {
+				u, _ := uint256.FromBig(new(big.Int).Lsh(big.NewInt(1), 255))
+				return u
+			}(),
+		},
+		"2^256 - 2 (one below max)": {
+			input: new(big.Int).Sub(
+				new(big.Int).Lsh(big.NewInt(1), 256),
+				big.NewInt(2),
+			),
+			expected: func() *uint256.Int {
+				u := new(uint256.Int)
+				u.SetAllOne()
+				one := uint256.NewInt(1)
+				u.Sub(u, one)
+				return u
+			}(),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := BigIntToUint256Err(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+
+			// verify round-trip: converting back should yield the original
+			roundTrip := Uint256ToBigInt(result)
+			require.Equal(t, 0, tt.input.Cmp(roundTrip),
+				"round-trip failed: input=%v got=%v", tt.input, roundTrip)
+		})
+	}
+}
+
+func TestBigIntToUint256Err_ErrorCases(t *testing.T) {
+	tests := map[string]struct {
+		input       *big.Int
+		expectedErr string
+	}{
+		"negative one": {
+			input:       big.NewInt(-1),
+			expectedErr: "negative",
+		},
+		"large negative": {
+			input:       big.NewInt(-1_000_000_000),
+			expectedErr: "negative",
+		},
+		"min int64": {
+			input:       new(big.Int).SetInt64(-(1 << 63)),
+			expectedErr: "negative",
+		},
+		"2^256 (one above max)": {
+			input:       new(big.Int).Lsh(big.NewInt(1), 256),
+			expectedErr: "exceeding 32 bytes",
+		},
+		"2^257": {
+			input:       new(big.Int).Lsh(big.NewInt(1), 257),
+			expectedErr: "exceeding 32 bytes",
+		},
+		"2^512": {
+			input:       new(big.Int).Lsh(big.NewInt(1), 512),
+			expectedErr: "exceeding 32 bytes",
+		},
+		"max uint256 + 1": {
+			input: new(big.Int).Add(
+				new(big.Int).Sub(
+					new(big.Int).Lsh(big.NewInt(1), 256),
+					big.NewInt(1),
+				),
+				big.NewInt(1),
+			),
+			expectedErr: "exceeding 32 bytes",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := BigIntToUint256Err(tt.input)
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.ErrorContains(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestBigIntToUint256Clamped_Clamps_Inputs(t *testing.T) {
 	tests := map[string]struct {
 		input    *big.Int
 		expected *uint256.Int


### PR DESCRIPTION
This PR introduces a version of `BigIntToUint256` which returns an error instead of panicking. This is the first PR in a series of prs which remove the panicking version. 