### PR TITLE
Remove panicking version of  big int to uint256 conversion

### DIFF
--- a/api/ethapi/transaction_args.go
+++ b/api/ethapi/transaction_args.go
@@ -299,19 +299,19 @@ func (args *TransactionArgs) ToTransaction() (*types.Transaction, error) {
 		if args.AccessList != nil {
 			al = *args.AccessList
 		}
-		chainId, err := utils.BigIntToUint256Err((*big.Int)(args.ChainID))
+		chainId, err := utils.BigIntToUint256((*big.Int)(args.ChainID))
 		if err != nil {
 			return nil, fmt.Errorf("invalid ChainID: %w", err)
 		}
-		gasFeeCap, err := utils.BigIntToUint256Err((*big.Int)(args.MaxFeePerGas))
+		gasFeeCap, err := utils.BigIntToUint256((*big.Int)(args.MaxFeePerGas))
 		if err != nil {
 			return nil, fmt.Errorf("invalid MaxFeePerGas: %w", err)
 		}
-		gasTipCap, err := utils.BigIntToUint256Err((*big.Int)(args.MaxPriorityFeePerGas))
+		gasTipCap, err := utils.BigIntToUint256((*big.Int)(args.MaxPriorityFeePerGas))
 		if err != nil {
 			return nil, fmt.Errorf("invalid MaxPriorityFeePerGas: %w", err)
 		}
-		value, err := utils.BigIntToUint256Err((*big.Int)(args.Value))
+		value, err := utils.BigIntToUint256((*big.Int)(args.Value))
 		if err != nil {
 			return nil, fmt.Errorf("invalid Value: %w", err)
 		}
@@ -334,23 +334,23 @@ func (args *TransactionArgs) ToTransaction() (*types.Transaction, error) {
 		if args.AccessList != nil {
 			al = *args.AccessList
 		}
-		chainId, err := utils.BigIntToUint256Err((*big.Int)(args.ChainID))
+		chainId, err := utils.BigIntToUint256((*big.Int)(args.ChainID))
 		if err != nil {
 			return nil, fmt.Errorf("invalid ChainID: %w", err)
 		}
-		gasFeeCap, err := utils.BigIntToUint256Err((*big.Int)(args.MaxFeePerGas))
+		gasFeeCap, err := utils.BigIntToUint256((*big.Int)(args.MaxFeePerGas))
 		if err != nil {
 			return nil, fmt.Errorf("invalid MaxFeePerGas: %w", err)
 		}
-		gasTipCap, err := utils.BigIntToUint256Err((*big.Int)(args.MaxPriorityFeePerGas))
+		gasTipCap, err := utils.BigIntToUint256((*big.Int)(args.MaxPriorityFeePerGas))
 		if err != nil {
 			return nil, fmt.Errorf("invalid MaxPriorityFeePerGas: %w", err)
 		}
-		blobFeeCap, err := utils.BigIntToUint256Err((*big.Int)(args.BlobFeeCap))
+		blobFeeCap, err := utils.BigIntToUint256((*big.Int)(args.BlobFeeCap))
 		if err != nil {
 			return nil, fmt.Errorf("invalid BlobFeeCap: %w", err)
 		}
-		value, err := utils.BigIntToUint256Err((*big.Int)(args.Value))
+		value, err := utils.BigIntToUint256((*big.Int)(args.Value))
 		if err != nil {
 			return nil, fmt.Errorf("invalid Value: %w", err)
 		}

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -501,14 +501,14 @@ func testAddBalance(pool *TxPool, addr common.Address, amount *big.Int) {
 	pool.mu.Lock()
 	original := pool.currentState.(*testTxPoolStateDb).balances[addr]
 	if original == nil {
-		amountU256 := utils.BigIntToUint256(amount)
+		amountU256 := utils.BigIntToUint256Clamped(amount)
 		pool.currentState.(*testTxPoolStateDb).balances[addr] = amountU256
 	} else {
 		if amount.Sign() >= 0 {
-			amountU256 := utils.BigIntToUint256(amount)
+			amountU256 := utils.BigIntToUint256Clamped(amount)
 			pool.currentState.(*testTxPoolStateDb).balances[addr] = original.Add(original, amountU256)
 		} else {
-			amountU256 := utils.BigIntToUint256(new(big.Int).Mul(amount, big.NewInt(-1)))
+			amountU256 := utils.BigIntToUint256Clamped(new(big.Int).Mul(amount, big.NewInt(-1)))
 			pool.currentState.(*testTxPoolStateDb).balances[addr] = original.Sub(original, amountU256)
 		}
 	}

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -111,7 +111,7 @@ func testConsensusCallback(t *testing.T, upgrades opera.Upgrades) {
 		require.NoError(err)
 		// subtract fees
 		for i, r := range rr {
-			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256(txs[i].GasPrice()))
+			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256Clamped(txs[i].GasPrice()))
 			balances[i] = uint256.NewInt(0).Sub(balances[i], fee)
 		}
 		// balance movements

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -341,13 +341,13 @@ func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
 		lazyTxs := make([]*txpool.LazyTransaction, 0, len(list))
 		for _, tx := range list {
 
-			gasFee, err := utils.BigIntToUint256Err(tx.GasFeeCap())
+			gasFee, err := utils.BigIntToUint256(tx.GasFeeCap())
 			if err != nil {
 				em.Log.Warn("Failed to convert tx fee cap to uint256", "hash", tx.Hash(), "gasFeeCap", tx.GasFeeCap(), "err", err)
 				// stop iteration, skipped transaction invalidates the rest of transactions because they introduce a nonce gap
 				break
 			}
-			gasTip, err := utils.BigIntToUint256Err(tx.GasTipCap())
+			gasTip, err := utils.BigIntToUint256(tx.GasTipCap())
 			if err != nil {
 				em.Log.Warn("Failed to convert tx tip cap to uint256", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap(), "err", err)
 				// stop iteration, skipped transaction invalidates the rest of transactions because they introduce a nonce gap

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -267,8 +267,8 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 				Hash:      test.tx.Hash(),
 				Tx:        test.tx,
 				Time:      test.tx.Time(),
-				GasFeeCap: utils.BigIntToUint256(test.tx.GasFeeCap()),
-				GasTipCap: utils.BigIntToUint256(test.tx.GasTipCap()),
+				GasFeeCap: utils.BigIntToUint256Clamped(test.tx.GasFeeCap()),
+				GasTipCap: utils.BigIntToUint256Clamped(test.tx.GasTipCap()),
 				Gas:       test.tx.Gas(),
 				BlobGas:   test.tx.BlobGas(),
 			}

--- a/gossip/sfc_test.go
+++ b/gossip/sfc_test.go
@@ -217,7 +217,7 @@ func circleTransfers(t *testing.T, env *testEnv, count uint64) {
 		rr, err := env.ApplyTxs(sameEpoch, txs...)
 		require.NoError(err)
 		for i, r := range rr {
-			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256(txs[i].GasPrice()))
+			fee := uint256.NewInt(0).Mul(new(uint256.Int).SetUint64(r.GasUsed), utils.BigIntToUint256Clamped(txs[i].GasPrice()))
 			balances[i] = uint256.NewInt(0).Sub(balances[i], fee)
 		}
 	}

--- a/utils/int.go
+++ b/utils/int.go
@@ -26,7 +26,6 @@ import (
 // BigIntToUint256 converts a big.Int to a uint256.Int.
 // It returns an error if the value is negative or too large to fit into a uint256.Int.
 // If the value is nil, nil is returned.
-// FIXME: rename to BigIntToUint256 once the panicking version is removed
 func BigIntToUint256(value *big.Int) (*uint256.Int, error) {
 	if value == nil {
 		return nil, nil

--- a/utils/int.go
+++ b/utils/int.go
@@ -24,24 +24,10 @@ import (
 )
 
 // BigIntToUint256 converts a big.Int to a uint256.Int.
-// It panics if the value is negative or too large to fit into a uint256.Int.
-// FIXME: remove in favour of BigIntToUint256Err
-func BigIntToUint256(value *big.Int) *uint256.Int {
-	if value.Sign() < 0 {
-		panic("unable to convert negative big.Int to uint256")
-	}
-	bytes := value.Bytes()
-	if len(bytes) > 32 {
-		panic("unable to convert big.Int exceeding 32 bytes to uint256")
-	}
-	return new(uint256.Int).SetBytes(bytes)
-}
-
-// BigIntToUint256Err converts a big.Int to a uint256.Int.
 // It returns an error if the value is negative or too large to fit into a uint256.Int.
 // If the value is nil, nil is returned.
 // FIXME: rename to BigIntToUint256 once the panicking version is removed
-func BigIntToUint256Err(value *big.Int) (*uint256.Int, error) {
+func BigIntToUint256(value *big.Int) (*uint256.Int, error) {
 	if value == nil {
 		return nil, nil
 	}

--- a/utils/int_test.go
+++ b/utils/int_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBigIntToUint256Err_ValidConversions(t *testing.T) {
+func TestBigIntToUint256_ValidConversions(t *testing.T) {
 	tests := map[string]struct {
 		input    *big.Int
 		expected *uint256.Int
@@ -139,7 +139,7 @@ func TestBigIntToUint256Err_ValidConversions(t *testing.T) {
 	}
 }
 
-func TestBigIntToUint256Err_ErrorCases(t *testing.T) {
+func TestBigIntToUint256_ErrorCases(t *testing.T) {
 	tests := map[string]struct {
 		input       *big.Int
 		expectedErr string

--- a/utils/int_test.go
+++ b/utils/int_test.go
@@ -123,7 +123,7 @@ func TestBigIntToUint256Err_ValidConversions(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			result, err := BigIntToUint256Err(tt.input)
+			result, err := BigIntToUint256(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 
@@ -182,7 +182,7 @@ func TestBigIntToUint256Err_ErrorCases(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			result, err := BigIntToUint256Err(tt.input)
+			result, err := BigIntToUint256(tt.input)
 			require.Error(t, err)
 			require.Nil(t, result)
 			require.ErrorContains(t, err, tt.expectedErr)

--- a/utils/to_ftm.go
+++ b/utils/to_ftm.go
@@ -29,5 +29,5 @@ func ToFtm(ftm uint64) *big.Int {
 
 // ToFtmU256 number of FTM to Wei using the uint256 type
 func ToFtmU256(ftm uint64) *uint256.Int {
-	return BigIntToUint256(ToFtm(ftm))
+	return BigIntToUint256Clamped(ToFtm(ftm))
 }

--- a/utils/to_ftm.go
+++ b/utils/to_ftm.go
@@ -29,5 +29,5 @@ func ToFtm(ftm uint64) *big.Int {
 
 // ToFtmU256 number of FTM to Wei using the uint256 type
 func ToFtmU256(ftm uint64) *uint256.Int {
-	return BigIntToUint256Clamped(ToFtm(ftm))
+	return BigIntToUint256(ToFtm(ftm))
 }


### PR DESCRIPTION
This PR removes the panicking flavor of `big.Int` to `uint256.Int` conversions.
Test code have been simplified to use the clamping version.

`ToFtmU256`  is used in fake and json genesis files, therefore it is testing tool as well. 
