### PR TITLE
Remove panicking uint256 conversions from emitter

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -334,22 +334,39 @@ func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
 			pendingTxs[from] = txs[:em.config.MaxTxsPerAddress]
 		}
 	}
+
 	// Convert to lists of LazyTransactions
 	txs := make(map[common.Address][]*txpool.LazyTransaction, len(pendingTxs))
 	for from, list := range pendingTxs {
 		lazyTxs := make([]*txpool.LazyTransaction, 0, len(list))
 		for _, tx := range list {
+
+			gasFee, err := utils.BigIntToUint256Err(tx.GasFeeCap())
+			if err != nil {
+				em.Log.Warn("Failed to convert tx fee cap to uint256", "hash", tx.Hash(), "gasFeeCap", tx.GasFeeCap(), "err", err)
+				// stop iteration, skipped transaction invalidates the rest of transactions because they introduce a nonce gap
+				break
+			}
+			gasTip, err := utils.BigIntToUint256Err(tx.GasTipCap())
+			if err != nil {
+				em.Log.Warn("Failed to convert tx tip cap to uint256", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap(), "err", err)
+				// stop iteration, skipped transaction invalidates the rest of transactions because they introduce a nonce gap
+				break
+			}
+
 			lazyTxs = append(lazyTxs, &txpool.LazyTransaction{
 				Hash:      tx.Hash(),
 				Tx:        tx,
 				Time:      tx.Time(),
-				GasFeeCap: utils.BigIntToUint256(tx.GasFeeCap()),
-				GasTipCap: utils.BigIntToUint256(tx.GasTipCap()),
+				GasFeeCap: gasFee,
+				GasTipCap: gasTip,
 				Gas:       tx.Gas(),
 				BlobGas:   tx.BlobGas(),
 			})
 		}
-		txs[from] = lazyTxs
+		if len(lazyTxs) != 0 {
+			txs[from] = lazyTxs
+		}
 	}
 
 	sortedTxs := newTransactionsByPriceAndNonce(em.world.TransactionSigner, txs, baseFee)

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -482,6 +482,192 @@ func TestEmitter_EmitEvent(t *testing.T) {
 	require.NotNil(t, e)
 }
 
+func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
+	any := gomock.Any()
+
+	validator := idx.ValidatorID(1)
+	builder := pos.NewBuilder()
+	builder.Set(validator, pos.Weight(1))
+	validators := builder.Build()
+
+	tests := map[string]struct {
+		tx               *types.Transaction
+		expectedLog      string
+		expectedArgument string
+	}{
+
+		"overflow GasPrice": {
+			tx: types.NewTx(&types.LegacyTx{
+				GasPrice: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"overflow GasFeeCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"overflow GasTipCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: big.NewInt(1),
+				GasTipCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+			}),
+			expectedLog:      "Failed to convert tx tip cap to uint256",
+			expectedArgument: "gasTipCap",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			ctrl := gomock.NewController(t)
+
+			world := NewMockExternal(ctrl)
+			world.EXPECT().GetRules().AnyTimes()
+			world.EXPECT().GetLastEvent(any, any).AnyTimes()
+			world.EXPECT().Build(any, any).AnyTimes()
+			world.EXPECT().Check(any, any).Return(nil).AnyTimes()
+			world.EXPECT().GetLatestBlock().Return(&inter.Block{}).AnyTimes()
+			world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
+			world.EXPECT().IsBusy().AnyTimes()
+			world.EXPECT().Lock()
+			world.EXPECT().Unlock()
+			world.EXPECT().Process(any)
+			world.EXPECT().Broadcast(any)
+
+			log := logger.NewMockLogger(ctrl)
+
+			txPool := NewMockTxPool(ctrl)
+			txPool.EXPECT().Count().Return(1)
+
+			transactions := map[common.Address]types.Transactions{
+				{1}: {tt.tx},
+			}
+
+			txPool.EXPECT().Pending(gomock.Any()).Return(transactions, nil)
+
+			signer := valkeystore.NewMockSignerAuthority(ctrl)
+			signer.EXPECT().Sign(gomock.Any()).AnyTimes()
+
+			baseFeeSource := NewMockBaseFeeSource(ctrl)
+			baseFeeSource.EXPECT().GetCurrentBaseFee()
+
+			em := &Emitter{
+				baseFeeSource: baseFeeSource,
+				Periodic: logger.Periodic{
+					Instance: logger.Instance{
+						Log: log,
+					},
+				},
+				config: config.Config{
+					MaxTxsPerAddress: 1,
+					Validator: config.ValidatorConfig{
+						ID: validator,
+					},
+				},
+				world: World{
+					External:     world,
+					TxPool:       txPool,
+					EventsSigner: signer,
+				},
+			}
+			em.validators.Store(validators)
+
+			log.EXPECT().Warn(tt.expectedLog, "hash", gomock.Any(), tt.expectedArgument, gomock.Any(), "err", gomock.Any())
+
+			e, err := em.EmitEvent()
+			require.NoError(t, err)
+			require.NotNil(t, e)
+		})
+	}
+}
+
+func TestEmitter_EmitEvent_skippingTxsAlsoSkipsGappedNoncesTxs(t *testing.T) {
+	any := gomock.Any()
+
+	validator := idx.ValidatorID(1)
+	builder := pos.NewBuilder()
+	builder.Set(validator, pos.Weight(1))
+	validators := builder.Build()
+
+	sender := common.Address{1}
+	validTx0 := types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		GasPrice: big.NewInt(1000),
+		Gas:      21000,
+	})
+	malformedTx1 := types.NewTx(&types.LegacyTx{
+		Nonce:    1,
+		GasPrice: new(big.Int).Neg(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+		Gas:      21000,
+	})
+	validTx2 := types.NewTx(&types.LegacyTx{
+		Nonce:    2,
+		GasPrice: big.NewInt(1000),
+		Gas:      21000,
+	})
+
+	ctrl := gomock.NewController(t)
+
+	world := NewMockExternal(ctrl)
+	world.EXPECT().GetRules().AnyTimes()
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
+
+	log := logger.NewMockLogger(ctrl)
+	// Expect exactly one warning for the malformed tx at nonce=1.
+	// The valid tx at nonce=2 should be silently skipped (no second warning).
+	log.EXPECT().Warn("Failed to convert tx fee cap to uint256",
+		"hash", malformedTx1.Hash(), "gasFeeCap", malformedTx1.GasPrice(), "err", gomock.Any())
+
+	txPool := NewMockTxPool(ctrl)
+	txPool.EXPECT().Count().Return(3)
+	txPool.EXPECT().Pending(any).Return(
+		map[common.Address]types.Transactions{
+			sender: {validTx0, malformedTx1, validTx2},
+		}, nil,
+	)
+
+	txSigner := NewMockTxSigner(ctrl)
+	txSigner.EXPECT().Sender(any).Return(sender, nil).AnyTimes()
+
+	em := &Emitter{
+		Periodic: logger.Periodic{
+			Instance: logger.Instance{
+				Log: log,
+			},
+		},
+		config: config.Config{
+			MaxTxsPerAddress: 10,
+			Validator: config.ValidatorConfig{
+				ID: validator,
+			},
+		},
+		world: World{
+			External:          world,
+			TxPool:            txPool,
+			TransactionSigner: txSigner,
+		},
+	}
+	em.validators.Store(validators)
+
+	sorted := em.getSortedTxs(big.NewInt(0))
+	require.NotNil(t, sorted)
+
+	// Only the valid tx at nonce=0 should survive.
+	// The malformed tx at nonce=1 was skipped, which breaks the loop
+	// and also drops the valid tx at nonce=2 due to the nonce gap.
+	tx, _ := sorted.Peek()
+	require.NotNil(t, tx, "expected the valid tx at nonce=0 to be present")
+	require.Equal(t, validTx0.Hash(), tx.Hash)
+
+	sorted.Shift()
+	tx, _ = sorted.Peek()
+	require.Nil(t, tx, "expected no more txs after the nonce gap")
+}
+
 func TestEmitter_ThrottlerWorldAdapter_ReturnsNilIfNoEventIsFound(t *testing.T) {
 	validator := idx.ValidatorID(1)
 

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -498,7 +498,7 @@ func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
 
 		"overflow GasPrice": {
 			tx: types.NewTx(&types.LegacyTx{
-				GasPrice: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+				GasPrice: new(big.Int).Lsh(big.NewInt(1), 256),
 			}),
 			expectedLog:      "Failed to convert tx fee cap to uint256",
 			expectedArgument: "gasFeeCap",

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -505,7 +505,7 @@ func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
 		},
 		"overflow GasFeeCap": {
 			tx: types.NewTx(&types.DynamicFeeTx{
-				GasFeeCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+				GasFeeCap: new(big.Int).Lsh(big.NewInt(1), 256),
 			}),
 			expectedLog:      "Failed to convert tx fee cap to uint256",
 			expectedArgument: "gasFeeCap",
@@ -513,7 +513,29 @@ func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
 		"overflow GasTipCap": {
 			tx: types.NewTx(&types.DynamicFeeTx{
 				GasFeeCap: big.NewInt(1),
-				GasTipCap: new(big.Int).Sub(big.NewInt(0), new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil)),
+				GasTipCap: new(big.Int).Lsh(big.NewInt(1), 256),
+			}),
+			expectedLog:      "Failed to convert tx tip cap to uint256",
+			expectedArgument: "gasTipCap",
+		},
+		"negative GasPrice": {
+			tx: types.NewTx(&types.LegacyTx{
+				GasPrice: big.NewInt(-1),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"negative GasFeeCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: big.NewInt(-1),
+			}),
+			expectedLog:      "Failed to convert tx fee cap to uint256",
+			expectedArgument: "gasFeeCap",
+		},
+		"negative GasTipCap": {
+			tx: types.NewTx(&types.DynamicFeeTx{
+				GasFeeCap: big.NewInt(1),
+				GasTipCap: big.NewInt(-1),
 			}),
 			expectedLog:      "Failed to convert tx tip cap to uint256",
 			expectedArgument: "gasTipCap",


### PR DESCRIPTION
This PR builds on https://github.com/0xsoniclabs/sonic/pull/972

The changes replace uses of `BigIntToUint256` with an error returning version. If the transaction `big.Int` values cannot be converted to `uint256.Int`, it will be skipped from emission. Any transaction from the same sender with larger nonce will be skipped as well.

