### PR TITLE
Fix epoch bounds check truncation in dag_getHeads

### DIFF
--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -302,7 +302,7 @@ func (b *EthAPIBackend) epochWithDefault(ctx context.Context, epoch rpc.BlockNum
 		requested = current
 	case isLatestBlockNumber(epoch):
 		requested = current - 1
-	case epoch >= 0 && idx.Epoch(epoch) <= current:
+	case epoch >= 0 && epoch <= rpc.BlockNumber(current):
 		requested = idx.Epoch(epoch)
 	default:
 		err = errors.New("epoch is not in range")

--- a/gossip/ethapi_backend_test.go
+++ b/gossip/ethapi_backend_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -182,4 +183,23 @@ func TestEthApiBackend_proposeTransactionsInternal_ReturnsEmissionIssue(t *testi
 
 	emitter.EXPECT().ForceEventEmissionForTesting(nil).Return(issue)
 	require.ErrorIs(t, backend.proposeTransactionsInternal(nil, emitter), issue)
+}
+
+func TestEthApiBackend_epochWithDefault_RejectsEpochsAboveUint32Max(t *testing.T) {
+	const currentEpoch = idx.Epoch(1000)
+
+	store, err := NewMemStore(t)
+	require.NoError(t, err)
+	store.SetBlockEpochState(iblockproc.BlockState{}, iblockproc.EpochState{Epoch: currentEpoch})
+	backend := &EthAPIBackend{
+		svc: &Service{
+			store: store,
+		},
+	}
+
+	// 2^32 + currentEpoch truncates to currentEpoch when cast to uint32,
+	// so a naive idx.Epoch(epoch) <= current check would incorrectly accept it.
+	outOfRange := rpc.BlockNumber(1<<32 + int64(currentEpoch))
+	_, err = backend.epochWithDefault(t.Context(), outOfRange)
+	require.Error(t, err, "epoch value above uint32 max must be rejected")
 }


### PR DESCRIPTION
The `dag_getHeads` RPC method accepts an epoch number as `rpc.BlockNumber` (int64), which is validated against the current epoch before use. The previous check cast the input to `idx.Epoch` (uint32) before comparing, silently truncating the upper 32 bits.

A call `dag_getHeads(4294968296)` before the fix would return epoch 1000, instead of returning not-existing-epoch error.