### PR TITLE
Add static transaction validation in c_block_callback

### DIFF
--- a/evmcore/error.go
+++ b/evmcore/error.go
@@ -68,17 +68,75 @@ var (
 	// current network configuration.
 	ErrTxTypeNotSupported = types.ErrTxTypeNotSupported
 
+	// ErrValueMissing is returned if the transaction value is missing.
+	ErrValueMissing = errors.New("value missing")
+
+	// ErrValueNegative is returned if the transaction value is negative.
+	ErrValueNegative = errors.New("negative value")
+
+	// ErrValueTooHigh is returned if the transaction value is higher than 2^256-1.
+	ErrValueTooHigh = errors.New("value higher than 2^256-1")
+
+	// ErrFeeCapMissing is returned if the transaction fee cap is missing in
+	// a transaction.
+	ErrFeeCapMissing = errors.New("max fee per gas missing")
+
+	// ErrFeeCapNegative is returned if the transaction fee cap is negative.
+	ErrFeeCapNegative = errors.New("max fee per gas negative")
+
+	// ErrFeeCapTooHigh is a sanity error to avoid extremely big numbers specified
+	// in the fee cap field.
+	ErrFeeCapTooHigh = errors.New("max fee per gas higher than 2^256-1")
+
+	// ErrTipCapMissing is returned if the transaction tip cap is missing in
+	// a transaction.
+	ErrTipCapMissing = errors.New("max priority fee per gas missing")
+
+	// ErrTipCapNegative is a sanity error to ensure no one is able to specify a
+	// transaction with a negative tip.
+	ErrTipCapNegative = errors.New("max priority fee per gas negative")
+
+	// ErrTipCapTooHigh is a sanity error to avoid extremely big numbers specified
+	// in the tip cap field.
+	ErrTipCapTooHigh = errors.New("max priority fee per gas higher than 2^256-1")
+
 	// ErrTipAboveFeeCap is a sanity error to ensure no one is able to specify a
 	// transaction with a tip higher than the total fee cap.
 	ErrTipAboveFeeCap = errors.New("max priority fee per gas higher than max fee per gas")
 
-	// ErrTipVeryHigh is a sanity error to avoid extremely big numbers specified
-	// in the tip field.
-	ErrTipVeryHigh = errors.New("max priority fee per gas higher than 2^256-1")
+	// ErrBlobGasFeeCapMissing is returned if the transaction blob fee cap is
+	// missing in a blob transaction.
+	ErrBlobGasFeeCapMissing = errors.New("max fee per blob gas missing")
 
-	// ErrFeeCapVeryHigh is a sanity error to avoid extremely big numbers specified
-	// in the fee cap field.
-	ErrFeeCapVeryHigh = errors.New("max fee per gas higher than 2^256-1")
+	// ErrBlobGasFeeCapNegative is returned if the transaction blob fee cap is negative.
+	ErrBlobGasFeeCapNegative = errors.New("max fee per blob gas negative")
+
+	// ErrBlobGasFeeCapTooHigh is a sanity error to avoid extremely big numbers specified
+	// in the blob gas fee cap field.
+	ErrBlobGasFeeCapTooHigh = errors.New("max fee per blob gas higher than 2^256-1")
+
+	// ErrGasPriceMissing is returned if the transaction gas price is missing.
+	ErrGasPriceMissing = errors.New("gas price missing")
+
+	// ErrGasPriceNegative is returned if the transaction gas price is negative.
+	ErrGasPriceNegative = errors.New("gas price negative")
+
+	// ErrGasPriceTooHigh is a sanity error to avoid extremely big numbers specified
+	// in the gas price field.
+	ErrGasPriceTooHigh = errors.New("gas price higher than 2^256-1")
+
+	// ErrGasPriceAboveFeeCap is a sanity error to ensure no one is able to
+	// specify a transaction with a gas price higher than the max fee per gas.
+	ErrGasPriceAboveFeeCap = errors.New("gas price higher than max fee per gas")
+
+	// ErrCostNegative is returned if the total cost of a transaction is negative.
+	ErrCostNegative = errors.New("total cost negative")
+
+	// ErrCostMissing is returned if the total cost of a transaction is missing.
+	ErrCostMissing = errors.New("total cost missing")
+
+	// ErrCostTooHigh is returned if the total cost of a transaction is higher than 2^256-1.
+	ErrCostTooHigh = errors.New("total cost higher than 2^256-1")
 
 	// ErrFeeCapTooLow is returned if the transaction fee cap is less than the
 	// the base fee of the block.
@@ -89,6 +147,9 @@ var (
 
 	// ErrEmptyAuthorizations is returned if a SetCode transaction has no authorizations.
 	ErrEmptyAuthorizations = errors.New("empty authorizations")
+
+	// ErrNonEmptyAuthorizations is returned if a non-SetCode transaction has authorizations.
+	ErrNonEmptyAuthorizations = errors.New("non-empty authorizations")
 
 	// ErrMaxInitCodeSizeExceeded is returned if creation transaction provides the init code bigger
 	// than init code size limit.

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -87,10 +87,6 @@ var (
 	// maximum allowance of the current block.
 	ErrGasLimit = errors.New("exceeds block gas limit")
 
-	// ErrNegativeValue is a sanity error to ensure no one is able to specify a
-	// transaction with a negative value.
-	ErrNegativeValue = errors.New("negative value")
-
 	// ErrOversizedData is returned if the input data of a transaction is greater
 	// than some meaningful limit a user might use. This is not a consensus error
 	// making the transaction invalid, rather a DOS protection.

--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -1193,8 +1193,8 @@ func TestTransactionNegativeValue(t *testing.T) {
 	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(-1), 200_000, big.NewInt(1), nil), types.HomesteadSigner{}, key)
 	from, _ := deriveSender(tx)
 	testAddBalance(pool, from, big.NewInt(1))
-	if err := pool.AddRemote(tx); err != ErrNegativeValue {
-		t.Error("expected", ErrNegativeValue, "got", err)
+	if err := pool.AddRemote(tx); err != ErrValueNegative {
+		t.Error("expected", ErrValueNegative, "got", err)
 	}
 }
 
@@ -1221,13 +1221,13 @@ func TestTransactionVeryHighValues(t *testing.T) {
 	veryBigNumber.Lsh(veryBigNumber, 300)
 
 	tx := dynamicFeeTx(0, 200_000, big.NewInt(1), veryBigNumber, key)
-	if err := pool.AddRemote(tx); err != ErrTipVeryHigh {
-		t.Error("expected", ErrTipVeryHigh, "got", err)
+	if err := pool.AddRemote(tx); err != ErrTipCapTooHigh {
+		t.Error("expected", ErrTipCapTooHigh, "got", err)
 	}
 
 	tx2 := dynamicFeeTx(0, 200_000, veryBigNumber, big.NewInt(1), key)
-	if err := pool.AddRemote(tx2); err != ErrFeeCapVeryHigh {
-		t.Error("expected", ErrFeeCapVeryHigh, "got", err)
+	if err := pool.AddRemote(tx2); err != ErrFeeCapTooHigh {
+		t.Error("expected", ErrFeeCapTooHigh, "got", err)
 	}
 }
 

--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -212,43 +212,134 @@ func ValidateTxForNetwork(tx *types.Transaction, rules NetworkRules, chain State
 }
 
 // ValidateTxStatic runs a set of verification independent from any context with
-// the aim to identify malformed transactions. It checks the transaction's:
-// - value (must be positive)
-// - gas fee cap and tip cap must be within the 256 bit range
-// - gas fee cap must be greater than or equal to the tip cap
-// - set code transactions must not have an empty authorization list
+// the aim to identify malformed transactions. It checks that the given
+// transaction is able to provide a valid value for the following fields:
+//   - value
+//   - nonce
+//   - gas fee cap
+//   - gas tip cap
+//   - gas price
+//   - cost
+//
+// Furthermore, the following relations between fields are checked:
+//   - gas fee cap must be greater than or equal to gas tip cap
+//   - if the transaction is a blob transaction, the blob gas fee cap must be valid as well
+//   - if the transaction is a set code transaction, it must have a non-empty authorization list
 //
 // It returns an error if any of the checks fail.
-func ValidateTxStatic(tx *types.Transaction) error {
+//
+// This function does not make any assumptions on the implementation of the
+// given transaction. Instead, it verifies the observable properties made
+// available through its public interface.
+func ValidateTxStatic(tx txValidationTarget) error {
 
-	// Transactions can't be negative. This may never happen using RLP decoded
-	// transactions but may occur if you create a transaction using the RPC.
-	if tx.Value().Sign() < 0 {
-		return ErrNegativeValue
+	// Check value ranges of individual fields.
+	if err := validateValueRanges(tx); err != nil {
+		return err
 	}
 
-	// Sanity check for extremely large numbers
-	if tx.GasFeeCap().BitLen() > 256 {
-		return ErrFeeCapVeryHigh
-	}
-	if tx.GasTipCap().BitLen() > 256 {
-		return ErrTipVeryHigh
-	}
+	// -- field combinations checks --
 
 	// Ensure gasFeeCap is greater than or equal to gasTipCap.
-	if tx.GasFeeCapIntCmp(tx.GasTipCap()) < 0 {
+	feeCap := tx.GasFeeCap()
+	tipCap := tx.GasTipCap()
+	if feeCap.Cmp(tipCap) < 0 {
 		return ErrTipAboveFeeCap
 	}
 
+	// The gas price must be less or equal the fee cap.
+	gasPrice := tx.GasPrice()
+	if gasPrice.Cmp(feeCap) > 0 {
+		return ErrGasPriceAboveFeeCap
+	}
+
 	// Check non-empty authorization list
-	if tx.Type() == types.SetCodeTxType && len(tx.SetCodeAuthorizations()) == 0 {
-		return ErrEmptyAuthorizations
+	if tx.Type() == types.SetCodeTxType {
+		if len(tx.SetCodeAuthorizations()) == 0 {
+			return ErrEmptyAuthorizations
+		}
+	} else if len(tx.SetCodeAuthorizations()) > 0 {
+		return ErrNonEmptyAuthorizations
+	}
+
+	return nil
+}
+
+// validateValueRanges checks that all big.Int values that can be read from a
+// transaction are within valid ranges.
+func validateValueRanges(tx txValidationTarget) error {
+	// Range-check all big.Int values retrievable from transactions to be valid
+	// uint256 values. This is a sanity check to prevent any potential value
+	// range issues in the EVM execution.
+
+	if err := validateU256(tx.Value(), ErrValueMissing, ErrValueNegative, ErrValueTooHigh); err != nil {
+		return err
+	}
+
+	if err := validateU256(tx.GasFeeCap(), ErrFeeCapMissing, ErrFeeCapNegative, ErrFeeCapTooHigh); err != nil {
+		return err
+	}
+
+	if err := validateU256(tx.GasTipCap(), ErrTipCapMissing, ErrTipCapNegative, ErrTipCapTooHigh); err != nil {
+		return err
+	}
+
+	if err := validateU256(tx.GasPrice(), ErrGasPriceMissing, ErrGasPriceNegative, ErrGasPriceTooHigh); err != nil {
+		return err
+	}
+
+	if err := validateU256(tx.Cost(), ErrCostMissing, ErrCostNegative, ErrCostTooHigh); err != nil {
+		return err
 	}
 
 	if tx.Nonce() == math.MaxUint64 {
 		return ErrNonceTooHigh
 	}
 
+	// Check blob gas fee cap range if transaction is a blob transaction.
+	if tx.Type() == types.BlobTxType || tx.BlobGasFeeCap() != nil {
+		if err := validateU256(tx.BlobGasFeeCap(), ErrBlobGasFeeCapMissing, ErrBlobGasFeeCapNegative, ErrBlobGasFeeCapTooHigh); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// txValidationTarget is an interface that abstracts the properties of a
+// transaction that are relevant for validation.
+type txValidationTarget interface {
+	Type() uint8
+	Nonce() uint64
+	Value() *big.Int
+
+	GasFeeCap() *big.Int
+	GasTipCap() *big.Int
+	BlobGasFeeCap() *big.Int
+
+	GasPrice() *big.Int
+	Cost() *big.Int
+
+	SetCodeAuthorizations() []types.SetCodeAuthorization
+}
+
+// validateU256 is a helper function to check that a big.Int value is a valid
+// uint256 and not nil.
+func validateU256(
+	value *big.Int,
+	missing error,
+	toLow error,
+	toHigh error,
+) error {
+	if value == nil {
+		return missing
+	}
+	if value.Sign() < 0 {
+		return toLow
+	}
+	if value.BitLen() > 256 {
+		return toHigh
+	}
 	return nil
 }
 

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -58,7 +58,7 @@ func TestValidateTxStatic_Value_RejectsTxWithNegativeValue(t *testing.T) {
 	for _, tx := range txs {
 		t.Run(transactionTypeName(tx), func(t *testing.T) {
 			err := ValidateTxStatic(types.NewTx(tx))
-			require.ErrorIs(t, err, ErrNegativeValue)
+			require.ErrorIs(t, err, ErrValueNegative)
 		})
 	}
 }
@@ -84,7 +84,7 @@ func TestValidateTxStatic_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 		for _, tx := range txs {
 			t.Run(transactionTypeName(tx), func(t *testing.T) {
 				err := ValidateTxStatic(types.NewTx(tx))
-				require.ErrorIs(t, err, ErrFeeCapVeryHigh)
+				require.ErrorIs(t, err, ErrFeeCapTooHigh)
 			})
 		}
 	})
@@ -101,7 +101,7 @@ func TestValidateTxStatic_GasPriceAndTip_RejectsTxWith(t *testing.T) {
 		for _, tx := range txs {
 			t.Run(transactionTypeName(tx), func(t *testing.T) {
 				err := ValidateTxStatic(types.NewTx(tx))
-				require.ErrorIs(t, err, ErrTipVeryHigh)
+				require.ErrorIs(t, err, ErrTipCapTooHigh)
 			})
 		}
 	})
@@ -172,6 +172,320 @@ func TestValidateTxStatic_AcceptsValidTransactions(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestValidateTxStatic_DetectsValueRangeIssues(t *testing.T) {
+	fakeTx := makeValidFakeTx()
+	require.NoError(t, ValidateTxStatic(fakeTx))
+
+	fakeTx.value = big.NewInt(-1)
+	err := ValidateTxStatic(fakeTx)
+	require.ErrorIs(t, err, ErrValueNegative)
+}
+
+func TestValidateTxStatic_IdentifiesFeeCapsHigherThanTipCaps(t *testing.T) {
+	tests := map[string]struct {
+		feeCap, tipCap int
+		ok             bool
+	}{
+		"fee cap > tip cap": {feeCap: 2, tipCap: 1, ok: true},
+		"fee cap = tip cap": {feeCap: 1, tipCap: 1, ok: true},
+		"fee cap < tip cap": {feeCap: 1, tipCap: 2, ok: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx := makeValidFakeTx()
+			tx.gasFeeCap = big.NewInt(int64(test.feeCap))
+			tx.gasTipCap = big.NewInt(int64(test.tipCap))
+			err := ValidateTxStatic(tx)
+			if test.ok {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, ErrTipAboveFeeCap)
+			}
+		})
+	}
+}
+
+func TestValidateTxStatic_IdentifiesGasPriceHigherThanFeeCap(t *testing.T) {
+	tests := map[string]struct {
+		gasPrice, feeCap int
+		ok               bool
+	}{
+		"gas price > fee cap": {gasPrice: 2, feeCap: 1, ok: false},
+		"gas price = fee cap": {gasPrice: 1, feeCap: 1, ok: true},
+		"gas price < fee cap": {gasPrice: 1, feeCap: 2, ok: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx := makeValidFakeTx()
+			tx.gasPrice = big.NewInt(int64(test.gasPrice))
+			tx.gasFeeCap = big.NewInt(int64(test.feeCap))
+			err := ValidateTxStatic(tx)
+			if test.ok {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, ErrGasPriceAboveFeeCap)
+			}
+		})
+	}
+}
+
+func TestValidateTxStatic_IdentifiesUnexpectedCodeAuthorizations(t *testing.T) {
+	tests := map[string]struct {
+		txType   uint8
+		authList []types.SetCodeAuthorization
+		expected error
+	}{
+		"non-SetCodeTx with empty auth list": {
+			txType:   types.LegacyTxType,
+			authList: nil,
+			expected: nil,
+		},
+		"non-SetCodeTx with non-empty auth list": {
+			txType:   types.LegacyTxType,
+			authList: []types.SetCodeAuthorization{{}},
+			expected: ErrNonEmptyAuthorizations,
+		},
+		"SetCodeTx with empty auth list": {
+			txType:   types.SetCodeTxType,
+			authList: nil,
+			expected: ErrEmptyAuthorizations,
+		},
+		"SetCodeTx with non-empty auth list": {
+			txType:   types.SetCodeTxType,
+			authList: []types.SetCodeAuthorization{{}},
+			expected: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx := makeValidFakeTx()
+			tx.txType = test.txType
+			tx.authList = test.authList
+			err := ValidateTxStatic(tx)
+			if test.expected != nil {
+				require.ErrorIs(t, err, test.expected)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_validateValueRanges_IdentifyExpectedIssues(t *testing.T) {
+
+	properties := map[string]struct {
+		set                        func(*fakeTxValidationTarget, *big.Int)
+		missing, negative, tooHigh error
+	}{
+		"value": {
+			set:      func(tx *fakeTxValidationTarget, val *big.Int) { tx.value = val },
+			missing:  ErrValueMissing,
+			negative: ErrValueNegative,
+			tooHigh:  ErrValueTooHigh,
+		},
+		"gas fee cap": {
+			set:      func(tx *fakeTxValidationTarget, val *big.Int) { tx.gasFeeCap = val },
+			missing:  ErrFeeCapMissing,
+			negative: ErrFeeCapNegative,
+			tooHigh:  ErrFeeCapTooHigh,
+		},
+		"gas tip cap": {
+			set:      func(tx *fakeTxValidationTarget, val *big.Int) { tx.gasTipCap = val },
+			missing:  ErrTipCapMissing,
+			negative: ErrTipCapNegative,
+			tooHigh:  ErrTipCapTooHigh,
+		},
+		"gas price": {
+			set:      func(tx *fakeTxValidationTarget, val *big.Int) { tx.gasPrice = val },
+			missing:  ErrGasPriceMissing,
+			negative: ErrGasPriceNegative,
+			tooHigh:  ErrGasPriceTooHigh,
+		},
+		"total cost": {
+			set:      func(tx *fakeTxValidationTarget, val *big.Int) { tx.cost = val },
+			missing:  ErrCostMissing,
+			negative: ErrCostNegative,
+			tooHigh:  ErrCostTooHigh,
+		},
+		"blob gas fee cap": {
+			set: func(tx *fakeTxValidationTarget, val *big.Int) {
+				tx.txType = types.BlobTxType
+				tx.blobGasFeeCap = val
+			},
+			missing:  ErrBlobGasFeeCapMissing,
+			negative: ErrBlobGasFeeCapNegative,
+			tooHigh:  ErrBlobGasFeeCapTooHigh,
+		},
+	}
+
+	type testCase struct {
+		mod      func(*fakeTxValidationTarget)
+		expected error
+	}
+	tests := map[string]testCase{}
+
+	minusOne := big.NewInt(-1)
+	zero := big.NewInt(0)
+	twoTo256 := new(big.Int).Lsh(big.NewInt(1), 256)
+	max := new(big.Int).Sub(twoTo256, big.NewInt(1))
+	for name, props := range properties {
+		tests[fmt.Sprintf("%s missing", name)] = testCase{
+			mod: func(tx *fakeTxValidationTarget) {
+				props.set(tx, nil)
+			},
+			expected: props.missing,
+		}
+		tests[fmt.Sprintf("%s negative", name)] = testCase{
+			mod: func(tx *fakeTxValidationTarget) {
+				props.set(tx, minusOne)
+			},
+			expected: props.negative,
+		}
+		tests[fmt.Sprintf("%s zero", name)] = testCase{
+			mod: func(tx *fakeTxValidationTarget) {
+				props.set(tx, zero)
+			},
+			expected: nil,
+		}
+		tests[fmt.Sprintf("%s max", name)] = testCase{
+			mod: func(tx *fakeTxValidationTarget) {
+				props.set(tx, max)
+			},
+			expected: nil,
+		}
+		tests[fmt.Sprintf("%s too high", name)] = testCase{
+			mod: func(tx *fakeTxValidationTarget) {
+				props.set(tx, twoTo256)
+			},
+			expected: props.tooHigh,
+		}
+	}
+
+	tests["nonce is zero"] = testCase{
+		mod: func(tx *fakeTxValidationTarget) {
+			tx.nonce = 0
+		},
+		expected: nil,
+	}
+
+	tests["nonce is max"] = testCase{
+		mod: func(tx *fakeTxValidationTarget) {
+			tx.nonce = math.MaxUint64
+		},
+		expected: ErrNonceTooHigh,
+	}
+
+	tests["nonce is max-1"] = testCase{
+		mod: func(tx *fakeTxValidationTarget) {
+			tx.nonce = math.MaxUint64 - 1
+		},
+		expected: nil,
+	}
+
+	tests["non-blob transactions can have nil as blob gas fee cap"] = testCase{
+		mod: func(tx *fakeTxValidationTarget) {
+			tx.txType = types.LegacyTxType
+			tx.blobGasFeeCap = nil
+		},
+		expected: nil,
+	}
+
+	tests["if present, blob gas fee cap must not be negative"] = testCase{
+		mod: func(tx *fakeTxValidationTarget) {
+			tx.txType = types.LegacyTxType
+			tx.blobGasFeeCap = minusOne
+		},
+		expected: ErrBlobGasFeeCapNegative,
+	}
+
+	tests["if present, blob gas fee cap must not exceed uint256"] = testCase{
+		mod: func(tx *fakeTxValidationTarget) {
+			tx.txType = types.LegacyTxType
+			tx.blobGasFeeCap = twoTo256
+		},
+		expected: ErrBlobGasFeeCapTooHigh,
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			valid := makeValidFakeTx()
+			require.NoError(t, validateValueRanges(valid))
+			test.mod(valid)
+			err := validateValueRanges(valid)
+			if test.expected == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, test.expected)
+			}
+		})
+	}
+
+}
+
+type fakeTxValidationTarget struct {
+	txType        uint8
+	nonce         uint64
+	value         *big.Int
+	gasPrice      *big.Int
+	gasTipCap     *big.Int
+	gasFeeCap     *big.Int
+	blobGasFeeCap *big.Int
+	cost          *big.Int
+	authList      []types.SetCodeAuthorization
+}
+
+func makeValidFakeTx() *fakeTxValidationTarget {
+	return &fakeTxValidationTarget{
+		txType:    types.DynamicFeeTxType,
+		nonce:     0,
+		value:     big.NewInt(0),
+		gasPrice:  big.NewInt(0),
+		gasTipCap: big.NewInt(0),
+		gasFeeCap: big.NewInt(0),
+		cost:      big.NewInt(0),
+		authList:  nil,
+	}
+}
+
+func (f *fakeTxValidationTarget) Type() uint8 {
+	return f.txType
+}
+
+func (f *fakeTxValidationTarget) Nonce() uint64 {
+	return f.nonce
+}
+
+func (f *fakeTxValidationTarget) Value() *big.Int {
+	return f.value
+}
+
+func (f *fakeTxValidationTarget) GasPrice() *big.Int {
+	return f.gasPrice
+}
+
+func (f *fakeTxValidationTarget) GasTipCap() *big.Int {
+	return f.gasTipCap
+}
+
+func (f *fakeTxValidationTarget) GasFeeCap() *big.Int {
+	return f.gasFeeCap
+}
+
+func (f *fakeTxValidationTarget) BlobGasFeeCap() *big.Int {
+	return f.blobGasFeeCap
+}
+
+func (f *fakeTxValidationTarget) Cost() *big.Int {
+	return f.cost
+}
+
+func (f *fakeTxValidationTarget) SetCodeAuthorizations() []types.SetCodeAuthorization {
+	return f.authList
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -868,6 +868,7 @@ func filterNonPermissibleTransactions(
 	log log.Logger,
 	counter metricCounter,
 ) []*types.Transaction {
+
 	// This filter is only enabled with the Allegro upgrade.
 	if !rules.Upgrades.Allegro {
 		return transactions
@@ -913,6 +914,16 @@ func isPermissibleInternal(
 ) error {
 	if tx == nil {
 		return fmt.Errorf("nil transaction")
+	}
+
+	// -- Check static properties --
+
+	// TODO: verify whether the static checks are backward compatible to allow
+	// this to be enabled before Brio as well.
+	if rules.Upgrades.Brio {
+		if err := evmcore.ValidateTxStatic(tx); err != nil {
+			return err
+		}
 	}
 
 	// -- Check transaction type --

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -793,6 +793,59 @@ func TestIsPermissible_AcceptsSetCodeTransactionsInAllegroAndBeyond(t *testing.T
 	}
 }
 
+func TestIsPermissible_WithBrio_RejectsTransactionsFailingStaticChecks(t *testing.T) {
+
+	invalidTx := types.NewTx(&types.DynamicFeeTx{
+		GasFeeCap: big.NewInt(-1), // Invalid gas price
+	})
+
+	issue := evmcore.ValidateTxStatic(invalidTx)
+	require.Error(t, issue)
+
+	// Before Brio, static checks are ignored for permissibility.
+	rules := opera.Rules{Upgrades: opera.Upgrades{Brio: false}}
+	require.NoError(t, isPermissible(invalidTx, &rules, nil))
+
+	// With Brio, transactions failing static checks are not permissible.
+	rules = opera.Rules{Upgrades: opera.Upgrades{Brio: true}}
+	require.ErrorIs(t, isPermissible(invalidTx, &rules, nil), issue)
+}
+
+func TestIsPermissible_WithBrio_DetectsInvalidTransactionsInBundles(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	invalidInnerTx := types.NewTx(&types.DynamicFeeTx{
+		GasFeeCap: new(big.Int).Lsh(big.NewInt(1), 256), // Invalid fee cap
+	})
+	issue := evmcore.ValidateTxStatic(invalidInnerTx)
+	require.Error(t, issue)
+
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	tests := map[string]*types.Transaction{
+		"invalid transaction in bundle": bundle.NewBuilder().AllOf(
+			bundle.Step(key, invalidInnerTx),
+		).WithSigner(signer).Build(),
+		"invalid nested transaction in bundle": bundle.NewBuilder().OneOf(
+			bundle.Step(key, bundle.NewBuilder().AllOf(
+				bundle.Step(key, invalidInnerTx),
+			).WithSigner(signer).Build()),
+		).WithSigner(signer).Build(),
+	}
+
+	for name, tx := range tests {
+		t.Run(name, func(t *testing.T) {
+			rules := opera.Rules{Upgrades: opera.Upgrades{
+				Brio:               true,
+				TransactionBundles: true,
+			}}
+			got := isPermissible(tx, &rules, signer)
+			require.ErrorIs(t, got, issue)
+		})
+	}
+}
+
 func TestIsPermissible_WithBrio_RejectsBundleOnlyTransactions(t *testing.T) {
 	require := require.New(t)
 	tx := types.NewTx(&types.AccessListTx{


### PR DESCRIPTION
This PR extends the range of checks applied to transactions to verify static properties and integrates those checks as a pre-filter in the block-formation process.

The PR performs the following modifications:
- extends the list of properties covered by [evmcore.ValidateTxStatic](https://github.com/0xsoniclabs/sonic/blob/07f2b72b66f2c6948c42b6545bd17733ceacf400/evmcore/tx_validation.go#L222) to include all known transaction properties that can be statically evaluated
- integrate this filter into the c_block_callback's [isPermissible](https://github.com/0xsoniclabs/sonic/blob/07f2b72b66f2c6948c42b6545bd17733ceacf400/gossip/c_block_callbacks.go#L900) filter
