### PR TITLE
Improve sonic RPC bundle tools testing

### DIFF
--- a/api/sonicapi/execution_plan_test.go
+++ b/api/sonicapi/execution_plan_test.go
@@ -527,6 +527,9 @@ func Test_RPCExecutionPlanComposable_UnmarshalJSON_FailsOnInvalidFirstLevelStep(
 		"step has invalid from field": `{
 			"steps": [{"from": "not-an-address", "hash": "0x0000000000000000000000000000000000000000000000000000000000000000"}]
 		}`,
+		"step has invalid hash field": `{
+			"steps": [{"from": "0x0000000000000000000000000000000000000000", "hash": "not-a-hash"}]
+		}`,
 		"step has nested steps with invalid content": `{
 			"steps": [{"steps": [true]}]
 		}`,

--- a/api/sonicapi/execution_plan_test.go
+++ b/api/sonicapi/execution_plan_test.go
@@ -497,3 +497,69 @@ func expectCanBeDeserialized[T any](t testing.TB, result *T, jsonValue string) {
 	err := json.Unmarshal([]byte(jsonValue), result)
 	require.NoError(t, err, "failed to unmarshal JSON into %T", result)
 }
+
+func Test_RPCExecutionPlanComposable_UnmarshalJSON_FailsOnInvalidTopLevel(t *testing.T) {
+	// Top-level structure cannot be deserialized (not valid JSON at all, or
+	// wrong types for known fields).
+	tests := map[string]string{
+		"not json at all":        `not json`,
+		"top level is an array":  `[]`,
+		"blockRange wrong type":  `{"blockRange": "invalid"}`,
+		"steps is not an array":  `{"steps": 123}`,
+		"oneOf is not a boolean": `{"oneOf": "yes", "steps": []}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var plan RPCExecutionPlanComposable
+			err := json.Unmarshal([]byte(input), &plan)
+			require.Error(t, err)
+		})
+	}
+}
+
+func Test_RPCExecutionPlanComposable_UnmarshalJSON_FailsOnInvalidFirstLevelStep(t *testing.T) {
+	// A step at the first level of "steps" cannot be deserialized.
+	tests := map[string]string{
+		"step is not an object": `{
+			"steps": [123]
+		}`,
+		"step has invalid from field": `{
+			"steps": [{"from": "not-an-address", "hash": "0x0000000000000000000000000000000000000000000000000000000000000000"}]
+		}`,
+		"step has nested steps with invalid content": `{
+			"steps": [{"steps": [true]}]
+		}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var plan RPCExecutionPlanComposable
+			err := json.Unmarshal([]byte(input), &plan)
+			require.Error(t, err)
+		})
+	}
+}
+
+func Test_RPCExecutionPlanComposable_UnmarshalJSON_FailsOnInvalidNestedLevelStep(t *testing.T) {
+	// A step at a deeper nested level cannot be deserialized.
+	tests := map[string]string{
+		"nested group contains non-object element": `{
+			"steps": [{"steps": [{"steps": [42]}]}]
+		}`,
+		"nested group contains invalid leaf": `{
+			"steps": [{"steps": [{"steps": [{"from": "bad", "hash": "0x00"}]}]}]
+		}`,
+		"deeply nested group has malformed steps array": `{
+			"steps": [{"steps": [{"steps": "not-an-array"}]}]
+		}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var plan RPCExecutionPlanComposable
+			err := json.Unmarshal([]byte(input), &plan)
+			require.Error(t, err)
+		})
+	}
+}

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -256,28 +256,28 @@ func convertToTransactionArgs(signer types.Signer, tx *types.Transaction) (ethap
 	}
 
 	if tx.Nonce() != 0 {
-		res.Nonce = toPtr(hexutil.Uint64(tx.Nonce()))
+		res.Nonce = new(hexutil.Uint64(tx.Nonce()))
 	}
 
 	if tx.To() == nil && tx.Data() != nil {
-		res.Input = toPtr(hexutil.Bytes(tx.Data()))
+		res.Input = new(hexutil.Bytes(tx.Data()))
 	}
 	if tx.To() != nil && tx.Data() != nil {
-		res.Data = toPtr(hexutil.Bytes(tx.Data()))
+		res.Data = new(hexutil.Bytes(tx.Data()))
 	}
 
 	if tx.Value() != nil && tx.Value().Cmp(big.NewInt(0)) > 0 {
-		res.Value = toPtr(hexutil.Big(*tx.Value()))
+		res.Value = new(hexutil.Big(*tx.Value()))
 	}
 
 	if tx.Gas() != 0 {
-		res.Gas = toPtr(hexutil.Uint64(tx.Gas()))
+		res.Gas = new(hexutil.Uint64(tx.Gas()))
 	}
 
 	// Type 1 tx
 
 	if tx.Type() >= types.AccessListTxType && len(tx.AccessList()) > 0 {
-		res.AccessList = toPtr(tx.AccessList())
+		res.AccessList = new(tx.AccessList())
 	}
 
 	// Type 2 txs, dynamic fees
@@ -285,14 +285,14 @@ func convertToTransactionArgs(signer types.Signer, tx *types.Transaction) (ethap
 	switch tx.Type() {
 	case types.LegacyTxType, types.AccessListTxType:
 		if tx.GasPrice().Cmp(big.NewInt(0)) > 0 {
-			res.GasPrice = toPtr(hexutil.Big(*tx.GasPrice()))
+			res.GasPrice = new(hexutil.Big(*tx.GasPrice()))
 		}
 	case types.DynamicFeeTxType, types.BlobTxType, types.SetCodeTxType:
 		if tx.GasTipCap().Cmp(big.NewInt(0)) > 0 {
-			res.MaxPriorityFeePerGas = toPtr(hexutil.Big(*tx.GasTipCap()))
+			res.MaxPriorityFeePerGas = new(hexutil.Big(*tx.GasTipCap()))
 		}
 		if tx.GasFeeCap().Cmp(big.NewInt(0)) > 0 {
-			res.MaxFeePerGas = toPtr(hexutil.Big(*tx.GasFeeCap()))
+			res.MaxFeePerGas = new(hexutil.Big(*tx.GasFeeCap()))
 		}
 	}
 
@@ -460,8 +460,4 @@ func transform(
 			Steps:            resultSteps,
 		},
 	}, nil
-}
-
-func toPtr[T any](v T) *T {
-	return &v
 }

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -1245,3 +1245,68 @@ func Test_convertProposalToPlan_ReturnsErrors(t *testing.T) {
 		})
 	}
 }
+
+func Test_RPCExecutionProposal_UnmarshalJSON_FailsOnInvalidTopLevel(t *testing.T) {
+	tests := map[string]string{
+		"not json at all":        `not json`,
+		"top level is an array":  `[]`,
+		"blockRange wrong type":  `{"blockRange": "invalid"}`,
+		"steps is not an array":  `{"steps": 123}`,
+		"oneOf is not a boolean": `{"oneOf": "yes", "steps": []}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var proposal RPCExecutionProposal
+			err := json.Unmarshal([]byte(input), &proposal)
+			require.Error(t, err)
+		})
+	}
+}
+
+func Test_RPCExecutionProposal_UnmarshalJSON_FailsOnInvalidFirstLevelStep(t *testing.T) {
+	tests := map[string]string{
+		"step is not an object": `{
+			"steps": [123]
+		}`,
+		"step has invalid from field": `{
+			"steps": [{"from": "not-an-address", "to": "0x0000000000000000000000000000000000000001"}]
+		}`,
+		"step has nested steps with invalid content": `{
+			"steps": [{"steps": [true]}]
+		}`,
+		"step has nested steps with invalid flags": `{
+			"steps": [{"tolerateFailed": "not a boolean"}]
+		}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var proposal RPCExecutionProposal
+			err := json.Unmarshal([]byte(input), &proposal)
+			require.Error(t, err)
+		})
+	}
+}
+
+func Test_RPCExecutionProposal_UnmarshalJSON_FailsOnInvalidNestedLevelStep(t *testing.T) {
+	tests := map[string]string{
+		"nested group contains non-object element": `{
+			"steps": [{"steps": [{"steps": [42]}]}]
+		}`,
+		"nested group contains invalid leaf": `{
+			"steps": [{"steps": [{"steps": [{"from": "bad"}]}]}]
+		}`,
+		"deeply nested group has malformed steps array": `{
+			"steps": [{"steps": [{"steps": "not-an-array"}]}]
+		}`,
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			var proposal RPCExecutionProposal
+			err := json.Unmarshal([]byte(input), &proposal)
+			require.Error(t, err)
+		})
+	}
+}

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -761,44 +761,235 @@ func Test_convertVisitorLeafIntoRPCExecutionPlanProposalLeaf_canReturnErrors(t *
 	}
 }
 
-func Test_transform(t *testing.T) {
+func Test_transform_AppliesFunctionToAllLeaves(t *testing.T) {
+	address := common.Address{1}
 
-	proposal := RPCExecutionProposal{
-		RPCExecutionPlanGroup: RPCExecutionPlanGroup{
-			Steps: []any{
-				RPCExecutionStepProposal{},
-				RPCExecutionPlanGroup{
+	markTolerateFailed := func(step RPCExecutionStepProposal) (RPCExecutionStepProposal, error) {
+		step.TolerateFailed = true
+		return step, nil
+	}
+
+	tests := map[string]struct {
+		proposal RPCExecutionProposal
+		expected RPCExecutionProposal
+	}{
+		"nil steps returns proposal unchanged": {
+			proposal: RPCExecutionProposal{},
+			expected: RPCExecutionProposal{},
+		},
+		"empty steps": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{Steps: []any{}},
+			},
+			expected: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{Steps: []any{}},
+			},
+		},
+		"single leaf step": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{RPCExecutionStepProposal{}},
+				},
+			},
+			expected: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{RPCExecutionStepProposal{TolerateFailed: true}},
+				},
+			},
+		},
+		"multiple leaf steps": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 					Steps: []any{
+						RPCExecutionStepProposal{},
+						RPCExecutionStepProposal{TolerateInvalid: true},
+					},
+				},
+			},
+			expected: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{TolerateFailed: true},
+						RPCExecutionStepProposal{TolerateFailed: true, TolerateInvalid: true},
+					},
+				},
+			},
+		},
+		"leaf mixed with nested group": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionStepProposal{},
+						RPCExecutionPlanGroup{
+							OneOf: true,
+							Steps: []any{RPCExecutionStepProposal{}},
+						},
 						RPCExecutionStepProposal{},
 					},
 				},
-				RPCExecutionStepProposal{},
 			},
-		},
-	}
-
-	newProposal, err := transform(proposal,
-		func(step RPCExecutionStepProposal) (RPCExecutionStepProposal, error) {
-			step.TolerateFailed = true
-			return step, nil
-		})
-	require.NoError(t, err)
-
-	expected := RPCExecutionProposal{
-		RPCExecutionPlanGroup: RPCExecutionPlanGroup{
-			Steps: []any{
-				RPCExecutionStepProposal{TolerateFailed: true},
-				RPCExecutionPlanGroup{
+			expected: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
 					Steps: []any{
+						RPCExecutionStepProposal{TolerateFailed: true},
+						RPCExecutionPlanGroup{
+							OneOf: true,
+							Steps: []any{RPCExecutionStepProposal{TolerateFailed: true}},
+						},
 						RPCExecutionStepProposal{TolerateFailed: true},
 					},
 				},
-				RPCExecutionStepProposal{TolerateFailed: true},
+			},
+		},
+		"deeply nested groups": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							Steps: []any{
+								RPCExecutionPlanGroup{
+									OneOf: true,
+									Steps: []any{RPCExecutionStepProposal{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							Steps: []any{
+								RPCExecutionPlanGroup{
+									OneOf: true,
+									Steps: []any{RPCExecutionStepProposal{TolerateFailed: true}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"preserves group flags": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					TolerateFailures: true,
+					OneOf:            true,
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TransactionArgs: ethapi.TransactionArgs{From: &address},
+						},
+					},
+				},
+			},
+			expected: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					TolerateFailures: true,
+					OneOf:            true,
+					Steps: []any{
+						RPCExecutionStepProposal{
+							TolerateFailed:  true,
+							TransactionArgs: ethapi.TransactionArgs{From: &address},
+						},
+					},
+				},
+			},
+		},
+		"preserves block range": {
+			proposal: RPCExecutionProposal{
+				BlockRange: &RPCRange{First: 10, Length: 20},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{RPCExecutionStepProposal{}},
+				},
+			},
+			expected: RPCExecutionProposal{
+				BlockRange: &RPCRange{First: 10, Length: 20},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{RPCExecutionStepProposal{TolerateFailed: true}},
+				},
 			},
 		},
 	}
 
-	require.Equal(t, expected, newProposal)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := transform(tt.proposal, markTolerateFailed)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_transform_ReturnsErrors(t *testing.T) {
+	injectedErr := fmt.Errorf("injected error")
+
+	alwaysFails := func(step RPCExecutionStepProposal) (RPCExecutionStepProposal, error) {
+		return step, injectedErr
+	}
+
+	tests := map[string]struct {
+		proposal RPCExecutionProposal
+	}{
+		"error on leaf step at top level": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{RPCExecutionStepProposal{}},
+				},
+			},
+		},
+		"error on leaf step inside nested group": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							Steps: []any{RPCExecutionStepProposal{}},
+						},
+					},
+				},
+			},
+		},
+		"error on leaf step inside deeply nested group": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							Steps: []any{
+								RPCExecutionPlanGroup{
+									Steps: []any{RPCExecutionStepProposal{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"unknown step type at top level": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{"unexpected string"},
+				},
+			},
+		},
+		"unknown step type inside nested group": {
+			proposal: RPCExecutionProposal{
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							Steps: []any{42},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := transform(tt.proposal, alwaysFails)
+			require.Error(t, err)
+		})
+	}
 }
 
 func Test_convertProposalToPlan(t *testing.T) {


### PR DESCRIPTION
- Improve coverage of error cases during deserialization of RPC json types.
- Improve coverage of error cases during transform of RPCBundleProposal 
- use golang 1.26 new expression instead of toPtr