### PR TITLE
Fix flaky tests where multiple nodes wait for same block.

### DIFF
--- a/tests/block_parameters_test.go
+++ b/tests/block_parameters_test.go
@@ -85,8 +85,7 @@ func testBlockHeaderMatchesObservableBlockParameters(
 
 			// Verify those block parameters against the block headers.
 			for blockNumber, fromTx := range fromBlocks {
-				block, err := client.BlockByNumber(t.Context(), big.NewInt(int64(blockNumber)))
-				require.NoError(err, "Failed to get block by number")
+				block := WaitForBlock(t, client, int(blockNumber))
 
 				require.Equal(fromTx.ChainId, net.GetChainId())
 				require.Equal(fromTx.Number, block.Number())

--- a/tests/randao_test.go
+++ b/tests/randao_test.go
@@ -63,8 +63,9 @@ func TestRandao_randaoIntegrationTest(t *testing.T) {
 					require.NoError(t, err)
 					defer client.Close()
 
-					block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
-					require.NoError(t, err)
+					// The receipt was obtained from node 0, but other
+					// nodes may not have synced the block yet.
+					block := WaitForBlock(t, client, int(receipt.BlockNumber.Int64()))
 					require.NotZero(t, block.Header().MixDigest)
 					randaoList[i] = block.Header().MixDigest
 				}

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -443,6 +443,26 @@ func GetStateRoot(t *testing.T, client *PooledEhtClient, blockNumber int) common
 	return common.BytesToHash(crypto.Keccak256(data))
 }
 
+// WaitForBlock waits until the block with the given number is available in the node, it errors
+// if the block is not available after a timeout.
+// It can be used to wait in multiple nodes for the same block, to ensure they have all processed it.
+func WaitForBlock(t *testing.T, client *PooledEhtClient, blockNumber int) *types.Block {
+	var block *types.Block
+	err := WaitFor(t.Context(), func(ctx context.Context) (bool, error) {
+		var err error
+		block, err = client.BlockByNumber(ctx, big.NewInt(int64(blockNumber)))
+		if err != nil {
+			if err == ethereum.NotFound {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	require.NoError(t, err, "failed to wait for block %d", blockNumber)
+	return block
+}
+
 func WaitForProofOf(t *testing.T, client *PooledEhtClient, blockNumber int) {
 	err := WaitFor(context.Background(), func(ctx context.Context) (bool, error) {
 		_, err := getProofFor(t, client, blockNumber)


### PR DESCRIPTION
Tests using multiple nodes shall not assume that a block is available in every node immediately. 
This PR adds a tool to wait on block creation. 
