### PR TITLE
Remove a must-to-uint256 from transaction utils

### DIFF
--- a/gossip/blockproc/bundle/builder.go
+++ b/gossip/blockproc/bundle/builder.go
@@ -92,7 +92,10 @@ func Step(key *ecdsa.PrivateKey, tx any) BuilderStep {
 	case types.SetCodeTx:
 		return BuilderStep{txRef: &txReference{key: key, tx: &tx}}
 	case *types.Transaction:
-		txData := utils.GetTxData(tx)
+		txData, err := utils.GetTxData(tx)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get TxData: %v", err))
+		}
 		// Legacy transactions are promoted to AccessListTx in the builder,
 		// to enable marking nested transactions with the bundle-only marker.
 		if data, ok := txData.(*types.LegacyTx); ok {
@@ -402,7 +405,11 @@ func (s BuilderStep) Clone() BuilderStep {
 	if res.txRef != nil {
 		res.txRef = &txReference{}
 		*res.txRef = *s.txRef
-		res.txRef.tx = utils.GetTxData(types.NewTx(res.txRef.tx))
+		tx, err := utils.GetTxData(types.NewTx(res.txRef.tx))
+		if err != nil {
+			panic(fmt.Sprintf("failed to get TxData: %v", err))
+		}
+		res.txRef.tx = tx
 	}
 	for i := range res.steps {
 		res.steps[i] = res.steps[i].Clone()

--- a/gossip/blockproc/bundle/bundle.go
+++ b/gossip/blockproc/bundle/bundle.go
@@ -133,6 +133,12 @@ func (tb *TransactionBundle) Copy() TransactionBundle {
 // By doing so, the signature of the transaction is erased. Therefore, the sender
 // or the ChainId can no longer be derived from the resulting transaction.
 func removeBundleOnlyMark(tx *types.Transaction) (*types.Transaction, error) {
+	// Create a copy of the transaction data with the modified access list.
+	txData, err := utils.GetTxData(tx) // < also checks for nil transaction
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transaction data: %v", err)
+	}
+
 	curAccessList := tx.AccessList()
 	newAccessList := make([]types.AccessTuple, 0, len(curAccessList))
 	for _, cur := range curAccessList {
@@ -141,8 +147,6 @@ func removeBundleOnlyMark(tx *types.Transaction) (*types.Transaction, error) {
 		}
 	}
 
-	// Create a copy of the transaction data with the modified access list.
-	txData := utils.GetTxData(tx)
 	switch data := txData.(type) {
 	case *types.AccessListTx:
 		data.AccessList = newAccessList

--- a/gossip/blockproc/bundle/bundle.go
+++ b/gossip/blockproc/bundle/bundle.go
@@ -136,7 +136,7 @@ func removeBundleOnlyMark(tx *types.Transaction) (*types.Transaction, error) {
 	// Create a copy of the transaction data with the modified access list.
 	txData, err := utils.GetTxData(tx) // < also checks for nil transaction
 	if err != nil {
-		return nil, fmt.Errorf("failed to get transaction data: %v", err)
+		return nil, fmt.Errorf("failed to get transaction data: %w", err)
 	}
 
 	curAccessList := tx.AccessList()

--- a/gossip/blockproc/bundle/bundle_test.go
+++ b/gossip/blockproc/bundle/bundle_test.go
@@ -270,6 +270,11 @@ func TestTransactionBundle_GetTransactionsInReferencedOrder_ReturnsTransactionsI
 	}
 }
 
+func TestRemoveBundleOnlyMark_DetectsTxDataExtractionError(t *testing.T) {
+	_, err := removeBundleOnlyMark(nil)
+	require.ErrorContains(t, err, "failed to get transaction data")
+}
+
 func TestRemoveBundleOnlyMark_FailsOnUnsupportedTransactionType(t *testing.T) {
 	tx := types.NewTx(&types.LegacyTx{})
 	_, err := removeBundleOnlyMark(tx)

--- a/gossip/blockproc/bundle/validate_test.go
+++ b/gossip/blockproc/bundle/validate_test.go
@@ -497,7 +497,9 @@ func TestValidateBundle_InvalidIndex_Rejected(t *testing.T) {
 	require.NoError(t, validateBundle(signer, bundle))
 
 	ref := slices.Collect(maps.Keys(bundle.Transactions))[0]
-	validTxData := utils.GetTxData(bundle.Transactions[ref]).(*types.AccessListTx)
+	txData, err := utils.GetTxData(bundle.Transactions[ref])
+	require.NoError(t, err)
+	validTxData := txData.(*types.AccessListTx)
 
 	// using an unsigned transaction in the index is detected
 	validTxData.R = nil
@@ -573,8 +575,9 @@ func TestValidateBundle_TransactionNotAgreeingToPlan_Rejected(t *testing.T) {
 	originalTx := bundle.GetTransactionsInReferencedOrder()[0]
 
 	// removing the agreement to the execution plan is detected
-	noAgreementData := utils.GetTxData(originalTx).(*types.AccessListTx)
-	noAgreementData.AccessList = []types.AccessTuple{{Address: BundleOnly}}
+	noAgreementData, err := utils.GetTxData(originalTx)
+	require.NoError(t, err)
+	noAgreementData.(*types.AccessListTx).AccessList = []types.AccessTuple{{Address: BundleOnly}}
 	noAgreement := types.MustSignNewTx(key, signer, noAgreementData)
 	require.True(t, IsBundleOnly(noAgreement))
 
@@ -590,8 +593,9 @@ func TestValidateBundle_TransactionNotAgreeingToPlan_Rejected(t *testing.T) {
 	require.NoError(t, validateBundle(signer, bundle))
 
 	// replacing the agreement with another execution hash is also detected
-	otherAgreementData := utils.GetTxData(originalTx).(*types.AccessListTx)
-	otherAgreementData.AccessList = []types.AccessTuple{{
+	otherAgreementData, err := utils.GetTxData(originalTx)
+	require.NoError(t, err)
+	otherAgreementData.(*types.AccessListTx).AccessList = []types.AccessTuple{{
 		Address:     BundleOnly,
 		StorageKeys: []common.Hash{{0x99}},
 	}}
@@ -640,7 +644,10 @@ func TestValidateBundle_AdditionalTransactionInIndex_Rejected(t *testing.T) {
 	ref1 := slices.Collect(maps.Keys(bundle.Transactions))[0]
 	validTx := bundle.Transactions[ref1]
 
-	extraTx := types.MustSignNewTx(key2, signer, utils.GetTxData(validTx))
+	txData, err := utils.GetTxData(validTx)
+	require.NoError(t, err)
+
+	extraTx := types.MustSignNewTx(key2, signer, txData)
 	refExtra := TxReference{
 		From: crypto.PubkeyToAddress(key2.PublicKey),
 		Hash: ref1.Hash,

--- a/utils/txs.go
+++ b/utils/txs.go
@@ -17,19 +17,27 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 )
 
 // GetTxData extracts the inner TxData from a given transaction, which is
 // handy for mutating transactions in various contexts.
-func GetTxData(tx *types.Transaction) types.TxData {
-
+func GetTxData(tx *types.Transaction) (types.TxData, error) {
 	// TODO: consider adding a modification to Sonic's go-ethereum fork to
 	// enable a direct call to tx.inner.copy(), having the same effect.
+	if tx == nil {
+		return nil, fmt.Errorf("transaction is nil")
+	}
+	return getTxDataInternal(tx)
+}
+
+func getTxDataInternal(tx txDataSource) (types.TxData, error) {
 
 	// Manually create a copy of the transactions's inner data type.
 	var txData types.TxData
@@ -77,53 +85,111 @@ func GetTxData(tx *types.Transaction) types.TxData {
 			S:          s,
 		}
 	case types.BlobTxType:
+		chainId, err1 := toUint256(tx.ChainId())
+		gasTipCap, err2 := toUint256(tx.GasTipCap())
+		gasFeeCap, err3 := toUint256(tx.GasFeeCap())
+		value, err4 := toUint256(tx.Value())
+		blobFeeCap, err5 := toUint256(tx.BlobGasFeeCap())
+		v, err6 := toUint256(v)
+		r, err7 := toUint256(r)
+		s, err8 := toUint256(s)
+
+		err := errors.Join(err1, err2, err3, err4, err5, err6, err7, err8)
+		if err != nil {
+			return nil, err
+		}
+
+		if tx.To() == nil {
+			return nil, fmt.Errorf("blob transactions must have a recipient")
+		}
+
 		txData = &types.BlobTx{
-			ChainID:    mustToUint256(tx.ChainId()),
+			ChainID:    chainId,
 			Nonce:      tx.Nonce(),
-			GasTipCap:  mustToUint256(tx.GasTipCap()),
-			GasFeeCap:  mustToUint256(tx.GasFeeCap()),
+			GasTipCap:  gasTipCap,
+			GasFeeCap:  gasFeeCap,
 			Gas:        tx.Gas(),
 			To:         *tx.To(),
-			Value:      mustToUint256(tx.Value()),
+			Value:      value,
 			Data:       tx.Data(),
 			AccessList: tx.AccessList(),
-			BlobFeeCap: mustToUint256(tx.BlobGasFeeCap()),
+			BlobFeeCap: blobFeeCap,
 			BlobHashes: tx.BlobHashes(),
-			V:          mustToUint256(v),
-			R:          mustToUint256(r),
-			S:          mustToUint256(s),
+			V:          v,
+			R:          r,
+			S:          s,
 		}
 
 	case types.SetCodeTxType:
+
+		chainId, err1 := toUint256(tx.ChainId())
+		gasTipCap, err2 := toUint256(tx.GasTipCap())
+		gasFeeCap, err3 := toUint256(tx.GasFeeCap())
+		value, err4 := toUint256(tx.Value())
+		v, err5 := toUint256(v)
+		r, err6 := toUint256(r)
+		s, err7 := toUint256(s)
+
+		err := errors.Join(err1, err2, err3, err4, err5, err6, err7)
+		if err != nil {
+			return nil, err
+		}
+
+		if tx.To() == nil {
+			return nil, fmt.Errorf("set code transactions must have a recipient")
+		}
+
 		txData = &types.SetCodeTx{
-			ChainID:    mustToUint256(tx.ChainId()),
+			ChainID:    chainId,
 			Nonce:      tx.Nonce(),
-			GasTipCap:  mustToUint256(tx.GasTipCap()),
-			GasFeeCap:  mustToUint256(tx.GasFeeCap()),
+			GasTipCap:  gasTipCap,
+			GasFeeCap:  gasFeeCap,
 			Gas:        tx.Gas(),
 			To:         *tx.To(),
-			Value:      mustToUint256(tx.Value()),
+			Value:      value,
 			Data:       tx.Data(),
 			AccessList: tx.AccessList(),
 			AuthList:   tx.SetCodeAuthorizations(),
-			V:          mustToUint256(v),
-			R:          mustToUint256(r),
-			S:          mustToUint256(s),
+			V:          v,
+			R:          r,
+			S:          s,
 		}
+
+	default:
+		return nil, fmt.Errorf("unsupported transaction type: %d", tx.Type())
+
 	}
-	return txData
+	return txData, nil
 }
 
-func mustToUint256(value *big.Int) *uint256.Int {
+type txDataSource interface {
+	ChainId() *big.Int
+	Nonce() uint64
+	GasPrice() *big.Int
+	GasFeeCap() *big.Int
+	GasTipCap() *big.Int
+	Gas() uint64
+	To() *common.Address
+	Value() *big.Int
+	Data() []byte
+	AccessList() types.AccessList
+	BlobGasFeeCap() *big.Int
+	BlobHashes() []common.Hash
+	SetCodeAuthorizations() []types.SetCodeAuthorization
+	Type() uint8
+	RawSignatureValues() (v, r, s *big.Int)
+}
+
+func toUint256(value *big.Int) (*uint256.Int, error) {
 	if value == nil {
-		return nil
+		return nil, nil
 	}
 	if value.Sign() < 0 {
-		panic(fmt.Sprintf("out of uint256 domain: %v", value))
+		return nil, fmt.Errorf("out of uint256 domain: %v", value)
 	}
 	res, overflow := uint256.FromBig(value)
 	if overflow {
-		panic(fmt.Sprintf("out of uint256 domain: %v", value))
+		return nil, fmt.Errorf("out of uint256 domain: %v", value)
 	}
-	return res
+	return res, nil
 }

--- a/utils/txs_test.go
+++ b/utils/txs_test.go
@@ -249,11 +249,11 @@ func TestGetTxData_ExtractsAllData(t *testing.T) {
 
 func Test_getTxDataInternal_DetectsUnsupportedTransactionType(t *testing.T) {
 	txDataSource := &fakeTxDataSource{
-		txType: 0x99, // an unsupported transaction type
+		txType: 123, // an unsupported transaction type
 	}
 
 	_, err := getTxDataInternal(txDataSource)
-	require.Error(t, err, "unsupported transaction type: 0x99")
+	require.ErrorContains(t, err, "unsupported transaction type: 123")
 }
 
 func Test_getTxDataInternal_DetectsNilToAddressForBlobTxType(t *testing.T) {
@@ -263,7 +263,7 @@ func Test_getTxDataInternal_DetectsNilToAddressForBlobTxType(t *testing.T) {
 	}
 
 	_, err := getTxDataInternal(txDataSource)
-	require.Error(t, err, "blob transactions must have a recipient")
+	require.ErrorContains(t, err, "blob transactions must have a recipient")
 }
 
 func Test_getTxDataInternal_BlobTxType_DetectsOutOfDomainValues(t *testing.T) {
@@ -302,7 +302,7 @@ func Test_getTxDataInternal_BlobTxType_DetectsOutOfDomainValues(t *testing.T) {
 				if value.valid {
 					require.NoError(t, err)
 				} else {
-					require.Error(t, err, fmt.Sprintf("out of uint256 domain: %v", value))
+					require.ErrorContains(t, err, fmt.Sprintf("out of uint256 domain: %v", value.value))
 				}
 			})
 		}
@@ -316,7 +316,7 @@ func Test_getTxDataInternal_DetectsNilToAddressForSetCodeTxType(t *testing.T) {
 	}
 
 	_, err := getTxDataInternal(txDataSource)
-	require.Error(t, err, "set code transactions must have a recipient")
+	require.ErrorContains(t, err, "set code transactions must have a recipient")
 }
 
 func Test_getTxDataInternal_SetCodeTxType_DetectsOutOfDomainValues(t *testing.T) {
@@ -354,7 +354,7 @@ func Test_getTxDataInternal_SetCodeTxType_DetectsOutOfDomainValues(t *testing.T)
 				if value.valid {
 					require.NoError(t, err)
 				} else {
-					require.Error(t, err, fmt.Sprintf("out of uint256 domain: %v", value))
+					require.ErrorContains(t, err, fmt.Sprintf("out of uint256 domain: %v", value.value))
 				}
 			})
 		}
@@ -404,7 +404,7 @@ func Test_toUint256_InvalidInputs_ReportsError(t *testing.T) {
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
 			_, err := toUint256(input)
-			require.Error(t, err, fmt.Sprintf("out of uint256 domain: %v", input))
+			require.ErrorContains(t, err, fmt.Sprintf("out of uint256 domain: %v", input))
 		})
 	}
 }

--- a/utils/txs_test.go
+++ b/utils/txs_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetTxData_NilTransaction_ReportsError(t *testing.T) {
+	_, err := GetTxData(nil)
+	require.ErrorContains(t, err, "transaction is nil")
+}
+
 func TestGetTxData_ExtractsAllData(t *testing.T) {
 
 	type msg struct {
@@ -126,7 +131,8 @@ func TestGetTxData_ExtractsAllData(t *testing.T) {
 
 			tx := types.NewTx(original)
 
-			txData := GetTxData(tx)
+			txData, err := GetTxData(tx)
+			require.NoError(t, err)
 
 			restored := txData.(*types.LegacyTx)
 			require.Equal(t, original, restored)
@@ -148,7 +154,8 @@ func TestGetTxData_ExtractsAllData(t *testing.T) {
 
 			tx := types.NewTx(original)
 
-			txData := GetTxData(tx)
+			txData, err := GetTxData(tx)
+			require.NoError(t, err)
 
 			restored := txData.(*types.AccessListTx)
 			require.Equal(t, original, restored)
@@ -172,7 +179,8 @@ func TestGetTxData_ExtractsAllData(t *testing.T) {
 
 			tx := types.NewTx(original)
 
-			txData := GetTxData(tx)
+			txData, err := GetTxData(tx)
+			require.NoError(t, err)
 
 			restored := txData.(*types.DynamicFeeTx)
 			require.Equal(t, original, restored)
@@ -201,7 +209,8 @@ func TestGetTxData_ExtractsAllData(t *testing.T) {
 
 			tx := types.NewTx(original)
 
-			txData := GetTxData(tx)
+			txData, err := GetTxData(tx)
+			require.NoError(t, err)
 
 			restored := txData.(*types.BlobTx)
 			require.Equal(t, original, restored)
@@ -229,7 +238,8 @@ func TestGetTxData_ExtractsAllData(t *testing.T) {
 
 			tx := types.NewTx(original)
 
-			txData := GetTxData(tx)
+			txData, err := GetTxData(tx)
+			require.NoError(t, err)
 
 			restored := txData.(*types.SetCodeTx)
 			require.Equal(t, original, restored)
@@ -237,7 +247,121 @@ func TestGetTxData_ExtractsAllData(t *testing.T) {
 	}
 }
 
-func Test_mustToUint256_ValidInputs_ProducesSameValueResult(t *testing.T) {
+func Test_getTxDataInternal_DetectsUnsupportedTransactionType(t *testing.T) {
+	txDataSource := &fakeTxDataSource{
+		txType: 0x99, // an unsupported transaction type
+	}
+
+	_, err := getTxDataInternal(txDataSource)
+	require.Error(t, err, "unsupported transaction type: 0x99")
+}
+
+func Test_getTxDataInternal_DetectsNilToAddressForBlobTxType(t *testing.T) {
+	txDataSource := &fakeTxDataSource{
+		txType: types.BlobTxType,
+		to:     nil, // BlobTx requires a non-nil To address
+	}
+
+	_, err := getTxDataInternal(txDataSource)
+	require.Error(t, err, "blob transactions must have a recipient")
+}
+
+func Test_getTxDataInternal_BlobTxType_DetectsOutOfDomainValues(t *testing.T) {
+	values := map[string]struct {
+		value *big.Int
+		valid bool
+	}{
+		"nil":       {value: nil, valid: true},
+		"zero":      {value: big.NewInt(0), valid: true},
+		"positive":  {value: big.NewInt(123456789), valid: true},
+		"negative":  {value: big.NewInt(-1), valid: false},
+		"too large": {value: new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), valid: false},
+	}
+
+	fields := map[string]func(*fakeTxDataSource, *big.Int){
+		"ChainId":    func(f *fakeTxDataSource, v *big.Int) { f.chainId = v },
+		"GasTipCap":  func(f *fakeTxDataSource, v *big.Int) { f.gasTipCap = v },
+		"GasFeeCap":  func(f *fakeTxDataSource, v *big.Int) { f.gasFeeCap = v },
+		"Value":      func(f *fakeTxDataSource, v *big.Int) { f.value = v },
+		"BlobFeeCap": func(f *fakeTxDataSource, v *big.Int) { f.blobGasFeeCap = v },
+		"V":          func(f *fakeTxDataSource, v *big.Int) { f.v = v },
+		"R":          func(f *fakeTxDataSource, v *big.Int) { f.r = v },
+		"S":          func(f *fakeTxDataSource, v *big.Int) { f.s = v },
+	}
+
+	for fieldName, setField := range fields {
+		for valueName, value := range values {
+			t.Run(fmt.Sprintf("%s=%s", fieldName, valueName), func(t *testing.T) {
+				txDataSource := &fakeTxDataSource{
+					txType: types.BlobTxType,
+					to:     &common.Address{0x01},
+				}
+				setField(txDataSource, value.value)
+
+				_, err := getTxDataInternal(txDataSource)
+				if value.valid {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err, fmt.Sprintf("out of uint256 domain: %v", value))
+				}
+			})
+		}
+	}
+}
+
+func Test_getTxDataInternal_DetectsNilToAddressForSetCodeTxType(t *testing.T) {
+	txDataSource := &fakeTxDataSource{
+		txType: types.SetCodeTxType,
+		to:     nil, // SetCodeTx requires a non-nil To address
+	}
+
+	_, err := getTxDataInternal(txDataSource)
+	require.Error(t, err, "set code transactions must have a recipient")
+}
+
+func Test_getTxDataInternal_SetCodeTxType_DetectsOutOfDomainValues(t *testing.T) {
+	values := map[string]struct {
+		value *big.Int
+		valid bool
+	}{
+		"nil":       {value: nil, valid: true},
+		"zero":      {value: big.NewInt(0), valid: true},
+		"positive":  {value: big.NewInt(123456789), valid: true},
+		"negative":  {value: big.NewInt(-1), valid: false},
+		"too large": {value: new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), valid: false},
+	}
+
+	fields := map[string]func(*fakeTxDataSource, *big.Int){
+		"ChainId":   func(f *fakeTxDataSource, v *big.Int) { f.chainId = v },
+		"GasTipCap": func(f *fakeTxDataSource, v *big.Int) { f.gasTipCap = v },
+		"GasFeeCap": func(f *fakeTxDataSource, v *big.Int) { f.gasFeeCap = v },
+		"Value":     func(f *fakeTxDataSource, v *big.Int) { f.value = v },
+		"V":         func(f *fakeTxDataSource, v *big.Int) { f.v = v },
+		"R":         func(f *fakeTxDataSource, v *big.Int) { f.r = v },
+		"S":         func(f *fakeTxDataSource, v *big.Int) { f.s = v },
+	}
+
+	for fieldName, setField := range fields {
+		for valueName, value := range values {
+			t.Run(fmt.Sprintf("%s=%s", fieldName, valueName), func(t *testing.T) {
+				txDataSource := &fakeTxDataSource{
+					txType: types.SetCodeTxType,
+					to:     &common.Address{0x01},
+				}
+				setField(txDataSource, value.value)
+
+				_, err := getTxDataInternal(txDataSource)
+				if value.valid {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err, fmt.Sprintf("out of uint256 domain: %v", value))
+				}
+			})
+		}
+	}
+}
+
+func Test_toUint256_ValidInputs_ProducesSameValueResult(t *testing.T) {
 	tests := map[string]struct {
 		input    *big.Int
 		expected *uint256.Int
@@ -258,7 +382,8 @@ func Test_mustToUint256_ValidInputs_ProducesSameValueResult(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			result := mustToUint256(test.input)
+			result, err := toUint256(test.input)
+			require.NoError(t, err)
 			require.Equal(t, test.expected, result)
 			if test.input != nil {
 				test.input.SetInt64(0)                  // mutate input to check for copying
@@ -268,7 +393,7 @@ func Test_mustToUint256_ValidInputs_ProducesSameValueResult(t *testing.T) {
 	}
 }
 
-func Test_mustToUint256_InvalidInputs_Panics(t *testing.T) {
+func Test_toUint256_InvalidInputs_ReportsError(t *testing.T) {
 	tests := map[string]*big.Int{
 		"-1":     new(big.Int).Sub(big.NewInt(0), big.NewInt(1)),
 		"-20":    new(big.Int).Sub(big.NewInt(0), big.NewInt(20)),
@@ -278,11 +403,88 @@ func Test_mustToUint256_InvalidInputs_Panics(t *testing.T) {
 
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.PanicsWithValue(t,
-				fmt.Sprintf("out of uint256 domain: %v", input), func() {
-					mustToUint256(input)
-				},
-			)
+			_, err := toUint256(input)
+			require.Error(t, err, fmt.Sprintf("out of uint256 domain: %v", input))
 		})
 	}
+}
+
+type fakeTxDataSource struct {
+	chainId       *big.Int
+	nonce         uint64
+	gasPrice      *big.Int
+	gasFeeCap     *big.Int
+	gasTipCap     *big.Int
+	gas           uint64
+	to            *common.Address
+	value         *big.Int
+	data          []byte
+	accessList    types.AccessList
+	blobGasFeeCap *big.Int
+	blobHashes    []common.Hash
+	authList      []types.SetCodeAuthorization
+	v             *big.Int
+	r             *big.Int
+	s             *big.Int
+	txType        uint8
+}
+
+func (f *fakeTxDataSource) ChainId() *big.Int {
+	return f.chainId
+}
+
+func (f *fakeTxDataSource) Nonce() uint64 {
+	return f.nonce
+}
+
+func (f *fakeTxDataSource) GasPrice() *big.Int {
+	return f.gasPrice
+}
+
+func (f *fakeTxDataSource) GasFeeCap() *big.Int {
+	return f.gasFeeCap
+}
+
+func (f *fakeTxDataSource) GasTipCap() *big.Int {
+	return f.gasTipCap
+}
+
+func (f *fakeTxDataSource) Gas() uint64 {
+	return f.gas
+}
+
+func (f *fakeTxDataSource) To() *common.Address {
+	return f.to
+}
+
+func (f *fakeTxDataSource) Value() *big.Int {
+	return f.value
+}
+
+func (f *fakeTxDataSource) Data() []byte {
+	return f.data
+}
+
+func (f *fakeTxDataSource) AccessList() types.AccessList {
+	return f.accessList
+}
+
+func (f *fakeTxDataSource) BlobGasFeeCap() *big.Int {
+	return f.blobGasFeeCap
+}
+
+func (f *fakeTxDataSource) BlobHashes() []common.Hash {
+	return f.blobHashes
+}
+
+func (f *fakeTxDataSource) SetCodeAuthorizations() []types.SetCodeAuthorization {
+	return f.authList
+}
+
+func (f *fakeTxDataSource) Type() uint8 {
+	return f.txType
+}
+
+func (f *fakeTxDataSource) RawSignatureValues() (v, r, s *big.Int) {
+	return f.v, f.r, f.s
 }


### PR DESCRIPTION
This PR eliminates a potential panic from the transaction utils by replacing it with explicit error handling.

The utility is used in the bundle validation, and is thus part of critical code.  This update removes the panic from the code.