### PR TITLE
Bypass txpool when testing skipped txs

### DIFF
--- a/tests/block_by_hash/block_by_hash_test.go
+++ b/tests/block_by_hash/block_by_hash_test.go
@@ -32,9 +32,6 @@ func TestRPCGetLogs_BlockWithSkippedTransaction_HasCorrectTxIndexes(t *testing.T
 
 	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
 		Upgrades: tests.AsPointer(opera.GetBrioUpgrades()),
-		ClientExtraArguments: []string{
-			"--disable-txPool-validation",
-		},
 	})
 
 	contract, receipt, err := tests.DeployContract(net, counter_event_emitter.DeployCounterEventEmitter)
@@ -60,7 +57,7 @@ func TestRPCGetLogs_BlockWithSkippedTransaction_HasCorrectTxIndexes(t *testing.T
 		}, accountSkipped)
 
 		// Send the transaction
-		err = client.SendTransaction(t.Context(), txSkip)
+		_, err = net.ForceEmit(t.Context(), txSkip)
 		require.NoError(t, err)
 
 		// make a transaction to log something

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -42,9 +42,6 @@ func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *te
 		t.Run(name, func(t *testing.T) {
 			net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
 				Upgrades: &version,
-				ClientExtraArguments: []string{
-					"--disable-txPool-validation",
-				},
 			})
 
 			client, err := net.GetClient()
@@ -78,7 +75,7 @@ func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *te
 			require.NoError(t, err)
 
 			// Send the transaction
-			err = client.SendTransaction(t.Context(), tx)
+			_, err = net.ForceEmit(t.Context(), tx)
 			require.NoError(t, err)
 
 			// Send another simple transaction to ensure a block is created

--- a/tests/regressions/gas_fee_overflow_test.go
+++ b/tests/regressions/gas_fee_overflow_test.go
@@ -129,9 +129,6 @@ func TestGasFeeOverflow_TransactionWithFeeOverflowInBundleAreIgnoredByBlockProce
 	// In this setup, all TxPool and RPC checks are enabled.
 	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
 		Upgrades: &upgrades,
-		ClientExtraArguments: []string{
-			"--disable-txPool-validation",
-		},
 	})
 
 	account := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))

--- a/tests/transaction_receipt_idx_test.go
+++ b/tests/transaction_receipt_idx_test.go
@@ -206,9 +206,6 @@ func TestReceipt_SkippedTransactionsDoNotChangeReceiptIndexOrCumulativeGasUsed(t
 func testSkippedTransactionsDoNotChangeReceiptIndexOrCumulativeGasUsed(t *testing.T, upgrades opera.Upgrades) {
 	net := StartIntegrationTestNetWithJsonGenesis(t, IntegrationTestNetOptions{
 		Upgrades: &upgrades,
-		ClientExtraArguments: []string{
-			"--disable-txPool-validation",
-		},
 	})
 
 	client, err := net.GetClient()
@@ -264,7 +261,7 @@ func testSkippedTransactionsDoNotChangeReceiptIndexOrCumulativeGasUsed(t *testin
 	}
 
 	// Send skipped transaction
-	err = client.SendTransaction(t.Context(), skippedTx)
+	_, err = net.ForceEmit(t.Context(), skippedTx)
 	require.NoError(t, err)
 
 	// Send second half of simple transactions


### PR DESCRIPTION
More interesting than submitting invalid txs to the emitter is to let them reach the block processor. Replicated code path must do the right thing. 

This PR updates old tests creating invalid transactions which may be dropped in the pool or emitter, so that these reach the block processor. expectations remain the same. 