### PR TITLE
Fix flaky bundles restart test

### DIFF
--- a/tests/bundles/stop_start_network_test.go
+++ b/tests/bundles/stop_start_network_test.go
@@ -49,7 +49,7 @@ func testBundle_GetBundleInfoSurvivesNetworkRestart(t *testing.T, net *tests.Int
 	defer client.Close()
 
 	signer := types.LatestSignerForChainID(net.GetChainId())
-	sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+	senders := tests.MakeAccountsWithBalance(t, net, numBundles, big.NewInt(1e18))
 
 	block, err := client.BlockNumber(t.Context())
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func testBundle_GetBundleInfoSurvivesNetworkRestart(t *testing.T, net *tests.Int
 		envelope, plan := bundle.NewBuilder().
 			WithSigner(signer).
 			SetEarliest(block).
-			AllOf(Step(t, net, sender, &types.AccessListTx{})).
+			AllOf(Step(t, net, senders[i], &types.AccessListTx{})).
 			BuildEnvelopeAndPlan()
 
 		_, err = net.Send(envelope)


### PR DESCRIPTION
Prevent submitting transactions with the same nonce by using different accounts. 