### PR TITLE
Add tooling to test rolled back bundles

### DIFF
--- a/tests/bundles/bundle_execution_flags_test.go
+++ b/tests/bundles/bundle_execution_flags_test.go
@@ -17,11 +17,9 @@
 package bundles
 
 import (
-	"context"
 	"math/big"
 	"slices"
 	"testing"
-	"time"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -35,165 +33,159 @@ func TestBundle_ExecutionFlagsOfSingleTxAreInterpretedCorrectly(t *testing.T) {
 
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.TransactionBundles = true
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-		// This tests submits clearly invalid bundles. TxPool will reject
-		// them directly, to test that they are correctly ignored, pool
-		// validation needs to be disabled.
-		ClientExtraArguments: []string{"--disable-txPool-validation"},
-	})
 
-	client, err := net.GetClient()
-	require.NoError(t, err)
-	defer client.Close()
+	for mode, net := range GetUnfilteredNetVariants(t, upgrades) {
+		t.Run(mode, func(t *testing.T) {
 
-	signer := types.LatestSignerForChainID(net.GetChainId())
-
-	revertAddress, revertInput := tests.MustDeployRevertContractAndGetMethodCallParameters(t, net)
-
-	senders := tests.MakeAccountsWithBalance(t, net, 2, big.NewInt(1e18))
-
-	successfulTx := types.AccessListTx{}
-	failingTx := types.AccessListTx{
-		To:   &revertAddress,
-		Gas:  1_000_000,
-		Data: revertInput,
-	}
-	invalidTx := types.AccessListTx{
-		Gas: 1, // insufficient gas
-	}
-
-	cases := map[string]struct {
-		tx    types.AccessListTx
-		flags bundle.ExecutionFlags
-		// Whether the whole bundle is expected to be rolled back. If this is
-		// the case, further expectations are ignored.
-		expectRollback bool
-		// The bundle contains case.tx and a successful transaction. This flag
-		// sets the expectation for the first transaction only.
-		expectInBlock bool
-	}{
-		"Default/SuccessfulTx": {
-			tx:             successfulTx,
-			flags:          bundle.EF_Default,
-			expectRollback: false,
-			expectInBlock:  true,
-		},
-		"Default/FailingTx": {
-			tx:             failingTx,
-			flags:          bundle.EF_Default,
-			expectRollback: true,
-		},
-		"Default/InvalidTx": {
-			tx:             invalidTx,
-			flags:          bundle.EF_Default,
-			expectRollback: true,
-		},
-		"TolerateInvalid/SuccessfulTx": {
-			tx:             successfulTx,
-			flags:          bundle.EF_TolerateInvalid,
-			expectRollback: false,
-			expectInBlock:  true,
-		},
-		"TolerateInvalid/FailingTx": {
-			tx:             failingTx,
-			flags:          bundle.EF_TolerateInvalid,
-			expectRollback: true,
-		},
-		"TolerateInvalid/InvalidTx": {
-			tx:             invalidTx,
-			flags:          bundle.EF_TolerateInvalid,
-			expectRollback: false,
-			expectInBlock:  false,
-		},
-		"TolerateFailed/SuccessfulTx": {
-			tx:             successfulTx,
-			flags:          bundle.EF_TolerateFailed,
-			expectRollback: false,
-			expectInBlock:  true,
-		},
-		"TolerateFailed/FailingTx": {
-			tx:             failingTx,
-			flags:          bundle.EF_TolerateFailed,
-			expectRollback: false,
-			expectInBlock:  true,
-		},
-		"TolerateFailed/InvalidTx": {
-			tx:             invalidTx,
-			flags:          bundle.EF_TolerateFailed,
-			expectRollback: true,
-		},
-		"TolerateInvalidTolerateFailed/SuccessfulTx": {
-			tx:             successfulTx,
-			flags:          bundle.EF_TolerateInvalid | bundle.EF_TolerateFailed,
-			expectRollback: false,
-			expectInBlock:  true,
-		},
-		"TolerateInvalidTolerateFailed/FailingTx": {
-			tx:             failingTx,
-			flags:          bundle.EF_TolerateInvalid | bundle.EF_TolerateFailed,
-			expectRollback: false,
-			expectInBlock:  true,
-		},
-		"TolerateInvalidTolerateFailed/InvalidTx": {
-			tx:             invalidTx,
-			flags:          bundle.EF_TolerateInvalid | bundle.EF_TolerateFailed,
-			expectRollback: false,
-			expectInBlock:  false,
-		},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			blockNumber, err := client.BlockNumber(t.Context())
+			client, err := net.GetClient()
 			require.NoError(t, err)
+			defer client.Close()
 
-			// Create the bundle: AllOf([c.flags]c.tx, successfulTx)
-			// The second transaction is needed for the cases with an invalid
-			// transaction to check whether it was tolerated or not.
-			envelope, bundle, plan := bundle.NewBuilder().
-				WithSigner(signer).
-				SetEarliest(blockNumber).
-				AllOf(
-					Step(t, net, senders[0], &c.tx).WithFlags(c.flags),
-					Step(t, net, senders[1], &successfulTx),
-				).
-				BuildEnvelopeBundleAndPlan()
+			signer := types.LatestSignerForChainID(net.GetChainId())
 
-			// Send the bundle.
-			_, err = net.Send(envelope)
-			require.NoError(t, err)
+			revertAddress, revertInput := tests.MustDeployRevertContractAndGetMethodCallParameters(t, net)
 
-			if c.expectRollback {
-				timeoutCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-				defer cancel()
+			senders := tests.MakeAccountsWithBalance(t, net, 2, big.NewInt(1e18))
 
-				_, err := WaitForBundleExecution(timeoutCtx, client.Client(), plan.Hash())
-				require.ErrorIs(t, err, context.DeadlineExceeded)
-				return
+			successfulTx := types.AccessListTx{}
+			failingTx := types.AccessListTx{
+				To:   &revertAddress,
+				Gas:  1_000_000,
+				Data: revertInput,
+			}
+			invalidTx := types.AccessListTx{
+				Gas: 1, // insufficient gas
 			}
 
-			// Wait for the bundle to be processed.
-			info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
-			require.NoError(t, err)
-
-			blockTxsHashes := getBlockTxsHashes(t, client, big.NewInt(info.Block.Int64()))
-			bundleTxs := bundle.GetTransactionsInReferencedOrder()
-
-			// If the transaction is expected to not be included in the block,
-			// only the successful transaction that follows it should be included.
-			if !c.expectInBlock {
-				require.Equal(t, 1, int(info.Count))
-				require.NotContains(t, blockTxsHashes, bundleTxs[0].Hash())
-				require.Contains(t, blockTxsHashes, bundleTxs[1].Hash())
-				return
+			cases := map[string]struct {
+				tx    types.AccessListTx
+				flags bundle.ExecutionFlags
+				// Whether the whole bundle is expected to be rolled back. If this is
+				// the case, further expectations are ignored.
+				expectRollback bool
+				// The bundle contains case.tx and a successful transaction. This flag
+				// sets the expectation for the first transaction only.
+				expectInBlock bool
+			}{
+				"Default/SuccessfulTx": {
+					tx:             successfulTx,
+					flags:          bundle.EF_Default,
+					expectRollback: false,
+					expectInBlock:  true,
+				},
+				"Default/FailingTx": {
+					tx:             failingTx,
+					flags:          bundle.EF_Default,
+					expectRollback: true,
+				},
+				"Default/InvalidTx": {
+					tx:             invalidTx,
+					flags:          bundle.EF_Default,
+					expectRollback: true,
+				},
+				"TolerateInvalid/SuccessfulTx": {
+					tx:             successfulTx,
+					flags:          bundle.EF_TolerateInvalid,
+					expectRollback: false,
+					expectInBlock:  true,
+				},
+				"TolerateInvalid/FailingTx": {
+					tx:             failingTx,
+					flags:          bundle.EF_TolerateInvalid,
+					expectRollback: true,
+				},
+				"TolerateInvalid/InvalidTx": {
+					tx:             invalidTx,
+					flags:          bundle.EF_TolerateInvalid,
+					expectRollback: false,
+					expectInBlock:  false,
+				},
+				"TolerateFailed/SuccessfulTx": {
+					tx:             successfulTx,
+					flags:          bundle.EF_TolerateFailed,
+					expectRollback: false,
+					expectInBlock:  true,
+				},
+				"TolerateFailed/FailingTx": {
+					tx:             failingTx,
+					flags:          bundle.EF_TolerateFailed,
+					expectRollback: false,
+					expectInBlock:  true,
+				},
+				"TolerateFailed/InvalidTx": {
+					tx:             invalidTx,
+					flags:          bundle.EF_TolerateFailed,
+					expectRollback: true,
+				},
+				"TolerateInvalidTolerateFailed/SuccessfulTx": {
+					tx:             successfulTx,
+					flags:          bundle.EF_TolerateInvalid | bundle.EF_TolerateFailed,
+					expectRollback: false,
+					expectInBlock:  true,
+				},
+				"TolerateInvalidTolerateFailed/FailingTx": {
+					tx:             failingTx,
+					flags:          bundle.EF_TolerateInvalid | bundle.EF_TolerateFailed,
+					expectRollback: false,
+					expectInBlock:  true,
+				},
+				"TolerateInvalidTolerateFailed/InvalidTx": {
+					tx:             invalidTx,
+					flags:          bundle.EF_TolerateInvalid | bundle.EF_TolerateFailed,
+					expectRollback: false,
+					expectInBlock:  false,
+				},
 			}
 
-			// The transactions itself and the successful transaction that
-			// follows it should be included.
-			require.Equal(t, 2, int(info.Count))
-			require.Contains(t, blockTxsHashes, bundleTxs[0].Hash())
-			require.Contains(t, blockTxsHashes, bundleTxs[1].Hash())
+			for name, c := range cases {
+				t.Run(name, func(t *testing.T) {
+					blockNumber, err := client.BlockNumber(t.Context())
+					require.NoError(t, err)
+
+					// Create the bundle: AllOf([c.flags]c.tx, successfulTx)
+					// The second transaction is needed for the cases with an invalid
+					// transaction to check whether it was tolerated or not.
+					envelope, bundle, plan := bundle.NewBuilder().
+						WithSigner(signer).
+						SetEarliest(blockNumber).
+						AllOf(
+							Step(t, net, senders[0], &c.tx).WithFlags(c.flags),
+							Step(t, net, senders[1], &successfulTx),
+						).
+						BuildEnvelopeBundleAndPlan()
+
+					// Send the bundle.
+					_, err = net.Send(envelope)
+					require.NoError(t, err)
+
+					if c.expectRollback {
+						net.Require_BundleYieldsZeroTransactions(t, plan.Hash())
+						return
+					}
+
+					// Wait for the bundle to be processed.
+					info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
+					require.NoError(t, err)
+
+					blockTxsHashes := getBlockTxsHashes(t, client, big.NewInt(info.Block.Int64()))
+					bundleTxs := bundle.GetTransactionsInReferencedOrder()
+
+					// If the transaction is expected to not be included in the block,
+					// only the successful transaction that follows it should be included.
+					if !c.expectInBlock {
+						require.Equal(t, 1, int(info.Count))
+						require.NotContains(t, blockTxsHashes, bundleTxs[0].Hash())
+						require.Contains(t, blockTxsHashes, bundleTxs[1].Hash())
+						return
+					}
+
+					// The transactions itself and the successful transaction that
+					// follows it should be included.
+					require.Equal(t, 2, int(info.Count))
+					require.Contains(t, blockTxsHashes, bundleTxs[0].Hash())
+					require.Contains(t, blockTxsHashes, bundleTxs[1].Hash())
+				})
+			}
 		})
 	}
 }
@@ -326,145 +318,138 @@ func TestBundle_AllOfGroupSucceedsIfAllStepsTolerated(t *testing.T) {
 func TestBundle_OneOfGroupSucceedsOnFirstToleratedStep(t *testing.T) {
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.TransactionBundles = true
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-		// This tests submits clearly invalid bundles. TxPool will reject
-		// them directly, to test that they are correctly ignored, pool
-		// validation needs to be disabled.
-		ClientExtraArguments: []string{"--disable-txPool-validation"},
-	})
+	for mode, net := range GetUnfilteredNetVariants(t, upgrades) {
+		t.Run(mode, func(t *testing.T) {
 
-	client, err := net.GetClient()
-	require.NoError(t, err)
-	defer client.Close()
-
-	signer := types.LatestSignerForChainID(net.GetChainId())
-
-	senders := tests.MakeAccountsWithBalance(t, net, 3, big.NewInt(1e18))
-
-	revertAddress, revertInput := tests.MustDeployRevertContractAndGetMethodCallParameters(t, net)
-	addContractAddr := tests.MustDeployContract(t, net, add.DeployAdd)
-	addContractInput := tests.MustGetMethodParameters(
-		t, add.AddMetaData, "add", big.NewInt(10_000),
-	)
-
-	successfulTx := types.AccessListTx{}
-	// The last successful transaction needs to be expensive enough for the
-	// bundle to pass the efficiency check.
-	successfulExpensiveTx := types.AccessListTx{
-		To:   &addContractAddr,
-		Data: addContractInput,
-	}
-
-	failingTx := types.AccessListTx{
-		To:   &revertAddress,
-		Gas:  1_000_000,
-		Data: revertInput,
-	}
-
-	// The bundle structure is: AllOf(OneOf[flags](firstTx, secondTx), successfulTx)
-	// The group under test is the inner OneOf. The trailing successful
-	// transaction in the outer group is needed to check whether the inner
-	// group was tolerated or not.
-	// expectInBlock is indexed by the position of the transaction in the
-	// bundle, in reference order.
-	cases := map[string]struct {
-		tolerateFailed bool
-		firstTx        types.AccessListTx
-		secondTx       types.AccessListTx
-		expectInBlock  [3]bool
-	}{
-		"Default/FirstTolerated": {
-			tolerateFailed: false,
-			firstTx:        successfulTx,
-			secondTx:       successfulTx,
-			expectInBlock:  [3]bool{true, false, true},
-		},
-		"Default/SecondTolerated": {
-			tolerateFailed: false,
-			firstTx:        failingTx,
-			secondTx:       successfulTx,
-			expectInBlock:  [3]bool{true, true, true},
-		},
-		"Default/OnlyNonTolerated": {
-			// Note: this test does not yield anything observable, timeout expected
-			tolerateFailed: false,
-			firstTx:        failingTx,
-			secondTx:       failingTx,
-			expectInBlock:  [3]bool{false, false, false},
-		},
-		"TolerateFailed/FirstTolerated": {
-			tolerateFailed: true,
-			firstTx:        successfulTx,
-			secondTx:       successfulTx,
-			expectInBlock:  [3]bool{true, false, true},
-		},
-		"TolerateFailed/SecondTolerated": {
-			tolerateFailed: true,
-			firstTx:        failingTx,
-			secondTx:       successfulTx,
-			expectInBlock:  [3]bool{true, true, true},
-		},
-		"TolerateFailed/OnlyNonTolerated": {
-			tolerateFailed: true,
-			firstTx:        failingTx,
-			secondTx:       failingTx,
-			expectInBlock:  [3]bool{false, false, true},
-		},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			blockNumber, err := client.BlockNumber(t.Context())
+			client, err := net.GetClient()
 			require.NoError(t, err)
+			defer client.Close()
 
-			flags := bundle.EF_Default
-			if c.tolerateFailed {
-				flags = bundle.EF_TolerateFailed
+			signer := types.LatestSignerForChainID(net.GetChainId())
+
+			senders := tests.MakeAccountsWithBalance(t, net, 3, big.NewInt(1e18))
+
+			revertAddress, revertInput := tests.MustDeployRevertContractAndGetMethodCallParameters(t, net)
+			addContractAddr := tests.MustDeployContract(t, net, add.DeployAdd)
+			addContractInput := tests.MustGetMethodParameters(
+				t, add.AddMetaData, "add", big.NewInt(10_000),
+			)
+
+			successfulTx := types.AccessListTx{}
+			// The last successful transaction needs to be expensive enough for the
+			// bundle to pass the efficiency check.
+			successfulExpensiveTx := types.AccessListTx{
+				To:   &addContractAddr,
+				Data: addContractInput,
 			}
 
-			envelope, bundle, plan := bundle.NewBuilder().
-				WithSigner(signer).
-				SetEarliest(blockNumber).
-				AllOf(
-					bundle.OneOf(
-						Step(t, net, senders[0], &c.firstTx),
-						Step(t, net, senders[1], &c.secondTx),
-					).WithFlags(flags),
-					Step(t, net, senders[2], &successfulExpensiveTx),
-				).
-				BuildEnvelopeBundleAndPlan()
-
-			// Send the bundle.
-			_, err = net.Send(envelope)
-			require.NoError(t, err)
-
-			if !slices.Contains(c.expectInBlock[:], true) {
-				timeoutCtx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
-				defer cancel()
-
-				_, err := WaitForBundleExecution(timeoutCtx, client.Client(), plan.Hash())
-				require.ErrorIs(t, err, context.DeadlineExceeded)
-
-				return
+			failingTx := types.AccessListTx{
+				To:   &revertAddress,
+				Gas:  1_000_000,
+				Data: revertInput,
 			}
 
-			// Wait for the bundle to be processed.
-			info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
-			require.NoError(t, err)
-
-			bundleTxs := bundle.GetTransactionsInReferencedOrder()
-			blockTxsHashes := getBlockTxsHashes(t, client, big.NewInt(info.Block.Int64()))
-
-			expectedCount := 0
-			for i, tx := range bundleTxs {
-				require.Equal(t, c.expectInBlock[i], slices.Contains(blockTxsHashes, tx.Hash()))
-				if c.expectInBlock[i] {
-					require.Equal(t, blockTxsHashes[int(info.Position)+expectedCount], tx.Hash())
-					expectedCount++
-				}
+			// The bundle structure is: AllOf(OneOf[flags](firstTx, secondTx), successfulTx)
+			// The group under test is the inner OneOf. The trailing successful
+			// transaction in the outer group is needed to check whether the inner
+			// group was tolerated or not.
+			// expectInBlock is indexed by the position of the transaction in the
+			// bundle, in reference order.
+			cases := map[string]struct {
+				tolerateFailed bool
+				firstTx        types.AccessListTx
+				secondTx       types.AccessListTx
+				expectInBlock  [3]bool
+			}{
+				"Default/FirstTolerated": {
+					tolerateFailed: false,
+					firstTx:        successfulTx,
+					secondTx:       successfulTx,
+					expectInBlock:  [3]bool{true, false, true},
+				},
+				"Default/SecondTolerated": {
+					tolerateFailed: false,
+					firstTx:        failingTx,
+					secondTx:       successfulTx,
+					expectInBlock:  [3]bool{true, true, true},
+				},
+				"Default/OnlyNonTolerated": {
+					// Note: this test does not yield anything observable, timeout expected
+					tolerateFailed: false,
+					firstTx:        failingTx,
+					secondTx:       failingTx,
+					expectInBlock:  [3]bool{false, false, false},
+				},
+				"TolerateFailed/FirstTolerated": {
+					tolerateFailed: true,
+					firstTx:        successfulTx,
+					secondTx:       successfulTx,
+					expectInBlock:  [3]bool{true, false, true},
+				},
+				"TolerateFailed/SecondTolerated": {
+					tolerateFailed: true,
+					firstTx:        failingTx,
+					secondTx:       successfulTx,
+					expectInBlock:  [3]bool{true, true, true},
+				},
+				"TolerateFailed/OnlyNonTolerated": {
+					tolerateFailed: true,
+					firstTx:        failingTx,
+					secondTx:       failingTx,
+					expectInBlock:  [3]bool{false, false, true},
+				},
 			}
-			require.Equal(t, expectedCount, int(info.Count))
+
+			for name, c := range cases {
+				t.Run(name, func(t *testing.T) {
+					blockNumber, err := client.BlockNumber(t.Context())
+					require.NoError(t, err)
+
+					flags := bundle.EF_Default
+					if c.tolerateFailed {
+						flags = bundle.EF_TolerateFailed
+					}
+
+					envelope, bundle, plan := bundle.NewBuilder().
+						WithSigner(signer).
+						SetEarliest(blockNumber).
+						AllOf(
+							bundle.OneOf(
+								Step(t, net, senders[0], &c.firstTx),
+								Step(t, net, senders[1], &c.secondTx),
+							).WithFlags(flags),
+							Step(t, net, senders[2], &successfulExpensiveTx),
+						).
+						BuildEnvelopeBundleAndPlan()
+
+					// Send the bundle.
+					_, err = net.Send(envelope)
+					require.NoError(t, err)
+
+					if !slices.Contains(c.expectInBlock[:], true) {
+						net.Require_BundleYieldsZeroTransactions(t, plan.Hash())
+						return
+					}
+
+					// Wait for the bundle to be processed.
+					info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
+					require.NoError(t, err)
+
+					bundleTxs := bundle.GetTransactionsInReferencedOrder()
+					blockTxsHashes := getBlockTxsHashes(t, client, big.NewInt(info.Block.Int64()))
+
+					expectedCount := 0
+					for i, tx := range bundleTxs {
+						require.Equal(t, c.expectInBlock[i], slices.Contains(blockTxsHashes, tx.Hash()))
+						if c.expectInBlock[i] {
+							require.Equal(t, blockTxsHashes[int(info.Position)+expectedCount], tx.Hash())
+							expectedCount++
+						}
+					}
+					require.Equal(t, expectedCount, int(info.Count))
+				})
+			}
+
 		})
 	}
 }

--- a/tests/bundles/empty_bundle_test.go
+++ b/tests/bundles/empty_bundle_test.go
@@ -17,10 +17,8 @@
 package bundles
 
 import (
-	"context"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -33,104 +31,97 @@ func TestBundle_BundleContainingAnyEmptyGroupIsRejected(t *testing.T) {
 	upgrades := opera.GetBrioUpgrades()
 	upgrades.TransactionBundles = true
 
-	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-		Upgrades: &upgrades,
-		ClientExtraArguments: []string{
-			"--disable-txPool-validation",
-		},
-	})
+	for mode, net := range GetUnfilteredNetVariants(t, upgrades) {
+		t.Run(mode, func(t *testing.T) {
 
-	client, err := net.GetClient()
-	require.NoError(t, err)
-	defer client.Close()
-
-	signer := types.LatestSignerForChainID(net.GetChainId())
-
-	senders := tests.MakeAccountsWithBalance(t, net, 4, big.NewInt(1e18))
-
-	tx := types.AccessListTx{}
-
-	cases := map[string]struct {
-		root         bundle.BuilderStep
-		ExpectReject bool
-	}{
-		"AllOf/NonEmpty": {
-			root: bundle.AllOf(
-				Step(t, net, senders[0], &tx),
-			),
-			ExpectReject: false,
-		},
-		"AllOf/Empty": {
-			root:         bundle.AllOf(),
-			ExpectReject: true,
-		},
-		"OneOf/NonEmpty": {
-			root: bundle.OneOf(
-				Step(t, net, senders[1], &tx),
-			),
-			ExpectReject: false,
-		},
-		"OneOf/Empty": {
-			root:         bundle.OneOf(),
-			ExpectReject: true,
-		},
-		"Layered/NonEmpty": {
-			root: bundle.AllOf(
-				bundle.AllOf(
-					Step(t, net, senders[2], &tx),
-				),
-			),
-			ExpectReject: false,
-		},
-		"Layered/EmptyAndNonEmptySubGroups": {
-			root: bundle.AllOf(
-				bundle.AllOf(
-					Step(t, net, senders[3], &tx),
-				),
-				bundle.AllOf(),
-			),
-			ExpectReject: false,
-		},
-		"Layered/OnlyEmptySubGroups": {
-			root: bundle.AllOf(
-				bundle.AllOf(),
-			),
-			ExpectReject: true,
-		},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			blockNumber, err := client.BlockNumber(t.Context())
+			client, err := net.GetClient()
 			require.NoError(t, err)
+			defer client.Close()
 
-			envelope, bundle, plan := bundle.NewBuilder().
-				WithSigner(signer).
-				SetEarliest(blockNumber).
-				With(c.root).
-				BuildEnvelopeBundleAndPlan()
+			signer := types.LatestSignerForChainID(net.GetChainId())
 
-			// Send the bundle.
-			_, err = net.Send(envelope)
-			require.NoError(t, err)
+			senders := tests.MakeAccountsWithBalance(t, net, 4, big.NewInt(1e18))
 
-			// Wait for the bundle to be processed.
-			timeout, timeoutCancel := context.WithTimeout(t.Context(), 1*time.Second)
-			defer timeoutCancel()
-			info, err := WaitForBundleExecution(timeout, client.Client(), plan.Hash())
+			tx := types.AccessListTx{}
 
-			if c.ExpectReject {
-				require.ErrorIs(t, err, context.DeadlineExceeded)
-				return
+			cases := map[string]struct {
+				root         bundle.BuilderStep
+				ExpectReject bool
+			}{
+				"AllOf/NonEmpty": {
+					root: bundle.AllOf(
+						Step(t, net, senders[0], &tx),
+					),
+					ExpectReject: false,
+				},
+				"AllOf/Empty": {
+					root:         bundle.AllOf(),
+					ExpectReject: true,
+				},
+				"OneOf/NonEmpty": {
+					root: bundle.OneOf(
+						Step(t, net, senders[1], &tx),
+					),
+					ExpectReject: false,
+				},
+				"OneOf/Empty": {
+					root:         bundle.OneOf(),
+					ExpectReject: true,
+				},
+				"Layered/NonEmpty": {
+					root: bundle.AllOf(
+						bundle.AllOf(
+							Step(t, net, senders[2], &tx),
+						),
+					),
+					ExpectReject: false,
+				},
+				"Layered/EmptyAndNonEmptySubGroups": {
+					root: bundle.AllOf(
+						bundle.AllOf(
+							Step(t, net, senders[3], &tx),
+						),
+						bundle.AllOf(),
+					),
+					ExpectReject: false,
+				},
+				"Layered/OnlyEmptySubGroups": {
+					root: bundle.AllOf(
+						bundle.AllOf(),
+					),
+					ExpectReject: true,
+				},
 			}
 
-			require.NoError(t, err)
+			for name, c := range cases {
+				t.Run(name, func(t *testing.T) {
+					blockNumber, err := client.BlockNumber(t.Context())
+					require.NoError(t, err)
 
-			blockTxsHashes := getBlockTxsHashes(t, client, big.NewInt(info.Block.Int64()))
-			bundleTxs := bundle.GetTransactionsInReferencedOrder()
+					envelope, bundle, plan := bundle.NewBuilder().
+						WithSigner(signer).
+						SetEarliest(blockNumber).
+						With(c.root).
+						BuildEnvelopeBundleAndPlan()
 
-			require.Equal(t, 1, int(info.Count))
-			require.Contains(t, blockTxsHashes, bundleTxs[0].Hash())
+					_, err = net.Send(envelope)
+					require.NoError(t, err)
+
+					if c.ExpectReject {
+						net.Require_BundleYieldsZeroTransactions(t, plan.Hash())
+						return
+					}
+
+					info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
+					require.NoError(t, err)
+
+					blockTxsHashes := getBlockTxsHashes(t, client, big.NewInt(info.Block.Int64()))
+					bundleTxs := bundle.GetTransactionsInReferencedOrder()
+
+					require.Equal(t, 1, int(info.Count))
+					require.Contains(t, blockTxsHashes, bundleTxs[0].Hash())
+				})
+			}
 		})
 	}
 }

--- a/tests/bundles/feature_flag_test.go
+++ b/tests/bundles/feature_flag_test.go
@@ -93,53 +93,52 @@ func TestBundle_EnvelopeAndBundleOnly_SemanticsEnabledByBrio_ExecutionEnabledByB
 			upgrades.Brio = tc.brio
 			upgrades.TransactionBundles = tc.transactionBundles
 
-			net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
-				Upgrades: &upgrades,
-				ClientExtraArguments: []string{
-					"--disable-txPool-validation",
-				},
-			})
-			client, err := net.GetClient()
-			require.NoError(t, err)
-			defer client.Close()
+			for mode, net := range GetUnfilteredNetVariants(t, upgrades) {
+				t.Run(mode, func(t *testing.T) {
 
-			signer := types.LatestSignerForChainID(net.GetChainId())
+					client, err := net.GetClient()
+					require.NoError(t, err)
+					defer client.Close()
 
-			sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+					signer := types.LatestSignerForChainID(net.GetChainId())
 
-			txBundle := bundle.NewBuilder().
-				WithSigner(signer).
-				AllOf(Step(t, net, sender, &types.AccessListTx{})).
-				BuildBundle()
-			gasPrice, err := client.SuggestGasPrice(t.Context())
-			require.NoError(t, err)
-			envelope := bundle.NewEnvelope(signer, sender.PrivateKey, 0, gasPrice, &txBundle)
-			innerTx := txBundle.GetTransactionsInReferencedOrder()[0]
+					sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 
-			// Submit the transaction.
-			if tc.sendEnvelope {
-				_, err = net.Send(envelope)
-			} else if tc.sendBundleOnly {
-				_, err = net.Send(innerTx)
-			}
-			require.NoError(t, err)
+					txBundle := bundle.NewBuilder().
+						WithSigner(signer).
+						AllOf(Step(t, net, sender, &types.AccessListTx{})).
+						BuildBundle()
+					gasPrice, err := client.SuggestGasPrice(t.Context())
+					require.NoError(t, err)
+					envelope := bundle.NewEnvelope(signer, sender.PrivateKey, 0, gasPrice, &txBundle)
+					innerTx := txBundle.GetTransactionsInReferencedOrder()[0]
 
-			time.Sleep(1 * time.Second)
+					// Submit the transaction.
+					if tc.sendEnvelope {
+						_, err = net.Send(envelope)
+					} else if tc.sendBundleOnly {
+						_, err = net.Send(innerTx)
+					}
+					require.NoError(t, err)
 
-			envelopeReceipt, err := client.TransactionReceipt(t.Context(), envelope.Hash())
-			if tc.expectEnvelopeReceipt {
-				require.NoError(t, err)
-				require.Equal(t, types.ReceiptStatusSuccessful, envelopeReceipt.Status)
-			} else {
-				require.ErrorContains(t, err, "not found")
-			}
+					time.Sleep(1 * time.Second)
 
-			innerReceipt, err := client.TransactionReceipt(t.Context(), innerTx.Hash())
-			if tc.expectInnerReceipt {
-				require.NoError(t, err)
-				require.Equal(t, types.ReceiptStatusSuccessful, innerReceipt.Status)
-			} else {
-				require.ErrorContains(t, err, "not found")
+					envelopeReceipt, err := client.TransactionReceipt(t.Context(), envelope.Hash())
+					if tc.expectEnvelopeReceipt {
+						require.NoError(t, err)
+						require.Equal(t, types.ReceiptStatusSuccessful, envelopeReceipt.Status)
+					} else {
+						require.ErrorContains(t, err, "not found")
+					}
+
+					innerReceipt, err := client.TransactionReceipt(t.Context(), innerTx.Hash())
+					if tc.expectInnerReceipt {
+						require.NoError(t, err)
+						require.Equal(t, types.ReceiptStatusSuccessful, innerReceipt.Status)
+					} else {
+						require.ErrorContains(t, err, "not found")
+					}
+				})
 			}
 		})
 	}

--- a/tests/bundles/skip_envelope_tools.go
+++ b/tests/bundles/skip_envelope_tools.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package bundles
+
+import (
+	"context"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// GetUnfilteredNetVariants returns a sequence of different unfiltered network variants to test against.
+// Each variant represents a different way of bypassing transaction validation, allowing testing of bundle execution
+// in various scenarios where transactions may not be filtered by the TxPool or the emitter.
+func GetUnfilteredNetVariants(t testing.TB, upgrades opera.Upgrades) iter.Seq2[string, UnfilteredNet] {
+	return func(yield func(string, UnfilteredNet) bool) {
+		if !yield("no-intake-validation net", NewNoIntakeValidationIntegrationTestNet(t, upgrades)) {
+			return
+		}
+		if !yield("no-intake-and-emission-validation net", NewNoIntakeAndEmissionValidationTestNet(t, upgrades)) {
+			return
+		}
+	}
+}
+
+// UnfilteredNet is an abstraction over different types of test networks
+// that can be used to test bundle execution without the transactions
+// being filtered by the TxPool or the emitter.
+type UnfilteredNet interface {
+	tests.IntegrationTestNetSession
+
+	Send(*types.Transaction) (common.Hash, error)
+	Require_BundleYieldsZeroTransactions(t testing.TB, planHash common.Hash)
+}
+
+type NoIntakeValidationTestNet struct {
+	tests.IntegrationTestNetSession
+}
+
+// NewNoIntakeValidationIntegrationTestNet creates a test network where the TxPool
+// validation is disabled, allowing transactions that would normally be synchronously
+// rejected to be pooled. These transactions may not be promoted or emitted in events.
+// Therefore execution of these transactions is not guaranteed and may still be
+// filtered by the frontend of the system.
+func NewNoIntakeValidationIntegrationTestNet(t testing.TB, upgrades opera.Upgrades) *NoIntakeValidationTestNet {
+	return &NoIntakeValidationTestNet{
+		tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+			Upgrades: &upgrades,
+			ClientExtraArguments: []string{
+				"--disable-txPool-validation",
+			},
+		}),
+	}
+}
+
+func (n *NoIntakeValidationTestNet) Send(tx *types.Transaction) (common.Hash, error) {
+	return n.IntegrationTestNetSession.Send(tx)
+}
+
+func (n *NoIntakeValidationTestNet) Require_BundleYieldsZeroTransactions(t testing.TB, planHash common.Hash) {
+
+	client, err := n.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// expect timeout
+	timedCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	_, err = WaitForBundleExecution(timedCtx, client.Client(), planHash)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+type NoIntakeAndEmissionValidationTestNet struct {
+	tests.IntegrationTestNetSession
+}
+
+// NewNoIntakeAndEmissionValidationTestNet creates a test network where the TxPool is
+// completely bypassed by sending envelopes directly to the consensus engine.
+// This allows testing bundle execution in a scenario where transactions reach
+// the block processor, with the intention of testing its resilience against
+// invalid transactions.
+func NewNoIntakeAndEmissionValidationTestNet(t testing.TB, upgrades opera.Upgrades) *NoIntakeAndEmissionValidationTestNet {
+	return &NoIntakeAndEmissionValidationTestNet{
+		tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+			Upgrades: &upgrades,
+		}),
+	}
+}
+
+func (n *NoIntakeAndEmissionValidationTestNet) Send(tx *types.Transaction) (common.Hash, error) {
+	return n.ForceEmit(context.Background(), tx)
+}
+
+func (n *NoIntakeAndEmissionValidationTestNet) Require_BundleYieldsZeroTransactions(t testing.TB, planHash common.Hash) {
+	client, err := n.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	info, err := WaitForBundleExecution(t.Context(), client.Client(), planHash)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.Zero(t, info.Count)
+}


### PR DESCRIPTION
Bundles are tested in 3 locations, intake, emitter, and block processor. Bundles may be dropped in any of these locations and therefore its worths testing both bundles which roll back both during emission or later in the block processor. 

This PR introduces tooling to use the same tests with both modes, factoring the submission method and the verification. 
Although diff seems quite large, the only change is to nest tests and invoke the new `require`method to verify bundle rollback, or emission skipped. 

