### PR TITLE
Limit block size in state processor

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -258,8 +258,8 @@ func runTransactions(
 	}
 }
 
-// realTxSize returns the size of the transaction,
-// including any overhead introduced by sponsorship requests.
+// realTxSize returns the size of the transaction, including any
+// overhead introduced by sponsorship requests and bundles.
 func realTxSize(context *runContext, tx *types.Transaction) uint64 {
 	if context.upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
 		size := uint64(0)
@@ -267,6 +267,9 @@ func realTxSize(context *runContext, tx *types.Transaction) uint64 {
 		if err != nil {
 			return size // = 0, in case the bundle can not be unpacked, it will not be added to the block.
 		}
+
+		// The full size of the bundle have to be considered even if not
+		// all transactions of the bundle are included in the block.
 		for _, innerTx := range txBundle.Transactions {
 			size += realTxSize(context, innerTx)
 		}

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -86,6 +86,7 @@ func NewStateProcessorForReplay(
 type ProcessSummary struct {
 	ProcessedTransactions []ProcessedTransaction
 	ExecutionCost         core_types.ExecutionCost
+	CausedBy              map[common.Hash]common.Hash
 }
 
 // ProcessedTransaction represents a transaction that was considered for
@@ -121,10 +122,10 @@ type ProcessedTransaction struct {
 // consistent.
 func (p *StateProcessor) Process(
 	block *EvmBlock, statedb state.StateDB, cfg vm.Config, gasLimit uint64,
-	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log),
+	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log), remainingSize uint64,
 ) ProcessSummary {
 	sonicDifficulty := big.NewInt(1)
-	return p.ProcessWithDifficulty(block, statedb, cfg, gasLimit, usedGas, trueTxOffset, onNewLog, sonicDifficulty)
+	return p.ProcessWithDifficulty(block, statedb, cfg, gasLimit, usedGas, trueTxOffset, onNewLog, sonicDifficulty, remainingSize)
 }
 
 // ProcessWithDifficulty is the same as Process, but allows specifying a custom
@@ -134,7 +135,7 @@ func (p *StateProcessor) Process(
 func (p *StateProcessor) ProcessWithDifficulty(
 	block *EvmBlock, statedb state.StateDB, cfg vm.Config, gasLimit uint64,
 	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log),
-	difficulty *big.Int,
+	difficulty *big.Int, remainingSize uint64,
 ) ProcessSummary {
 	var (
 		gp           = core.NewGasPool(gasLimit)
@@ -155,7 +156,7 @@ func (p *StateProcessor) ProcessWithDifficulty(
 	return runTransactions(newRunContext(
 		signer, header.BaseFee, statedb, gp, blockNumber, block.Time, usedGas,
 		onNewLog, p.upgrades, &transactionRunner{evm{vmenv}}, p.forReplay,
-	), block.Transactions, trueTxOffset)
+	), block.Transactions, trueTxOffset, remainingSize)
 }
 
 // runContext bundles the parameters required for processing transactions in a
@@ -217,9 +218,11 @@ func runTransactions(
 	context *runContext,
 	transactions types.Transactions,
 	trueTxIndexOffset int,
+	remainingSize uint64,
 ) ProcessSummary {
 	processedTxs := make([]ProcessedTransaction, 0, len(transactions))
 	totalExecCost := core_types.ExecutionCost(0)
+	causedBy := make(map[common.Hash]common.Hash)
 	for _, tx := range transactions {
 		// Bundle-only transactions are only valid within a bundle and must
 		// be rejected at the top level when processing the head state.
@@ -228,12 +231,21 @@ func runTransactions(
 			continue
 		}
 
+		neededSpace := realTxSize(context, tx)
+		if context.upgrades.Brio && neededSpace > remainingSize {
+			// Add the transaction to the processed ones with a nil receipt to increase skipped counter.
+			processedTxs = append(processedTxs, ProcessedTransaction{Transaction: tx})
+			continue
+		}
+
 		txs, _, execCost := runTransaction(context, tx, trueTxIndexOffset)
 		totalExecCost += execCost
 
-		for _, tx := range txs {
-			if tx.Receipt != nil { // < only transactions included in the block
+		for _, processedTx := range txs {
+			if processedTx.Receipt != nil { // < only transactions included in the block
 				trueTxIndexOffset++
+				remainingSize -= processedTx.Transaction.Size()
+				causedBy[processedTx.Transaction.Hash()] = tx.Hash()
 			}
 		}
 		processedTxs = append(processedTxs, txs...)
@@ -242,7 +254,32 @@ func runTransactions(
 	return ProcessSummary{
 		ProcessedTransactions: processedTxs,
 		ExecutionCost:         totalExecCost,
+		CausedBy:              causedBy,
 	}
+}
+
+// realTxSize returns the size of the transaction,
+// including any overhead introduced by sponsorship requests.
+func realTxSize(context *runContext, tx *types.Transaction) uint64 {
+	if context.upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
+		size := uint64(0)
+		txBundle, _, err := bundle.ValidateEnvelope(context.signer, tx)
+		if err != nil {
+			return size // = 0, in case the bundle can not be unpacked, it will not be added to the block.
+		}
+		for _, innerTx := range txBundle.Transactions {
+			size += realTxSize(context, innerTx)
+		}
+		return size
+	}
+
+	if context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
+		size := tx.Size()
+		size += subsidies.RlpEncodedFeeChargingTxSizeInBytes
+		return size
+	}
+
+	return tx.Size()
 }
 
 // runTransaction processes the given transaction and returns a list of all
@@ -713,7 +750,7 @@ func (tp *TransactionProcessor) Run(i int, tx *types.Transaction) ProcessSummary
 		tp.signer, tp.header.BaseFee, tp.stateDb, tp.gp, tp.blockNumber, tp.blockTime,
 		&tp.usedGas, tp.onNewLog, tp.upgrades, &transactionRunner{evm{tp.vmEnvironment}},
 		false,
-	), []*types.Transaction{tx}, i)
+	), []*types.Transaction{tx}, i, math.MaxUint64)
 }
 
 // ApplyTransactionWithEVM attempts to apply a transaction to the given state database

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -237,8 +237,14 @@ func runTransactions(
 		for _, processedTx := range txs {
 			if processedTx.Receipt != nil { // < only transactions included in the block
 				trueTxIndexOffset++
-				remainingSize -= processedTx.Transaction.Size()
 				causedBy[processedTx.Transaction.Hash()] = tx.Hash()
+
+				if remainingSize < processedTx.Transaction.Size() {
+					log.Debug("Block size limit exceeded,", "tx", processedTx.Transaction.Hash().Hex(),
+						"txSize", processedTx.Transaction.Size(), "remainingSize", remainingSize)
+					break
+				}
+				remainingSize -= processedTx.Transaction.Size()
 			}
 		}
 		processedTxs = append(processedTxs, txs...)
@@ -362,7 +368,8 @@ func (r *transactionRunner) runSponsoredTransaction(
 ) ([]ProcessedTransaction, core_types.TransactionResult) {
 	// check whether the size limit is large enough for the transaction and its payment
 	if tx.Size()+subsidies.RlpEncodedFeeChargingTxSizeInBytes > sizeLimit {
-		log.Debug("Transaction skipped due to block size limit", "tx", tx.Hash().Hex(), "txSize", tx.Size(), "estimatedPaymentTxSize", subsidies.RlpEncodedFeeChargingTxSizeInBytes, "sizeLimit", sizeLimit)
+		log.Debug("Transaction skipped due to block size limit",
+			"tx", tx.Hash().Hex(), "txSize", tx.Size(), "estimatedPaymentTxSize", subsidies.RlpEncodedFeeChargingTxSizeInBytes, "sizeLimit", sizeLimit)
 		return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid
 	}
 

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -242,9 +242,10 @@ func runTransactions(
 				if remainingSize < processedTx.Transaction.Size() {
 					log.Debug("Block size limit exceeded,", "tx", processedTx.Transaction.Hash().Hex(),
 						"txSize", processedTx.Transaction.Size(), "remainingSize", remainingSize)
-					break
+					remainingSize = 0
+				} else {
+					remainingSize -= processedTx.Transaction.Size()
 				}
-				remainingSize -= processedTx.Transaction.Size()
 			}
 		}
 		processedTxs = append(processedTxs, txs...)

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -261,7 +261,7 @@ func runTransactions(
 // computeRealTxSize returns the size of the transaction, including any
 // overhead introduced by sponsorship requests and bundles.
 func computeRealTxSize(context *runContext, tx *types.Transaction) uint64 {
-	if context.upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
+	if context.upgrades.Brio && context.upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
 		size := uint64(0)
 		txBundle, err := bundle.OpenEnvelope(context.signer, tx)
 		if err != nil {

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -84,9 +84,9 @@ func NewStateProcessorForReplay(
 // processing, including gas from rolled-back bundles, which distinguishes it
 // from the usedGas counter that gets reverted on snapshot rollback.
 type ProcessSummary struct {
-	ProcessedTransactions []ProcessedTransaction
-	ExecutionCost         core_types.ExecutionCost
-	CausedBy              map[common.Hash]common.Hash
+	ProcessedTransactions []ProcessedTransaction      // List of processed transactions with their receipts (nil receipt for skipped transactions).
+	ExecutionCost         core_types.ExecutionCost    // Total execution cost (gas used) for all processed transactions, including rolled-back bundles.
+	CausedBy              map[common.Hash]common.Hash // Mapping from transaction hash to the hash of the transaction that caused it.
 }
 
 // ProcessedTransaction represents a transaction that was considered for
@@ -231,7 +231,7 @@ func runTransactions(
 			continue
 		}
 
-		neededSpace := realTxSize(context, tx)
+		neededSpace := computeRealTxSize(context, tx)
 		if context.upgrades.Brio && neededSpace > remainingSize {
 			// Add the transaction to the processed ones with a nil receipt to increase skipped counter.
 			processedTxs = append(processedTxs, ProcessedTransaction{Transaction: tx})
@@ -258,12 +258,12 @@ func runTransactions(
 	}
 }
 
-// realTxSize returns the size of the transaction, including any
+// computeRealTxSize returns the size of the transaction, including any
 // overhead introduced by sponsorship requests and bundles.
-func realTxSize(context *runContext, tx *types.Transaction) uint64 {
+func computeRealTxSize(context *runContext, tx *types.Transaction) uint64 {
 	if context.upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
 		size := uint64(0)
-		txBundle, _, err := bundle.ValidateEnvelope(context.signer, tx)
+		txBundle, err := bundle.OpenEnvelope(context.signer, tx)
 		if err != nil {
 			return size // = 0, in case the bundle can not be unpacked, it will not be added to the block.
 		}
@@ -271,7 +271,7 @@ func realTxSize(context *runContext, tx *types.Transaction) uint64 {
 		// The full size of the bundle have to be considered even if not
 		// all transactions of the bundle are included in the block.
 		for _, innerTx := range txBundle.Transactions {
-			size += realTxSize(context, innerTx)
+			size += computeRealTxSize(context, innerTx)
 		}
 		return size
 	}

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -231,14 +231,7 @@ func runTransactions(
 			continue
 		}
 
-		neededSpace := computeRealTxSize(context, tx)
-		if context.upgrades.Brio && neededSpace > remainingSize {
-			// Add the transaction to the processed ones with a nil receipt to increase skipped counter.
-			processedTxs = append(processedTxs, ProcessedTransaction{Transaction: tx})
-			continue
-		}
-
-		txs, _, execCost := runTransaction(context, tx, trueTxIndexOffset)
+		txs, _, execCost := runTransaction(context, tx, trueTxIndexOffset, remainingSize)
 		totalExecCost += execCost
 
 		for _, processedTx := range txs {
@@ -258,33 +251,6 @@ func runTransactions(
 	}
 }
 
-// computeRealTxSize returns the size of the transaction, including any
-// overhead introduced by sponsorship requests and bundles.
-func computeRealTxSize(context *runContext, tx *types.Transaction) uint64 {
-	if context.upgrades.Brio && context.upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
-		size := uint64(0)
-		txBundle, err := bundle.OpenEnvelope(context.signer, tx)
-		if err != nil {
-			return size // = 0, in case the bundle can not be unpacked, it will not be added to the block.
-		}
-
-		// The full size of the bundle have to be considered even if not
-		// all transactions of the bundle are included in the block.
-		for _, innerTx := range txBundle.Transactions {
-			size += computeRealTxSize(context, innerTx)
-		}
-		return size
-	}
-
-	if context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
-		size := tx.Size()
-		size += subsidies.RlpEncodedFeeChargingTxSizeInBytes
-		return size
-	}
-
-	return tx.Size()
-}
-
 // runTransaction processes the given transaction and returns a list of all
 // processed transactions (transactions and receipts), and the result of
 // processing the transaction. The only exception is for invalid bundles, where
@@ -294,18 +260,19 @@ func runTransaction(
 	context *runContext,
 	tx *types.Transaction,
 	trueTxIndexOffset int,
+	sizeLimit uint64,
 ) ([]ProcessedTransaction, core_types.TransactionResult, core_types.ExecutionCost) {
 	// Since a transaction bundle has a gas-price of 0 it would be considered a
 	// sponsorship request. Thus, we need to check for bundles first.
 	if context.upgrades.Brio && bundle.IsEnvelope(tx) {
 		if context.upgrades.TransactionBundles {
-			return context.runner.runTransactionBundle(context, tx, trueTxIndexOffset)
+			return context.runner.runTransactionBundle(context, tx, trueTxIndexOffset, sizeLimit)
 		} else {
 			return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid, 0
 		}
 	}
 	if !context.forReplay && context.upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
-		res, result := context.runner.runSponsoredTransaction(context, tx, trueTxIndexOffset)
+		res, result := context.runner.runSponsoredTransaction(context, tx, trueTxIndexOffset, sizeLimit)
 		execCost := core_types.ExecutionCost(0)
 		for _, r := range res {
 			if r.Receipt != nil {
@@ -314,7 +281,7 @@ func runTransaction(
 		}
 		return res, result, execCost
 	} else {
-		res, result := context.runner.runRegularTransaction(context, tx, trueTxIndexOffset)
+		res, result := context.runner.runRegularTransaction(context, tx, trueTxIndexOffset, sizeLimit)
 		execCost := core_types.ExecutionCost(0)
 		if res.Receipt != nil {
 			execCost = core_types.ExecutionCost(res.Receipt.GasUsed)
@@ -331,6 +298,7 @@ type _transactionRunner interface {
 		ctxt *runContext,
 		tx *types.Transaction,
 		trueTxIndexOffset int,
+		sizeLimit uint64,
 	) (
 		ProcessedTransaction,
 		core_types.TransactionResult,
@@ -340,6 +308,7 @@ type _transactionRunner interface {
 		ctxt *runContext,
 		tx *types.Transaction,
 		trueTxIndexOffset int,
+		sizeLimit uint64,
 	) (
 		[]ProcessedTransaction,
 		core_types.TransactionResult,
@@ -349,6 +318,7 @@ type _transactionRunner interface {
 		ctxt *runContext,
 		tx *types.Transaction,
 		trueTxIndexOffset int,
+		sizeLimit uint64,
 	) (
 		[]ProcessedTransaction,
 		core_types.TransactionResult,
@@ -366,7 +336,13 @@ func (r *transactionRunner) runRegularTransaction(
 	ctxt *runContext,
 	tx *types.Transaction,
 	txIndex int,
+	sizeLimit uint64,
 ) (ProcessedTransaction, core_types.TransactionResult) {
+	if size := tx.Size(); size > sizeLimit {
+		log.Debug("Transaction skipped due to block size limit", "tx", tx.Hash().Hex(), "txSize", size, "sizeLimit", sizeLimit)
+		return ProcessedTransaction{Transaction: tx}, core_types.TransactionResultInvalid
+	}
+
 	res := r.evm.runWithBaseFeeCheck(ctxt, tx, txIndex)
 	if res.Receipt != nil {
 		if res.Receipt.Status == types.ReceiptStatusSuccessful {
@@ -382,7 +358,14 @@ func (r *transactionRunner) runSponsoredTransaction(
 	ctxt *runContext,
 	tx *types.Transaction,
 	txIndex int,
+	sizeLimit uint64,
 ) ([]ProcessedTransaction, core_types.TransactionResult) {
+	// check whether the size limit is large enough for the transaction and its payment
+	if tx.Size()+subsidies.RlpEncodedFeeChargingTxSizeInBytes > sizeLimit {
+		log.Debug("Transaction skipped due to block size limit", "tx", tx.Hash().Hex(), "txSize", tx.Size(), "estimatedPaymentTxSize", subsidies.RlpEncodedFeeChargingTxSizeInBytes, "sizeLimit", sizeLimit)
+		return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid
+	}
+
 	// Run the IsCovered query in a snapshot to avoid spilling any side-effects
 	// like warm storage slots or refunds into the actual transaction.
 	snapshot := ctxt.statedb.Snapshot()
@@ -461,8 +444,9 @@ func (r *transactionRunner) runTransactionBundle(
 	ctxt *runContext,
 	tx *types.Transaction,
 	trueTxIndexOffset int,
+	sizeLimit uint64,
 ) ([]ProcessedTransaction, core_types.TransactionResult, core_types.ExecutionCost) {
-	return r.runTransactionBundleInternal(ctxt, tx, trueTxIndexOffset, log.Root())
+	return r.runTransactionBundleInternal(ctxt, tx, trueTxIndexOffset, log.Root(), sizeLimit)
 }
 
 func (r *transactionRunner) runTransactionBundleInternal(
@@ -470,6 +454,7 @@ func (r *transactionRunner) runTransactionBundleInternal(
 	tx *types.Transaction,
 	trueTxOffset int,
 	log logger,
+	sizeLimit uint64,
 ) ([]ProcessedTransaction, core_types.TransactionResult, core_types.ExecutionCost) {
 	if !ctxt.upgrades.TransactionBundles {
 		log.Warn("Transaction bundles are not enabled, bundle transaction skipped", "tx", tx.Hash().Hex())
@@ -506,6 +491,7 @@ func (r *transactionRunner) runTransactionBundleInternal(
 	runner := bundleTransactionRunner{
 		ctxt:         ctxt,
 		trueTxOffset: trueTxOffset,
+		sizeLimit:    sizeLimit,
 	}
 	if !bundle.RunBundle(txBundle, &runner) {
 		// Mark the execution plan as processed in the StateDB to prevent processing
@@ -545,16 +531,25 @@ type bundleTransactionRunner struct {
 	processedTransactions []ProcessedTransaction
 	snapshots             []bundleTransactionRunnerSnapshot
 	executionCost         core_types.ExecutionCost // not included in snapshots
+	sizeLimit             uint64
 }
 
 func (b *bundleTransactionRunner) Run(tx *types.Transaction) core_types.TransactionResult {
-	processed, result, execCost := runTransaction(b.ctxt, tx, b.trueTxOffset)
+
+	snapshot := b.CreateSnapshot()
+
+	processed, result, execCost := runTransaction(b.ctxt, tx, b.trueTxOffset, b.sizeLimit)
 	b.executionCost += execCost
 	b.processedTransactions = append(b.processedTransactions, processed...)
 
 	for _, p := range processed {
 		if p.Receipt != nil {
 			b.trueTxOffset++
+			if b.sizeLimit < p.Transaction.Size() {
+				b.RevertToSnapshot(snapshot)
+				return core_types.TransactionResultInvalid
+			}
+			b.sizeLimit -= p.Transaction.Size()
 		}
 	}
 
@@ -568,6 +563,7 @@ func (b *bundleTransactionRunner) CreateSnapshot() int {
 		processedTransactionListLength: len(b.processedTransactions),
 		usedGas:                        *b.ctxt.usedGas,
 		gasPool:                        b.ctxt.gasPool.Snapshot(),
+		sizeLimit:                      b.sizeLimit,
 	}
 	b.snapshots = append(b.snapshots, snapshot)
 	return len(b.snapshots) - 1
@@ -587,6 +583,7 @@ func (b *bundleTransactionRunner) RevertToSnapshot(id int) {
 	b.processedTransactions = b.processedTransactions[:snapshot.processedTransactionListLength]
 	*b.ctxt.usedGas = snapshot.usedGas
 	b.ctxt.gasPool.Set(snapshot.gasPool)
+	b.sizeLimit = snapshot.sizeLimit
 	b.snapshots = b.snapshots[:id]
 }
 
@@ -596,6 +593,7 @@ type bundleTransactionRunnerSnapshot struct {
 	processedTransactionListLength int
 	usedGas                        uint64
 	gasPool                        *core.GasPool
+	sizeLimit                      uint64
 }
 
 // _evm is an interface to an EVM instance that can be used to run a single

--- a/evmcore/state_processor_mock.go
+++ b/evmcore/state_processor_mock.go
@@ -46,39 +46,39 @@ func (m *Mock_transactionRunner) EXPECT() *Mock_transactionRunnerMockRecorder {
 }
 
 // runRegularTransaction mocks base method.
-func (m *Mock_transactionRunner) runRegularTransaction(ctxt *runContext, tx *types.Transaction, trueTxIndexOffset int) (ProcessedTransaction, core_types.TransactionResult) {
+func (m *Mock_transactionRunner) runRegularTransaction(ctxt *runContext, tx *types.Transaction, trueTxIndexOffset int, sizeLimit uint64) (ProcessedTransaction, core_types.TransactionResult) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "runRegularTransaction", ctxt, tx, trueTxIndexOffset)
+	ret := m.ctrl.Call(m, "runRegularTransaction", ctxt, tx, trueTxIndexOffset, sizeLimit)
 	ret0, _ := ret[0].(ProcessedTransaction)
 	ret1, _ := ret[1].(core_types.TransactionResult)
 	return ret0, ret1
 }
 
 // runRegularTransaction indicates an expected call of runRegularTransaction.
-func (mr *Mock_transactionRunnerMockRecorder) runRegularTransaction(ctxt, tx, trueTxIndexOffset any) *gomock.Call {
+func (mr *Mock_transactionRunnerMockRecorder) runRegularTransaction(ctxt, tx, trueTxIndexOffset, sizeLimit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runRegularTransaction", reflect.TypeOf((*Mock_transactionRunner)(nil).runRegularTransaction), ctxt, tx, trueTxIndexOffset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runRegularTransaction", reflect.TypeOf((*Mock_transactionRunner)(nil).runRegularTransaction), ctxt, tx, trueTxIndexOffset, sizeLimit)
 }
 
 // runSponsoredTransaction mocks base method.
-func (m *Mock_transactionRunner) runSponsoredTransaction(ctxt *runContext, tx *types.Transaction, trueTxIndexOffset int) ([]ProcessedTransaction, core_types.TransactionResult) {
+func (m *Mock_transactionRunner) runSponsoredTransaction(ctxt *runContext, tx *types.Transaction, trueTxIndexOffset int, sizeLimit uint64) ([]ProcessedTransaction, core_types.TransactionResult) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "runSponsoredTransaction", ctxt, tx, trueTxIndexOffset)
+	ret := m.ctrl.Call(m, "runSponsoredTransaction", ctxt, tx, trueTxIndexOffset, sizeLimit)
 	ret0, _ := ret[0].([]ProcessedTransaction)
 	ret1, _ := ret[1].(core_types.TransactionResult)
 	return ret0, ret1
 }
 
 // runSponsoredTransaction indicates an expected call of runSponsoredTransaction.
-func (mr *Mock_transactionRunnerMockRecorder) runSponsoredTransaction(ctxt, tx, trueTxIndexOffset any) *gomock.Call {
+func (mr *Mock_transactionRunnerMockRecorder) runSponsoredTransaction(ctxt, tx, trueTxIndexOffset, sizeLimit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runSponsoredTransaction", reflect.TypeOf((*Mock_transactionRunner)(nil).runSponsoredTransaction), ctxt, tx, trueTxIndexOffset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runSponsoredTransaction", reflect.TypeOf((*Mock_transactionRunner)(nil).runSponsoredTransaction), ctxt, tx, trueTxIndexOffset, sizeLimit)
 }
 
 // runTransactionBundle mocks base method.
-func (m *Mock_transactionRunner) runTransactionBundle(ctxt *runContext, tx *types.Transaction, trueTxIndexOffset int) ([]ProcessedTransaction, core_types.TransactionResult, core_types.ExecutionCost) {
+func (m *Mock_transactionRunner) runTransactionBundle(ctxt *runContext, tx *types.Transaction, trueTxIndexOffset int, sizeLimit uint64) ([]ProcessedTransaction, core_types.TransactionResult, core_types.ExecutionCost) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "runTransactionBundle", ctxt, tx, trueTxIndexOffset)
+	ret := m.ctrl.Call(m, "runTransactionBundle", ctxt, tx, trueTxIndexOffset, sizeLimit)
 	ret0, _ := ret[0].([]ProcessedTransaction)
 	ret1, _ := ret[1].(core_types.TransactionResult)
 	ret2, _ := ret[2].(core_types.ExecutionCost)
@@ -86,9 +86,9 @@ func (m *Mock_transactionRunner) runTransactionBundle(ctxt *runContext, tx *type
 }
 
 // runTransactionBundle indicates an expected call of runTransactionBundle.
-func (mr *Mock_transactionRunnerMockRecorder) runTransactionBundle(ctxt, tx, trueTxIndexOffset any) *gomock.Call {
+func (mr *Mock_transactionRunnerMockRecorder) runTransactionBundle(ctxt, tx, trueTxIndexOffset, sizeLimit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runTransactionBundle", reflect.TypeOf((*Mock_transactionRunner)(nil).runTransactionBundle), ctxt, tx, trueTxIndexOffset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "runTransactionBundle", reflect.TypeOf((*Mock_transactionRunner)(nil).runTransactionBundle), ctxt, tx, trueTxIndexOffset, sizeLimit)
 }
 
 // Mock_evm is a mock of _evm interface.

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -4393,3 +4393,41 @@ func TestRunTransactions_SmallerTransactionsAreProcessedAfterLargeTransactionExc
 		{Transaction: tx1, Receipt: &types.Receipt{}},
 	}, summary.ProcessedTransactions)
 }
+
+func TestRunTransactions_RemainingSizeIsSetToZeroWhenProcessedTxExceedsIt(t *testing.T) {
+	tx0 := getRegularTransaction(t)
+	tx1 := getRegularTransaction(t)
+
+	// Set remaining size smaller than tx0's size. The mock will still return a
+	// receipt (simulating a transaction that passed the runner's size check but
+	// exceeds the tracked remaining budget).
+	remainingSize := tx0.Size() - 1
+
+	ctrl := gomock.NewController(t)
+	runner := NewMock_transactionRunner(ctrl)
+
+	context := &runContext{
+		signer:   types.LatestSignerForChainID(big.NewInt(1)),
+		upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
+		runner:   runner,
+	}
+
+	gomock.InOrder(
+		runner.EXPECT().runRegularTransaction(context, tx0, 0, remainingSize).Return(
+			ProcessedTransaction{Transaction: tx0, Receipt: &types.Receipt{}},
+			core_types.TransactionResultSuccessful,
+		),
+
+		// After tx0 exceeds remaining size, remainingSize becomes 0.
+		// The next transaction should be called with sizeLimit = 0.
+		runner.EXPECT().runRegularTransaction(context, tx1, 1, uint64(0)).Return(
+			ProcessedTransaction{Transaction: tx1, Receipt: nil},
+			core_types.TransactionResultInvalid,
+		),
+	)
+
+	summary := runTransactions(context, []*types.Transaction{tx0, tx1}, 0, remainingSize)
+	require.Len(t, summary.ProcessedTransactions, 2)
+	require.NotNil(t, summary.ProcessedTransactions[0].Receipt)
+	require.Nil(t, summary.ProcessedTransactions[1].Receipt)
+}

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -4013,7 +4013,7 @@ func TestRunSponsoredTransaction_SkipsTransactionExceedingSizeLimit(t *testing.T
 	}
 }
 
-func TestBundleTransactionRunner_Run_DeductsSizeLimit(t *testing.T) {
+func TestBundleTransactionRunner_Run_DeductsSizeLimitOnlyIfReceiptIsNotNil(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	runner := NewMock_transactionRunner(ctrl)
 
@@ -4023,6 +4023,9 @@ func TestBundleTransactionRunner_Run_DeductsSizeLimit(t *testing.T) {
 
 	tx1 := getRegularTransaction(t)
 	tx2 := getRegularTransaction(t)
+	skippedTx := types.NewTx(&types.LegacyTx{
+		Nonce: 0, To: &common.Address{1}, Gas: 21_000, GasPrice: big.NewInt(1),
+	})
 
 	ctxt := &runContext{
 		runner:  runner,
@@ -4044,6 +4047,16 @@ func TestBundleTransactionRunner_Run_DeductsSizeLimit(t *testing.T) {
 
 	result := bundleRunner.Run(tx1)
 	require.Equal(t, core_types.TransactionResultSuccessful, result)
+	require.Equal(t, initialSizeLimit-tx1.Size(), bundleRunner.sizeLimit)
+
+	// Running a transaction that is skipped (receipt is nil) should not reduce the size limit
+	runner.EXPECT().runRegularTransaction(ctxt, skippedTx, 1, initialSizeLimit-tx1.Size()).Return(
+		ProcessedTransaction{Transaction: skippedTx, Receipt: nil},
+		core_types.TransactionResultInvalid,
+	)
+
+	result = bundleRunner.Run(skippedTx)
+	require.Equal(t, core_types.TransactionResultInvalid, result)
 	require.Equal(t, initialSizeLimit-tx1.Size(), bundleRunner.sizeLimit)
 
 	// Second transaction should get the reduced sizeLimit
@@ -4144,7 +4157,7 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 			txs:           []*types.Transaction{regular1},
 			remainingSize: regular1.Size(),
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runRegularTransaction(ctx, regular1, 0, gomock.Any()).Return(
+				runner.EXPECT().runRegularTransaction(ctx, regular1, 0, regular1.Size()).Return(
 					ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
 					core_types.TransactionResultSuccessful,
 				)
@@ -4157,15 +4170,15 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 			remainingSize: regular1.Size() + regular2.Size() + regular3.Size(),
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
 				gomock.InOrder(
-					runner.EXPECT().runRegularTransaction(ctx, regular1, 0, gomock.Any()).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular1, 0, regular1.Size()+regular2.Size()+regular3.Size()).Return(
 						ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
-					runner.EXPECT().runRegularTransaction(ctx, regular2, 1, gomock.Any()).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular2, 1, regular2.Size()+regular3.Size()).Return(
 						ProcessedTransaction{Transaction: regular2, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
-					runner.EXPECT().runRegularTransaction(ctx, regular3, 2, gomock.Any()).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular3, 2, regular3.Size()).Return(
 						ProcessedTransaction{Transaction: regular3, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
@@ -4191,7 +4204,7 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 		},
 		"bundle transaction": {
 			txs:           []*types.Transaction{bundle.AllOf(bundle.Step(key, regular1)).Build()},
-			remainingSize: regular1.Size() + 1024, // Add some extra space for the bundle overhead
+			remainingSize: regular1.Size() + 1024, // Add some extra space for the bundle marker added by the builder
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
 				runner.EXPECT().runTransactionBundle(ctx, gomock.Any(), 0, gomock.Any()).Return(
 					[]ProcessedTransaction{
@@ -4203,6 +4216,28 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 			},
 			wantProcessed: 1,
 			wantIncluded:  1,
+		},
+		"combination of regular and skipped transactions": {
+			txs:           []*types.Transaction{regular1, types.NewTx(&types.LegacyTx{Data: []byte{0}}), regular2},
+			remainingSize: regular1.Size() + regular2.Size(),
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				gomock.InOrder(
+					runner.EXPECT().runRegularTransaction(ctx, regular1, 0, regular1.Size()+regular2.Size()).Return(
+						ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
+						core_types.TransactionResultSuccessful,
+					),
+					runner.EXPECT().runRegularTransaction(ctx, gomock.Any(), 1, regular2.Size()).Return(
+						ProcessedTransaction{Transaction: types.NewTx(&types.LegacyTx{Data: []byte{0}}), Receipt: nil},
+						core_types.TransactionResultInvalid,
+					),
+					runner.EXPECT().runRegularTransaction(ctx, regular2, 1, regular2.Size()).Return(
+						ProcessedTransaction{Transaction: regular2, Receipt: &types.Receipt{}},
+						core_types.TransactionResultSuccessful,
+					),
+				)
+			},
+			wantProcessed: 3,
+			wantIncluded:  2,
 		},
 	}
 

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2868,18 +2868,19 @@ func TestBundleTransactionRunner_Run_KeepsTrackOfProcessedTransactions(t *testin
 		usedGas:  new(uint64),
 		statedb:  stateDb,
 	}
-	bundleTransactionRunner := &bundleTransactionRunner{ctxt: ctxt}
+	sizeLimit := uint64(math.MaxUint64)
+	bundleTransactionRunner := &bundleTransactionRunner{ctxt: ctxt, sizeLimit: sizeLimit}
 
 	tx1 := getRegularTransaction(t)
 	tx2 := getSponsorshipRequest(t)
 	tx2payment := getSponsorshipRequest(t) // some dummy tx
 	tx3 := getRegularTransaction(t)
 
-	runner.EXPECT().runRegularTransaction(ctxt, tx1, gomock.Any(), gomock.Any()).
+	runner.EXPECT().runRegularTransaction(ctxt, tx1, gomock.Any(), sizeLimit).
 		Return(ProcessedTransaction{Transaction: tx1}, core_types.TransactionResultSuccessful)
-	runner.EXPECT().runSponsoredTransaction(ctxt, tx2, gomock.Any(), gomock.Any()).
+	runner.EXPECT().runSponsoredTransaction(ctxt, tx2, gomock.Any(), sizeLimit).
 		Return([]ProcessedTransaction{{Transaction: tx2}, {Transaction: tx2payment}}, core_types.TransactionResultFailed)
-	runner.EXPECT().runRegularTransaction(ctxt, tx3, gomock.Any(), gomock.Any()).
+	runner.EXPECT().runRegularTransaction(ctxt, tx3, gomock.Any(), sizeLimit).
 		Return(ProcessedTransaction{Transaction: tx3}, core_types.TransactionResultInvalid)
 
 	// one processed transaction with status successful
@@ -2992,6 +2993,7 @@ func TestBundleTransactionRunner_CreateSnapshot_CallsInterTxSnapshotOnStateDbAnd
 		ctxt:                  ctxt,
 		trueTxOffset:          13,
 		processedTransactions: make([]ProcessedTransaction, 14),
+		sizeLimit:             15,
 	}
 
 	snapshotId := bundleTransactionRunner.CreateSnapshot()
@@ -3002,6 +3004,7 @@ func TestBundleTransactionRunner_CreateSnapshot_CallsInterTxSnapshotOnStateDbAnd
 	require.EqualValues(t, 11, bundleTransactionRunner.snapshots[0].usedGas)
 	require.Equal(t, 13, bundleTransactionRunner.snapshots[0].trueTxOffset)
 	require.Equal(t, 14, bundleTransactionRunner.snapshots[0].processedTransactionListLength)
+	require.EqualValues(t, 15, bundleTransactionRunner.snapshots[0].sizeLimit)
 }
 
 func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOnStateDbAndResetsLocalState(t *testing.T) {
@@ -3018,6 +3021,7 @@ func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOn
 		ctxt:                  ctxt,
 		trueTxOffset:          51,
 		processedTransactions: make([]ProcessedTransaction, 100),
+		sizeLimit:             999,
 	}
 
 	bundleTransactionRunner.snapshots = []bundleTransactionRunnerSnapshot{{
@@ -3026,6 +3030,7 @@ func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOn
 		processedTransactionListLength: 5,
 		usedGas:                        6,
 		gasPool:                        core.NewGasPool(7),
+		sizeLimit:                      42,
 	}}
 	bundleTransactionRunner.RevertToSnapshot(0)
 
@@ -3034,6 +3039,7 @@ func TestBundleTransactionRunner_RevertToSnapshot_CallsRevertToInterTxSnapshotOn
 	require.Len(t, bundleTransactionRunner.processedTransactions, 5)
 	require.EqualValues(t, 6, *ctxt.usedGas)
 	require.EqualValues(t, 7, ctxt.gasPool.Gas())
+	require.EqualValues(t, 42, bundleTransactionRunner.sizeLimit)
 }
 
 func TestBundleTransactionRunner_CreatingAndRevertingSnapshotsDoesNotAlterUsedGasAndGasPoolAddressesOfContext(t *testing.T) {
@@ -3094,6 +3100,7 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToRegularTxC
 			stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
 			stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
 
+			sizeLimit := uint64(1_000_000)
 			ctxt := &runContext{
 				runner:  runner,
 				gasPool: core.NewGasPool(math.MaxUint64),
@@ -3103,11 +3110,12 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToRegularTxC
 			bundleTransactionRunner := &bundleTransactionRunner{
 				ctxt:         ctxt,
 				trueTxOffset: offset + 1,
+				sizeLimit:    sizeLimit,
 			}
 
 			tx := getRegularTransaction(t)
 
-			runner.EXPECT().runRegularTransaction(ctxt, tx, offset+1, gomock.Any())
+			runner.EXPECT().runRegularTransaction(ctxt, tx, offset+1, sizeLimit)
 			bundleTransactionRunner.Run(tx)
 		})
 	}
@@ -3123,6 +3131,7 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToSponsoredT
 			stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
 			stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
 
+			sizeLimit := uint64(1_000_000)
 			ctxt := &runContext{
 				runner:   runner,
 				upgrades: opera.Upgrades{GasSubsidies: true},
@@ -3133,11 +3142,12 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToSponsoredT
 			bundleTransactionRunner := &bundleTransactionRunner{
 				ctxt:         ctxt,
 				trueTxOffset: offset + 1,
+				sizeLimit:    sizeLimit,
 			}
 
 			tx := getSponsorshipRequest(t)
 
-			runner.EXPECT().runSponsoredTransaction(ctxt, tx, offset+1, gomock.Any())
+			runner.EXPECT().runSponsoredTransaction(ctxt, tx, offset+1, sizeLimit)
 			bundleTransactionRunner.Run(tx)
 		})
 	}
@@ -3153,6 +3163,7 @@ func TestBundleTransactionRunner_Run_ForwardsTrueTransactionOffsetToBundleTxCall
 			stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
 			stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
 
+			sizeLimit := uint64(1_000_000)
 			upgrades := opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true}
 			ctxt := &runContext{
 				runner:   runner,
@@ -3164,11 +3175,12 @@ func TestBundleTransactionRunner_Run_ForwardsTrueTransactionOffsetToBundleTxCall
 			bundleTransactionRunner := &bundleTransactionRunner{
 				ctxt:         ctxt,
 				trueTxOffset: trueOffset,
+				sizeLimit:    sizeLimit,
 			}
 
 			tx := getTransactionBundle(t)
 
-			runner.EXPECT().runTransactionBundle(ctxt, tx, trueOffset, gomock.Any())
+			runner.EXPECT().runTransactionBundle(ctxt, tx, trueOffset, sizeLimit)
 			bundleTransactionRunner.Run(tx)
 		})
 	}
@@ -3921,90 +3933,195 @@ func TestRunTransaction_Bundle_ReturnsExecutionCostFromBundleExecution(t *testin
 	require.Equal(t, core_types.ExecutionCost(150_000), execCost)
 }
 
-/*
-func TestRunTransactions_SkipsTransactionsExceedingBlockSizeLimit(t *testing.T) {
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	regular1 := getRegularTransaction(t)
-	regular2 := getRegularTransaction(t)
-	regular3 := getRegularTransaction(t)
-	sponsored := getSponsorshipRequest(t)
+func TestRunRegularTransaction_AcceptsTransactionIfItIsWithinSizeLimit(t *testing.T) {
+	tx := types.NewTx(&types.LegacyTx{})
 
 	tests := map[string]struct {
-		txs           []*types.Transaction
-		remainingSize uint64
-		setupMock     func(*runContext, *Mock_transactionRunner)
-		wantProcessed int
-		wantIncluded  int // transactions with non-nil receipt
+		sizeLimit  uint64
+		successful bool
 	}{
-		"single transaction": {
-			txs:           []*types.Transaction{regular1},
-			remainingSize: regular1.Size() - 1, // too small
-			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
-			wantProcessed: 1,
-			wantIncluded:  0,
+		"size limit smaller than transaction size": {
+			sizeLimit: tx.Size() - 1,
 		},
-		"multiple transactions": {
-			txs:           []*types.Transaction{regular1, regular2, regular3},
-			remainingSize: regular1.Size() + regular2.Size(),
-			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				gomock.InOrder(
-					runner.EXPECT().runRegularTransaction(ctx, regular1, 0, gomock.Any()).Return(
-						ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
-						core_types.TransactionResultSuccessful,
-					),
-					runner.EXPECT().runRegularTransaction(ctx, regular2, 1, gomock.Any()).Return(
-						ProcessedTransaction{Transaction: regular2, Receipt: &types.Receipt{}},
-						core_types.TransactionResultSuccessful,
-					),
+		"size limit equal to transaction size": {
+			sizeLimit:  tx.Size(),
+			successful: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			evm := NewMock_evm(ctrl)
+			ctxt := &runContext{}
+
+			if test.successful {
+				evm.EXPECT().runWithBaseFeeCheck(ctxt, tx, 0).Return(
+					ProcessedTransaction{Transaction: tx, Receipt: &types.Receipt{Status: types.ReceiptStatusSuccessful}},
 				)
-			},
-			wantProcessed: 3,
-			wantIncluded:  2,
+			}
+
+			runner := transactionRunner{evm}
+			got, status := runner.runRegularTransaction(ctxt, tx, 0, test.sizeLimit)
+			require.Equal(t, tx, got.Transaction)
+
+			if test.successful {
+				require.Equal(t, core_types.TransactionResultSuccessful, status)
+				require.NotNil(t, got.Receipt)
+			} else {
+				require.Equal(t, core_types.TransactionResultInvalid, status)
+				require.Nil(t, got.Receipt)
+			}
+		})
+	}
+}
+
+func TestRunSponsoredTransaction_SkipsTransactionExceedingSizeLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	evm := NewMock_evm(ctrl)
+
+	tx := getSponsorshipRequest(t)
+
+	context := &runContext{
+		upgrades: opera.Upgrades{GasSubsidies: true},
+		signer:   types.LatestSignerForChainID(nil),
+	}
+
+	tests := map[string]struct {
+		sizeLimit uint64
+	}{
+		"no space": {
+			sizeLimit: 0,
 		},
-		"sponsored transactions with payment": {
-			txs:           []*types.Transaction{sponsored},
-			remainingSize: sponsored.Size(), // not enough for sponsored + fee-charging tx
-			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
-			wantProcessed: 1,
-			wantIncluded:  0,
+		"only space for tx, not payment": {
+			sizeLimit: tx.Size(),
 		},
-		"bundle transaction": {
-			txs:           []*types.Transaction{bundle.AllOf(bundle.Step(key, regular1)).Build()},
-			remainingSize: regular1.Size() - 1, // too small for the inner transaction
-			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
-			wantProcessed: 1,
-			wantIncluded:  0,
+		"just under the required size": {
+			sizeLimit: tx.Size() + subsidies.RlpEncodedFeeChargingTxSizeInBytes - 1,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			runner := NewMock_transactionRunner(ctrl)
-
-			context := &runContext{
-				upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
-				signer:   types.LatestSignerForChainID(big.NewInt(1)),
-				runner:   runner,
-			}
-			tc.setupMock(context, runner)
-
-			summary := runTransactions(context, tc.txs, 0, tc.remainingSize)
-
-			require.Len(t, summary.ProcessedTransactions, tc.wantProcessed)
-			included := 0
-			for _, processedTx := range summary.ProcessedTransactions {
-				if processedTx.Receipt != nil {
-					included++
-				}
-			}
-			require.Equal(t, tc.wantIncluded, included)
+			runner := &transactionRunner{evm: evm}
+			got, status := runner.runSponsoredTransaction(context, tx, 0, tc.sizeLimit)
+			require.Equal(t, core_types.TransactionResultInvalid, status)
+			require.Len(t, got, 1)
+			require.Equal(t, tx, got[0].Transaction)
+			require.Nil(t, got[0].Receipt)
 		})
 	}
 }
-*/
+
+func TestBundleTransactionRunner_Run_DeductsSizeLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	runner := NewMock_transactionRunner(ctrl)
+
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+	stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
+	tx1 := getRegularTransaction(t)
+	tx2 := getRegularTransaction(t)
+
+	ctxt := &runContext{
+		runner:  runner,
+		gasPool: core.NewGasPool(math.MaxUint64),
+		usedGas: new(uint64),
+		statedb: stateDb,
+	}
+
+	initialSizeLimit := tx1.Size() + tx2.Size()
+	bundleRunner := &bundleTransactionRunner{
+		ctxt:      ctxt,
+		sizeLimit: initialSizeLimit,
+	}
+
+	runner.EXPECT().runRegularTransaction(ctxt, tx1, 0, initialSizeLimit).Return(
+		ProcessedTransaction{Transaction: tx1, Receipt: &types.Receipt{}},
+		core_types.TransactionResultSuccessful,
+	)
+
+	result := bundleRunner.Run(tx1)
+	require.Equal(t, core_types.TransactionResultSuccessful, result)
+	require.Equal(t, initialSizeLimit-tx1.Size(), bundleRunner.sizeLimit)
+
+	// Second transaction should get the reduced sizeLimit
+	runner.EXPECT().runRegularTransaction(ctxt, tx2, 1, initialSizeLimit-tx1.Size()).Return(
+		ProcessedTransaction{Transaction: tx2, Receipt: &types.Receipt{}},
+		core_types.TransactionResultSuccessful,
+	)
+
+	result = bundleRunner.Run(tx2)
+	require.Equal(t, core_types.TransactionResultSuccessful, result)
+	require.Equal(t, initialSizeLimit-tx1.Size()-tx2.Size(), bundleRunner.sizeLimit)
+}
+
+func TestBundleTransactionRunner_Run_RevertsWhenSizeLimitExceeded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	runner := NewMock_transactionRunner(ctrl)
+
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+	stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
+	tx := getRegularTransaction(t)
+
+	ctxt := &runContext{
+		runner:  runner,
+		gasPool: core.NewGasPool(math.MaxUint64),
+		usedGas: new(uint64),
+		statedb: stateDb,
+	}
+
+	// sizeLimit is smaller than the transaction
+	bundleRunner := &bundleTransactionRunner{
+		ctxt:      ctxt,
+		sizeLimit: tx.Size() - 1,
+	}
+
+	// The transaction will be run (runner is called with sizeLimit),
+	// but since the runner returns a receipt and the processed tx size
+	// exceeds the remaining sizeLimit, the bundle runner reverts.
+	runner.EXPECT().runRegularTransaction(ctxt, tx, 0, tx.Size()-1).Return(
+		ProcessedTransaction{Transaction: tx, Receipt: &types.Receipt{}},
+		core_types.TransactionResultSuccessful,
+	)
+
+	result := bundleRunner.Run(tx)
+	require.Equal(t, core_types.TransactionResultInvalid, result)
+	// After revert, processed transactions should be empty
+	require.Empty(t, bundleRunner.processedTransactions)
+}
+
+func TestBundleTransactionRunner_Snapshot_CoversSizeLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().InterTxSnapshot().AnyTimes()
+	stateDb.EXPECT().RevertToInterTxSnapshot(gomock.Any()).AnyTimes()
+
+	runner := &bundleTransactionRunner{
+		ctxt:      &runContext{statedb: stateDb, usedGas: new(uint64), gasPool: core.NewGasPool(1_000_000)},
+		sizeLimit: 1000,
+	}
+
+	s1 := runner.CreateSnapshot()
+	require.EqualValues(t, 1000, runner.snapshots[0].sizeLimit)
+
+	runner.sizeLimit = 500
+	s2 := runner.CreateSnapshot()
+	require.EqualValues(t, 500, runner.snapshots[1].sizeLimit)
+
+	runner.sizeLimit = 100
+
+	// revert to s2, should restore sizeLimit to 500
+	runner.RevertToSnapshot(s2)
+	require.EqualValues(t, 500, runner.sizeLimit)
+
+	// revert to s1, should restore sizeLimit to 1000
+	runner.RevertToSnapshot(s1)
+	require.EqualValues(t, 1000, runner.sizeLimit)
+}
 
 func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing.T) {
 	key, err := crypto.GenerateKey()

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -3892,7 +3892,7 @@ func TestRealTransactionSize_CanHandleAllTxTypes(t *testing.T) {
 				TransactionBundles: true,
 				GasSubsidies:       true,
 			}}
-			size := realTxSize(context, test.tx)
+			size := computeRealTxSize(context, test.tx)
 			require.Equal(t, test.expectedSize, size)
 		})
 	}
@@ -3926,13 +3926,13 @@ func TestRealTransactionSize_OnlyConsidersSpecialTxsWhenEnabled(t *testing.T) {
 			upgrades := opera.Upgrades{} // no special tx types enabled
 
 			context := &runContext{signer: signer, upgrades: upgrades}
-			size := realTxSize(context, tx)
+			size := computeRealTxSize(context, tx)
 			require.Equal(t, tx.Size(), size)
 		})
 	}
 }
 
-func TestRunTransactions_EnforcesBlockSizeLimit(t *testing.T) {
+func TestRunTransactions_SkipsTransactionsExceedingBlockSizeLimit(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
@@ -3948,14 +3948,14 @@ func TestRunTransactions_EnforcesBlockSizeLimit(t *testing.T) {
 		wantProcessed int
 		wantIncluded  int // transactions with non-nil receipt
 	}{
-		"single large transaction": {
+		"single transaction": {
 			txs:           []*types.Transaction{regular1},
 			remainingSize: regular1.Size() - 1, // too small
 			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
 			wantProcessed: 1,
 			wantIncluded:  0,
 		},
-		"multiple transactions exceeding limit": {
+		"multiple transactions": {
 			txs:           []*types.Transaction{regular1, regular2, regular3},
 			remainingSize: regular1.Size() + regular2.Size(),
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
@@ -3973,19 +3973,14 @@ func TestRunTransactions_EnforcesBlockSizeLimit(t *testing.T) {
 			wantProcessed: 3,
 			wantIncluded:  2,
 		},
-		"transaction followed by sponsored transactions": {
-			txs:           []*types.Transaction{regular1, sponsored},
-			remainingSize: regular1.Size() + sponsored.Size(), // not enough for sponsored + fee-charging tx
-			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
-					ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
-					core_types.TransactionResultSuccessful,
-				)
-			},
-			wantProcessed: 2,
-			wantIncluded:  1,
+		"sponsored transactions with payment": {
+			txs:           []*types.Transaction{sponsored},
+			remainingSize: sponsored.Size(), // not enough for sponsored + fee-charging tx
+			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
+			wantProcessed: 1,
+			wantIncluded:  0,
 		},
-		"bundle transaction exceeding limit": {
+		"bundle transaction": {
 			txs:           []*types.Transaction{bundle.AllOf(bundle.Step(key, regular1)).Build()},
 			remainingSize: regular1.Size() - 1, // too small for the inner transaction
 			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
@@ -4016,6 +4011,196 @@ func TestRunTransactions_EnforcesBlockSizeLimit(t *testing.T) {
 				}
 			}
 			require.Equal(t, tc.wantIncluded, included)
+		})
+	}
+}
+
+func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	regular1 := getRegularTransaction(t)
+	regular2 := getRegularTransaction(t)
+	regular3 := getRegularTransaction(t)
+	sponsored := getSponsorshipRequest(t)
+	paymentTx := types.NewTx(&types.LegacyTx{Nonce: 99})
+
+	tests := map[string]struct {
+		txs           []*types.Transaction
+		remainingSize uint64
+		setupMock     func(*runContext, *Mock_transactionRunner)
+		wantProcessed int
+		wantIncluded  int
+	}{
+		"single transaction": {
+			txs:           []*types.Transaction{regular1},
+			remainingSize: regular1.Size(),
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
+					ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
+					core_types.TransactionResultSuccessful,
+				)
+			},
+			wantProcessed: 1,
+			wantIncluded:  1,
+		},
+		"multiple transactions": {
+			txs:           []*types.Transaction{regular1, regular2, regular3},
+			remainingSize: regular1.Size() + regular2.Size() + regular3.Size(),
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				gomock.InOrder(
+					runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
+						ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
+						core_types.TransactionResultSuccessful,
+					),
+					runner.EXPECT().runRegularTransaction(ctx, regular2, 1).Return(
+						ProcessedTransaction{Transaction: regular2, Receipt: &types.Receipt{}},
+						core_types.TransactionResultSuccessful,
+					),
+					runner.EXPECT().runRegularTransaction(ctx, regular3, 2).Return(
+						ProcessedTransaction{Transaction: regular3, Receipt: &types.Receipt{}},
+						core_types.TransactionResultSuccessful,
+					),
+				)
+			},
+			wantProcessed: 3,
+			wantIncluded:  3,
+		},
+		"sponsored transaction with payment": {
+			txs:           []*types.Transaction{sponsored},
+			remainingSize: sponsored.Size() + subsidies.RlpEncodedFeeChargingTxSizeInBytes,
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				runner.EXPECT().runSponsoredTransaction(ctx, sponsored, 0).Return(
+					[]ProcessedTransaction{
+						{Transaction: sponsored, Receipt: &types.Receipt{}},
+						{Transaction: paymentTx, Receipt: &types.Receipt{}},
+					},
+					core_types.TransactionResultSuccessful,
+				)
+			},
+			wantProcessed: 2,
+			wantIncluded:  2,
+		},
+		"bundle transaction": {
+			txs:           []*types.Transaction{bundle.AllOf(bundle.Step(key, regular1)).Build()},
+			remainingSize: regular1.Size() + 1024, // Add some extra space for the bundle overhead
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				runner.EXPECT().runTransactionBundle(ctx, gomock.Any(), 0).Return(
+					[]ProcessedTransaction{
+						{Transaction: regular1, Receipt: &types.Receipt{}},
+					},
+					core_types.TransactionResultSuccessful,
+					core_types.ExecutionCost(0),
+				)
+			},
+			wantProcessed: 1,
+			wantIncluded:  1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			runner := NewMock_transactionRunner(ctrl)
+
+			context := &runContext{
+				upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
+				signer:   types.LatestSignerForChainID(big.NewInt(1)),
+				runner:   runner,
+			}
+			tc.setupMock(context, runner)
+
+			summary := runTransactions(context, tc.txs, 0, tc.remainingSize)
+
+			require.Len(t, summary.ProcessedTransactions, tc.wantProcessed)
+			included := 0
+			for _, processedTx := range summary.ProcessedTransactions {
+				if processedTx.Receipt != nil {
+					included++
+				}
+			}
+			require.Equal(t, tc.wantIncluded, included)
+		})
+	}
+}
+
+func TestRunTransaction_CollectsCausedByInformationForAllTransactionTypes(t *testing.T) {
+
+	regularTx := getRegularTransaction(t)
+	sponsoredTx := getSponsorshipRequest(t)
+	bundleTx := getTransactionBundle(t)
+
+	// Simulated output transactions from the runner.
+	paymentTx := types.NewTx(&types.LegacyTx{Nonce: 99})
+	bundleInner1 := types.NewTx(&types.LegacyTx{Nonce: 200})
+	bundleInner2 := types.NewTx(&types.LegacyTx{Nonce: 201})
+
+	tests := map[string]struct {
+		tx           *types.Transaction
+		setupMock    func(*runContext, *Mock_transactionRunner)
+		wantCausedBy map[common.Hash]common.Hash
+	}{
+		"basic transaction": {
+			tx: regularTx,
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				runner.EXPECT().runRegularTransaction(ctx, regularTx, 0).Return(
+					ProcessedTransaction{Transaction: regularTx, Receipt: &types.Receipt{}},
+					core_types.TransactionResultSuccessful,
+				)
+			},
+			wantCausedBy: map[common.Hash]common.Hash{
+				regularTx.Hash(): regularTx.Hash(),
+			},
+		},
+		"sponsored transaction": {
+			tx: sponsoredTx,
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				runner.EXPECT().runSponsoredTransaction(ctx, sponsoredTx, 0).Return(
+					[]ProcessedTransaction{
+						{Transaction: sponsoredTx, Receipt: &types.Receipt{}},
+						{Transaction: paymentTx, Receipt: &types.Receipt{}},
+					},
+					core_types.TransactionResultSuccessful,
+				)
+			},
+			wantCausedBy: map[common.Hash]common.Hash{
+				sponsoredTx.Hash(): sponsoredTx.Hash(),
+				paymentTx.Hash():   sponsoredTx.Hash(),
+			},
+		},
+		"bundle transaction": {
+			tx: bundleTx,
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				runner.EXPECT().runTransactionBundle(ctx, bundleTx, 0).Return(
+					[]ProcessedTransaction{
+						{Transaction: bundleInner1, Receipt: &types.Receipt{}},
+						{Transaction: bundleInner2, Receipt: &types.Receipt{}},
+					},
+					core_types.TransactionResultSuccessful,
+					core_types.ExecutionCost(0),
+				)
+			},
+			wantCausedBy: map[common.Hash]common.Hash{
+				bundleInner1.Hash(): bundleTx.Hash(),
+				bundleInner2.Hash(): bundleTx.Hash(),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			runner := NewMock_transactionRunner(ctrl)
+
+			context := &runContext{
+				signer:   types.LatestSignerForChainID(big.NewInt(1)),
+				upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
+				runner:   runner,
+			}
+			tc.setupMock(context, runner)
+
+			summary := runTransactions(context, []*types.Transaction{tc.tx}, 0, math.MaxUint64)
+			require.Equal(t, tc.wantCausedBy, summary.CausedBy)
 		})
 	}
 }

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -4075,8 +4075,12 @@ func TestBundleTransactionRunner_Run_RevertsWhenSizeLimitExceeded(t *testing.T) 
 	runner := NewMock_transactionRunner(ctrl)
 
 	stateDb := state.NewMockStateDB(ctrl)
-	stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
-	stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
+	interTxSnapshot := 42
+	gomock.InOrder(
+		stateDb.EXPECT().InterTxSnapshot().Return(interTxSnapshot),
+		stateDb.EXPECT().RevertToInterTxSnapshot(interTxSnapshot),
+	)
 
 	tx := getRegularTransaction(t)
 
@@ -4346,4 +4350,46 @@ func TestRunTransaction_CollectsCausedByInformationForAllTransactionTypes(t *tes
 			require.Equal(t, tc.wantCausedBy, summary.CausedBy)
 		})
 	}
+}
+
+func TestRunTransactions_SmallerTransactionsAreProcessedAfterLargeTransactionExceedingSizeLimit(t *testing.T) {
+	sizeLimit := uint64(1_000)
+
+	// Create a tx that exceeds the size limit
+	largeTx := types.NewTx(&types.LegacyTx{Data: make([]byte, sizeLimit+1)})
+
+	// Following txs are not skipped
+	tx0 := getRegularTransaction(t)
+	tx1 := getRegularTransaction(t)
+
+	transactions := []*types.Transaction{largeTx, tx0, tx1}
+
+	ctrl := gomock.NewController(t)
+	runner := NewMock_transactionRunner(ctrl)
+
+	context := &runContext{
+		signer:   types.LatestSignerForChainID(big.NewInt(1)),
+		upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
+		runner:   runner,
+	}
+
+	runner.EXPECT().runRegularTransaction(context, largeTx, 0, sizeLimit).Return(
+		ProcessedTransaction{Transaction: largeTx, Receipt: nil},
+		core_types.TransactionResultSuccessful,
+	)
+	runner.EXPECT().runRegularTransaction(context, tx0, 0, sizeLimit).Return(
+		ProcessedTransaction{Transaction: tx0, Receipt: &types.Receipt{}},
+		core_types.TransactionResultInvalid,
+	)
+	runner.EXPECT().runRegularTransaction(context, tx1, 1, sizeLimit-tx0.Size()).Return(
+		ProcessedTransaction{Transaction: tx1, Receipt: &types.Receipt{}},
+		core_types.TransactionResultInvalid,
+	)
+
+	summary := runTransactions(context, transactions, 0, sizeLimit)
+	require.Equal(t, []ProcessedTransaction{
+		{Transaction: largeTx, Receipt: nil},
+		{Transaction: tx0, Receipt: &types.Receipt{}},
+		{Transaction: tx1, Receipt: &types.Receipt{}},
+	}, summary.ProcessedTransactions)
 }

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -3889,12 +3889,133 @@ func TestRealTransactionSize_CanHandleAllTxTypes(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			context := &runContext{signer: signer, upgrades: opera.Upgrades{
-				Brio:               true,
 				TransactionBundles: true,
 				GasSubsidies:       true,
 			}}
 			size := realTxSize(context, test.tx)
 			require.Equal(t, test.expectedSize, size)
+		})
+	}
+}
+
+func TestRealTransactionSize_OnlyConsidersSpecialTxsWhenEnabled(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	basicTx := types.NewTx(&types.AccessListTx{
+		To:       &common.Address{0x42},
+		GasPrice: big.NewInt(100),
+		V:        big.NewInt(1),
+	})
+	sponsoredTx := types.NewTx(&types.LegacyTx{
+		To:       &common.Address{0x42},
+		GasPrice: big.NewInt(0),
+		V:        big.NewInt(1),
+	})
+	bundleTx := bundle.AllOf(bundle.Step(key, basicTx)).Build()
+
+	tests := map[string]*types.Transaction{
+		"basic tx":     basicTx,
+		"sponsored tx": sponsoredTx,
+		"bundle tx":    bundleTx,
+	}
+
+	for name, tx := range tests {
+		t.Run(name, func(t *testing.T) {
+			signer := types.LatestSignerForChainID(big.NewInt(1))
+			upgrades := opera.Upgrades{} // no special tx types enabled
+
+			context := &runContext{signer: signer, upgrades: upgrades}
+			size := realTxSize(context, tx)
+			require.Equal(t, tx.Size(), size)
+		})
+	}
+}
+
+func TestRunTransactions_EnforcesBlockSizeLimit(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	regular1 := getRegularTransaction(t)
+	regular2 := getRegularTransaction(t)
+	regular3 := getRegularTransaction(t)
+	sponsored := getSponsorshipRequest(t)
+
+	tests := map[string]struct {
+		txs           []*types.Transaction
+		remainingSize uint64
+		setupMock     func(*runContext, *Mock_transactionRunner)
+		wantProcessed int
+		wantIncluded  int // transactions with non-nil receipt
+	}{
+		"single large transaction": {
+			txs:           []*types.Transaction{regular1},
+			remainingSize: regular1.Size() - 1, // too small
+			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
+			wantProcessed: 1,
+			wantIncluded:  0,
+		},
+		"multiple transactions exceeding limit": {
+			txs:           []*types.Transaction{regular1, regular2, regular3},
+			remainingSize: regular1.Size() + regular2.Size(),
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				gomock.InOrder(
+					runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
+						ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
+						core_types.TransactionResultSuccessful,
+					),
+					runner.EXPECT().runRegularTransaction(ctx, regular2, 1).Return(
+						ProcessedTransaction{Transaction: regular2, Receipt: &types.Receipt{}},
+						core_types.TransactionResultSuccessful,
+					),
+				)
+			},
+			wantProcessed: 3,
+			wantIncluded:  2,
+		},
+		"transaction followed by sponsored transactions": {
+			txs:           []*types.Transaction{regular1, sponsored},
+			remainingSize: regular1.Size() + sponsored.Size(), // not enough for sponsored + fee-charging tx
+			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
+				runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
+					ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
+					core_types.TransactionResultSuccessful,
+				)
+			},
+			wantProcessed: 2,
+			wantIncluded:  1,
+		},
+		"bundle transaction exceeding limit": {
+			txs:           []*types.Transaction{bundle.AllOf(bundle.Step(key, regular1)).Build()},
+			remainingSize: regular1.Size() - 1, // too small for the inner transaction
+			setupMock:     func(_ *runContext, _ *Mock_transactionRunner) {},
+			wantProcessed: 1,
+			wantIncluded:  0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			runner := NewMock_transactionRunner(ctrl)
+
+			context := &runContext{
+				upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
+				signer:   types.LatestSignerForChainID(big.NewInt(1)),
+				runner:   runner,
+			}
+			tc.setupMock(context, runner)
+
+			summary := runTransactions(context, tc.txs, 0, tc.remainingSize)
+
+			require.Len(t, summary.ProcessedTransactions, tc.wantProcessed)
+			included := 0
+			for _, processedTx := range summary.ProcessedTransactions {
+				if processedTx.Receipt != nil {
+					included++
+				}
+			}
+			require.Equal(t, tc.wantIncluded, included)
 		})
 	}
 }

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -51,7 +51,7 @@ import (
 // Process method.
 func (p *StateProcessor) process_iteratively(
 	block *EvmBlock, stateDb state.StateDB, cfg vm.Config, gasLimit uint64,
-	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log),
+	usedGas *uint64, trueTxOffset int, onNewLog func(*core_types.Log), maxBlockSize uint64,
 ) ProcessSummary {
 	// This implementation is a wrapper around the BeginBlock function, which
 	// handles the actual transaction processing.
@@ -127,7 +127,7 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 			gasLimit := uint64(blockGasLimit)
 			usedGas := new(uint64)
 
-			summary := process(block, state, vmConfig, gasLimit, usedGas, 0, onLog)
+			summary := process(block, state, vmConfig, gasLimit, usedGas, 0, onLog, math.MaxUint64)
 			processed := summary.ProcessedTransactions
 
 			// Receipts should be set accordingly.
@@ -232,7 +232,7 @@ func TestProcess_DetectsTransactionThatCanNotBeConvertedIntoAMessage(t *testing.
 			gasLimit := uint64(math.MaxUint64)
 			usedGas := new(uint64)
 
-			summary := process(block, state, vmConfig, gasLimit, usedGas, 0, nil)
+			summary := process(block, state, vmConfig, gasLimit, usedGas, 0, nil, math.MaxUint64)
 			processed := summary.ProcessedTransactions
 
 			require.Len(processed, len(transactions))
@@ -307,7 +307,7 @@ func TestProcess_TracksParentBlockHashIfPragueIsEnabled(t *testing.T) {
 				vmConfig := vm.Config{}
 				gasLimit := uint64(math.MaxUint64)
 				usedGas := new(uint64)
-				processed := process(block, state, vmConfig, gasLimit, usedGas, 0, nil).ProcessedTransactions
+				processed := process(block, state, vmConfig, gasLimit, usedGas, 0, nil, math.MaxUint64).ProcessedTransactions
 				require.Empty(processed)
 			})
 		}
@@ -366,7 +366,7 @@ func TestProcess_FailingTransactionAreSkippedButTheBlockIsNotTerminated(t *testi
 	// Process the block
 	gasLimit := uint64(math.MaxUint64)
 	usedGas := new(uint64)
-	processed := processor.Process(block, state, vm.Config{}, gasLimit, usedGas, 0, nil).ProcessedTransactions
+	processed := processor.Process(block, state, vm.Config{}, gasLimit, usedGas, 0, nil, math.MaxUint64).ProcessedTransactions
 
 	require.Len(t, processed, 2)
 	require.Equal(t, processed[0].Transaction, block.Transactions[0])
@@ -445,7 +445,7 @@ func TestProcess_EnforcesGasLimitBySkippingExcessiveTransactions(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					require := require.New(t)
 					gasLimit := test.gasLimit
-					processed := process(block, state, vmConfig, gasLimit, usedGas, 0, nil).ProcessedTransactions
+					processed := process(block, state, vmConfig, gasLimit, usedGas, 0, nil, math.MaxUint64).ProcessedTransactions
 					require.Len(processed, 3)
 
 					for i, tx := range transactions {
@@ -471,7 +471,7 @@ func TestProcess_UsesDifficultyOfOne(t *testing.T) {
 	state, block := createScenarioWithTxCheckingDifficulty(ctrl, big.NewInt(1))
 
 	// Check that the difficulty of 1 is used.
-	results := processor.Process(block, state, vm.Config{}, math.MaxUint64, new(uint64), 0, nil).ProcessedTransactions
+	results := processor.Process(block, state, vm.Config{}, math.MaxUint64, new(uint64), 0, nil, math.MaxUint64).ProcessedTransactions
 	require.Len(t, results, 1)
 	require.NotNil(t, results[0].Receipt)
 	require.Equal(t, types.ReceiptStatusSuccessful, results[0].Receipt.Status)
@@ -479,7 +479,7 @@ func TestProcess_UsesDifficultyOfOne(t *testing.T) {
 	// Check that an unexpected difficulty causes a revert.
 	wrongDifficulty := big.NewInt(2)
 	state, block = createScenarioWithTxCheckingDifficulty(ctrl, wrongDifficulty)
-	results = processor.Process(block, state, vm.Config{}, math.MaxUint64, new(uint64), 0, nil).ProcessedTransactions
+	results = processor.Process(block, state, vm.Config{}, math.MaxUint64, new(uint64), 0, nil, math.MaxUint64).ProcessedTransactions
 	require.Len(t, results, 1)
 	require.NotNil(t, results[0].Receipt)
 	require.Equal(t, types.ReceiptStatusFailed, results[0].Receipt.Status)
@@ -495,7 +495,7 @@ func TestProcessWithDifficulty_UsesProvidedDifficulty(t *testing.T) {
 			state, block := createScenarioWithTxCheckingDifficulty(ctrl, difficulty)
 			results := processor.ProcessWithDifficulty(
 				block, state, vm.Config{}, math.MaxUint64,
-				new(uint64), 0, nil, difficulty,
+				new(uint64), 0, nil, difficulty, math.MaxUint64,
 			).ProcessedTransactions
 			require.Len(t, results, 1)
 			require.NotNil(t, results[0].Receipt)
@@ -595,7 +595,7 @@ func TestProcessWithDifficulty_ForwardsTimeToBundleProcessing(t *testing.T) {
 
 	summary := processor.ProcessWithDifficulty(
 		block, stateDb, vm.Config{}, math.MaxUint64,
-		new(uint64), 0, nil, big.NewInt(1),
+		new(uint64), 0, nil, big.NewInt(1), math.MaxUint64,
 	)
 
 	// The rejected bundle should be listed in the summary, the accepted not,
@@ -660,7 +660,7 @@ func TestProcess_ForwardsCorrectIndexToTransactionProcessor(t *testing.T) {
 			}
 
 			// run the block on the processor with the desired initial offset
-			processor.Process(block, state, vm.Config{}, math.MaxUint64, new(uint64), offset, nil)
+			processor.Process(block, state, vm.Config{}, math.MaxUint64, new(uint64), offset, nil, math.MaxUint64)
 		})
 	}
 }
@@ -891,6 +891,7 @@ type processFunction = func(
 	usedGas *uint64,
 	trueTxOffset int,
 	onNewLog func(*core_types.Log),
+	maxBlockSize uint64,
 ) ProcessSummary
 
 func getStateDbMockForTransactions(
@@ -1006,7 +1007,7 @@ func TestRunTransactions_RunsAllTransactionsAndCollectsProcessedTransactions(t *
 
 	// run the transactions; as a side-effect, check that the
 	// transaction offset is correctly initialized and updated.
-	summary := runTransactions(context, txs, 4)
+	summary := runTransactions(context, txs, 4, math.MaxUint64)
 	got := summary.ProcessedTransactions
 	require.Len(t, got, 6)
 
@@ -1113,7 +1114,7 @@ func TestRunTransactions_ProvidesNextIndexAsOriginalIndexPlusNumberOfPreviouslyP
 		),
 	)
 
-	summary := runTransactions(context, txs, trueStartIndex)
+	summary := runTransactions(context, txs, trueStartIndex, math.MaxUint64)
 	got := summary.ProcessedTransactions
 
 	want := []ProcessedTransaction{}
@@ -1230,7 +1231,7 @@ func TestRunTransactions_GasSubsidiesDisabled_BundlesDisabled_ProcessesAsRegular
 		},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1255,7 +1256,7 @@ func TestRunTransactions_GasSubsidiesEnabled_BundlesDisabled_ProcessesAsSponsors
 		}},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1279,7 +1280,7 @@ func TestRunTransactions_BundlesEnabled_RunsRegularTransactionOnItsOwn(t *testin
 		},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1303,7 +1304,7 @@ func TestRunTransactions_BundlesEnabled_RunsSponsorshipRequestWithSponsorship(t 
 		}},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1397,7 +1398,7 @@ func TestRunTransactions_EnvelopeAndBundleOnly_SemanticsEnabledByBrio_ExecutionE
 					Return([]ProcessedTransaction{{Transaction: tc.tx, Receipt: &types.Receipt{}}}, core_types.TransactionResultSuccessful, core_types.ExecutionCost(0))
 			}
 
-			summary := runTransactions(context, []*types.Transaction{tc.tx}, 0)
+			summary := runTransactions(context, []*types.Transaction{tc.tx}, 0, math.MaxUint64)
 			processed := summary.ProcessedTransactions
 			require.Len(t, processed, 1)
 			if tc.expectInvalid {
@@ -1455,7 +1456,7 @@ func TestRunTransactions_BundleOnlyTxsAreNotFilteredDuringReplay(t *testing.T) {
 			runner.EXPECT().runRegularTransaction(context, bundleOnlyTx, 0).
 				Return(ProcessedTransaction{Transaction: bundleOnlyTx, Receipt: &types.Receipt{}}, core_types.TransactionResultSuccessful)
 
-			summary := runTransactions(context, []*types.Transaction{bundleOnlyTx}, 0)
+			summary := runTransactions(context, []*types.Transaction{bundleOnlyTx}, 0, math.MaxUint64)
 			processed := summary.ProcessedTransactions
 			require.Len(t, processed, 1)
 			require.Equal(t, ProcessedTransaction{bundleOnlyTx, &types.Receipt{}}, processed[0])
@@ -3703,7 +3704,7 @@ func TestRunTransactions_AccumulatesExecutionCostFromAllTransactions(t *testing.
 		runner.EXPECT().runSponsoredTransaction(context, txs[1], 1).Return(
 			[]ProcessedTransaction{
 				{Transaction: txs[1], Receipt: &types.Receipt{GasUsed: 200}},
-				{Transaction: &types.Transaction{}, Receipt: &types.Receipt{GasUsed: 300}},
+				{Transaction: types.NewTx(&types.LegacyTx{}), Receipt: &types.Receipt{GasUsed: 300}},
 			},
 			core_types.TransactionResultSuccessful,
 		),
@@ -3714,7 +3715,7 @@ func TestRunTransactions_AccumulatesExecutionCostFromAllTransactions(t *testing.
 		),
 	)
 
-	summary := runTransactions(context, txs, 0)
+	summary := runTransactions(context, txs, 0, math.MaxUint64)
 	require.Equal(t, core_types.ExecutionCost(100+200+300+500), summary.ExecutionCost)
 }
 
@@ -3816,4 +3817,84 @@ func TestRunTransaction_Bundle_ReturnsExecutionCostFromBundleExecution(t *testin
 
 	_, _, execCost := runTransaction(context, tx, 0)
 	require.Equal(t, core_types.ExecutionCost(150_000), execCost)
+}
+
+func TestRealTransactionSize_CanHandleAllTxTypes(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	basicTx := types.NewTx(&types.AccessListTx{
+		To:       &common.Address{0x42},
+		GasPrice: big.NewInt(100),
+		V:        big.NewInt(1),
+	})
+
+	sponsoredTx := types.NewTx(&types.LegacyTx{
+		To:       &common.Address{0x42},
+		GasPrice: big.NewInt(0),
+		V:        big.NewInt(1),
+	})
+
+	bundleTx := bundle.AllOf(bundle.Step(key, basicTx)).Build()
+
+	bundleWithSponsorTx := bundle.AllOf(
+		bundle.Step(key, basicTx),
+		bundle.Step(key, &types.AccessListTx{
+			To:       &common.Address{0x42},
+			GasPrice: big.NewInt(0), // < makes it a sponsorship request
+		}),
+	).Build()
+
+	// Compute expected sizes from the actual inner transactions in the built bundles.
+	bundleTxInner, _, err := bundle.ValidateEnvelope(signer, bundleTx)
+	require.NoError(t, err)
+	expectedBundleSize := uint64(0)
+	for _, tx := range bundleTxInner.Transactions {
+		expectedBundleSize += tx.Size()
+	}
+
+	bundleWithSponsorInner, _, err := bundle.ValidateEnvelope(signer, bundleWithSponsorTx)
+	require.NoError(t, err)
+	expectedBundleWithSponsorSize := uint64(0)
+	for _, tx := range bundleWithSponsorInner.Transactions {
+		expectedBundleWithSponsorSize += tx.Size()
+		if subsidies.IsSponsorshipRequest(tx) {
+			expectedBundleWithSponsorSize += subsidies.RlpEncodedFeeChargingTxSizeInBytes
+		}
+	}
+
+	tests := map[string]struct {
+		tx           *types.Transaction
+		expectedSize uint64
+	}{
+		"regular tx": {
+			tx:           basicTx,
+			expectedSize: basicTx.Size(),
+		},
+		"sponsored tx": {
+			tx:           sponsoredTx,
+			expectedSize: sponsoredTx.Size() + subsidies.RlpEncodedFeeChargingTxSizeInBytes,
+		},
+		"bundle tx": {
+			tx:           bundleTx,
+			expectedSize: expectedBundleSize,
+		},
+		"bundle tx with sponsorship request": {
+			tx:           bundleWithSponsorTx,
+			expectedSize: expectedBundleWithSponsorSize,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			context := &runContext{signer: signer, upgrades: opera.Upgrades{
+				Brio:               true,
+				TransactionBundles: true,
+				GasSubsidies:       true,
+			}}
+			size := realTxSize(context, test.tx)
+			require.Equal(t, test.expectedSize, size)
+		})
+	}
 }

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -988,6 +988,7 @@ func TestRunTransactions_RunsAllTransactionsAndCollectsProcessedTransactions(t *
 	context := &runContext{
 		runner:   runner,
 		upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
+		signer:   types.LatestSignerForChainID(big.NewInt(1)),
 	}
 	gomock.InOrder(
 		runner.EXPECT().runRegularTransaction(context, txs[0], 4).Return(
@@ -1072,6 +1073,7 @@ func TestRunTransactions_ProvidesNextIndexAsOriginalIndexPlusNumberOfPreviouslyP
 	}
 
 	context := &runContext{
+		signer: types.LatestSignerForChainID(big.NewInt(1)),
 		runner: runner,
 		upgrades: opera.Upgrades{
 			Brio:               true,
@@ -3686,6 +3688,7 @@ func TestRunTransactions_AccumulatesExecutionCostFromAllTransactions(t *testing.
 	runner := NewMock_transactionRunner(ctrl)
 
 	context := &runContext{
+		signer:   types.LatestSignerForChainID(big.NewInt(1)),
 		runner:   runner,
 		upgrades: opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true},
 	}
@@ -3889,6 +3892,7 @@ func TestRealTransactionSize_CanHandleAllTxTypes(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			context := &runContext{signer: signer, upgrades: opera.Upgrades{
+				Brio:               true,
 				TransactionBundles: true,
 				GasSubsidies:       true,
 			}}
@@ -3923,7 +3927,7 @@ func TestRealTransactionSize_OnlyConsidersSpecialTxsWhenEnabled(t *testing.T) {
 	for name, tx := range tests {
 		t.Run(name, func(t *testing.T) {
 			signer := types.LatestSignerForChainID(big.NewInt(1))
-			upgrades := opera.Upgrades{} // no special tx types enabled
+			upgrades := opera.Upgrades{Brio: true} // no special tx types enabled
 
 			context := &runContext{signer: signer, upgrades: upgrades}
 			size := computeRealTxSize(context, tx)

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -991,15 +991,15 @@ func TestRunTransactions_RunsAllTransactionsAndCollectsProcessedTransactions(t *
 		signer:   types.LatestSignerForChainID(big.NewInt(1)),
 	}
 	gomock.InOrder(
-		runner.EXPECT().runRegularTransaction(context, txs[0], 4).Return(
+		runner.EXPECT().runRegularTransaction(context, txs[0], 4, gomock.Any()).Return(
 			regularTxResult,
 			core_types.TransactionResultSuccessful,
 		),
-		runner.EXPECT().runSponsoredTransaction(context, txs[1], 5).Return(
+		runner.EXPECT().runSponsoredTransaction(context, txs[1], 5, gomock.Any()).Return(
 			sponsoredTxResult,
 			core_types.TransactionResultSuccessful,
 		),
-		runner.EXPECT().runTransactionBundle(context, txs[2], 7).Return(
+		runner.EXPECT().runTransactionBundle(context, txs[2], 7, gomock.Any()).Return(
 			bundleTxResult,
 			core_types.TransactionResultSuccessful,
 			core_types.ExecutionCost(0),
@@ -1084,25 +1084,25 @@ func TestRunTransactions_ProvidesNextIndexAsOriginalIndexPlusNumberOfPreviouslyP
 
 	trueStartIndex := 7
 	gomock.InOrder(
-		runner.EXPECT().runSponsoredTransaction(context, txs[0], trueStartIndex).Return(
+		runner.EXPECT().runSponsoredTransaction(context, txs[0], trueStartIndex, gomock.Any()).Return(
 			sponsoredTxResult1,
 			core_types.TransactionResultSuccessful,
 		),
 		// the sponsored transaction results in two processed transactions: the sponsored transaction itself and an internal fee deduction transaction, so the next transaction should have index startIndex + 2
-		runner.EXPECT().runRegularTransaction(context, txs[1], trueStartIndex+2).Return(
+		runner.EXPECT().runRegularTransaction(context, txs[1], trueStartIndex+2, gomock.Any()).Return(
 			regularTxResult2,
 			core_types.TransactionResultSuccessful,
 		),
 		// the regular transaction has a nil receipt, which does not increase
 		// the transaction offset.
-		runner.EXPECT().runRegularTransaction(context, txs[2], trueStartIndex+2).Return(
+		runner.EXPECT().runRegularTransaction(context, txs[2], trueStartIndex+2, gomock.Any()).Return(
 			regularTxResult3,
 			core_types.TransactionResultSuccessful,
 		),
 		// the bundle transaction has 3 results, one with a nil receipt, but all
 		// should be counted towards the legacy offset of the next transaction,
 		// but only the accepted ones should be counted towards the true offset
-		runner.EXPECT().runTransactionBundle(context, txs[3], trueStartIndex+3).Return(
+		runner.EXPECT().runTransactionBundle(context, txs[3], trueStartIndex+3, gomock.Any()).Return(
 			bundleTxResult4,
 			core_types.TransactionResultSuccessful,
 			core_types.ExecutionCost(0),
@@ -1110,7 +1110,7 @@ func TestRunTransactions_ProvidesNextIndexAsOriginalIndexPlusNumberOfPreviouslyP
 		// the next regular transaction should see all transactions processed
 		// for the bundle transaction, even the one with the nil receipt; the
 		// true index ignores the nil receipts.
-		runner.EXPECT().runRegularTransaction(context, txs[4], trueStartIndex+5).Return(
+		runner.EXPECT().runRegularTransaction(context, txs[4], trueStartIndex+5, gomock.Any()).Return(
 			regularTxResult5,
 			core_types.TransactionResultSuccessful,
 		),
@@ -1142,8 +1142,9 @@ func TestRunTransaction_GasSubsidiesDisabled_ProcessesRegularTransaction(t *test
 				runner:   runner,
 				upgrades: opera.Upgrades{GasSubsidies: false},
 			}
-			runner.EXPECT().runRegularTransaction(context, tx, 0)
-			runTransaction(context, tx, 0)
+			sizeLimit := uint64(1234)
+			runner.EXPECT().runRegularTransaction(context, tx, 0, sizeLimit)
+			runTransaction(context, tx, 0, sizeLimit)
 		})
 	}
 }
@@ -1162,8 +1163,8 @@ func TestRunTransaction_GasSubsidiesEnabled_RunsRegularTransactionWithoutSponsor
 		runner:   runner,
 		upgrades: opera.Upgrades{GasSubsidies: true},
 	}
-	runner.EXPECT().runRegularTransaction(context, tx, 123).Return(processed, core_types.TransactionResultSuccessful)
-	got, status, execCost := runTransaction(context, tx, 123)
+	runner.EXPECT().runRegularTransaction(context, tx, 123, uint64(456)).Return(processed, core_types.TransactionResultSuccessful)
+	got, status, execCost := runTransaction(context, tx, 123, 456)
 	require.Equal(t, []ProcessedTransaction{processed}, got)
 	require.Equal(t, core_types.TransactionResultSuccessful, status)
 	require.EqualValues(t, processed.Receipt.GasUsed, execCost)
@@ -1179,14 +1180,14 @@ func TestRunTransaction_GasSubsidiesEnabled_RunsSponsorshipRequestWithSponsorshi
 		runner:   runner,
 		upgrades: opera.Upgrades{GasSubsidies: true},
 	}
-	runner.EXPECT().runSponsoredTransaction(context, tx, 123).Return(
+	runner.EXPECT().runSponsoredTransaction(context, tx, 123, uint64(456)).Return(
 		[]ProcessedTransaction{{
 			Transaction: tx,
 			Receipt:     &types.Receipt{GasUsed: 1},
 		}},
 		core_types.TransactionResultSuccessful,
 	)
-	processed, status, execCost := runTransaction(context, tx, 123)
+	processed, status, execCost := runTransaction(context, tx, 123, 456)
 	require.Equal(t, core_types.TransactionResultSuccessful, status)
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1209,8 +1210,8 @@ func TestRunTransaction_GasSubsidiesEnabled_ForReplay_RunsSponsorshipRequestAsRe
 		upgrades:  opera.Upgrades{GasSubsidies: true},
 		forReplay: true,
 	}
-	runner.EXPECT().runRegularTransaction(context, tx, 123).Return(processed, core_types.TransactionResultSuccessful)
-	got, status, execCost := runTransaction(context, tx, 123)
+	runner.EXPECT().runRegularTransaction(context, tx, 123, uint64(456)).Return(processed, core_types.TransactionResultSuccessful)
+	got, status, execCost := runTransaction(context, tx, 123, 456)
 	require.Equal(t, []ProcessedTransaction{processed}, got)
 	require.Equal(t, core_types.TransactionResultSuccessful, status)
 	require.Equal(t, core_types.ExecutionCost(1), execCost)
@@ -1226,14 +1227,15 @@ func TestRunTransactions_GasSubsidiesDisabled_BundlesDisabled_ProcessesAsRegular
 		runner:   runner,
 		upgrades: opera.Upgrades{TransactionBundles: false, GasSubsidies: false},
 	}
-	runner.EXPECT().runRegularTransaction(context, tx, 123).Return(
+	sizeLimit := uint64(math.MaxUint64)
+	runner.EXPECT().runRegularTransaction(context, tx, 123, sizeLimit).Return(
 		ProcessedTransaction{
 			Transaction: tx,
 			Receipt:     nil,
 		},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, sizeLimit)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1250,7 +1252,8 @@ func TestRunTransactions_GasSubsidiesEnabled_BundlesDisabled_ProcessesAsSponsors
 		runner:   runner,
 		upgrades: opera.Upgrades{TransactionBundles: false, GasSubsidies: true},
 	}
-	runner.EXPECT().runSponsoredTransaction(context, tx, 123).Return(
+	sizeLimit := uint64(math.MaxUint64)
+	runner.EXPECT().runSponsoredTransaction(context, tx, 123, sizeLimit).Return(
 		[]ProcessedTransaction{{
 
 			Transaction: tx,
@@ -1258,7 +1261,7 @@ func TestRunTransactions_GasSubsidiesEnabled_BundlesDisabled_ProcessesAsSponsors
 		}},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, sizeLimit)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1275,14 +1278,15 @@ func TestRunTransactions_BundlesEnabled_RunsRegularTransactionOnItsOwn(t *testin
 		runner:   runner,
 		upgrades: opera.Upgrades{TransactionBundles: true},
 	}
-	runner.EXPECT().runRegularTransaction(context, tx, 123).Return(
+	sizeLimit := uint64(math.MaxUint64)
+	runner.EXPECT().runRegularTransaction(context, tx, 123, sizeLimit).Return(
 		ProcessedTransaction{
 			Transaction: tx,
 			Receipt:     nil,
 		},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, sizeLimit)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1299,14 +1303,15 @@ func TestRunTransactions_BundlesEnabled_RunsSponsorshipRequestWithSponsorship(t 
 		runner:   runner,
 		upgrades: opera.Upgrades{GasSubsidies: true, TransactionBundles: true},
 	}
-	runner.EXPECT().runSponsoredTransaction(context, tx, 123).Return(
+	sizeLimit := uint64(math.MaxUint64)
+	runner.EXPECT().runSponsoredTransaction(context, tx, 123, sizeLimit).Return(
 		[]ProcessedTransaction{{
 			Transaction: tx,
 			Receipt:     nil,
 		}},
 		core_types.TransactionResultSuccessful,
 	)
-	summary := runTransactions(context, []*types.Transaction{tx}, 123, math.MaxUint64)
+	summary := runTransactions(context, []*types.Transaction{tx}, 123, sizeLimit)
 	processed := summary.ProcessedTransactions
 	require.Len(t, processed, 1)
 	require.Equal(t, tx, processed[0].Transaction)
@@ -1391,16 +1396,17 @@ func TestRunTransactions_EnvelopeAndBundleOnly_SemanticsEnabledByBrio_ExecutionE
 				},
 			}
 
+			sizeLimit := uint64(math.MaxUint64)
 			if tc.expectRunRegular {
-				runner.EXPECT().runRegularTransaction(context, tc.tx, 0).
+				runner.EXPECT().runRegularTransaction(context, tc.tx, 0, sizeLimit).
 					Return(ProcessedTransaction{Transaction: tc.tx, Receipt: &types.Receipt{}}, core_types.TransactionResultSuccessful)
 			}
 			if tc.expectRunBundle {
-				runner.EXPECT().runTransactionBundle(context, tc.tx, 0).
+				runner.EXPECT().runTransactionBundle(context, tc.tx, 0, sizeLimit).
 					Return([]ProcessedTransaction{{Transaction: tc.tx, Receipt: &types.Receipt{}}}, core_types.TransactionResultSuccessful, core_types.ExecutionCost(0))
 			}
 
-			summary := runTransactions(context, []*types.Transaction{tc.tx}, 0, math.MaxUint64)
+			summary := runTransactions(context, []*types.Transaction{tc.tx}, 0, sizeLimit)
 			processed := summary.ProcessedTransactions
 			require.Len(t, processed, 1)
 			if tc.expectInvalid {
@@ -1454,11 +1460,11 @@ func TestRunTransactions_BundleOnlyTxsAreNotFilteredDuringReplay(t *testing.T) {
 				},
 				forReplay: true, // this is the relevant part for this test
 			}
-
-			runner.EXPECT().runRegularTransaction(context, bundleOnlyTx, 0).
+			sizeLimit := uint64(math.MaxUint64)
+			runner.EXPECT().runRegularTransaction(context, bundleOnlyTx, 0, sizeLimit).
 				Return(ProcessedTransaction{Transaction: bundleOnlyTx, Receipt: &types.Receipt{}}, core_types.TransactionResultSuccessful)
 
-			summary := runTransactions(context, []*types.Transaction{bundleOnlyTx}, 0, math.MaxUint64)
+			summary := runTransactions(context, []*types.Transaction{bundleOnlyTx}, 0, sizeLimit)
 			processed := summary.ProcessedTransactions
 			require.Len(t, processed, 1)
 			require.Equal(t, ProcessedTransaction{bundleOnlyTx, &types.Receipt{}}, processed[0])
@@ -1551,7 +1557,8 @@ func TestRunSponsoredTransaction_InsufficientGas_SkipsTransaction(t *testing.T) 
 			}
 
 			runner := &transactionRunner{evm: evm}
-			got, status := runner.runSponsoredTransaction(context, tx, 0)
+			sizeLimit := uint64(math.MaxUint64)
+			got, status := runner.runSponsoredTransaction(context, tx, 0, sizeLimit)
 			if test.shouldSkip {
 				require.Equal(t, core_types.TransactionResultInvalid, status)
 			} else {
@@ -1595,7 +1602,8 @@ func TestRunSponsoredTransaction_SponsorshipNotCovered_ReturnsASkippedTransactio
 	}
 
 	runner := &transactionRunner{}
-	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	sizeLimit := uint64(math.MaxUint64)
+	got, status := runner.runSponsoredTransaction(context, tx, 0, sizeLimit)
 	require.Equal(t, core_types.TransactionResultInvalid, status)
 	want := []ProcessedTransaction{{
 		Transaction: tx,
@@ -1630,7 +1638,8 @@ func TestRunSponsoredTransaction_SponsorshipCoverageCheckFails_ReturnsASkippedTr
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	sizeLimit := uint64(math.MaxUint64)
+	got, status := runner.runSponsoredTransaction(context, tx, 0, sizeLimit)
 	require.Equal(t, core_types.TransactionResultInvalid, status)
 	want := []ProcessedTransaction{{
 		Transaction: tx,
@@ -1674,7 +1683,8 @@ func TestRunSponsoredTransaction_SponsoredTransactionIsSkipped_NoFeeDeductionTxI
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	sizeLimit := uint64(math.MaxUint64)
+	got, status := runner.runSponsoredTransaction(context, tx, 0, sizeLimit)
 	require.Equal(t, core_types.TransactionResultInvalid, status)
 	want := []ProcessedTransaction{{
 		Transaction: tx,
@@ -1743,7 +1753,8 @@ func TestRunSponsoredTransaction_FailingCreationOfFeeDeduction_TransactionIsAcce
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	sizeLimit := uint64(math.MaxUint64)
+	got, status := runner.runSponsoredTransaction(context, tx, 0, sizeLimit)
 	require.Equal(t, core_types.TransactionResultSuccessful, status)
 	want := []ProcessedTransaction{processed}
 	require.Equal(t, want, got)
@@ -1796,8 +1807,9 @@ func TestRunSponsoredTransaction_FeeDeductionTxIsSkipped_TransactionIsAcceptedWi
 		upgrades: opera.Upgrades{GasSubsidies: true},
 	}
 
+	sizeLimit := uint64(math.MaxUint64)
 	runner := &transactionRunner{evm: evm}
-	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0, sizeLimit)
 	require.Equal(t, core_types.TransactionResultSuccessful, status)
 	want := []ProcessedTransaction{
 		processedSponsoredTransaction,
@@ -1854,9 +1866,9 @@ func TestRunSponsoredTransaction_FeeDeductionTxFails_TransactionIsAcceptedWithou
 		gasPool:  gasPool,
 		upgrades: opera.Upgrades{GasSubsidies: true},
 	}
-
+	sizeLimit := uint64(math.MaxUint64)
 	runner := &transactionRunner{evm: evm}
-	got, status := runner.runSponsoredTransaction(context, tx, 0)
+	got, status := runner.runSponsoredTransaction(context, tx, 0, sizeLimit)
 	require.Equal(t, core_types.TransactionResultSuccessful, status)
 	want := []ProcessedTransaction{
 		processedSponsoredTransaction,
@@ -1908,7 +1920,8 @@ func TestRunSponsoredTransaction_TxIndexIsIncrementedForFeeDeductionTx(t *testin
 	}
 
 	runner := &transactionRunner{evm: evm}
-	got, status := runner.runSponsoredTransaction(context, tx, txIndex)
+	sizeLimit := uint64(math.MaxUint64)
+	got, status := runner.runSponsoredTransaction(context, tx, txIndex, sizeLimit)
 	require.Equal(t, core_types.TransactionResultFailed, status)
 	require.Len(t, got, 2)
 	require.Equal(t, tx, got[0].Transaction)
@@ -2078,7 +2091,7 @@ func TestRunSponsoredTransaction_CoveredTransaction_ProcessesTwoTransactionsSucc
 
 	// --- start of actual test ---
 
-	processedTransactions, status := runner.runSponsoredTransaction(context, tx, txIndex)
+	processedTransactions, status := runner.runSponsoredTransaction(context, tx, txIndex, math.MaxUint64)
 	require.Equal(core_types.TransactionResultSuccessful, status)
 
 	// the transaction should be sponsored successfully
@@ -2216,7 +2229,7 @@ func TestRunSponsoredTransaction_MatchesCoveredAndReceiptToStatus(t *testing.T) 
 			}
 
 			runner := transactionRunner{evm}
-			_, status := runner.runSponsoredTransaction(ctxt, tx, txIndex)
+			_, status := runner.runSponsoredTransaction(ctxt, tx, txIndex, math.MaxUint64)
 			require.Equal(t, test.status, status)
 		})
 	}
@@ -2235,7 +2248,7 @@ func TestRunTransactionBundle_BundlesDisabled_ReturnsEnvelopeAndResultInvalid(t 
 
 	runner := &transactionRunner{}
 
-	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log)
+	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log, math.MaxUint64)
 	require.Len(t, processedTransactions, 1)
 	require.Equal(t, tx, processedTransactions[0].Transaction)
 	require.Nil(t, processedTransactions[0].Receipt)
@@ -2258,7 +2271,7 @@ func TestRunTransactionBundle_InvalidEnvelope_ReturnsEnvelopeAndResultInvalid(t 
 
 	runner := &transactionRunner{}
 
-	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log)
+	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log, math.MaxUint64)
 	require.Len(t, processedTransactions, 1)
 	require.Equal(t, tx, processedTransactions[0].Transaction)
 	require.Nil(t, processedTransactions[0].Receipt)
@@ -2297,7 +2310,7 @@ func TestRunTransactionBundle_BundleOutOfRange_ReturnsEnvelopeAndResultInvalid(t
 
 	runner := &transactionRunner{}
 
-	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log)
+	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log, math.MaxUint64)
 	require.Len(t, processedTransactions, 1)
 	require.Equal(t, tx, processedTransactions[0].Transaction)
 	require.Nil(t, processedTransactions[0].Receipt)
@@ -2337,7 +2350,7 @@ func TestRunTransactionBundle_BundleOutOfTime_ReturnsEnvelopeAndResultInvalid(t 
 
 	runner := &transactionRunner{}
 
-	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log)
+	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log, math.MaxUint64)
 	require.Len(t, processedTransactions, 1)
 	require.Equal(t, tx, processedTransactions[0].Transaction)
 	require.Nil(t, processedTransactions[0].Receipt)
@@ -2369,7 +2382,7 @@ func TestRunTransactionBundle_PreviouslyProcessedBundle_ReturnsEnvelopeAndResult
 
 	runner := &transactionRunner{}
 
-	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log)
+	processedTransactions, result, execCost := runner.runTransactionBundleInternal(context, tx, 0, log, math.MaxUint64)
 	require.Len(t, processedTransactions, 1)
 	require.Equal(t, tx, processedTransactions[0].Transaction)
 	require.Nil(t, processedTransactions[0].Receipt)
@@ -2412,7 +2425,7 @@ func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResu
 
 	runner := &transactionRunner{evm: evm}
 
-	processedTransactions, result, execCost := runner.runTransactionBundle(context, tx, txOffset)
+	processedTransactions, result, execCost := runner.runTransactionBundle(context, tx, txOffset, math.MaxUint64)
 	require.Len(t, processedTransactions, 0)
 	require.Equal(t, core_types.TransactionResultFailed, result)
 	require.Zero(t, execCost)
@@ -2434,7 +2447,8 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReturnsBundleOnlyTransactionAn
 
 	gomock.InOrder(
 		state.EXPECT().HasBundleRecentlyBeenProcessed(plan.Hash()),
-		state.EXPECT().InterTxSnapshot().Return(1),
+		state.EXPECT().InterTxSnapshot().Return(0), // < snapshot for size check
+		state.EXPECT().InterTxSnapshot().Return(1), // < snapshot for execution
 		state.EXPECT().AddProcessedBundle(plan.Hash(), bundle.PositionInBlock{
 			Offset: uint32(trueTxOffset),
 			Count:  1,
@@ -2462,7 +2476,7 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReturnsBundleOnlyTransactionAn
 			Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: txs[0].Gas()},
 		})
 
-	processedTransactions, result, execCost := runner.runTransactionBundle(context, envelope, trueTxOffset)
+	processedTransactions, result, execCost := runner.runTransactionBundle(context, envelope, trueTxOffset, math.MaxUint64)
 	require.Len(t, processedTransactions, 1)
 	require.Equal(t, txs[0], processedTransactions[0].Transaction)
 	require.NotNil(t, processedTransactions[0].Receipt)
@@ -2538,6 +2552,7 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 			state := state.NewMockStateDB(ctrl)
 			gomock.InOrder(
 				state.EXPECT().HasBundleRecentlyBeenProcessed(gomock.Any()),
+				state.EXPECT().InterTxSnapshot().Return(0),
 				state.EXPECT().InterTxSnapshot().Return(1),
 				state.EXPECT().AddProcessedBundle(gomock.Any(), bundle.PositionInBlock{
 					Offset: test.offset, // < these two fields are the main test targets
@@ -2554,13 +2569,13 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 					receipt = &types.Receipt{GasUsed: 1}
 				}
 				execResult = append(execResult, ProcessedTransaction{
-					Transaction: &types.Transaction{},
+					Transaction: types.NewTx(&types.LegacyTx{}),
 					Receipt:     receipt,
 				})
 			}
 
 			innerRunner := NewMock_transactionRunner(ctrl)
-			innerRunner.EXPECT().runSponsoredTransaction(gomock.Any(), gomock.Any(), int(trueTxOffset)).Return(
+			innerRunner.EXPECT().runSponsoredTransaction(gomock.Any(), gomock.Any(), int(trueTxOffset), uint64(math.MaxUint64)).Return(
 				execResult, core_types.TransactionResultSuccessful,
 			)
 
@@ -2578,7 +2593,7 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 			}
 
 			runner := &transactionRunner{}
-			processedTransactions, result, execCost := runner.runTransactionBundle(context, envelope, int(trueTxOffset))
+			processedTransactions, result, execCost := runner.runTransactionBundle(context, envelope, int(trueTxOffset), math.MaxUint64)
 			require.Equal(t, execResult, processedTransactions)
 			require.Equal(t, core_types.TransactionResultSuccessful, result)
 			execCostExpected := uint64(0)
@@ -2661,7 +2676,7 @@ func TestRunRegularTransaction_InternalTransactions_SkipsTransactionChecksTrue(t
 	require.True(t, internaltx.IsInternal(unsignedTx))
 
 	// run an internal transaction with gas over the max tx gas limit.
-	got, status := runner.runRegularTransaction(context, unsignedTx, 0)
+	got, status := runner.runRegularTransaction(context, unsignedTx, 0, math.MaxUint64)
 	require.Equal(t, core_types.TransactionResultSuccessful, status)
 
 	require.Equal(t, unsignedTx, got.Transaction)
@@ -2675,7 +2690,7 @@ func TestRunRegularTransaction_InternalTransactions_SkipsTransactionChecksTrue(t
 	regularTx := types.MustSignNewTx(key, signer, &types.LegacyTx{
 		Nonce: 0, To: &common.Address{1}, Gas: maxTxGas * 2, GasPrice: big.NewInt(1),
 	})
-	got, status = runner.runRegularTransaction(context, regularTx, 0)
+	got, status = runner.runRegularTransaction(context, regularTx, 0, math.MaxUint64)
 	require.Equal(t, core_types.TransactionResultInvalid, status)
 	require.Equal(t, regularTx, got.Transaction)
 	require.Nil(t, got.Receipt)
@@ -2788,7 +2803,7 @@ func TestRunRegularTransaction_RegularTransaction(t *testing.T) {
 				Nonce: 0, To: &common.Address{1}, Gas: maxTxGas + 1, GasPrice: big.NewInt(1),
 			})
 
-			got, status := runner.runRegularTransaction(context, regularTx, 0)
+			got, status := runner.runRegularTransaction(context, regularTx, 0, math.MaxUint64)
 			require.Equal(t, test.status, status)
 
 			require.Equal(t, regularTx, got.Transaction)
@@ -2822,7 +2837,7 @@ func TestRunRegularTransaction_MatchesReceiptToStatus(t *testing.T) {
 			evm := NewMock_evm(ctrl)
 
 			ctxt := &runContext{}
-			tx := &types.Transaction{}
+			tx := types.NewTx(&types.LegacyTx{})
 
 			evm.EXPECT().runWithBaseFeeCheck(ctxt, tx, 12).Return(
 				ProcessedTransaction{
@@ -2832,7 +2847,7 @@ func TestRunRegularTransaction_MatchesReceiptToStatus(t *testing.T) {
 			)
 
 			runner := transactionRunner{evm}
-			_, status := runner.runRegularTransaction(ctxt, tx, 12)
+			_, status := runner.runRegularTransaction(ctxt, tx, 12, math.MaxUint64)
 			require.Equal(t, test.status, status)
 		})
 	}
@@ -2842,7 +2857,17 @@ func TestBundleTransactionRunner_Run_KeepsTrackOfProcessedTransactions(t *testin
 	ctrl := gomock.NewController(t)
 	runner := NewMock_transactionRunner(ctrl)
 
-	ctxt := &runContext{runner: runner, upgrades: opera.Upgrades{GasSubsidies: true}}
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+	stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
+	ctxt := &runContext{
+		runner:   runner,
+		upgrades: opera.Upgrades{GasSubsidies: true},
+		gasPool:  core.NewGasPool(math.MaxUint64),
+		usedGas:  new(uint64),
+		statedb:  stateDb,
+	}
 	bundleTransactionRunner := &bundleTransactionRunner{ctxt: ctxt}
 
 	tx1 := getRegularTransaction(t)
@@ -2850,11 +2875,11 @@ func TestBundleTransactionRunner_Run_KeepsTrackOfProcessedTransactions(t *testin
 	tx2payment := getSponsorshipRequest(t) // some dummy tx
 	tx3 := getRegularTransaction(t)
 
-	runner.EXPECT().runRegularTransaction(ctxt, tx1, gomock.Any()).
+	runner.EXPECT().runRegularTransaction(ctxt, tx1, gomock.Any(), gomock.Any()).
 		Return(ProcessedTransaction{Transaction: tx1}, core_types.TransactionResultSuccessful)
-	runner.EXPECT().runSponsoredTransaction(ctxt, tx2, gomock.Any()).
+	runner.EXPECT().runSponsoredTransaction(ctxt, tx2, gomock.Any(), gomock.Any()).
 		Return([]ProcessedTransaction{{Transaction: tx2}, {Transaction: tx2payment}}, core_types.TransactionResultFailed)
-	runner.EXPECT().runRegularTransaction(ctxt, tx3, gomock.Any()).
+	runner.EXPECT().runRegularTransaction(ctxt, tx3, gomock.Any(), gomock.Any()).
 		Return(ProcessedTransaction{Transaction: tx3}, core_types.TransactionResultInvalid)
 
 	// one processed transaction with status successful
@@ -2882,12 +2907,23 @@ func TestBundleTransactionRunner_Run_IncrementsTrueOffsetBasedOnProcessedTransac
 	ctrl := gomock.NewController(t)
 	runner := NewMock_transactionRunner(ctrl)
 
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+	stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
 	trueStartOffset := 50
 
-	ctxt := &runContext{runner: runner, upgrades: opera.Upgrades{GasSubsidies: true}}
+	ctxt := &runContext{
+		runner:   runner,
+		upgrades: opera.Upgrades{GasSubsidies: true},
+		gasPool:  core.NewGasPool(math.MaxUint64),
+		usedGas:  new(uint64),
+		statedb:  stateDb,
+	}
 	bundleTransactionRunner := &bundleTransactionRunner{
 		ctxt:         ctxt,
 		trueTxOffset: trueStartOffset,
+		sizeLimit:    math.MaxUint64,
 	}
 
 	tx1 := getRegularTransaction(t)
@@ -2895,24 +2931,30 @@ func TestBundleTransactionRunner_Run_IncrementsTrueOffsetBasedOnProcessedTransac
 	tx3 := getSponsorshipRequest(t)
 	tx4 := getRegularTransaction(t)
 
-	runner.EXPECT().runRegularTransaction(ctxt, tx1, gomock.Any()).
+	runner.EXPECT().runRegularTransaction(ctxt, tx1, gomock.Any(), gomock.Any()).
 		Return(
-			ProcessedTransaction{Receipt: &types.Receipt{}},
+			ProcessedTransaction{Transaction: tx1, Receipt: &types.Receipt{}},
 			core_types.TransactionResultSuccessful,
 		)
-	runner.EXPECT().runSponsoredTransaction(ctxt, tx2, gomock.Any()).
+	runner.EXPECT().runSponsoredTransaction(ctxt, tx2, gomock.Any(), gomock.Any()).
 		Return(
-			[]ProcessedTransaction{{Receipt: &types.Receipt{}}, {Receipt: &types.Receipt{}}},
+			[]ProcessedTransaction{
+				{Transaction: tx2, Receipt: &types.Receipt{}},
+				{Transaction: tx2, Receipt: &types.Receipt{}},
+			},
 			core_types.TransactionResultFailed,
 		)
-	runner.EXPECT().runSponsoredTransaction(ctxt, tx3, gomock.Any()).
+	runner.EXPECT().runSponsoredTransaction(ctxt, tx3, gomock.Any(), gomock.Any()).
 		Return(
-			[]ProcessedTransaction{{Receipt: &types.Receipt{}}, {Receipt: nil}},
+			[]ProcessedTransaction{
+				{Transaction: tx3, Receipt: &types.Receipt{}},
+				{Transaction: tx3, Receipt: nil},
+			},
 			core_types.TransactionResultInvalid,
 		)
-	runner.EXPECT().runRegularTransaction(ctxt, tx4, gomock.Any()).
+	runner.EXPECT().runRegularTransaction(ctxt, tx4, gomock.Any(), gomock.Any()).
 		Return(
-			ProcessedTransaction{Receipt: nil},
+			ProcessedTransaction{Transaction: tx4, Receipt: nil},
 			core_types.TransactionResultSuccessful,
 		)
 
@@ -3048,7 +3090,16 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToRegularTxC
 			ctrl := gomock.NewController(t)
 			runner := NewMock_transactionRunner(ctrl)
 
-			ctxt := &runContext{runner: runner}
+			stateDb := state.NewMockStateDB(ctrl)
+			stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+			stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
+			ctxt := &runContext{
+				runner:  runner,
+				gasPool: core.NewGasPool(math.MaxUint64),
+				usedGas: new(uint64),
+				statedb: stateDb,
+			}
 			bundleTransactionRunner := &bundleTransactionRunner{
 				ctxt:         ctxt,
 				trueTxOffset: offset + 1,
@@ -3056,7 +3107,7 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToRegularTxC
 
 			tx := getRegularTransaction(t)
 
-			runner.EXPECT().runRegularTransaction(ctxt, tx, offset+1)
+			runner.EXPECT().runRegularTransaction(ctxt, tx, offset+1, gomock.Any())
 			bundleTransactionRunner.Run(tx)
 		})
 	}
@@ -3068,7 +3119,17 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToSponsoredT
 			ctrl := gomock.NewController(t)
 			runner := NewMock_transactionRunner(ctrl)
 
-			ctxt := &runContext{runner: runner, upgrades: opera.Upgrades{GasSubsidies: true}}
+			stateDb := state.NewMockStateDB(ctrl)
+			stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+			stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
+			ctxt := &runContext{
+				runner:   runner,
+				upgrades: opera.Upgrades{GasSubsidies: true},
+				gasPool:  core.NewGasPool(math.MaxUint64),
+				usedGas:  new(uint64),
+				statedb:  stateDb,
+			}
 			bundleTransactionRunner := &bundleTransactionRunner{
 				ctxt:         ctxt,
 				trueTxOffset: offset + 1,
@@ -3076,7 +3137,7 @@ func TestBundleTransactionRunner_Run_ForwardsLegacyTransactionOffsetToSponsoredT
 
 			tx := getSponsorshipRequest(t)
 
-			runner.EXPECT().runSponsoredTransaction(ctxt, tx, offset+1)
+			runner.EXPECT().runSponsoredTransaction(ctxt, tx, offset+1, gomock.Any())
 			bundleTransactionRunner.Run(tx)
 		})
 	}
@@ -3088,8 +3149,18 @@ func TestBundleTransactionRunner_Run_ForwardsTrueTransactionOffsetToBundleTxCall
 			ctrl := gomock.NewController(t)
 			runner := NewMock_transactionRunner(ctrl)
 
+			stateDb := state.NewMockStateDB(ctrl)
+			stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+			stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
 			upgrades := opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true}
-			ctxt := &runContext{runner: runner, upgrades: upgrades}
+			ctxt := &runContext{
+				runner:   runner,
+				upgrades: upgrades,
+				gasPool:  core.NewGasPool(math.MaxUint64),
+				usedGas:  new(uint64),
+				statedb:  stateDb,
+			}
 			bundleTransactionRunner := &bundleTransactionRunner{
 				ctxt:         ctxt,
 				trueTxOffset: trueOffset,
@@ -3097,7 +3168,7 @@ func TestBundleTransactionRunner_Run_ForwardsTrueTransactionOffsetToBundleTxCall
 
 			tx := getTransactionBundle(t)
 
-			runner.EXPECT().runTransactionBundle(ctxt, tx, trueOffset)
+			runner.EXPECT().runTransactionBundle(ctxt, tx, trueOffset, gomock.Any())
 			bundleTransactionRunner.Run(tx)
 		})
 	}
@@ -3130,17 +3201,32 @@ func TestBundleTransactionRunner_Run_UpdatesTxIndexBasedOnNumberOfAcceptedTransa
 			ctrl := gomock.NewController(t)
 			runner := NewMock_transactionRunner(ctrl)
 
+			stateDb := state.NewMockStateDB(ctrl)
+			stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+			stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
 			trueStartOffset := 7
 
-			ctxt := &runContext{runner: runner, upgrades: opera.Upgrades{GasSubsidies: true}}
+			ctxt := &runContext{
+				runner:   runner,
+				upgrades: opera.Upgrades{GasSubsidies: true},
+				gasPool:  core.NewGasPool(math.MaxUint64),
+				usedGas:  new(uint64),
+				statedb:  stateDb,
+			}
 			bundleTransactionRunner := &bundleTransactionRunner{
 				ctxt:         ctxt,
 				trueTxOffset: trueStartOffset,
+				sizeLimit:    math.MaxUint64,
 			}
 
 			tx := getSponsorshipRequest(t)
 
-			runner.EXPECT().runSponsoredTransaction(ctxt, tx, trueStartOffset).Return(
+			for i := range test.execResult {
+				test.execResult[i].Transaction = types.NewTx(&types.LegacyTx{})
+			}
+
+			runner.EXPECT().runSponsoredTransaction(ctxt, tx, trueStartOffset, gomock.Any()).Return(
 				test.execResult,
 				core_types.TransactionResultSuccessful,
 			)
@@ -3216,14 +3302,27 @@ func TestBundleTransactionRunner_Run_CollectsProcessedTransactionsInOrder(t *tes
 
 	for i, tx := range txs {
 		require.True(t, subsidies.IsSponsorshipRequest(tx))
-		txRunner.EXPECT().runSponsoredTransaction(gomock.Any(), tx, gomock.Any()).Return(
+		txRunner.EXPECT().runSponsoredTransaction(gomock.Any(), tx, gomock.Any(), gomock.Any()).Return(
 			results[i],
 			core_types.TransactionResultSuccessful,
 		)
 	}
 
-	ctxt := &runContext{runner: txRunner, upgrades: opera.Upgrades{GasSubsidies: true}}
-	runner := &bundleTransactionRunner{ctxt: ctxt}
+	stateDb := state.NewMockStateDB(ctrl)
+	stateDb.EXPECT().InterTxSnapshot().Return(1).AnyTimes()
+	stateDb.EXPECT().RevertToInterTxSnapshot(1).AnyTimes()
+
+	ctxt := &runContext{
+		runner:   txRunner,
+		upgrades: opera.Upgrades{GasSubsidies: true},
+		gasPool:  core.NewGasPool(math.MaxUint64),
+		usedGas:  new(uint64),
+		statedb:  stateDb,
+	}
+	runner := &bundleTransactionRunner{
+		ctxt:      ctxt,
+		sizeLimit: math.MaxUint64,
+	}
 
 	var want []ProcessedTransaction
 	require.Equal(t, want, runner.processedTransactions)
@@ -3494,10 +3593,10 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 
 			// regular transactions all pass, but we check whether the
 			// given nonce matches the transaction index.
-			runner.EXPECT().runRegularTransaction(any, any, any).DoAndReturn(
+			runner.EXPECT().runRegularTransaction(any, any, any, any).DoAndReturn(
 				func(
 					ctxt *runContext, tx *types.Transaction,
-					trueTxOffset int,
+					trueTxOffset int, sizeLimit uint64,
 				) (ProcessedTransaction, core_types.TransactionResult) {
 					require.Equal(int(tx.Value().Int64()), trueTxOffset)
 					seenTxNonces = append(seenTxNonces, int(tx.Nonce()))
@@ -3518,10 +3617,10 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 
 			// sponsored transactions all pass and produce two successful
 			// processed transactions, the sponsored and the payment tx
-			runner.EXPECT().runSponsoredTransaction(any, any, any).DoAndReturn(
+			runner.EXPECT().runSponsoredTransaction(any, any, any, any).DoAndReturn(
 				func(
 					ctxt *runContext, tx *types.Transaction,
-					trueTxOffset int,
+					trueTxOffset int, sizeLimit uint64,
 				) ([]ProcessedTransaction, core_types.TransactionResult) {
 					require.Equal(int(tx.Value().Int64()), trueTxOffset)
 					seenTxNonces = append(seenTxNonces, int(tx.Nonce()))
@@ -3531,7 +3630,7 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 							Receipt:     &types.Receipt{},
 						},
 						{
-							Transaction: &types.Transaction{},
+							Transaction: types.NewTx(&types.LegacyTx{}), // < the payment transaction, we don't care about the details here
 							Receipt:     &types.Receipt{},
 						},
 					}, core_types.TransactionResultSuccessful
@@ -3539,7 +3638,7 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 			).AnyTimes()
 
 			// bundle envelopes are opened and executed
-			runner.EXPECT().runTransactionBundle(any, any, any).DoAndReturn(
+			runner.EXPECT().runTransactionBundle(any, any, any, any).DoAndReturn(
 				// we want to use the real implementation here to check the
 				// correct forwarding of the transaction indices
 				new(transactionRunner).runTransactionBundle,
@@ -3567,7 +3666,7 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 			}
 
 			// the actual execution of the test case
-			runTransaction(ctxt, tx, 0)
+			runTransaction(ctxt, tx, 0, math.MaxUint64)
 
 			// make sure that all transactions have indeed been processed
 			wantedTxNonces := collectAllReferencedTransactionNonces(t, signer, tx)
@@ -3700,18 +3799,18 @@ func TestRunTransactions_AccumulatesExecutionCostFromAllTransactions(t *testing.
 	}
 
 	gomock.InOrder(
-		runner.EXPECT().runRegularTransaction(context, txs[0], 0).Return(
+		runner.EXPECT().runRegularTransaction(context, txs[0], 0, gomock.Any()).Return(
 			ProcessedTransaction{Transaction: txs[0], Receipt: &types.Receipt{GasUsed: 100}},
 			core_types.TransactionResultSuccessful,
 		),
-		runner.EXPECT().runSponsoredTransaction(context, txs[1], 1).Return(
+		runner.EXPECT().runSponsoredTransaction(context, txs[1], 1, gomock.Any()).Return(
 			[]ProcessedTransaction{
 				{Transaction: txs[1], Receipt: &types.Receipt{GasUsed: 200}},
 				{Transaction: types.NewTx(&types.LegacyTx{}), Receipt: &types.Receipt{GasUsed: 300}},
 			},
 			core_types.TransactionResultSuccessful,
 		),
-		runner.EXPECT().runTransactionBundle(context, txs[2], 3).Return(
+		runner.EXPECT().runTransactionBundle(context, txs[2], 3, gomock.Any()).Return(
 			[]ProcessedTransaction{{Transaction: txs[2], Receipt: &types.Receipt{GasUsed: 400}}},
 			core_types.TransactionResultSuccessful,
 			core_types.ExecutionCost(500), // higher than receipt gas
@@ -3746,12 +3845,12 @@ func TestRunTransaction_RegularTransaction_ReturnsExecutionCostFromReceipt(t *te
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			runner.EXPECT().runRegularTransaction(context, tx, 0).Return(
+			runner.EXPECT().runRegularTransaction(context, tx, 0, gomock.Any()).Return(
 				ProcessedTransaction{Transaction: tx, Receipt: tc.receipt},
 				core_types.TransactionResultSuccessful,
 			)
 
-			_, _, execCost := runTransaction(context, tx, 0)
+			_, _, execCost := runTransaction(context, tx, 0, math.MaxUint64)
 			require.Equal(t, tc.expectExecCost, execCost)
 		})
 	}
@@ -3785,7 +3884,7 @@ func TestRunTransaction_SponsoredTransaction_ReturnsExecutionCostFromReceipts(t 
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			runner.EXPECT().runSponsoredTransaction(context, tx, 0).Return(
+			runner.EXPECT().runSponsoredTransaction(context, tx, 0, gomock.Any()).Return(
 				[]ProcessedTransaction{
 					{Transaction: tx, Receipt: tc.receipts[0]},
 					{Transaction: &types.Transaction{}, Receipt: tc.receipts[1]},
@@ -3793,7 +3892,7 @@ func TestRunTransaction_SponsoredTransaction_ReturnsExecutionCostFromReceipts(t 
 				core_types.TransactionResultSuccessful,
 			)
 
-			_, _, execCost := runTransaction(context, tx, 0)
+			_, _, execCost := runTransaction(context, tx, 0, math.MaxUint64)
 			require.Equal(t, tc.expectExecCost, execCost)
 		})
 	}
@@ -3812,130 +3911,17 @@ func TestRunTransaction_Bundle_ReturnsExecutionCostFromBundleExecution(t *testin
 		},
 	}
 
-	runner.EXPECT().runTransactionBundle(context, tx, 0).Return(
+	runner.EXPECT().runTransactionBundle(context, tx, 0, gomock.Any()).Return(
 		[]ProcessedTransaction{{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100_000}}},
 		core_types.TransactionResultSuccessful,
 		core_types.ExecutionCost(150_000), // higher than receipt gas due to rolled-back steps
 	)
 
-	_, _, execCost := runTransaction(context, tx, 0)
+	_, _, execCost := runTransaction(context, tx, 0, math.MaxUint64)
 	require.Equal(t, core_types.ExecutionCost(150_000), execCost)
 }
 
-func TestRealTransactionSize_CanHandleAllTxTypes(t *testing.T) {
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-	signer := types.LatestSignerForChainID(big.NewInt(1))
-
-	basicTx := types.NewTx(&types.AccessListTx{
-		To:       &common.Address{0x42},
-		GasPrice: big.NewInt(100),
-		V:        big.NewInt(1),
-	})
-
-	sponsoredTx := types.NewTx(&types.LegacyTx{
-		To:       &common.Address{0x42},
-		GasPrice: big.NewInt(0),
-		V:        big.NewInt(1),
-	})
-
-	bundleTx := bundle.AllOf(bundle.Step(key, basicTx)).Build()
-
-	bundleWithSponsorTx := bundle.AllOf(
-		bundle.Step(key, basicTx),
-		bundle.Step(key, &types.AccessListTx{
-			To:       &common.Address{0x42},
-			GasPrice: big.NewInt(0), // < makes it a sponsorship request
-		}),
-	).Build()
-
-	// Compute expected sizes from the actual inner transactions in the built bundles.
-	bundleTxInner, _, err := bundle.ValidateEnvelope(signer, bundleTx)
-	require.NoError(t, err)
-	expectedBundleSize := uint64(0)
-	for _, tx := range bundleTxInner.Transactions {
-		expectedBundleSize += tx.Size()
-	}
-
-	bundleWithSponsorInner, _, err := bundle.ValidateEnvelope(signer, bundleWithSponsorTx)
-	require.NoError(t, err)
-	expectedBundleWithSponsorSize := uint64(0)
-	for _, tx := range bundleWithSponsorInner.Transactions {
-		expectedBundleWithSponsorSize += tx.Size()
-		if subsidies.IsSponsorshipRequest(tx) {
-			expectedBundleWithSponsorSize += subsidies.RlpEncodedFeeChargingTxSizeInBytes
-		}
-	}
-
-	tests := map[string]struct {
-		tx           *types.Transaction
-		expectedSize uint64
-	}{
-		"regular tx": {
-			tx:           basicTx,
-			expectedSize: basicTx.Size(),
-		},
-		"sponsored tx": {
-			tx:           sponsoredTx,
-			expectedSize: sponsoredTx.Size() + subsidies.RlpEncodedFeeChargingTxSizeInBytes,
-		},
-		"bundle tx": {
-			tx:           bundleTx,
-			expectedSize: expectedBundleSize,
-		},
-		"bundle tx with sponsorship request": {
-			tx:           bundleWithSponsorTx,
-			expectedSize: expectedBundleWithSponsorSize,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			context := &runContext{signer: signer, upgrades: opera.Upgrades{
-				Brio:               true,
-				TransactionBundles: true,
-				GasSubsidies:       true,
-			}}
-			size := computeRealTxSize(context, test.tx)
-			require.Equal(t, test.expectedSize, size)
-		})
-	}
-}
-
-func TestRealTransactionSize_OnlyConsidersSpecialTxsWhenEnabled(t *testing.T) {
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-
-	basicTx := types.NewTx(&types.AccessListTx{
-		To:       &common.Address{0x42},
-		GasPrice: big.NewInt(100),
-		V:        big.NewInt(1),
-	})
-	sponsoredTx := types.NewTx(&types.LegacyTx{
-		To:       &common.Address{0x42},
-		GasPrice: big.NewInt(0),
-		V:        big.NewInt(1),
-	})
-	bundleTx := bundle.AllOf(bundle.Step(key, basicTx)).Build()
-
-	tests := map[string]*types.Transaction{
-		"basic tx":     basicTx,
-		"sponsored tx": sponsoredTx,
-		"bundle tx":    bundleTx,
-	}
-
-	for name, tx := range tests {
-		t.Run(name, func(t *testing.T) {
-			signer := types.LatestSignerForChainID(big.NewInt(1))
-			upgrades := opera.Upgrades{Brio: true} // no special tx types enabled
-
-			context := &runContext{signer: signer, upgrades: upgrades}
-			size := computeRealTxSize(context, tx)
-			require.Equal(t, tx.Size(), size)
-		})
-	}
-}
-
+/*
 func TestRunTransactions_SkipsTransactionsExceedingBlockSizeLimit(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -3964,11 +3950,11 @@ func TestRunTransactions_SkipsTransactionsExceedingBlockSizeLimit(t *testing.T) 
 			remainingSize: regular1.Size() + regular2.Size(),
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
 				gomock.InOrder(
-					runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular1, 0, gomock.Any()).Return(
 						ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
-					runner.EXPECT().runRegularTransaction(ctx, regular2, 1).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular2, 1, gomock.Any()).Return(
 						ProcessedTransaction{Transaction: regular2, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
@@ -4018,6 +4004,7 @@ func TestRunTransactions_SkipsTransactionsExceedingBlockSizeLimit(t *testing.T) 
 		})
 	}
 }
+*/
 
 func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing.T) {
 	key, err := crypto.GenerateKey()
@@ -4040,7 +4027,7 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 			txs:           []*types.Transaction{regular1},
 			remainingSize: regular1.Size(),
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
+				runner.EXPECT().runRegularTransaction(ctx, regular1, 0, gomock.Any()).Return(
 					ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
 					core_types.TransactionResultSuccessful,
 				)
@@ -4053,15 +4040,15 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 			remainingSize: regular1.Size() + regular2.Size() + regular3.Size(),
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
 				gomock.InOrder(
-					runner.EXPECT().runRegularTransaction(ctx, regular1, 0).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular1, 0, gomock.Any()).Return(
 						ProcessedTransaction{Transaction: regular1, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
-					runner.EXPECT().runRegularTransaction(ctx, regular2, 1).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular2, 1, gomock.Any()).Return(
 						ProcessedTransaction{Transaction: regular2, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
-					runner.EXPECT().runRegularTransaction(ctx, regular3, 2).Return(
+					runner.EXPECT().runRegularTransaction(ctx, regular3, 2, gomock.Any()).Return(
 						ProcessedTransaction{Transaction: regular3, Receipt: &types.Receipt{}},
 						core_types.TransactionResultSuccessful,
 					),
@@ -4074,7 +4061,7 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 			txs:           []*types.Transaction{sponsored},
 			remainingSize: sponsored.Size() + subsidies.RlpEncodedFeeChargingTxSizeInBytes,
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runSponsoredTransaction(ctx, sponsored, 0).Return(
+				runner.EXPECT().runSponsoredTransaction(ctx, sponsored, 0, gomock.Any()).Return(
 					[]ProcessedTransaction{
 						{Transaction: sponsored, Receipt: &types.Receipt{}},
 						{Transaction: paymentTx, Receipt: &types.Receipt{}},
@@ -4089,7 +4076,7 @@ func TestRunTransactions_ProcessesAllTransactionsWithinBlockSizeLimit(t *testing
 			txs:           []*types.Transaction{bundle.AllOf(bundle.Step(key, regular1)).Build()},
 			remainingSize: regular1.Size() + 1024, // Add some extra space for the bundle overhead
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runTransactionBundle(ctx, gomock.Any(), 0).Return(
+				runner.EXPECT().runTransactionBundle(ctx, gomock.Any(), 0, gomock.Any()).Return(
 					[]ProcessedTransaction{
 						{Transaction: regular1, Receipt: &types.Receipt{}},
 					},
@@ -4147,7 +4134,7 @@ func TestRunTransaction_CollectsCausedByInformationForAllTransactionTypes(t *tes
 		"basic transaction": {
 			tx: regularTx,
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runRegularTransaction(ctx, regularTx, 0).Return(
+				runner.EXPECT().runRegularTransaction(ctx, regularTx, 0, gomock.Any()).Return(
 					ProcessedTransaction{Transaction: regularTx, Receipt: &types.Receipt{}},
 					core_types.TransactionResultSuccessful,
 				)
@@ -4159,7 +4146,7 @@ func TestRunTransaction_CollectsCausedByInformationForAllTransactionTypes(t *tes
 		"sponsored transaction": {
 			tx: sponsoredTx,
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runSponsoredTransaction(ctx, sponsoredTx, 0).Return(
+				runner.EXPECT().runSponsoredTransaction(ctx, sponsoredTx, 0, gomock.Any()).Return(
 					[]ProcessedTransaction{
 						{Transaction: sponsoredTx, Receipt: &types.Receipt{}},
 						{Transaction: paymentTx, Receipt: &types.Receipt{}},
@@ -4175,7 +4162,7 @@ func TestRunTransaction_CollectsCausedByInformationForAllTransactionTypes(t *tes
 		"bundle transaction": {
 			tx: bundleTx,
 			setupMock: func(ctx *runContext, runner *Mock_transactionRunner) {
-				runner.EXPECT().runTransactionBundle(ctx, bundleTx, 0).Return(
+				runner.EXPECT().runTransactionBundle(ctx, bundleTx, 0, gomock.Any()).Return(
 					[]ProcessedTransaction{
 						{Transaction: bundleInner1, Receipt: &types.Receipt{}},
 						{Transaction: bundleInner2, Receipt: &types.Receipt{}},

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -142,7 +142,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 	return evmcore.NewEvmBlock(h, txs)
 }
 
-func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) evmcore.ProcessSummary {
+func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64, sizeLimit uint64) evmcore.ProcessSummary {
 	evmProcessor := p.processorFactory.NewStateProcessorForHeadState(p.evmCfg, p.reader, p.rules.Upgrades)
 	trueTxsOffset := int(0)
 	for _, tx := range p.processedTxs {
@@ -155,7 +155,7 @@ func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) evm
 
 	// Process txs
 	evmBlock := p.evmBlockWith(txs)
-	summary := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, trueTxsOffset, p.onNewLog)
+	summary := evmProcessor.Process(evmBlock, p.statedb, vmConfig, gasLimit, &p.gasUsed, trueTxsOffset, p.onNewLog, sizeLimit)
 
 	p.processedTxs = append(p.processedTxs, summary.ProcessedTransactions...)
 
@@ -223,6 +223,7 @@ type _stateProcessor interface {
 		gasUsed *uint64,
 		trueTxOffset int,
 		onNewLog func(*core_types.Log),
+		remainingSize uint64,
 	) evmcore.ProcessSummary
 }
 

--- a/gossip/blockproc/evmmodule/evm_mock.go
+++ b/gossip/blockproc/evmmodule/evm_mock.go
@@ -98,15 +98,15 @@ func (m *Mock_stateProcessor) EXPECT() *Mock_stateProcessorMockRecorder {
 }
 
 // Process mocks base method.
-func (m *Mock_stateProcessor) Process(block *evmcore.EvmBlock, statedb state.StateDB, vmCfg vm.Config, gasLimit uint64, gasUsed *uint64, trueTxOffset int, onNewLog func(*core_types.Log)) evmcore.ProcessSummary {
+func (m *Mock_stateProcessor) Process(block *evmcore.EvmBlock, statedb state.StateDB, vmCfg vm.Config, gasLimit uint64, gasUsed *uint64, trueTxOffset int, onNewLog func(*core_types.Log), maxBlockSize uint64) evmcore.ProcessSummary {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Process", block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog)
+	ret := m.ctrl.Call(m, "Process", block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, maxBlockSize)
 	ret0, _ := ret[0].(evmcore.ProcessSummary)
 	return ret0
 }
 
 // Process indicates an expected call of Process.
-func (mr *Mock_stateProcessorMockRecorder) Process(block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog any) *gomock.Call {
+func (mr *Mock_stateProcessorMockRecorder) Process(block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, maxBlockSize any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*Mock_stateProcessor)(nil).Process), block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*Mock_stateProcessor)(nil).Process), block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, maxBlockSize)
 }

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -98,7 +98,7 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 	nonce := uint64(15)
 	inner := types.NewTransaction(nonce, targetAddress, common.Big0, 1e10, common.Big0, nil)
 
-	summary := processor.Execute([]*types.Transaction{inner}, math.MaxUint64)
+	summary := processor.Execute([]*types.Transaction{inner}, math.MaxUint64, math.MaxUint64)
 	processed := summary.ProcessedTransactions
 
 	if len(processed) != 1 {
@@ -169,7 +169,7 @@ func TestOperaEVMProcessor_Execute_ProducesContinuousTxIndexesInReceipts(t *test
 	// transactions and some have just one.
 	txIndex := uint(0)
 	for range N {
-		summary := processor.Execute([]*types.Transaction{tx, tx}, math.MaxUint64)
+		summary := processor.Execute([]*types.Transaction{tx, tx}, math.MaxUint64, math.MaxUint64)
 		processed := summary.ProcessedTransactions
 		require.Len(processed, 2)
 		require.NotNil(processed[0].Receipt)
@@ -179,7 +179,7 @@ func TestOperaEVMProcessor_Execute_ProducesContinuousTxIndexesInReceipts(t *test
 		require.Equal(txIndex, processed[1].Receipt.TransactionIndex)
 		txIndex++
 
-		summary = processor.Execute([]*types.Transaction{tx}, math.MaxUint64)
+		summary = processor.Execute([]*types.Transaction{tx}, math.MaxUint64, math.MaxUint64)
 		processed = summary.ProcessedTransactions
 		require.Len(processed, 1)
 		require.NotNil(processed[0].Receipt)
@@ -216,11 +216,11 @@ func TestOperaEVMProcessor_Execute_StateProcessorIntroducesTransactions_Produces
 	}
 
 	stateProcessor.EXPECT().Process(
-		any, any, any, any, any, 0, any,
+		any, any, any, any, any, 0, any, any,
 	).Return(summary1)
 
 	stateProcessor.EXPECT().Process(
-		any, any, any, any, any, 5, any,
+		any, any, any, any, any, 5, any, any,
 	).Return(summary2)
 
 	processor := &OperaEVMProcessor{
@@ -232,14 +232,14 @@ func TestOperaEVMProcessor_Execute_StateProcessorIntroducesTransactions_Produces
 	})
 
 	// The first patch should index transactions as they are executed.
-	result := processor.Execute([]*types.Transaction{tx}, math.MaxUint64)
+	result := processor.Execute([]*types.Transaction{tx}, math.MaxUint64, math.MaxUint64)
 	require.Equal(summary1, result)
 	for i, p := range result.ProcessedTransactions {
 		require.Equal(uint(i), p.Receipt.TransactionIndex)
 	}
 
 	// the next batch should be offset by the first patch
-	result = processor.Execute([]*types.Transaction{tx}, math.MaxUint64)
+	result = processor.Execute([]*types.Transaction{tx}, math.MaxUint64, math.MaxUint64)
 	require.Equal(summary2, result)
 	for i, p := range result.ProcessedTransactions {
 		require.Equal(uint(i+len(summary1.ProcessedTransactions)), p.Receipt.TransactionIndex)
@@ -262,7 +262,7 @@ func TestOperaEVMProcessor_Execute_StateProcessorProducesTransactionsAndBundles_
 		},
 	}
 
-	stateProcessor.EXPECT().Process(any, any, any, any, any, any, any).Return(summary)
+	stateProcessor.EXPECT().Process(any, any, any, any, any, any, any, any).Return(summary)
 	processor := &OperaEVMProcessor{
 		processorFactory: factory,
 	}
@@ -270,7 +270,7 @@ func TestOperaEVMProcessor_Execute_StateProcessorProducesTransactionsAndBundles_
 	tx := types.NewTx(&types.LegacyTx{})
 
 	// The result of the processor should be returned without modifications.
-	result := processor.Execute([]*types.Transaction{tx}, math.MaxUint64)
+	result := processor.Execute([]*types.Transaction{tx}, math.MaxUint64, math.MaxUint64)
 	require.Equal(summary, result)
 }
 
@@ -309,7 +309,7 @@ func TestOperaEVMProcessor_Execute_UsesNumberOfAcceptedTransactionsAsTransaction
 			}
 
 			stateProcessor.EXPECT().
-				Process(any, any, any, any, any, numPreAccepted, any).
+				Process(any, any, any, any, any, numPreAccepted, any, any).
 				Return(evmcore.ProcessSummary{
 					ProcessedTransactions: []evmcore.ProcessedTransaction{
 						{Receipt: &types.Receipt{TransactionIndex: uint(numPreAccepted)}},
@@ -322,7 +322,7 @@ func TestOperaEVMProcessor_Execute_UsesNumberOfAcceptedTransactionsAsTransaction
 				processedTxs:     processedTransactions,
 			}
 
-			summary := processor.Execute(nil, 0)
+			summary := processor.Execute(nil, 0, 0)
 
 			require.Len(t, summary.ProcessedTransactions, 2)
 			for i, cur := range summary.ProcessedTransactions {
@@ -367,14 +367,14 @@ func TestOperaEVMProcessor_Execute_UsesNumberOfTransactionsWithReceiptsAsTransac
 					wantedOffset++
 				}
 			}
-			stateProcessor.EXPECT().Process(any, any, any, any, any, wantedOffset, any)
+			stateProcessor.EXPECT().Process(any, any, any, any, any, wantedOffset, any, any)
 
 			processor := &OperaEVMProcessor{
 				processorFactory: factory,
 				processedTxs:     processedTransactions,
 			}
 
-			processor.Execute(nil, 0)
+			processor.Execute(nil, 0, 0)
 		})
 	}
 }
@@ -431,7 +431,7 @@ func TestOperaEVMProcessor_Finalize_ReportsAggregatedNumberOfSkippedTransactions
 		To: &common.Address{}, Nonce: 1, Gas: 21_0000,
 	})
 
-	processed := processor.Execute(types.Transactions{validTx}, math.MaxUint64).ProcessedTransactions
+	processed := processor.Execute(types.Transactions{validTx}, math.MaxUint64, math.MaxUint64).ProcessedTransactions
 	require.Len(processed, 1)
 	require.Equal(validTx, processed[0].Transaction)
 	require.NotNil(processed[0].Receipt)
@@ -439,7 +439,7 @@ func TestOperaEVMProcessor_Finalize_ReportsAggregatedNumberOfSkippedTransactions
 	_, numSkipped, _ := processor.Finalize()
 	require.Equal(0, numSkipped)
 
-	processed = processor.Execute(types.Transactions{skippedTx}, math.MaxUint64).ProcessedTransactions
+	processed = processor.Execute(types.Transactions{skippedTx}, math.MaxUint64, math.MaxUint64).ProcessedTransactions
 	require.Len(processed, 1)
 	require.Equal(skippedTx, processed[0].Transaction)
 	require.Nil(processed[0].Receipt)
@@ -447,7 +447,7 @@ func TestOperaEVMProcessor_Finalize_ReportsAggregatedNumberOfSkippedTransactions
 	_, numSkipped, _ = processor.Finalize()
 	require.Equal(1, numSkipped)
 
-	processed = processor.Execute(types.Transactions{skippedTx, validTx, skippedTx}, math.MaxUint64).ProcessedTransactions
+	processed = processor.Execute(types.Transactions{skippedTx, validTx, skippedTx}, math.MaxUint64, math.MaxUint64).ProcessedTransactions
 	require.Len(processed, 3)
 	require.Equal(skippedTx, processed[0].Transaction)
 	require.Nil(processed[0].Receipt)

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -74,7 +74,7 @@ type ConfirmedEventsModule interface {
 }
 
 type EVMProcessor interface {
-	Execute(txs types.Transactions, gasLimit uint64) evmcore.ProcessSummary
+	Execute(txs types.Transactions, gasLimit uint64, sizeLimit uint64) evmcore.ProcessSummary
 	Finalize() (evmBlock *evmcore.EvmBlock, numSkipped int, receipts types.Receipts)
 }
 

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -393,17 +393,17 @@ func (m *MockEVMProcessor) EXPECT() *MockEVMProcessorMockRecorder {
 }
 
 // Execute mocks base method.
-func (m *MockEVMProcessor) Execute(txs types.Transactions, gasLimit uint64) evmcore.ProcessSummary {
+func (m *MockEVMProcessor) Execute(txs types.Transactions, gasLimit, sizeLimit uint64) evmcore.ProcessSummary {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", txs, gasLimit)
+	ret := m.ctrl.Call(m, "Execute", txs, gasLimit, sizeLimit)
 	ret0, _ := ret[0].(evmcore.ProcessSummary)
 	return ret0
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockEVMProcessorMockRecorder) Execute(txs, gasLimit any) *gomock.Call {
+func (mr *MockEVMProcessorMockRecorder) Execute(txs, gasLimit, sizeLimit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockEVMProcessor)(nil).Execute), txs, gasLimit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockEVMProcessor)(nil).Execute), txs, gasLimit, sizeLimit)
 }
 
 // Finalize mocks base method.

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -622,10 +622,8 @@ func processUserTransactions(
 ) (
 	causedBy map[common.Hash]common.Hash,
 ) {
-	var remainingSize uint64
-	if !upgrades.Brio {
-		remainingSize = math.MaxUint64
-	} else {
+	remainingSize := uint64(math.MaxUint64)
+	if upgrades.Brio {
 		remainingSize = uint64(params.MaxBlockSize - rlpEncodedMaxHeaderSizeInBytes)
 		for _, tx := range blockBuilder.GetTransactions() {
 			txSize := tx.Size()

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -610,8 +610,7 @@ const rlpEncodedMaxHeaderSizeInBytes = 1024
 
 // processUserTransactions executes user transactions in order, adding them to
 // the block until all transactions are processed or the gas/block size limit is
-// reached. The function returns the number of input transactions skipped due
-// to capacity limitations as well as a map linking the hashes of accepted
+// reached. The function returns a map linking the hashes of accepted
 // transactions to the transaction they are derived from in the given list.
 func processUserTransactions(
 	evmProcessor blockproc.EVMProcessor,

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"cmp"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"sync"
@@ -45,7 +46,6 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
-	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/verwatcher"
 	"github.com/0xsoniclabs/sonic/gossip/emitter"
 	"github.com/0xsoniclabs/sonic/gossip/evmstore"
@@ -338,7 +338,7 @@ func consensusCallbackBeginBlockFn(
 
 				// Execute pre-internal transactions
 				preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
-				preInternalProcessedTxs := evmProcessor.Execute(preInternalTxs, maxBlockGas).ProcessedTransactions
+				preInternalProcessedTxs := evmProcessor.Execute(preInternalTxs, maxBlockGas, math.MaxUint64).ProcessedTransactions
 				bs = txListener.Finalize()
 				for _, tx := range preInternalProcessedTxs {
 					if tx.Receipt == nil || tx.Receipt.Status == 0 {
@@ -412,7 +412,7 @@ func consensusCallbackBeginBlockFn(
 
 					// Execute post-internal transactions
 					internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
-					internalProcessedTxs := evmProcessor.Execute(internalTxs, maxBlockGas).ProcessedTransactions
+					internalProcessedTxs := evmProcessor.Execute(internalTxs, maxBlockGas, math.MaxUint64).ProcessedTransactions
 					for _, tx := range internalProcessedTxs {
 						if tx.Receipt == nil || tx.Receipt.Status == 0 {
 							log.Warn("Internal transaction skipped or reverted", "txid", tx.Transaction.Hash().String())
@@ -428,20 +428,15 @@ func consensusCallbackBeginBlockFn(
 						}
 					}
 
-					orderedTxs := proposal.Transactions
-					numSkippedDueToBlockLimits := 0
-					var txCausedBy map[common.Hash]common.Hash
-					if es.Rules.Upgrades.Brio {
-						// Limit block size and gas while adding user transactions
-						numSkippedDueToBlockLimits, txCausedBy =
-							processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit)
-					} else {
-						// Pre brio there were no limits on user transactions
-						processUserTransactionsNoLimits(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit)
-					}
+					txCausedBy := processUserTransactions(
+						evmProcessor,
+						blockBuilder,
+						proposal.Transactions,
+						userTransactionGasLimit,
+						es.Rules.Upgrades,
+					)
 
 					evmBlock, numSkippedTxs, allReceipts := evmProcessor.Finalize()
-					numSkippedTxs += numSkippedDueToBlockLimits
 
 					// Add results of the transaction processing to the block.
 					blockBuilder.
@@ -609,22 +604,6 @@ func consensusCallbackBeginBlockFn(
 	}
 }
 
-// processUserTransactionsNoLimits executes user transactions in order, adding them to the block.
-func processUserTransactionsNoLimits(
-	evmProcessor blockproc.EVMProcessor,
-	blockBuilder *inter.BlockBuilder,
-	orderedTxs []*types.Transaction,
-	userTransactionGasLimit uint64) {
-	for _, processed := range evmProcessor.Execute(orderedTxs, userTransactionGasLimit).ProcessedTransactions {
-		if processed.Receipt != nil { // < nil if skipped
-			blockBuilder.AddTransaction(
-				processed.Transaction,
-				processed.Receipt,
-			)
-		}
-	}
-}
-
 // rlpEncodedMaxHeaderSizeInBytes is an upper bound of the EVM block header size
 // used for block size calculations.
 const rlpEncodedMaxHeaderSizeInBytes = 1024
@@ -639,54 +618,38 @@ func processUserTransactions(
 	blockBuilder *inter.BlockBuilder,
 	orderedTxs []*types.Transaction,
 	userTransactionGasLimit uint64,
+	upgrades opera.Upgrades,
 ) (
-	skippedCount int,
 	causedBy map[common.Hash]common.Hash,
 ) {
-	remainingGas := userTransactionGasLimit
-	remainingSize := uint64(params.MaxBlockSize - rlpEncodedMaxHeaderSizeInBytes)
-	internalTxs := blockBuilder.GetTransactions()
-	for _, tx := range internalTxs {
-		txSize := tx.Size()
-		if txSize > remainingSize {
-			log.Warn("block filled with only internal transactions")
-			return len(orderedTxs), nil
-		}
-		remainingSize -= txSize
-	}
-
-	causedBy = make(map[common.Hash]common.Hash)
-	skippedCounter := 0
-	for _, tx := range orderedTxs {
-		neededSpace := txSizeIncludingSubsidies(tx)
-		if neededSpace <= remainingSize {
-			for _, processed := range evmProcessor.Execute([]*types.Transaction{tx}, remainingGas).ProcessedTransactions {
-				if processed.Receipt != nil { // < nil if skipped
-					blockBuilder.AddTransaction(
-						processed.Transaction,
-						processed.Receipt,
-					)
-					remainingGas -= processed.Receipt.GasUsed
-					remainingSize -= processed.Transaction.Size()
-					causedBy[processed.Transaction.Hash()] = tx.Hash()
-				}
+	var remainingSize uint64
+	if !upgrades.Brio {
+		remainingSize = math.MaxUint64
+	} else {
+		remainingSize = uint64(params.MaxBlockSize - rlpEncodedMaxHeaderSizeInBytes)
+		for _, tx := range blockBuilder.GetTransactions() {
+			txSize := tx.Size()
+			if txSize > remainingSize {
+				// Still call evmProcessor execute with 0 remaining size to track skipped transactions correctly.
+				log.Warn("block filled with only internal transactions")
+				remainingSize = 0
+				break
 			}
-		} else {
-			skippedCounter++
+			remainingSize -= txSize
 		}
 	}
-	return skippedCounter, causedBy
-}
 
-// txSizeIncludingSubsidies returns the size of the transaction,
-// including any overhead introduced by sponsorship requests.
-func txSizeIncludingSubsidies(tx *types.Transaction) uint64 {
-	size := tx.Size()
-	if subsidies.IsSponsorshipRequest(tx) {
-		size += subsidies.RlpEncodedFeeChargingTxSizeInBytes
+	summary := evmProcessor.Execute(orderedTxs, userTransactionGasLimit, remainingSize)
+	for _, processed := range summary.ProcessedTransactions {
+		if processed.Receipt != nil { // < nil if skipped
+			blockBuilder.AddTransaction(
+				processed.Transaction,
+				processed.Receipt,
+			)
+		}
 	}
 
-	return size
+	return summary.CausedBy
 }
 
 // resolveRandaoMix computes the randao mix to be used by the block processor

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1399,6 +1399,8 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 			// Create a user tx that would only fit without the internal tx
 			userTx := types.NewTx(&types.LegacyTx{})
 			upgrades := opera.Upgrades{Brio: true}
+
+			evmProcessor.EXPECT().Execute(gomock.Any(), gomock.Any(), gomock.Any()).Return(evmcore.ProcessSummary{})
 			processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000, upgrades)
 
 			// Only internal tx should be present

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1460,6 +1460,36 @@ func TestProcessUserTransactions_RecordsOriginTransactionForAcceptedProcessedTra
 	require.Equal(t, wantCausedBy, gotCausedBy)
 }
 
+func TestProcessUserTransactions_BlockSizeLimitIsEnforcedStartingFromBrio(t *testing.T) {
+	tests := map[string]struct {
+		upgrades          opera.Upgrades
+		expectedSizeLimit uint64
+	}{
+		"before Brio, no size limit is enforced": {
+			upgrades:          opera.Upgrades{Brio: false},
+			expectedSizeLimit: math.MaxUint64,
+		},
+		"with Brio, block size limit is enforced": {
+			upgrades:          opera.Upgrades{Brio: true},
+			expectedSizeLimit: uint64(params.MaxBlockSize - rlpEncodedMaxHeaderSizeInBytes),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+			blockBuilder := inter.NewBlockBuilder()
+
+			// Ensure the evmProcessor is called with the expected size limit
+			evmProcessor.EXPECT().Execute(gomock.Any(), gomock.Any(), test.expectedSizeLimit)
+
+			processUserTransactions(
+				evmProcessor, blockBuilder, []*types.Transaction{}, math.MaxUint64, test.upgrades)
+		})
+	}
+}
+
 func TestSpillBlockEvents(t *testing.T) {
 
 	makeEventPayload :=

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1183,26 +1183,26 @@ func TestProcessUserTransactions_DeductsInternalTxsSize(t *testing.T) {
 	blockBuilder := inter.NewBlockBuilder()
 
 	// Add an internal tx to blockBuilder
-	internalTx := types.NewTx(&types.LegacyTx{Data: make([]byte, params.MaxBlockSize/2)})
+	internalTx := types.NewTx(&types.LegacyTx{Data: make([]byte, 1000)})
 	blockBuilder.AddTransaction(internalTx, &types.Receipt{})
 
-	// Create a user tx that would only fit without the internal tx
-	userTx := types.NewTx(&types.LegacyTx{Data: make([]byte, params.MaxBlockSize/2)})
+	// Create a user tx
+	userTx := types.NewTx(&types.LegacyTx{Data: make([]byte, 1000)})
 
-	// All user txs are passed to Execute; the EVMProcessor handles size-based skipping
+	// Ensure the evmProcessor is called with the correct remaining size after accounting for the internal transaction.
 	orderedTxs := []*types.Transaction{userTx}
 	evmProcessor.EXPECT().
-		Execute(orderedTxs, uint64(10000), gomock.Any()).
+		Execute(orderedTxs, uint64(10000), params.MaxBlockSize-rlpEncodedMaxHeaderSizeInBytes-internalTx.Size()).
 		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{
-			{Transaction: userTx, Receipt: nil}, // skipped due to size
+			{Transaction: userTx, Receipt: &types.Receipt{}},
 		}})
 
 	upgrades := opera.Upgrades{Brio: true}
 	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, 10000, upgrades)
 
-	// Only the internal tx should be present
+	// Ensure both internal and user transactions are included.
 	gotTxs := blockBuilder.GetTransactions()
-	require.Equal(t, types.Transactions{internalTx}, gotTxs)
+	require.Equal(t, types.Transactions{internalTx, userTx}, gotTxs)
 }
 
 func TestProcessUserTransactions_SkipsTxsExceedingSizeLimit(t *testing.T) {

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -275,7 +275,7 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 				txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
 
 				evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
-				evmProcessor.EXPECT().Execute(_any, _any).MinTimes(1)
+				evmProcessor.EXPECT().Execute(_any, _any, _any).MinTimes(1)
 				evmProcessor.EXPECT().Finalize().Return(&evmcore.EvmBlock{
 					EvmHeader: evmcore.EvmHeader{
 						BaseFee: big.NewInt(0),
@@ -1138,19 +1138,19 @@ func TestProcessUserTransactions_ForwardsBlockGasLimitToEVMProcessor(t *testing.
 
 	userTransactionGasLimit := uint64(3000)
 
-	// Mock EVMProcessor.Execute to return receipts for each tx
-	evmProcessor.EXPECT().
-		Execute([]*types.Transaction{tx1}, userTransactionGasLimit).
-		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx1, Receipt: receipt1}}})
-	evmProcessor.EXPECT().
-		Execute([]*types.Transaction{tx2}, userTransactionGasLimit-receipt1.GasUsed).
-		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx2, Receipt: receipt2}}})
-	evmProcessor.EXPECT().
-		Execute([]*types.Transaction{tx3}, userTransactionGasLimit-receipt1.GasUsed-receipt2.GasUsed).
-		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx3, Receipt: receipt3}}})
-
 	orderedTxs := []*types.Transaction{tx1, tx2, tx3}
-	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit)
+
+	// Mock EVMProcessor.Execute to be called once with all txs and the full gas limit
+	evmProcessor.EXPECT().
+		Execute(orderedTxs, userTransactionGasLimit, gomock.Any()).
+		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: tx1, Receipt: receipt1},
+			{Transaction: tx2, Receipt: receipt2},
+			{Transaction: tx3, Receipt: receipt3},
+		}})
+
+	upgrades := opera.Upgrades{Brio: true}
+	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, userTransactionGasLimit, upgrades)
 
 	// All transactions should be included
 	gotTxs := blockBuilder.GetTransactions()
@@ -1166,14 +1166,11 @@ func TestProcessUserTransactions_TransactionsWithNoReceiptAreNotIncluded(t *test
 
 	// Simulate skipped transaction (no receipt)
 	evmProcessor.EXPECT().
-		Execute([]*types.Transaction{tx}, gomock.Any()).
+		Execute([]*types.Transaction{tx}, gomock.Any(), gomock.Any()).
 		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx, Receipt: nil}}})
 
-	skippedCount, _ :=
-		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx}, 10000)
-
-	require.Equal(t, 0, skippedCount,
-		"transactions with no receipt should be taking into account by the evm processor")
+	upgrades := opera.Upgrades{Brio: true}
+	processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx}, 10000, upgrades)
 
 	// Should not be added to blockBuilder
 	gotTxs := blockBuilder.GetTransactions()
@@ -1191,12 +1188,21 @@ func TestProcessUserTransactions_DeductsInternalTxsSize(t *testing.T) {
 
 	// Create a user tx that would only fit without the internal tx
 	userTx := types.NewTx(&types.LegacyTx{Data: make([]byte, params.MaxBlockSize/2)})
-	skippedCount, _ := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
 
-	// Both internal and user tx should be present
+	// All user txs are passed to Execute; the EVMProcessor handles size-based skipping
+	orderedTxs := []*types.Transaction{userTx}
+	evmProcessor.EXPECT().
+		Execute(orderedTxs, uint64(10000), gomock.Any()).
+		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: userTx, Receipt: nil}, // skipped due to size
+		}})
+
+	upgrades := opera.Upgrades{Brio: true}
+	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, 10000, upgrades)
+
+	// Only the internal tx should be present
 	gotTxs := blockBuilder.GetTransactions()
 	require.Equal(t, types.Transactions{internalTx}, gotTxs)
-	require.Equal(t, 1, skippedCount)
 }
 
 func TestProcessUserTransactions_SkipsTxsExceedingSizeLimit(t *testing.T) {
@@ -1211,17 +1217,19 @@ func TestProcessUserTransactions_SkipsTxsExceedingSizeLimit(t *testing.T) {
 	tx0 := types.NewTx(&types.LegacyTx{Data: []byte{0x01}})
 	tx1 := types.NewTx(&types.LegacyTx{Data: []byte{0x01}})
 
-	evmProcessor.EXPECT().
-		Execute([]*types.Transaction{tx0}, gomock.Any()).
-		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx0, Receipt: &types.Receipt{}}}})
-	evmProcessor.EXPECT().
-		Execute([]*types.Transaction{tx1}, gomock.Any()).
-		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx1, Receipt: &types.Receipt{}}}})
+	orderedTxs := []*types.Transaction{largeTx, tx0, tx1}
 
-	skippedCount, _ :=
-		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{largeTx, tx0, tx1}, 10000)
+	// All txs are passed to Execute; the EVMProcessor handles size-based skipping
+	evmProcessor.EXPECT().
+		Execute(orderedTxs, uint64(10000), gomock.Any()).
+		Return(evmcore.ProcessSummary{ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: largeTx, Receipt: nil}, // skipped due to size
+			{Transaction: tx0, Receipt: &types.Receipt{}},
+			{Transaction: tx1, Receipt: &types.Receipt{}},
+		}})
 
-	require.Equal(t, 1, skippedCount)
+	upgrades := opera.Upgrades{Brio: true}
+	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, 10000, upgrades)
 
 	// Huge transactions should not be added
 	gotTxs := blockBuilder.GetTransactions()
@@ -1266,7 +1274,7 @@ func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransa
 
 	internalTx := types.NewTx(&types.LegacyTx{To: &common.Address{0x41}, Gas: 21_000})
 	internalTxGasLimit := uint64(30_000)
-	internalProcessedTxs := evmProcessor.Execute([]*types.Transaction{internalTx}, internalTxGasLimit).ProcessedTransactions
+	internalProcessedTxs := evmProcessor.Execute([]*types.Transaction{internalTx}, internalTxGasLimit, math.MaxUint64).ProcessedTransactions
 	require.Len(t, internalProcessedTxs, 1)
 
 	userTx0 := types.NewTx(&types.LegacyTx{To: &common.Address{0x42}, Gas: 21_000})
@@ -1275,11 +1283,8 @@ func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransa
 	// the user transaction only fits into the user transaction gas limit if
 	// the internal transaction gas is not counted towards it
 	userTransactionGasLimit := uint64(30_000)
-	skippedCount, _ :=
-		processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx0, skippedTx}, userTransactionGasLimit)
-
-	// the skipped transaction is counted by the evm processor
-	require.Equal(t, 0, skippedCount)
+	upgrades := opera.Upgrades{Brio: true}
+	processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx0, skippedTx}, userTransactionGasLimit, upgrades)
 
 	gotTxs := blockBuilder.GetTransactions()
 	require.Equal(t, types.Transactions{userTx0}, gotTxs)
@@ -1319,36 +1324,36 @@ func TestProcessUserTransactions_SponsoredTxSizeIsAccountedCorrectly(t *testing.
 				Data: make([]byte, remainingSize-100), // leave some room for other fields in tx
 			})
 
-			processedTx1 := []evmcore.ProcessedTransaction{{Transaction: tx1, Receipt: &types.Receipt{}}}
+			var processedTxs []evmcore.ProcessedTransaction
 			var feeChargingTransaction *types.Transaction
 			if test.gasPrice == 0 {
 				feeChargingTransaction = types.NewTx(&types.LegacyTx{
 					// Fill the tx to simulate the size of a fee charging tx
 					Data: make([]byte, subsidies.RlpEncodedFeeChargingTxSizeInBytes),
 				})
-				processedTx1 = append(processedTx1, evmcore.ProcessedTransaction{
-					Transaction: feeChargingTransaction,
-					Receipt:     &types.Receipt{},
-				})
+				processedTxs = []evmcore.ProcessedTransaction{
+					{Transaction: tx0, Receipt: &types.Receipt{}},
+					{Transaction: tx1, Receipt: &types.Receipt{}},
+					{Transaction: feeChargingTransaction, Receipt: &types.Receipt{}},
+					{Transaction: tx2, Receipt: nil}, // skipped due to size
+				}
+			} else {
+				processedTxs = []evmcore.ProcessedTransaction{
+					{Transaction: tx0, Receipt: &types.Receipt{}},
+					{Transaction: tx1, Receipt: &types.Receipt{}},
+					{Transaction: tx2, Receipt: &types.Receipt{}},
+				}
 			}
 
+			orderedTxs := []*types.Transaction{tx0, tx1, tx2}
 			evmProcessor.EXPECT().
-				Execute([]*types.Transaction{tx0}, gomock.Any()).
+				Execute(orderedTxs, uint64(10000), gomock.Any()).
 				Return(evmcore.ProcessSummary{
-					ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx0, Receipt: &types.Receipt{}}},
+					ProcessedTransactions: processedTxs,
 				})
-			evmProcessor.EXPECT().
-				Execute([]*types.Transaction{tx1}, gomock.Any()).
-				Return(evmcore.ProcessSummary{
-					ProcessedTransactions: processedTx1,
-				})
-			evmProcessor.EXPECT().
-				Execute([]*types.Transaction{tx2}, gomock.Any()).
-				Return(evmcore.ProcessSummary{
-					ProcessedTransactions: []evmcore.ProcessedTransaction{{Transaction: tx2, Receipt: &types.Receipt{}}},
-				}).AnyTimes()
 
-			skippedCount, _ := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{tx0, tx1, tx2}, 10000)
+			upgrades := opera.Upgrades{Brio: true}
+			processUserTransactions(evmProcessor, blockBuilder, orderedTxs, 10000, upgrades)
 
 			gotTxs := blockBuilder.GetTransactions()
 			require.Contains(t, gotTxs, tx0)
@@ -1360,10 +1365,8 @@ func TestProcessUserTransactions_SponsoredTxSizeIsAccountedCorrectly(t *testing.
 				require.Equal(t, feeChargingTransaction, gotTxs[2])
 
 				require.NotContains(t, gotTxs, tx2)
-				require.Equal(t, 1, skippedCount)
 			} else {
 				require.Contains(t, gotTxs, tx2)
-				require.Equal(t, 0, skippedCount)
 			}
 		})
 	}
@@ -1395,12 +1398,12 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 
 			// Create a user tx that would only fit without the internal tx
 			userTx := types.NewTx(&types.LegacyTx{})
-			skippedCount, _ := processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000)
+			upgrades := opera.Upgrades{Brio: true}
+			processUserTransactions(evmProcessor, blockBuilder, []*types.Transaction{userTx}, 10000, upgrades)
 
 			// Only internal tx should be present
 			gotTxs := blockBuilder.GetTransactions()
 			require.Equal(t, types.Transactions(internalTxs), gotTxs)
-			require.Equal(t, 1, skippedCount)
 		})
 	}
 }
@@ -1422,27 +1425,6 @@ func TestProcessUserTransactions_RecordsOriginTransactionForAcceptedProcessedTra
 		types.NewTx(&types.LegacyTx{Nonce: 23}),
 	}
 
-	results := []evmcore.ProcessSummary{
-		{ProcessedTransactions: []evmcore.ProcessedTransaction{
-			{Transaction: transactions[0], Receipt: &types.Receipt{}},
-		}},
-		{ProcessedTransactions: []evmcore.ProcessedTransaction{
-			{Transaction: transactions[1], Receipt: &types.Receipt{}},
-			{Transaction: extras[0], Receipt: &types.Receipt{}},
-		}},
-		{ProcessedTransactions: []evmcore.ProcessedTransaction{
-			{Transaction: extras[1], Receipt: &types.Receipt{}},
-			{Transaction: extras[2], Receipt: &types.Receipt{}},
-			{Transaction: extras[3], Receipt: nil},
-		}},
-	}
-
-	for i, tx := range transactions {
-		evmProcessor.EXPECT().
-			Execute([]*types.Transaction{tx}, gomock.Any()).
-			Return(results[i])
-	}
-
 	wantCausedBy := map[common.Hash]common.Hash{
 		transactions[0].Hash(): transactions[0].Hash(),
 		transactions[1].Hash(): transactions[1].Hash(),
@@ -1452,48 +1434,28 @@ func TestProcessUserTransactions_RecordsOriginTransactionForAcceptedProcessedTra
 		// no entry for extras[3] since it has no receipt
 	}
 
-	_, gotCausedBy := processUserTransactions(
+	evmProcessor.EXPECT().
+		Execute(transactions, gomock.Any(), gomock.Any()).
+		Return(evmcore.ProcessSummary{
+			ProcessedTransactions: []evmcore.ProcessedTransaction{
+				{Transaction: transactions[0], Receipt: &types.Receipt{}},
+				{Transaction: transactions[1], Receipt: &types.Receipt{}},
+				{Transaction: extras[0], Receipt: &types.Receipt{}},
+				{Transaction: extras[1], Receipt: &types.Receipt{}},
+				{Transaction: extras[2], Receipt: &types.Receipt{}},
+				{Transaction: extras[3], Receipt: nil},
+			},
+			CausedBy: wantCausedBy,
+		})
+
+	gotCausedBy := processUserTransactions(
 		evmProcessor,
 		inter.NewBlockBuilder(),
 		transactions,
 		math.MaxUint64,
+		opera.Upgrades{Brio: true},
 	)
 	require.Equal(t, wantCausedBy, gotCausedBy)
-}
-
-func TestTransactionSize_ConsidersSponsoredTxs(t *testing.T) {
-	basicTx := types.NewTx(&types.LegacyTx{
-		To:       &common.Address{0x42},
-		GasPrice: big.NewInt(100),
-		V:        big.NewInt(1),
-	})
-
-	sponsoredTx := types.NewTx(&types.LegacyTx{
-		To:       &common.Address{0x42},
-		GasPrice: big.NewInt(0),
-		V:        big.NewInt(1),
-	})
-
-	tests := map[string]struct {
-		tx           *types.Transaction
-		expectedSize uint64
-	}{
-		"regular tx": {
-			tx:           basicTx,
-			expectedSize: basicTx.Size(),
-		},
-		"sponsored tx": {
-			tx:           sponsoredTx,
-			expectedSize: sponsoredTx.Size() + subsidies.RlpEncodedFeeChargingTxSizeInBytes,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			size := txSizeIncludingSubsidies(test.tx)
-			require.Equal(t, test.expectedSize, size)
-		})
-	}
 }
 
 func TestSpillBlockEvents(t *testing.T) {

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1410,6 +1410,32 @@ func TestProcessUserTransactions_SkipUserTransactionIfInternalTransactionsExceed
 	}
 }
 
+func TestProcessUserTransactions_InternalTxsExceedingBlockSizePassesZeroRemainingSize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+	blockBuilder := inter.NewBlockBuilder()
+
+	// Add two internal transactions: one that nearly fills the block, and one that exceeds the remaining size.
+	smallTx := types.NewTx(&types.LegacyTx{Data: make([]byte, params.MaxBlockSize-rlpEncodedMaxHeaderSizeInBytes-100)})
+	overflowTx := types.NewTx(&types.LegacyTx{Data: make([]byte, 200)})
+	blockBuilder.AddTransaction(smallTx, &types.Receipt{})
+	blockBuilder.AddTransaction(overflowTx, &types.Receipt{})
+
+	userTx := types.NewTx(&types.LegacyTx{})
+	orderedTxs := []*types.Transaction{userTx}
+	upgrades := opera.Upgrades{Brio: true}
+
+	// After the overflow is detected, remainingSize is set to 0
+	evmProcessor.EXPECT().
+		Execute(orderedTxs, uint64(10000), gomock.Any()).
+		DoAndReturn(func(txs []*types.Transaction, gas uint64, size uint64) evmcore.ProcessSummary {
+			require.Equal(t, uint64(0), size) // Ensure the user transactions are processed with zero remaining size
+			return evmcore.ProcessSummary{}
+		})
+
+	processUserTransactions(evmProcessor, blockBuilder, orderedTxs, 10000, upgrades)
+}
+
 func TestProcessUserTransactions_RecordsOriginTransactionForAcceptedProcessedTransactions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -269,12 +270,12 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	)
 
 	// Execute genesis transactions
-	evmProcessor.Execute(genesisTxs, es.Rules.Blocks.MaxBlockGas)
+	evmProcessor.Execute(genesisTxs, es.Rules.Blocks.MaxBlockGas, math.MaxUint64)
 	bs = txListener.Finalize()
 
 	// Execute pre-internal transactions
 	preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
-	evmProcessor.Execute(preInternalTxs, es.Rules.Blocks.MaxBlockGas)
+	evmProcessor.Execute(preInternalTxs, es.Rules.Blocks.MaxBlockGas, math.MaxUint64)
 	bs = txListener.Finalize()
 
 	// Seal epoch
@@ -288,7 +289,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 
 	// Execute post-internal transactions
 	internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
-	evmProcessor.Execute(internalTxs, es.Rules.Blocks.MaxBlockGas)
+	evmProcessor.Execute(internalTxs, es.Rules.Blocks.MaxBlockGas, math.MaxUint64)
 
 	evmBlock, numSkippedTxs, receipts := evmProcessor.Finalize()
 	for i, r := range receipts {

--- a/tests/block_verifiability_utils.go
+++ b/tests/block_verifiability_utils.go
@@ -18,6 +18,7 @@ package tests
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"testing"
@@ -257,6 +258,7 @@ func (s *State) ApplyBlock(
 		&usedGas,
 		0, // tx index offset
 		nil,
+		math.MaxUint64, // the blocks have already been produced, the size limit is not relevant for the replay
 	).ProcessedTransactions
 
 	receipts := types.Receipts{}


### PR DESCRIPTION
The enforcing of the block size limit ([eip-7934](https://eips.ethereum.org/EIPS/eip-7934)) is moved to the state processor to increase test coverage with historical tests.