### PR TITLE
Enable sonic RPC namespace by default

### DIFF
--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -275,8 +275,8 @@ func lachesisMainInternal(
 			if strings.ToLower(module) == "ftm" {
 				log.Warn(fmt.Sprintf("The 'ftm' API is deprecated, use 'eth' instead (--%s).", flag))
 			}
-			if strings.ToLower(module) == "sonic" {
-				log.Warn(fmt.Sprintf("The 'sonic' API is experimental and should not be used in production environments (--%s).", flag))
+			if strings.ToLower(module) == "scc" {
+				log.Warn(fmt.Sprintf("The 'scc' API is experimental and should not be used in production environments (--%s).", flag))
 			}
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -459,8 +459,8 @@ func DefaultNodeConfig() node.Config {
 	cfg := NodeDefaultConfig
 	cfg.Name = ClientIdentifier
 	cfg.Version = version.StringWithCommit()
-	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "dag", "abft", "web3")
-	cfg.WSModules = append(cfg.WSModules, "eth", "dag", "abft", "web3")
+	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "dag", "abft", "web3", "sonic")
+	cfg.WSModules = append(cfg.WSModules, "eth", "dag", "abft", "web3", "sonic")
 	cfg.IPCPath = "sonic.ipc"
 	return cfg
 }


### PR DESCRIPTION
This PR enables `sonic` RPC namespace by default. Users can use transaction bundles on the RPC as they are enabled by this flag. `Sonic` tag is no longer experimental, as it was used for the `SCC`, which was moved into separate RPC namespace and warning for an experimental namespace is now used for `scc`.

https://github.com/0xsoniclabs/sonic-admin/issues/778