### PR TITLE
Extend timeout of RPC methods in tests

### DIFF
--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -563,6 +563,10 @@ func (n *IntegrationTestNet) start() error {
 				"--ws", "--ws.addr", "127.0.0.1", "--ws.port", "0",
 				"--ws.api", "admin,eth",
 
+				// extend rpc timeout to avoid flakes in tests that perform heavy operations or run on slow machines
+				"--rpc.timeout", "60s",
+				"--rpc.evmtimeout", "60s",
+
 				//  net options
 				"--port", "0",
 				"--nat", "none",


### PR DESCRIPTION
This PR extends RPC timeout in integration tests to avoid timeouts during race detection runs in machines with limited resources. 