### PR TITLE
Add monitoring metrics to bundle pre-checks

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -25,10 +25,17 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/metrics"
 	lru "github.com/hashicorp/golang-lru"
+)
+
+var (
+	evaluatedBundlesCount         = metrics.GetOrRegisterCounter("bundles/pre_check/count", nil)
+	evaluatedBundlesExecutionCost = metrics.GetOrRegisterCounter("bundles/pre_check/execution_cost", nil)
 )
 
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
@@ -350,6 +357,8 @@ func trialRunBundle(
 		stateDb,
 		realTransactionProcessorFactory{},
 		rand.Read,
+		evaluatedBundlesCount,
+		evaluatedBundlesExecutionCost,
 	)
 }
 
@@ -361,6 +370,8 @@ func trialRunBundleInternal(
 	stateDb state.StateDB,
 	factory transactionProcessorFactory,
 	readRandom func([]byte) (int, error),
+	evaluatedBundlesCount utils.MetricsCounterWrapper,
+	evaluatedBundlesExecutionCost utils.MetricsCounterWrapper,
 ) (*float64, bool) {
 	latestHeader := chain.GetLatestHeader()
 	blobBaseFee := GetBlobBaseFee()
@@ -398,6 +409,9 @@ func trialRunBundleInternal(
 			usedGas += tx.Receipt.GasUsed
 		}
 	}
+
+	evaluatedBundlesCount.Inc(1)
+	evaluatedBundlesExecutionCost.Inc(int64(summary.ExecutionCost))
 
 	// Calculate the gas efficiency of the bundle and check if it meets the minimum threshold.
 	gasEfficiency := new(float64)

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -36,12 +36,12 @@ import (
 var (
 	// evaluatedBundleTxsCount is a counter of the number of bundle envelopes
 	// that have been trial-run during bundle pre-checks.
-	evaluatedBundlesCount = metrics.GetOrRegisterCounter("bundles/pre_check/count", nil)
-	// evaluatedBundlesExecutionCost is a counter of the total execution cost in gas of
+	evaluatedBundlesCounter = metrics.GetOrRegisterCounter("bundles/pre_check/count", nil)
+	// evaluatedBundlesExecutionCostCounter is a counter of the total execution cost in gas of
 	// bundle envelopes that have been trial-run during bundle pre-checks.
 	// This counter reports effective execution cost accounting for rolled-back transactions,
 	// so it reflects the actual resource consumption of the trial runs.
-	evaluatedBundlesExecutionCost = metrics.GetOrRegisterCounter("bundles/pre_check/execution_cost", nil)
+	evaluatedBundlesExecutionCostCounter = metrics.GetOrRegisterCounter("bundles/pre_check/execution_cost", nil)
 )
 
 //go:generate mockgen -source=bundle_precheck.go -destination=bundle_precheck_mock.go -package=evmcore
@@ -363,8 +363,8 @@ func trialRunBundle(
 		stateDb,
 		realTransactionProcessorFactory{},
 		rand.Read,
-		evaluatedBundlesCount,
-		evaluatedBundlesExecutionCost,
+		evaluatedBundlesCounter,
+		evaluatedBundlesExecutionCostCounter,
 	)
 }
 

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -376,8 +376,8 @@ func trialRunBundleInternal(
 	stateDb state.StateDB,
 	factory transactionProcessorFactory,
 	readRandom func([]byte) (int, error),
-	evaluatedBundlesCount utils.MetricsCounterWrapper,
-	evaluatedBundlesExecutionCost utils.MetricsCounterWrapper,
+	evaluatedBundlesCount utils.MetricsCounter,
+	evaluatedBundlesExecutionCost utils.MetricsCounter,
 ) (*float64, bool) {
 	latestHeader := chain.GetLatestHeader()
 	blobBaseFee := GetBlobBaseFee()

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -34,7 +34,13 @@ import (
 )
 
 var (
-	evaluatedBundlesCount         = metrics.GetOrRegisterCounter("bundles/pre_check/count", nil)
+	// evaluatedBundleTxsCount is a counter of the number of bundle envelopes
+	// that have been trial-run during bundle pre-checks.
+	evaluatedBundlesCount = metrics.GetOrRegisterCounter("bundles/pre_check/count", nil)
+	// evaluatedBundlesExecutionCost is a counter of the total execution cost in gas of
+	// bundle envelopes that have been trial-run during bundle pre-checks.
+	// This counter reports effective execution cost accounting for rolled-back transactions,
+	// so it reflects the actual resource consumption of the trial runs.
 	evaluatedBundlesExecutionCost = metrics.GetOrRegisterCounter("bundles/pre_check/execution_cost", nil)
 )
 

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -1512,8 +1512,8 @@ func Test_trialRunBundleInternal_IncrementsMetrics(t *testing.T) {
 	db.EXPECT().InterTxSnapshot()
 	db.EXPECT().RevertToInterTxSnapshot(any)
 
-	countMock := utils.NewMockMetricsCounterWrapper(ctrl)
-	gasMock := utils.NewMockMetricsCounterWrapper(ctrl)
+	countMock := utils.NewMockMetricsCounter(ctrl)
+	gasMock := utils.NewMockMetricsCounter(ctrl)
 
 	countMock.EXPECT().Inc(int64(1))
 	gasMock.EXPECT().Inc(int64(expectedExecCost))

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -740,8 +740,8 @@ func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t
 				db,
 				factory,
 				rand.Read,
-				evaluatedBundlesCount,
-				evaluatedBundlesExecutionCost,
+				evaluatedBundlesCounter,
+				evaluatedBundlesExecutionCostCounter,
 			)
 			require.Equal(t, tc.expectAccept, valid)
 
@@ -879,7 +879,7 @@ func Test_trialRunBundleInternal_CreatesSnapshotAndRevertsAfterExecution(t *test
 		Number: big.NewInt(0),
 	})
 
-	trialRunBundleInternal(nil, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
+	trialRunBundleInternal(nil, chainState, db, factory, rand.Read, evaluatedBundlesCounter, evaluatedBundlesExecutionCostCounter)
 }
 
 func Test_trialRunBundleInternal_UsesRandomSourceToFillPrevRandao(t *testing.T) {
@@ -927,7 +927,7 @@ func Test_trialRunBundleInternal_UsesRandomSourceToFillPrevRandao(t *testing.T) 
 				Number: big.NewInt(0),
 			})
 
-			trialRunBundleInternal(nil, chainState, db, factory, read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
+			trialRunBundleInternal(nil, chainState, db, factory, read, evaluatedBundlesCounter, evaluatedBundlesExecutionCostCounter)
 			require.True(called)
 		})
 	}
@@ -952,7 +952,7 @@ func Test_trialRunBundleInternal_FailsIfRandomSourceFails(t *testing.T) {
 				return tc.n, tc.err
 			}
 
-			gasEfficiency, valid := trialRunBundleInternal(nil, chain, nil, nil, readRandom, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
+			gasEfficiency, valid := trialRunBundleInternal(nil, chain, nil, nil, readRandom, evaluatedBundlesCounter, evaluatedBundlesExecutionCostCounter)
 			require.False(t, valid)
 			require.Nil(t, gasEfficiency)
 		})
@@ -999,7 +999,7 @@ func Test_trialRunBundleInternal_DerivesHeaderFieldsFromChainState(t *testing.T)
 	db.EXPECT().InterTxSnapshot()
 	db.EXPECT().RevertToInterTxSnapshot(any)
 
-	trialRunBundleInternal(nil, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
+	trialRunBundleInternal(nil, chainState, db, factory, rand.Read, evaluatedBundlesCounter, evaluatedBundlesExecutionCostCounter)
 }
 
 func Test_trialRunBundleInternal_ForwardsEnvelopeToProcessor(t *testing.T) {
@@ -1025,7 +1025,7 @@ func Test_trialRunBundleInternal_ForwardsEnvelopeToProcessor(t *testing.T) {
 	db.EXPECT().InterTxSnapshot()
 	db.EXPECT().RevertToInterTxSnapshot(any)
 
-	trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
+	trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read, evaluatedBundlesCounter, evaluatedBundlesExecutionCostCounter)
 }
 
 func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.T) {
@@ -1083,7 +1083,7 @@ func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.
 			db.EXPECT().InterTxSnapshot()
 			db.EXPECT().RevertToInterTxSnapshot(any)
 
-			_, valid := trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
+			_, valid := trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read, evaluatedBundlesCounter, evaluatedBundlesExecutionCostCounter)
 			require.Equal(t, tc.expectedResult, valid)
 		})
 	}
@@ -1412,7 +1412,7 @@ func Test_trialRunBundleInternal_ReturnsCorrectGasEfficiency(t *testing.T) {
 			db.EXPECT().InterTxSnapshot()
 			db.EXPECT().RevertToInterTxSnapshot(any)
 
-			gasEfficiency, valid := trialRunBundleInternal(envelope, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
+			gasEfficiency, valid := trialRunBundleInternal(envelope, chainState, db, factory, rand.Read, evaluatedBundlesCounter, evaluatedBundlesExecutionCostCounter)
 			require.Equal(t, tc.expectedAccept, valid)
 			require.InDelta(t, tc.expectedEfficiency, *gasEfficiency, 1e-9)
 		})

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -733,7 +734,15 @@ func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t
 			db.EXPECT().InterTxSnapshot()
 			db.EXPECT().RevertToInterTxSnapshot(any)
 
-			gasEfficiency, valid := trialRunBundleInternal(envelope, chainState, db, factory, rand.Read)
+			gasEfficiency, valid := trialRunBundleInternal(
+				envelope,
+				chainState,
+				db,
+				factory,
+				rand.Read,
+				evaluatedBundlesCount,
+				evaluatedBundlesExecutionCost,
+			)
 			require.Equal(t, tc.expectAccept, valid)
 
 			expectedEfficiency := 0.0
@@ -870,7 +879,7 @@ func Test_trialRunBundleInternal_CreatesSnapshotAndRevertsAfterExecution(t *test
 		Number: big.NewInt(0),
 	})
 
-	trialRunBundleInternal(nil, chainState, db, factory, rand.Read)
+	trialRunBundleInternal(nil, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
 }
 
 func Test_trialRunBundleInternal_UsesRandomSourceToFillPrevRandao(t *testing.T) {
@@ -918,7 +927,7 @@ func Test_trialRunBundleInternal_UsesRandomSourceToFillPrevRandao(t *testing.T) 
 				Number: big.NewInt(0),
 			})
 
-			trialRunBundleInternal(nil, chainState, db, factory, read)
+			trialRunBundleInternal(nil, chainState, db, factory, read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
 			require.True(called)
 		})
 	}
@@ -943,7 +952,7 @@ func Test_trialRunBundleInternal_FailsIfRandomSourceFails(t *testing.T) {
 				return tc.n, tc.err
 			}
 
-			gasEfficiency, valid := trialRunBundleInternal(nil, chain, nil, nil, readRandom)
+			gasEfficiency, valid := trialRunBundleInternal(nil, chain, nil, nil, readRandom, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
 			require.False(t, valid)
 			require.Nil(t, gasEfficiency)
 		})
@@ -990,7 +999,7 @@ func Test_trialRunBundleInternal_DerivesHeaderFieldsFromChainState(t *testing.T)
 	db.EXPECT().InterTxSnapshot()
 	db.EXPECT().RevertToInterTxSnapshot(any)
 
-	trialRunBundleInternal(nil, chainState, db, factory, rand.Read)
+	trialRunBundleInternal(nil, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
 }
 
 func Test_trialRunBundleInternal_ForwardsEnvelopeToProcessor(t *testing.T) {
@@ -1016,7 +1025,7 @@ func Test_trialRunBundleInternal_ForwardsEnvelopeToProcessor(t *testing.T) {
 	db.EXPECT().InterTxSnapshot()
 	db.EXPECT().RevertToInterTxSnapshot(any)
 
-	trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read)
+	trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
 }
 
 func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.T) {
@@ -1074,7 +1083,7 @@ func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.
 			db.EXPECT().InterTxSnapshot()
 			db.EXPECT().RevertToInterTxSnapshot(any)
 
-			_, valid := trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read)
+			_, valid := trialRunBundleInternal(myEnvelope, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
 			require.Equal(t, tc.expectedResult, valid)
 		})
 	}
@@ -1403,7 +1412,7 @@ func Test_trialRunBundleInternal_ReturnsCorrectGasEfficiency(t *testing.T) {
 			db.EXPECT().InterTxSnapshot()
 			db.EXPECT().RevertToInterTxSnapshot(any)
 
-			gasEfficiency, valid := trialRunBundleInternal(envelope, chainState, db, factory, rand.Read)
+			gasEfficiency, valid := trialRunBundleInternal(envelope, chainState, db, factory, rand.Read, evaluatedBundlesCount, evaluatedBundlesExecutionCost)
 			require.Equal(t, tc.expectedAccept, valid)
 			require.InDelta(t, tc.expectedEfficiency, *gasEfficiency, 1e-9)
 		})
@@ -1465,4 +1474,52 @@ func Test_makeRunnableState_StoresGasEfficiency(t *testing.T) {
 			require.Equal(t, efficiency, *state.GasEfficiency)
 		})
 	}
+}
+
+func Test_trialRunBundleInternal_IncrementsMetrics(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+
+	// any envelope works, execution result is mocked
+	envelope := bundle.AllOf(
+		bundle.Step(key, &types.AccessListTx{
+			To:  &common.Address{},
+			Gas: 21_000,
+		}),
+	).Build()
+
+	processedTx := ProcessedTransaction{} // tx after subgroup succeeds
+	expectedExecCost := core_types.ExecutionCost(50_000)
+
+	chainState := NewMockChainStateForBundleEval(ctrl)
+	chainState.EXPECT().GetLatestHeader().Return(&EvmHeader{
+		Number: big.NewInt(0),
+	})
+
+	any := gomock.Any()
+	processor := NewMocktransactionProcessor(ctrl)
+	processor.EXPECT().Run(any, any).Return(ProcessSummary{
+		ProcessedTransactions: []ProcessedTransaction{processedTx},
+		ExecutionCost:         expectedExecCost,
+	})
+
+	factory := NewMocktransactionProcessorFactory(ctrl)
+	factory.EXPECT().newTransactionProcessor(any, any, any).Return(processor)
+
+	db := state.NewMockStateDB(ctrl)
+	db.EXPECT().InterTxSnapshot()
+	db.EXPECT().RevertToInterTxSnapshot(any)
+
+	countMock := utils.NewMockMetricsCounterWrapper(ctrl)
+	gasMock := utils.NewMockMetricsCounterWrapper(ctrl)
+
+	countMock.EXPECT().Inc(int64(1))
+	gasMock.EXPECT().Inc(int64(expectedExecCost))
+
+	trialRunBundleInternal(
+		envelope, chainState, db, factory, rand.Read,
+		countMock, gasMock,
+	)
 }

--- a/utils/metrics.go
+++ b/utils/metrics.go
@@ -45,3 +45,9 @@ func NewPrometheusHistogram(opts prometheus.HistogramOpts) *PrometheusHistogram 
 func (h *PrometheusHistogram) Update(v float64) {
 	h.histogram.Observe(v)
 }
+
+// MetricsCounterWrapper is an interface that wraps the methods of a
+// prometheus Counter to facilitate testing with mocks.
+type MetricsCounterWrapper interface {
+	Inc(int64)
+}

--- a/utils/metrics.go
+++ b/utils/metrics.go
@@ -46,8 +46,8 @@ func (h *PrometheusHistogram) Update(v float64) {
 	h.histogram.Observe(v)
 }
 
-// MetricsCounterWrapper is an interface that wraps the methods of a
+// MetricsCounter is an interface that wraps the methods of a
 // prometheus Counter to facilitate testing with mocks.
-type MetricsCounterWrapper interface {
+type MetricsCounter interface {
 	Inc(int64)
 }

--- a/utils/metrics_mock.go
+++ b/utils/metrics_mock.go
@@ -51,38 +51,38 @@ func (mr *MockMetricsHistogramWrapperMockRecorder) Update(arg0 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockMetricsHistogramWrapper)(nil).Update), arg0)
 }
 
-// MockMetricsCounterWrapper is a mock of MetricsCounterWrapper interface.
-type MockMetricsCounterWrapper struct {
+// MockMetricsCounter is a mock of MetricsCounter interface.
+type MockMetricsCounter struct {
 	ctrl     *gomock.Controller
-	recorder *MockMetricsCounterWrapperMockRecorder
+	recorder *MockMetricsCounterMockRecorder
 	isgomock struct{}
 }
 
-// MockMetricsCounterWrapperMockRecorder is the mock recorder for MockMetricsCounterWrapper.
-type MockMetricsCounterWrapperMockRecorder struct {
-	mock *MockMetricsCounterWrapper
+// MockMetricsCounterMockRecorder is the mock recorder for MockMetricsCounter.
+type MockMetricsCounterMockRecorder struct {
+	mock *MockMetricsCounter
 }
 
-// NewMockMetricsCounterWrapper creates a new mock instance.
-func NewMockMetricsCounterWrapper(ctrl *gomock.Controller) *MockMetricsCounterWrapper {
-	mock := &MockMetricsCounterWrapper{ctrl: ctrl}
-	mock.recorder = &MockMetricsCounterWrapperMockRecorder{mock}
+// NewMockMetricsCounter creates a new mock instance.
+func NewMockMetricsCounter(ctrl *gomock.Controller) *MockMetricsCounter {
+	mock := &MockMetricsCounter{ctrl: ctrl}
+	mock.recorder = &MockMetricsCounterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockMetricsCounterWrapper) EXPECT() *MockMetricsCounterWrapperMockRecorder {
+func (m *MockMetricsCounter) EXPECT() *MockMetricsCounterMockRecorder {
 	return m.recorder
 }
 
 // Inc mocks base method.
-func (m *MockMetricsCounterWrapper) Inc(arg0 int64) {
+func (m *MockMetricsCounter) Inc(arg0 int64) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Inc", arg0)
 }
 
 // Inc indicates an expected call of Inc.
-func (mr *MockMetricsCounterWrapperMockRecorder) Inc(arg0 any) *gomock.Call {
+func (mr *MockMetricsCounterMockRecorder) Inc(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Inc", reflect.TypeOf((*MockMetricsCounterWrapper)(nil).Inc), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Inc", reflect.TypeOf((*MockMetricsCounter)(nil).Inc), arg0)
 }

--- a/utils/metrics_mock.go
+++ b/utils/metrics_mock.go
@@ -50,3 +50,39 @@ func (mr *MockMetricsHistogramWrapperMockRecorder) Update(arg0 any) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockMetricsHistogramWrapper)(nil).Update), arg0)
 }
+
+// MockMetricsCounterWrapper is a mock of MetricsCounterWrapper interface.
+type MockMetricsCounterWrapper struct {
+	ctrl     *gomock.Controller
+	recorder *MockMetricsCounterWrapperMockRecorder
+	isgomock struct{}
+}
+
+// MockMetricsCounterWrapperMockRecorder is the mock recorder for MockMetricsCounterWrapper.
+type MockMetricsCounterWrapperMockRecorder struct {
+	mock *MockMetricsCounterWrapper
+}
+
+// NewMockMetricsCounterWrapper creates a new mock instance.
+func NewMockMetricsCounterWrapper(ctrl *gomock.Controller) *MockMetricsCounterWrapper {
+	mock := &MockMetricsCounterWrapper{ctrl: ctrl}
+	mock.recorder = &MockMetricsCounterWrapperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockMetricsCounterWrapper) EXPECT() *MockMetricsCounterWrapperMockRecorder {
+	return m.recorder
+}
+
+// Inc mocks base method.
+func (m *MockMetricsCounterWrapper) Inc(arg0 int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Inc", arg0)
+}
+
+// Inc indicates an expected call of Inc.
+func (mr *MockMetricsCounterWrapperMockRecorder) Inc(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Inc", reflect.TypeOf((*MockMetricsCounterWrapper)(nil).Inc), arg0)
+}


### PR DESCRIPTION
This metric can be used to localize load issues in the pool-emitter as they share this utility.
These metrics do not provide overview of the bundles used submitted to the network, but instead it can be used to monitor the overhead of processing these bundles in the frontend. 

Bundles pre-check is shared among TX validation on intake, pool promotion and demotion, and the emitter. Values reported by these metrics can be correlated to CPU usage to diagnose the client. 

These metrics are normal counters and can be integrated into norma without further development. 