### PR TITLE
Sponsorship and Bundle metrics

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -420,12 +420,16 @@ func trialRunBundleInternal(
 	evaluatedBundlesExecutionCost.Inc(int64(summary.ExecutionCost))
 
 	// Calculate the gas efficiency of the bundle and check if it meets the minimum threshold.
+	totalExecCost := core_types.ExecutionCost(0)
+	for _, cost := range summary.ExecutionCost {
+		totalExecCost += cost
+	}
 	gasEfficiency := new(float64)
-	if summary.ExecutionCost > 0 {
-		efficiency := float64(usedGas) / float64(summary.ExecutionCost)
+	if totalExecCost > 0 {
+		efficiency := float64(usedGas) / float64(totalExecCost)
 		*gasEfficiency = efficiency
 	}
-	if summary.ExecutionCost == 0 || *gasEfficiency < MinBundleEfficiency {
+	if totalExecCost == 0 || *gasEfficiency < MinBundleEfficiency {
 		return gasEfficiency, false
 	}
 

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -417,10 +417,7 @@ func trialRunBundleInternal(
 	}
 
 	// Calculate the gas efficiency of the bundle and check if it meets the minimum threshold.
-	totalExecCost := core_types.ExecutionCost(0)
-	for _, cost := range summary.ExecutionCost {
-		totalExecCost += cost
-	}
+	totalExecCost := summary.TotalExecutionCost()
 
 	evaluatedBundlesCount.Inc(1)
 	evaluatedBundlesExecutionCost.Inc(int64(totalExecCost))

--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -416,14 +416,15 @@ func trialRunBundleInternal(
 		}
 	}
 
-	evaluatedBundlesCount.Inc(1)
-	evaluatedBundlesExecutionCost.Inc(int64(summary.ExecutionCost))
-
 	// Calculate the gas efficiency of the bundle and check if it meets the minimum threshold.
 	totalExecCost := core_types.ExecutionCost(0)
 	for _, cost := range summary.ExecutionCost {
 		totalExecCost += cost
 	}
+
+	evaluatedBundlesCount.Inc(1)
+	evaluatedBundlesExecutionCost.Inc(int64(totalExecCost))
+
 	gasEfficiency := new(float64)
 	if totalExecCost > 0 {
 		efficiency := float64(usedGas) / float64(totalExecCost)

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -1495,7 +1495,7 @@ func Test_trialRunBundleInternal_IncrementsMetrics(t *testing.T) {
 	).Build()
 
 	processedTx := ProcessedTransaction{} // tx after subgroup succeeds
-	expectedExecCost := core_types.ExecutionCost(50_000)
+	expectedExecCost := map[common.Hash]core_types.ExecutionCost{{0x01}: 50_000}
 
 	chainState := NewMockChainStateForBundleEval(ctrl)
 	chainState.EXPECT().GetLatestHeader().Return(&EvmHeader{
@@ -1520,7 +1520,7 @@ func Test_trialRunBundleInternal_IncrementsMetrics(t *testing.T) {
 	gasMock := utils.NewMockMetricsCounter(ctrl)
 
 	countMock.EXPECT().Inc(int64(1))
-	gasMock.EXPECT().Inc(int64(expectedExecCost))
+	gasMock.EXPECT().Inc(int64(expectedExecCost[common.Hash{0x01}]))
 
 	trialRunBundleInternal(
 		envelope, chainState, db, factory, rand.Read,

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -723,7 +723,7 @@ func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t
 			processor.EXPECT().Run(any, any).Return(
 				ProcessSummary{
 					ProcessedTransactions: tc.processedTxs,
-					ExecutionCost:         tc.execCost,
+					ExecutionCosts:        tc.execCost,
 				},
 			)
 
@@ -1077,7 +1077,7 @@ func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.
 			processor := NewMocktransactionProcessor(ctrl)
 			processor.EXPECT().Run(any, any).Return(ProcessSummary{
 				ProcessedTransactions: tc.processedTxs,
-				ExecutionCost:         map[common.Hash]core_types.ExecutionCost{{}: 1},
+				ExecutionCosts:        map[common.Hash]core_types.ExecutionCost{{}: 1},
 			})
 
 			factory := NewMocktransactionProcessorFactory(ctrl)
@@ -1405,7 +1405,7 @@ func Test_trialRunBundleInternal_ReturnsCorrectGasEfficiency(t *testing.T) {
 			processor.EXPECT().Run(any, any).Return(
 				ProcessSummary{
 					ProcessedTransactions: tc.processedTxs,
-					ExecutionCost:         tc.execCost,
+					ExecutionCosts:        tc.execCost,
 				},
 			)
 
@@ -1506,7 +1506,7 @@ func Test_trialRunBundleInternal_IncrementsMetrics(t *testing.T) {
 	processor := NewMocktransactionProcessor(ctrl)
 	processor.EXPECT().Run(any, any).Return(ProcessSummary{
 		ProcessedTransactions: []ProcessedTransaction{processedTx},
-		ExecutionCost:         expectedExecCost,
+		ExecutionCosts:        expectedExecCost,
 	})
 
 	factory := NewMocktransactionProcessorFactory(ctrl)

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -665,22 +665,22 @@ func Test_trialRunBundle_DoesRunTransactionsThroughEVMAndReturnsIfTransactionsGo
 func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t *testing.T) {
 	tests := map[string]struct {
 		processedTxs []ProcessedTransaction
-		execCost     core_types.ExecutionCost
+		execCost     map[common.Hash]core_types.ExecutionCost
 		expectAccept bool
 	}{
 		"below threshold with empty bundle": {
 			processedTxs: []ProcessedTransaction{},
-			execCost:     core_types.ExecutionCost(0),
+			execCost:     map[common.Hash]core_types.ExecutionCost{},
 			expectAccept: false,
 		},
 		"below threshold with no receipts": {
 			processedTxs: []ProcessedTransaction{},
-			execCost:     core_types.ExecutionCost(100),
+			execCost:     map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectAccept: false,
 		},
 		"below threshold with single receipt": {
 			processedTxs: []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 19}}},
-			execCost:     core_types.ExecutionCost(100),
+			execCost:     map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectAccept: false,
 		},
 		"below threshold with multiple receipts": {
@@ -688,12 +688,12 @@ func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t
 				{Receipt: &types.Receipt{GasUsed: 9}},
 				{Receipt: &types.Receipt{GasUsed: 10}},
 			},
-			execCost:     core_types.ExecutionCost(100),
+			execCost:     map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectAccept: false,
 		},
 		"above threshold with single receipt": {
 			processedTxs: []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 21}}},
-			execCost:     core_types.ExecutionCost(100),
+			execCost:     map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectAccept: true,
 		},
 		"above threshold with multiple receipts": {
@@ -701,7 +701,7 @@ func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t
 				{Receipt: &types.Receipt{GasUsed: 10}},
 				{Receipt: &types.Receipt{GasUsed: 11}},
 			},
-			execCost:     core_types.ExecutionCost(100),
+			execCost:     map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectAccept: true,
 		},
 	}
@@ -745,13 +745,17 @@ func Test_trialRunBundleInternal_RejectsBundlesWhereEfficiencyIsBelowThreshold(t
 			)
 			require.Equal(t, tc.expectAccept, valid)
 
+			totalExecCost := core_types.ExecutionCost(0)
+			for _, cost := range tc.execCost {
+				totalExecCost += cost
+			}
 			expectedEfficiency := 0.0
-			if tc.execCost > 0 {
+			if totalExecCost > 0 {
 				gasUsed := uint64(0)
 				for _, tx := range tc.processedTxs {
 					gasUsed += tx.Receipt.GasUsed
 				}
-				expectedEfficiency = float64(gasUsed) / float64(tc.execCost)
+				expectedEfficiency = float64(gasUsed) / float64(totalExecCost)
 			}
 			require.InDelta(t, expectedEfficiency, *gasEfficiency, 1e-9)
 		})
@@ -1073,7 +1077,7 @@ func Test_trialRunBundleInternal_UsesPresentsOfReceiptToDecideResult(t *testing.
 			processor := NewMocktransactionProcessor(ctrl)
 			processor.EXPECT().Run(any, any).Return(ProcessSummary{
 				ProcessedTransactions: tc.processedTxs,
-				ExecutionCost:         1,
+				ExecutionCost:         map[common.Hash]core_types.ExecutionCost{{}: 1},
 			})
 
 			factory := NewMocktransactionProcessorFactory(ctrl)
@@ -1329,31 +1333,31 @@ func Test_BundleEvaluationCache_ReturnsErrorForInvalidEnvelope(t *testing.T) {
 func Test_trialRunBundleInternal_ReturnsCorrectGasEfficiency(t *testing.T) {
 	tests := map[string]struct {
 		processedTxs       []ProcessedTransaction
-		execCost           core_types.ExecutionCost
+		execCost           map[common.Hash]core_types.ExecutionCost
 		expectedEfficiency float64
 		expectedAccept     bool
 	}{
 		"zero execution cost returns zero efficiency": {
 			processedTxs:       []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 50}}},
-			execCost:           core_types.ExecutionCost(0),
+			execCost:           map[common.Hash]core_types.ExecutionCost{},
 			expectedEfficiency: 0.0,
 			expectedAccept:     false,
 		},
 		"below threshold efficiency": {
 			processedTxs:       []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 10}}},
-			execCost:           core_types.ExecutionCost(100),
+			execCost:           map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectedEfficiency: 0.1,
 			expectedAccept:     false,
 		},
 		"exact threshold efficiency": {
 			processedTxs:       []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 20}}},
-			execCost:           core_types.ExecutionCost(100),
+			execCost:           map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectedEfficiency: 0.2,
 			expectedAccept:     true, // < not <=
 		},
 		"above threshold single receipt": {
 			processedTxs:       []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 50}}},
-			execCost:           core_types.ExecutionCost(100),
+			execCost:           map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectedEfficiency: 0.5,
 			expectedAccept:     true,
 		},
@@ -1362,13 +1366,13 @@ func Test_trialRunBundleInternal_ReturnsCorrectGasEfficiency(t *testing.T) {
 				{Receipt: &types.Receipt{GasUsed: 30}},
 				{Receipt: &types.Receipt{GasUsed: 40}},
 			},
-			execCost:           core_types.ExecutionCost(100),
+			execCost:           map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectedEfficiency: 0.7,
 			expectedAccept:     true,
 		},
 		"full efficiency": {
 			processedTxs:       []ProcessedTransaction{{Receipt: &types.Receipt{GasUsed: 100}}},
-			execCost:           core_types.ExecutionCost(100),
+			execCost:           map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectedEfficiency: 1.0,
 			expectedAccept:     true,
 		},
@@ -1378,7 +1382,7 @@ func Test_trialRunBundleInternal_ReturnsCorrectGasEfficiency(t *testing.T) {
 				{},
 				{Receipt: &types.Receipt{GasUsed: 25}},
 			},
-			execCost:           core_types.ExecutionCost(100),
+			execCost:           map[common.Hash]core_types.ExecutionCost{{}: 100},
 			expectedEfficiency: 0.5,
 			expectedAccept:     true,
 		},

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
@@ -35,10 +36,15 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 )
 
 //go:generate mockgen -source=state_processor.go -destination=state_processor_mock.go -package=evmcore
+
+var (
+	rolledBackBundleCounter = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/bundles/rolledBack", nil))
+)
 
 // StateProcessor is a basic Processor, which takes care of transitioning
 // state from one point to another.
@@ -155,7 +161,7 @@ func (p *StateProcessor) ProcessWithDifficulty(
 	// Iterate over and process the individual transactions
 	return runTransactions(newRunContext(
 		signer, header.BaseFee, statedb, gp, blockNumber, block.Time, usedGas,
-		onNewLog, p.upgrades, &transactionRunner{evm{vmenv}}, p.forReplay,
+		onNewLog, p.upgrades, &transactionRunner{evm{vmenv}}, p.forReplay, rolledBackBundleCounter,
 	), block.Transactions, trueTxOffset, remainingSize)
 }
 
@@ -163,17 +169,18 @@ func (p *StateProcessor) ProcessWithDifficulty(
 // block. It is used as input to the runTransactions helper function and passed
 // along the processing layers to make the parameters available where needed.
 type runContext struct {
-	signer      types.Signer
-	baseFee     *big.Int
-	statedb     state.StateDB
-	gasPool     *core.GasPool
-	blockNumber *big.Int
-	blockTime   inter.Timestamp
-	usedGas     *uint64
-	onNewLog    func(*core_types.Log)
-	upgrades    opera.Upgrades
-	runner      _transactionRunner
-	forReplay   bool // Whether the context is used for replaying transactions or for head state processing.
+	signer                  types.Signer
+	baseFee                 *big.Int
+	statedb                 state.StateDB
+	gasPool                 *core.GasPool
+	blockNumber             *big.Int
+	blockTime               inter.Timestamp
+	usedGas                 *uint64
+	onNewLog                func(*core_types.Log)
+	upgrades                opera.Upgrades
+	runner                  _transactionRunner
+	forReplay               bool // Whether the context is used for replaying transactions or for head state processing.
+	rolledBackBundleCounter utils.MetricsCounter
 }
 
 // newRunContext creates a new runContext instance bundling the given parameters
@@ -192,19 +199,21 @@ func newRunContext(
 	upgrades opera.Upgrades,
 	runner _transactionRunner,
 	isReplay bool,
+	metricsRolledBackBundleCounter utils.MetricsCounter,
 ) *runContext {
 	return &runContext{
-		signer:      signer,
-		baseFee:     baseFee,
-		statedb:     statedb,
-		gasPool:     gasPool,
-		blockNumber: blockNumber,
-		blockTime:   blockTime,
-		usedGas:     usedGas,
-		onNewLog:    onNewLog,
-		upgrades:    upgrades,
-		runner:      runner,
-		forReplay:   isReplay,
+		signer:                  signer,
+		baseFee:                 baseFee,
+		statedb:                 statedb,
+		gasPool:                 gasPool,
+		blockNumber:             blockNumber,
+		blockTime:               blockTime,
+		usedGas:                 usedGas,
+		onNewLog:                onNewLog,
+		upgrades:                upgrades,
+		runner:                  runner,
+		forReplay:               isReplay,
+		rolledBackBundleCounter: metricsRolledBackBundleCounter,
 	}
 }
 
@@ -502,6 +511,10 @@ func (r *transactionRunner) runTransactionBundleInternal(
 		sizeLimit:    sizeLimit,
 	}
 	if !bundle.RunBundle(txBundle, &runner) {
+
+		// Track unsuccessful bundle execution in metrics.
+		ctxt.rolledBackBundleCounter.Inc(1)
+
 		// Mark the execution plan as processed in the StateDB to prevent processing
 		// another bundle with the same execution plan in the same block. Also keep
 		// track of the position of the bundle in the block.
@@ -758,7 +771,7 @@ func (tp *TransactionProcessor) Run(i int, tx *types.Transaction) ProcessSummary
 	return runTransactions(newRunContext(
 		tp.signer, tp.header.BaseFee, tp.stateDb, tp.gp, tp.blockNumber, tp.blockTime,
 		&tp.usedGas, tp.onNewLog, tp.upgrades, &transactionRunner{evm{tp.vmEnvironment}},
-		false,
+		false, rolledBackBundleCounter,
 	), []*types.Transaction{tx}, i, math.MaxUint64)
 }
 

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
@@ -42,10 +41,6 @@ import (
 
 //go:generate mockgen -source=state_processor.go -destination=state_processor_mock.go -package=evmcore
 
-var (
-	rolledBackBundleCounter = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/bundles/rolledBack", nil))
-)
-
 // StateProcessor is a basic Processor, which takes care of transitioning
 // state from one point to another.
 //
@@ -55,6 +50,8 @@ type StateProcessor struct {
 	bc        DummyChain          // Canonical block chain
 	upgrades  opera.Upgrades      // Enabled network upgrades
 	forReplay bool                // Whether the state processor is used for replaying transactions or for head state processing.
+
+	rolledBackBundleCounter utils.MetricsCounter
 }
 
 // NewStateProcessorForHeadState initializes a new StateProcessor for head state processing.
@@ -62,11 +59,13 @@ func NewStateProcessorForHeadState(
 	config *params.ChainConfig,
 	bc DummyChain,
 	upgrades opera.Upgrades,
+	rolledBackBundleCounter utils.MetricsCounter,
 ) *StateProcessor {
 	return &StateProcessor{
-		config:   config,
-		bc:       bc,
-		upgrades: upgrades,
+		config:                  config,
+		bc:                      bc,
+		upgrades:                upgrades,
+		rolledBackBundleCounter: rolledBackBundleCounter,
 	}
 }
 
@@ -181,7 +180,7 @@ func (p *StateProcessor) ProcessWithDifficulty(
 	// Iterate over and process the individual transactions
 	return runTransactions(newRunContext(
 		signer, header.BaseFee, statedb, gp, blockNumber, block.Time, usedGas,
-		onNewLog, p.upgrades, &transactionRunner{evm{vmenv}}, p.forReplay, rolledBackBundleCounter,
+		onNewLog, p.upgrades, &transactionRunner{evm{vmenv}}, p.forReplay, p.rolledBackBundleCounter,
 	), block.Transactions, trueTxOffset, remainingSize)
 }
 
@@ -533,7 +532,9 @@ func (r *transactionRunner) runTransactionBundleInternal(
 	if !bundle.RunBundle(txBundle, &runner) {
 
 		// Track unsuccessful bundle execution in metrics.
-		ctxt.rolledBackBundleCounter.Inc(1)
+		if ctxt.rolledBackBundleCounter != nil {
+			ctxt.rolledBackBundleCounter.Inc(1)
+		}
 
 		// Mark the execution plan as processed in the StateDB to prevent processing
 		// another bundle with the same execution plan in the same block. Also keep
@@ -727,7 +728,7 @@ func NewTransactionProcessorForBlock(
 	// in the scheduler. See the scheduler.Schedule method for details. The
 	// total gas used for attempting to schedule transactions is not limited.
 	gasLimit := uint64(math.MaxUint64)
-	stateProcessor := NewStateProcessorForHeadState(chainCfg, chain, rules.Upgrades)
+	stateProcessor := NewStateProcessorForHeadState(chainCfg, chain, rules.Upgrades, nil)
 	return stateProcessor.BeginBlock(block, state, vmConfig, gasLimit, nil)
 }
 
@@ -791,7 +792,7 @@ func (tp *TransactionProcessor) Run(i int, tx *types.Transaction) ProcessSummary
 	return runTransactions(newRunContext(
 		tp.signer, tp.header.BaseFee, tp.stateDb, tp.gp, tp.blockNumber, tp.blockTime,
 		&tp.usedGas, tp.onNewLog, tp.upgrades, &transactionRunner{evm{tp.vmEnvironment}},
-		false, rolledBackBundleCounter,
+		false, nil,
 	), []*types.Transaction{tx}, i, math.MaxUint64)
 }
 

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -84,9 +84,9 @@ func NewStateProcessorForReplay(
 // processing, including gas from rolled-back bundles, which distinguishes it
 // from the usedGas counter that gets reverted on snapshot rollback.
 type ProcessSummary struct {
-	ProcessedTransactions []ProcessedTransaction      // List of processed transactions with their receipts (nil receipt for skipped transactions).
-	ExecutionCost         core_types.ExecutionCost    // Total execution cost (gas used) for all processed transactions, including rolled-back bundles.
-	CausedBy              map[common.Hash]common.Hash // Mapping from transaction hash to the hash of the transaction that caused it.
+	ProcessedTransactions []ProcessedTransaction                   // List of processed transactions with their receipts (nil receipt for skipped transactions).
+	ExecutionCost         map[common.Hash]core_types.ExecutionCost // Mapping from transaction hash to the execution cost of the transaction, including rolled-back bundles.
+	CausedBy              map[common.Hash]common.Hash              // Mapping from transaction hash to the hash of the transaction that caused it.
 }
 
 // ProcessedTransaction represents a transaction that was considered for
@@ -221,7 +221,7 @@ func runTransactions(
 	remainingSize uint64,
 ) ProcessSummary {
 	processedTxs := make([]ProcessedTransaction, 0, len(transactions))
-	totalExecCost := core_types.ExecutionCost(0)
+	execCosts := make(map[common.Hash]core_types.ExecutionCost)
 	causedBy := make(map[common.Hash]common.Hash)
 	for _, tx := range transactions {
 		// Bundle-only transactions are only valid within a bundle and must
@@ -232,7 +232,7 @@ func runTransactions(
 		}
 
 		txs, _, execCost := runTransaction(context, tx, trueTxIndexOffset, remainingSize)
-		totalExecCost += execCost
+		execCosts[tx.Hash()] = execCost
 
 		for _, processedTx := range txs {
 			if processedTx.Receipt != nil { // < only transactions included in the block
@@ -253,7 +253,7 @@ func runTransactions(
 	}
 	return ProcessSummary{
 		ProcessedTransactions: processedTxs,
-		ExecutionCost:         totalExecCost,
+		ExecutionCost:         execCosts,
 		CausedBy:              causedBy,
 	}
 }

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -93,7 +93,7 @@ type ProcessSummary struct {
 	// with their receipts (nil receipt for skipped transactions).
 	ProcessedTransactions []ProcessedTransaction
 
-	// ExecutionCost contains the raw execution cost for each transaction,
+	// ExecutionCosts contains the raw execution cost for each transaction,
 	// this differs from gas used as it also includes the gas from rolled-back
 	// bundles.
 	// This is a map from the hash of the transaction that triggered execution to
@@ -101,7 +101,7 @@ type ProcessSummary struct {
 	// - For regular transactions and sponsored transactions, the key is the
 	// hash of the transaction itself.
 	// - For bundles, the key is the hash of the envelope transaction of the bundle.
-	ExecutionCost map[common.Hash]core_types.ExecutionCost
+	ExecutionCosts map[common.Hash]core_types.ExecutionCost
 
 	// CausedBy is a map tx.Hash -> tx.Hash, where the key is the hash
 	// of the transaction that got processed and the value is the hash
@@ -112,6 +112,14 @@ type ProcessSummary struct {
 	// - For transactions included as part of a bundle, the value is the hash
 	// of the envelope transaction of the bundle.
 	CausedBy map[common.Hash]common.Hash
+}
+
+func (s ProcessSummary) TotalExecutionCost() core_types.ExecutionCost {
+	var total core_types.ExecutionCost
+	for _, cost := range s.ExecutionCosts {
+		total += cost
+	}
+	return total
 }
 
 // ProcessedTransaction represents a transaction that was considered for
@@ -281,7 +289,7 @@ func runTransactions(
 	}
 	return ProcessSummary{
 		ProcessedTransactions: processedTxs,
-		ExecutionCost:         execCosts,
+		ExecutionCosts:        execCosts,
 		CausedBy:              causedBy,
 	}
 }

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -90,9 +90,29 @@ func NewStateProcessorForReplay(
 // processing, including gas from rolled-back bundles, which distinguishes it
 // from the usedGas counter that gets reverted on snapshot rollback.
 type ProcessSummary struct {
-	ProcessedTransactions []ProcessedTransaction                   // List of processed transactions with their receipts (nil receipt for skipped transactions).
-	ExecutionCost         map[common.Hash]core_types.ExecutionCost // Mapping from transaction hash to the execution cost of the transaction, including rolled-back bundles.
-	CausedBy              map[common.Hash]common.Hash              // Mapping from transaction hash to the hash of the transaction that caused it.
+	// ProcessedTransactions is a list of processed transactions
+	// with their receipts (nil receipt for skipped transactions).
+	ProcessedTransactions []ProcessedTransaction
+
+	// ExecutionCost contains the raw execution cost for each transaction,
+	// this differs from gas used as it also includes the gas from rolled-back
+	// bundles.
+	// This is a map from the hash of the transaction that triggered execution to
+	// its execution cost.
+	// - For regular transactions and sponsored transactions, the key is the
+	// hash of the transaction itself.
+	// - For bundles, the key is the hash of the envelope transaction of the bundle.
+	ExecutionCost map[common.Hash]core_types.ExecutionCost
+
+	// CausedBy is a map tx.Hash -> tx.Hash, where the key is the hash
+	// of the transaction that got processed and the value is the hash
+	// of the transaction that caused the processing of the key transaction.
+	// - For regular transactions, the value is the same as the key.
+	// - For sponsored transactions, the fees-payment transaction is mapped
+	// to the sponsored transaction.
+	// - For transactions included as part of a bundle, the value is the hash
+	// of the envelope transaction of the bundle.
+	CausedBy map[common.Hash]common.Hash
 }
 
 // ProcessedTransaction represents a transaction that was considered for

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -101,7 +101,7 @@ func TestProcess_ReportsReceiptsOfProcessedTransactions(t *testing.T) {
 
 	chainConfig := params.ChainConfig{}
 	chain := NewMockDummyChain(ctrl)
-	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{}, nil)
 
 	tests := map[string]processFunction{
 		"bulk":        processor.Process,
@@ -212,7 +212,7 @@ func TestProcess_DetectsTransactionThatCanNotBeConvertedIntoAMessage(t *testing.
 	}
 
 	state := getStateDbMockForTransactions(ctrl, transactions)
-	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{}, nil)
 	tests := map[string]processFunction{
 		"bulk":        processor.Process,
 		"incremental": processor.process_iteratively,
@@ -273,7 +273,7 @@ func TestProcess_TracksParentBlockHashIfPragueIsEnabled(t *testing.T) {
 		}
 		chain := NewMockDummyChain(ctrl)
 
-		processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
+		processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{}, nil)
 
 		tests := map[string]processFunction{
 			"bulk":        processor.Process,
@@ -321,7 +321,7 @@ func TestProcess_FailingTransactionAreSkippedButTheBlockIsNotTerminated(t *testi
 
 	chainConfig := params.ChainConfig{}
 	chain := NewMockDummyChain(ctrl)
-	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{}, nil)
 
 	block := &EvmBlock{
 		EvmHeader: EvmHeader{
@@ -380,7 +380,7 @@ func TestProcess_EnforcesGasLimitBySkippingExcessiveTransactions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	chainConfig := params.ChainConfig{}
 	chain := NewMockDummyChain(ctrl)
-	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&chainConfig, chain, opera.Upgrades{}, nil)
 
 	tests := map[string]processFunction{
 		"bulk":        processor.Process,
@@ -467,7 +467,7 @@ func TestProcess_EnforcesGasLimitBySkippingExcessiveTransactions(t *testing.T) {
 
 func TestProcess_UsesDifficultyOfOne(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, opera.Upgrades{})
+	processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, opera.Upgrades{}, nil)
 
 	state, block := createScenarioWithTxCheckingDifficulty(ctrl, big.NewInt(1))
 
@@ -491,7 +491,7 @@ func TestProcessWithDifficulty_UsesProvidedDifficulty(t *testing.T) {
 	for _, difficulty := range []*big.Int{big.NewInt(0), big.NewInt(2), big.NewInt(42)} {
 		t.Run(fmt.Sprintf("difficulty=%s", difficulty.String()), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, opera.Upgrades{})
+			processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, opera.Upgrades{}, nil)
 
 			state, block := createScenarioWithTxCheckingDifficulty(ctrl, difficulty)
 			results := processor.ProcessWithDifficulty(
@@ -581,7 +581,7 @@ func TestProcessWithDifficulty_ForwardsTimeToBundleProcessing(t *testing.T) {
 	processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, opera.Upgrades{
 		Brio:               true,
 		TransactionBundles: true,
-	})
+	}, nil)
 
 	block := &EvmBlock{
 		EvmHeader: EvmHeader{
@@ -613,7 +613,7 @@ func TestProcess_ForwardsCorrectIndexToTransactionProcessor(t *testing.T) {
 		t.Run(fmt.Sprintf("offset=%d", offset), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			upgrades := opera.Upgrades{Brio: true, TransactionBundles: true}
-			processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, upgrades)
+			processor := NewStateProcessorForHeadState(&params.ChainConfig{}, nil, upgrades, nil)
 
 			any := gomock.Any()
 			state := state.NewMockStateDB(ctrl)
@@ -2460,21 +2460,17 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReturnsBundleOnlyTransactionAn
 		}),
 	)
 
-	// No calls in case of successful execution.
-	rolledBackBundlesCounter := utils.NewMockMetricsCounter(ctrl)
-
 	runner := &transactionRunner{evm: evm}
 
 	context := &runContext{
-		statedb:                 state,
-		signer:                  signer,
-		baseFee:                 big.NewInt(1),
-		usedGas:                 new(uint64),
-		gasPool:                 core.NewGasPool(1_000_000),
-		upgrades:                opera.Upgrades{TransactionBundles: true},
-		blockNumber:             big.NewInt(0),
-		runner:                  runner,
-		rolledBackBundleCounter: rolledBackBundlesCounter,
+		statedb:     state,
+		signer:      signer,
+		baseFee:     big.NewInt(1),
+		usedGas:     new(uint64),
+		gasPool:     core.NewGasPool(1_000_000),
+		upgrades:    opera.Upgrades{TransactionBundles: true},
+		blockNumber: big.NewInt(0),
+		runner:      runner,
 	}
 
 	txs := txBundle.GetTransactionsInReferencedOrder()
@@ -2588,9 +2584,6 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 				execResult, core_types.TransactionResultSuccessful,
 			)
 
-			// No calls in case of successful execution.
-			rolledBackBundleCounter := utils.NewMockMetricsCounter(ctrl)
-
 			context := &runContext{
 				statedb: state,
 				signer:  signer,
@@ -2600,9 +2593,8 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 					GasSubsidies:       true,
 					TransactionBundles: true,
 				},
-				blockNumber:             big.NewInt(0),
-				runner:                  innerRunner,
-				rolledBackBundleCounter: rolledBackBundleCounter,
+				blockNumber: big.NewInt(0),
+				runner:      innerRunner,
 			}
 
 			runner := &transactionRunner{}
@@ -3681,14 +3673,13 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 			signer := types.LatestSignerForChainID(big.NewInt(1))
 			upgrades := opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true}
 			ctxt := &runContext{
-				signer:                  signer,
-				usedGas:                 new(uint64),
-				gasPool:                 core.NewGasPool(1_000_000),
-				upgrades:                upgrades,
-				blockNumber:             big.NewInt(0),
-				statedb:                 stateDb,
-				runner:                  runner,
-				rolledBackBundleCounter: rolledBackBundleCounter,
+				signer:      signer,
+				usedGas:     new(uint64),
+				gasPool:     core.NewGasPool(1_000_000),
+				upgrades:    upgrades,
+				blockNumber: big.NewInt(0),
+				statedb:     stateDb,
+				runner:      runner,
 			}
 
 			// the actual execution of the test case

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2391,6 +2391,42 @@ func TestRunTransactionBundle_PreviouslyProcessedBundle_ReturnsEnvelopeAndResult
 	require.Zero(t, execCost)
 }
 
+func TestRunTransactionBundle_RunBundleNotSuccessful_IncrementsRolledBackBundleCounter(t *testing.T) {
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	evm := NewMock_evm(ctrl)
+
+	tx := bundle.OneOf().Build() // an empty OneOf bundle will fail
+	_, plan, err := bundle.ValidateEnvelope(signer, tx)
+	require.NoError(t, err)
+
+	gomock.InOrder(
+		stateDb.EXPECT().HasBundleRecentlyBeenProcessed(plan.Hash()),
+		stateDb.EXPECT().InterTxSnapshot().Return(1),
+		stateDb.EXPECT().RevertToInterTxSnapshot(1),
+		stateDb.EXPECT().AddProcessedBundle(plan.Hash(), gomock.Any()),
+	)
+
+	counter := utils.NewMockMetricsCounter(ctrl)
+	counter.EXPECT().Inc(int64(1))
+
+	context := &runContext{
+		statedb:                 stateDb,
+		signer:                  signer,
+		baseFee:                 big.NewInt(1),
+		usedGas:                 new(uint64),
+		gasPool:                 core.NewGasPool(1_000_000),
+		upgrades:                opera.Upgrades{TransactionBundles: true},
+		blockNumber:             big.NewInt(0),
+		rolledBackBundleCounter: counter,
+	}
+
+	runner := &transactionRunner{evm: evm}
+	_, result, _ := runner.runTransactionBundle(context, tx, 0, math.MaxUint64)
+	require.Equal(t, core_types.TransactionResultFailed, result)
+}
+
 func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResultFailed_AndMarksBundleAsProcessed(t *testing.T) {
 	signer := types.LatestSignerForChainID(big.NewInt(1))
 	ctrl := gomock.NewController(t)
@@ -3839,7 +3875,42 @@ func TestRunTransactions_AccumulatesExecutionCostFromAllTransactions(t *testing.
 		txs[0].Hash(): 100,
 		txs[1].Hash(): 200 + 300,
 		txs[2].Hash(): 500,
-	}, summary.ExecutionCost)
+	}, summary.ExecutionCosts)
+}
+
+func TestProcessSummary_TotalExecutionCost(t *testing.T) {
+	tests := map[string]struct {
+		costs    map[common.Hash]core_types.ExecutionCost
+		expected core_types.ExecutionCost
+	}{
+		"nil map returns zero": {
+			costs:    nil,
+			expected: 0,
+		},
+		"empty map returns zero": {
+			costs:    map[common.Hash]core_types.ExecutionCost{},
+			expected: 0,
+		},
+		"single entry": {
+			costs:    map[common.Hash]core_types.ExecutionCost{{1}: 42},
+			expected: 42,
+		},
+		"multiple entries are summed": {
+			costs: map[common.Hash]core_types.ExecutionCost{
+				{1}: 100,
+				{2}: 200,
+				{3}: 300,
+			},
+			expected: 600,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			summary := ProcessSummary{ExecutionCosts: tc.costs}
+			require.Equal(t, tc.expected, summary.TotalExecutionCost())
+		})
+	}
 }
 
 func TestRunTransaction_RegularTransaction_ReturnsExecutionCostFromReceipt(t *testing.T) {

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -3830,7 +3830,11 @@ func TestRunTransactions_AccumulatesExecutionCostFromAllTransactions(t *testing.
 	)
 
 	summary := runTransactions(context, txs, 0, math.MaxUint64)
-	require.Equal(t, core_types.ExecutionCost(100+200+300+500), summary.ExecutionCost)
+	require.Equal(t, map[common.Hash]core_types.ExecutionCost{
+		txs[0].Hash(): 100,
+		txs[1].Hash(): 200 + 300,
+		txs[2].Hash(): 500,
+	}, summary.ExecutionCost)
 }
 
 func TestRunTransaction_RegularTransaction_ReturnsExecutionCostFromReceipt(t *testing.T) {

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/contracts/sfc"
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -2412,15 +2413,19 @@ func TestRunTransactionBundle_RunBundleNotSuccessful_ReturnsNoTransactionAndResu
 		}),
 	)
 
+	counter := utils.NewMockMetricsCounter(ctrl)
+	counter.EXPECT().Inc(int64(1))
+
 	gasPool := core.NewGasPool(1_000_000)
 	context := &runContext{
-		statedb:     state,
-		signer:      signer,
-		baseFee:     big.NewInt(1),
-		usedGas:     new(uint64),
-		gasPool:     gasPool,
-		upgrades:    opera.Upgrades{TransactionBundles: true},
-		blockNumber: big.NewInt(0),
+		statedb:                 state,
+		signer:                  signer,
+		baseFee:                 big.NewInt(1),
+		usedGas:                 new(uint64),
+		gasPool:                 gasPool,
+		upgrades:                opera.Upgrades{TransactionBundles: true},
+		blockNumber:             big.NewInt(0),
+		rolledBackBundleCounter: counter,
 	}
 
 	runner := &transactionRunner{evm: evm}
@@ -2455,17 +2460,21 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReturnsBundleOnlyTransactionAn
 		}),
 	)
 
+	// No calls in case of successful execution.
+	rolledBackBundlesCounter := utils.NewMockMetricsCounter(ctrl)
+
 	runner := &transactionRunner{evm: evm}
 
 	context := &runContext{
-		statedb:     state,
-		signer:      signer,
-		baseFee:     big.NewInt(1),
-		usedGas:     new(uint64),
-		gasPool:     core.NewGasPool(1_000_000),
-		upgrades:    opera.Upgrades{TransactionBundles: true},
-		blockNumber: big.NewInt(0),
-		runner:      runner,
+		statedb:                 state,
+		signer:                  signer,
+		baseFee:                 big.NewInt(1),
+		usedGas:                 new(uint64),
+		gasPool:                 core.NewGasPool(1_000_000),
+		upgrades:                opera.Upgrades{TransactionBundles: true},
+		blockNumber:             big.NewInt(0),
+		runner:                  runner,
+		rolledBackBundleCounter: rolledBackBundlesCounter,
 	}
 
 	txs := txBundle.GetTransactionsInReferencedOrder()
@@ -2579,6 +2588,9 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 				execResult, core_types.TransactionResultSuccessful,
 			)
 
+			// No calls in case of successful execution.
+			rolledBackBundleCounter := utils.NewMockMetricsCounter(ctrl)
+
 			context := &runContext{
 				statedb: state,
 				signer:  signer,
@@ -2588,8 +2600,9 @@ func TestRunTransactionBundle_RunBundleSuccessful_ReportsCorrectOffsetAndCountTo
 					GasSubsidies:       true,
 					TransactionBundles: true,
 				},
-				blockNumber: big.NewInt(0),
-				runner:      innerRunner,
+				blockNumber:             big.NewInt(0),
+				runner:                  innerRunner,
+				rolledBackBundleCounter: rolledBackBundleCounter,
 			}
 
 			runner := &transactionRunner{}
@@ -3668,13 +3681,14 @@ func TestTrackingOfTxIndicesInNestedAndComposedBundles(t *testing.T) {
 			signer := types.LatestSignerForChainID(big.NewInt(1))
 			upgrades := opera.Upgrades{Brio: true, GasSubsidies: true, TransactionBundles: true}
 			ctxt := &runContext{
-				signer:      signer,
-				usedGas:     new(uint64),
-				gasPool:     core.NewGasPool(1_000_000),
-				upgrades:    upgrades,
-				blockNumber: big.NewInt(0),
-				statedb:     stateDb,
-				runner:      runner,
+				signer:                  signer,
+				usedGas:                 new(uint64),
+				gasPool:                 core.NewGasPool(1_000_000),
+				upgrades:                upgrades,
+				blockNumber:             big.NewInt(0),
+				statedb:                 stateDb,
+				runner:                  runner,
+				rolledBackBundleCounter: rolledBackBundleCounter,
 			}
 
 			// the actual execution of the test case

--- a/evmcore/tx_validation_mock.go
+++ b/evmcore/tx_validation_mock.go
@@ -115,3 +115,153 @@ func (mr *MockSignerMockRecorder) SignatureValues(tx, sig any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignatureValues", reflect.TypeOf((*MockSigner)(nil).SignatureValues), tx, sig)
 }
+
+// MocktxValidationTarget is a mock of txValidationTarget interface.
+type MocktxValidationTarget struct {
+	ctrl     *gomock.Controller
+	recorder *MocktxValidationTargetMockRecorder
+	isgomock struct{}
+}
+
+// MocktxValidationTargetMockRecorder is the mock recorder for MocktxValidationTarget.
+type MocktxValidationTargetMockRecorder struct {
+	mock *MocktxValidationTarget
+}
+
+// NewMocktxValidationTarget creates a new mock instance.
+func NewMocktxValidationTarget(ctrl *gomock.Controller) *MocktxValidationTarget {
+	mock := &MocktxValidationTarget{ctrl: ctrl}
+	mock.recorder = &MocktxValidationTargetMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocktxValidationTarget) EXPECT() *MocktxValidationTargetMockRecorder {
+	return m.recorder
+}
+
+// BlobGasFeeCap mocks base method.
+func (m *MocktxValidationTarget) BlobGasFeeCap() *big.Int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlobGasFeeCap")
+	ret0, _ := ret[0].(*big.Int)
+	return ret0
+}
+
+// BlobGasFeeCap indicates an expected call of BlobGasFeeCap.
+func (mr *MocktxValidationTargetMockRecorder) BlobGasFeeCap() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlobGasFeeCap", reflect.TypeOf((*MocktxValidationTarget)(nil).BlobGasFeeCap))
+}
+
+// Cost mocks base method.
+func (m *MocktxValidationTarget) Cost() *big.Int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Cost")
+	ret0, _ := ret[0].(*big.Int)
+	return ret0
+}
+
+// Cost indicates an expected call of Cost.
+func (mr *MocktxValidationTargetMockRecorder) Cost() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cost", reflect.TypeOf((*MocktxValidationTarget)(nil).Cost))
+}
+
+// GasFeeCap mocks base method.
+func (m *MocktxValidationTarget) GasFeeCap() *big.Int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GasFeeCap")
+	ret0, _ := ret[0].(*big.Int)
+	return ret0
+}
+
+// GasFeeCap indicates an expected call of GasFeeCap.
+func (mr *MocktxValidationTargetMockRecorder) GasFeeCap() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GasFeeCap", reflect.TypeOf((*MocktxValidationTarget)(nil).GasFeeCap))
+}
+
+// GasPrice mocks base method.
+func (m *MocktxValidationTarget) GasPrice() *big.Int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GasPrice")
+	ret0, _ := ret[0].(*big.Int)
+	return ret0
+}
+
+// GasPrice indicates an expected call of GasPrice.
+func (mr *MocktxValidationTargetMockRecorder) GasPrice() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GasPrice", reflect.TypeOf((*MocktxValidationTarget)(nil).GasPrice))
+}
+
+// GasTipCap mocks base method.
+func (m *MocktxValidationTarget) GasTipCap() *big.Int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GasTipCap")
+	ret0, _ := ret[0].(*big.Int)
+	return ret0
+}
+
+// GasTipCap indicates an expected call of GasTipCap.
+func (mr *MocktxValidationTargetMockRecorder) GasTipCap() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GasTipCap", reflect.TypeOf((*MocktxValidationTarget)(nil).GasTipCap))
+}
+
+// Nonce mocks base method.
+func (m *MocktxValidationTarget) Nonce() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Nonce")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// Nonce indicates an expected call of Nonce.
+func (mr *MocktxValidationTargetMockRecorder) Nonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MocktxValidationTarget)(nil).Nonce))
+}
+
+// SetCodeAuthorizations mocks base method.
+func (m *MocktxValidationTarget) SetCodeAuthorizations() []types.SetCodeAuthorization {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetCodeAuthorizations")
+	ret0, _ := ret[0].([]types.SetCodeAuthorization)
+	return ret0
+}
+
+// SetCodeAuthorizations indicates an expected call of SetCodeAuthorizations.
+func (mr *MocktxValidationTargetMockRecorder) SetCodeAuthorizations() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCodeAuthorizations", reflect.TypeOf((*MocktxValidationTarget)(nil).SetCodeAuthorizations))
+}
+
+// Type mocks base method.
+func (m *MocktxValidationTarget) Type() uint8 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Type")
+	ret0, _ := ret[0].(uint8)
+	return ret0
+}
+
+// Type indicates an expected call of Type.
+func (mr *MocktxValidationTargetMockRecorder) Type() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MocktxValidationTarget)(nil).Type))
+}
+
+// Value mocks base method.
+func (m *MocktxValidationTarget) Value() *big.Int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Value")
+	ret0, _ := ret[0].(*big.Int)
+	return ret0
+}
+
+// Value indicates an expected call of Value.
+func (mr *MocktxValidationTargetMockRecorder) Value() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Value", reflect.TypeOf((*MocktxValidationTarget)(nil).Value))
+}

--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -33,6 +33,7 @@ import (
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/utils"
 )
 
 //go:generate mockgen -source=evm.go -destination=evm_mock.go -package=evmmodule
@@ -51,6 +52,7 @@ func (p *EVMModule) Start(
 	rules opera.Rules,
 	evmCfg *params.ChainConfig,
 	prevrandao common.Hash,
+	rollbackBundlesCounter utils.MetricsCounter,
 ) blockproc.EVMProcessor {
 	var prevBlockHash common.Hash
 	var baseFee *big.Int
@@ -70,17 +72,18 @@ func (p *EVMModule) Start(
 	statedb.BeginBlock(uint64(block.Idx))
 
 	return &OperaEVMProcessor{
-		block:            block,
-		reader:           reader,
-		statedb:          statedb,
-		onNewLog:         onNewLog,
-		rules:            rules,
-		evmCfg:           evmCfg,
-		blockIdx:         uint64(block.Idx),
-		prevBlockHash:    prevBlockHash,
-		prevRandao:       prevrandao,
-		gasBaseFee:       baseFee,
-		processorFactory: stateProcessorFactory{},
+		block:                  block,
+		reader:                 reader,
+		statedb:                statedb,
+		onNewLog:               onNewLog,
+		rules:                  rules,
+		evmCfg:                 evmCfg,
+		blockIdx:               uint64(block.Idx),
+		prevBlockHash:          prevBlockHash,
+		prevRandao:             prevrandao,
+		gasBaseFee:             baseFee,
+		processorFactory:       stateProcessorFactory{},
+		rollbackBundlesCounter: rollbackBundlesCounter,
 	}
 }
 
@@ -102,6 +105,8 @@ type OperaEVMProcessor struct {
 	prevRandao   common.Hash
 
 	processorFactory _stateProcessorFactory
+
+	rollbackBundlesCounter utils.MetricsCounter
 }
 
 func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlock {
@@ -143,7 +148,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 }
 
 func (p *OperaEVMProcessor) Execute(txs types.Transactions, gasLimit uint64, sizeLimit uint64) evmcore.ProcessSummary {
-	evmProcessor := p.processorFactory.NewStateProcessorForHeadState(p.evmCfg, p.reader, p.rules.Upgrades)
+	evmProcessor := p.processorFactory.NewStateProcessorForHeadState(p.evmCfg, p.reader, p.rules.Upgrades, p.rollbackBundlesCounter)
 	trueTxsOffset := int(0)
 	for _, tx := range p.processedTxs {
 		if tx.Receipt != nil {
@@ -203,6 +208,7 @@ type _stateProcessorFactory interface {
 		evmCfg *params.ChainConfig,
 		reader evmcore.DummyChain,
 		upgrades opera.Upgrades,
+		rollbackBundlesCounter utils.MetricsCounter,
 	) _stateProcessor
 
 	NewStateProcessorForReplay(
@@ -235,8 +241,9 @@ func (stateProcessorFactory) NewStateProcessorForHeadState(
 	evmCfg *params.ChainConfig,
 	reader evmcore.DummyChain,
 	upgrades opera.Upgrades,
+	rollbackBundlesCounter utils.MetricsCounter,
 ) _stateProcessor {
-	return evmcore.NewStateProcessorForHeadState(evmCfg, reader, upgrades)
+	return evmcore.NewStateProcessorForHeadState(evmCfg, reader, upgrades, rollbackBundlesCounter)
 }
 
 func (stateProcessorFactory) NewStateProcessorForReplay(

--- a/gossip/blockproc/evmmodule/evm_mock.go
+++ b/gossip/blockproc/evmmodule/evm_mock.go
@@ -16,6 +16,7 @@ import (
 	core_types "github.com/0xsoniclabs/sonic/evmcore/core_types"
 	state "github.com/0xsoniclabs/sonic/inter/state"
 	opera "github.com/0xsoniclabs/sonic/opera"
+	utils "github.com/0xsoniclabs/sonic/utils"
 	vm "github.com/ethereum/go-ethereum/core/vm"
 	params "github.com/ethereum/go-ethereum/params"
 	gomock "go.uber.org/mock/gomock"
@@ -46,17 +47,17 @@ func (m *Mock_stateProcessorFactory) EXPECT() *Mock_stateProcessorFactoryMockRec
 }
 
 // NewStateProcessorForHeadState mocks base method.
-func (m *Mock_stateProcessorFactory) NewStateProcessorForHeadState(evmCfg *params.ChainConfig, reader evmcore.DummyChain, upgrades opera.Upgrades) _stateProcessor {
+func (m *Mock_stateProcessorFactory) NewStateProcessorForHeadState(evmCfg *params.ChainConfig, reader evmcore.DummyChain, upgrades opera.Upgrades, rollbackBundlesCounter utils.MetricsCounter) _stateProcessor {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewStateProcessorForHeadState", evmCfg, reader, upgrades)
+	ret := m.ctrl.Call(m, "NewStateProcessorForHeadState", evmCfg, reader, upgrades, rollbackBundlesCounter)
 	ret0, _ := ret[0].(_stateProcessor)
 	return ret0
 }
 
 // NewStateProcessorForHeadState indicates an expected call of NewStateProcessorForHeadState.
-func (mr *Mock_stateProcessorFactoryMockRecorder) NewStateProcessorForHeadState(evmCfg, reader, upgrades any) *gomock.Call {
+func (mr *Mock_stateProcessorFactoryMockRecorder) NewStateProcessorForHeadState(evmCfg, reader, upgrades, rollbackBundlesCounter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStateProcessorForHeadState", reflect.TypeOf((*Mock_stateProcessorFactory)(nil).NewStateProcessorForHeadState), evmCfg, reader, upgrades)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewStateProcessorForHeadState", reflect.TypeOf((*Mock_stateProcessorFactory)(nil).NewStateProcessorForHeadState), evmCfg, reader, upgrades, rollbackBundlesCounter)
 }
 
 // NewStateProcessorForReplay mocks base method.
@@ -98,15 +99,15 @@ func (m *Mock_stateProcessor) EXPECT() *Mock_stateProcessorMockRecorder {
 }
 
 // Process mocks base method.
-func (m *Mock_stateProcessor) Process(block *evmcore.EvmBlock, statedb state.StateDB, vmCfg vm.Config, gasLimit uint64, gasUsed *uint64, trueTxOffset int, onNewLog func(*core_types.Log), maxBlockSize uint64) evmcore.ProcessSummary {
+func (m *Mock_stateProcessor) Process(block *evmcore.EvmBlock, statedb state.StateDB, vmCfg vm.Config, gasLimit uint64, gasUsed *uint64, trueTxOffset int, onNewLog func(*core_types.Log), remainingSize uint64) evmcore.ProcessSummary {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Process", block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, maxBlockSize)
+	ret := m.ctrl.Call(m, "Process", block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, remainingSize)
 	ret0, _ := ret[0].(evmcore.ProcessSummary)
 	return ret0
 }
 
 // Process indicates an expected call of Process.
-func (mr *Mock_stateProcessorMockRecorder) Process(block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, maxBlockSize any) *gomock.Call {
+func (mr *Mock_stateProcessorMockRecorder) Process(block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, remainingSize any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*Mock_stateProcessor)(nil).Process), block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, maxBlockSize)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*Mock_stateProcessor)(nil).Process), block, statedb, vmCfg, gasLimit, gasUsed, trueTxOffset, onNewLog, remainingSize)
 }

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -90,6 +90,7 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 			LondonBlock: big.NewInt(0),
 		},
 		common.Hash{},
+		nil, // no metric tracking in tests
 	)
 
 	// This inner transaction has a gas price of 0, which is less than the MinGasPrice
@@ -154,6 +155,7 @@ func TestOperaEVMProcessor_Execute_ProducesContinuousTxIndexesInReceipts(t *test
 	processor := evmModule.Start(
 		iblockproc.BlockCtx{}, stateDb, nil, logConsumer.OnNewLog,
 		opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+		nil, // no metric tracking in tests
 	)
 
 	key, err := crypto.GenerateKey()
@@ -195,7 +197,7 @@ func TestOperaEVMProcessor_Execute_StateProcessorIntroducesTransactions_Produces
 	stateProcessor := NewMock_stateProcessor(ctrl)
 
 	any := gomock.Any()
-	factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor).AnyTimes()
+	factory.EXPECT().NewStateProcessorForHeadState(any, any, any, any).Return(stateProcessor).AnyTimes()
 
 	summary1 := evmcore.ProcessSummary{
 		ProcessedTransactions: []evmcore.ProcessedTransaction{
@@ -253,7 +255,7 @@ func TestOperaEVMProcessor_Execute_StateProcessorProducesTransactionsAndBundles_
 	stateProcessor := NewMock_stateProcessor(ctrl)
 
 	any := gomock.Any()
-	factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor).AnyTimes()
+	factory.EXPECT().NewStateProcessorForHeadState(any, any, any, any).Return(stateProcessor).AnyTimes()
 
 	summary := evmcore.ProcessSummary{
 		ProcessedTransactions: []evmcore.ProcessedTransaction{
@@ -299,7 +301,7 @@ func TestOperaEVMProcessor_Execute_UsesNumberOfAcceptedTransactionsAsTransaction
 			stateProcessor := NewMock_stateProcessor(ctrl)
 
 			any := gomock.Any()
-			factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor)
+			factory.EXPECT().NewStateProcessorForHeadState(any, any, any, any).Return(stateProcessor)
 
 			numPreAccepted := 0
 			for _, cur := range processedTransactions {
@@ -359,7 +361,7 @@ func TestOperaEVMProcessor_Execute_UsesNumberOfTransactionsWithReceiptsAsTransac
 			stateProcessor := NewMock_stateProcessor(ctrl)
 
 			any := gomock.Any()
-			factory.EXPECT().NewStateProcessorForHeadState(any, any, any).Return(stateProcessor)
+			factory.EXPECT().NewStateProcessorForHeadState(any, any, any, any).Return(stateProcessor)
 
 			wantedOffset := 0
 			for _, cur := range processedTransactions {
@@ -411,6 +413,7 @@ func TestOperaEVMProcessor_Finalize_ReportsAggregatedNumberOfSkippedTransactions
 	processor := evmModule.Start(
 		iblockproc.BlockCtx{}, stateDb, nil, logConsumer.OnNewLog,
 		opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+		nil, // no metric tracking in tests
 	)
 
 	key, err := crypto.GenerateKey()
@@ -478,6 +481,7 @@ func TestOperaEVMProcessor_Finalize_DoesNotBlockOnSyncChannel_WhenBlockIsOlderTh
 				Time: inter.FromUnix(blockTime.Unix()),
 			},
 			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+			nil, // no metric tracking in tests
 		)
 
 		finalizeDone := false
@@ -510,6 +514,7 @@ func TestOperaEVMProcessor_Finalize_DoesNotBlockOnSyncChannel_WhenSyncChannelIsN
 				Time: inter.FromUnix(blockTime.Unix()),
 			},
 			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+			nil, // no metric tracking in tests
 		)
 
 		finalizeDone := false
@@ -542,6 +547,7 @@ func TestOperaEVMProcessor_Finalize_BlockOnSyncChannel_WhenBlockIsYoungerThanOne
 				Time: inter.FromUnix(blockTime.Unix()),
 			},
 			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
+			nil, // no metric tracking in tests
 		)
 
 		finalizeDone := false

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -31,6 +31,7 @@ import (
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/utils"
 )
 
 //go:generate mockgen -source=interface.go -package=blockproc -destination=interface_mock.go
@@ -87,5 +88,6 @@ type EVM interface {
 		net opera.Rules,
 		evmCfg *params.ChainConfig,
 		prevrandao common.Hash,
+		rollbackBundlesCounter utils.MetricsCounter,
 	) EVMProcessor
 }

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -19,6 +19,7 @@ import (
 	iblockproc "github.com/0xsoniclabs/sonic/inter/iblockproc"
 	state "github.com/0xsoniclabs/sonic/inter/state"
 	opera "github.com/0xsoniclabs/sonic/opera"
+	utils "github.com/0xsoniclabs/sonic/utils"
 	hash "github.com/Fantom-foundation/lachesis-base/hash"
 	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
 	common "github.com/ethereum/go-ethereum/common"
@@ -447,15 +448,15 @@ func (m *MockEVM) EXPECT() *MockEVMMockRecorder {
 }
 
 // Start mocks base method.
-func (m *MockEVM) Start(block iblockproc.BlockCtx, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*core_types.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash) EVMProcessor {
+func (m *MockEVM) Start(block iblockproc.BlockCtx, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*core_types.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash, rollbackBundlesCounter utils.MetricsCounter) EVMProcessor {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", block, statedb, reader, onNewLog, net, evmCfg, prevrandao)
+	ret := m.ctrl.Call(m, "Start", block, statedb, reader, onNewLog, net, evmCfg, prevrandao, rollbackBundlesCounter)
 	ret0, _ := ret[0].(EVMProcessor)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockEVMMockRecorder) Start(block, statedb, reader, onNewLog, net, evmCfg, prevrandao any) *gomock.Call {
+func (mr *MockEVMMockRecorder) Start(block, statedb, reader, onNewLog, net, evmCfg, prevrandao, rollbackBundlesCounter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockEVM)(nil).Start), block, statedb, reader, onNewLog, net, evmCfg, prevrandao)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockEVM)(nil).Start), block, statedb, reader, onNewLog, net, evmCfg, prevrandao, rollbackBundlesCounter)
 }

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -82,6 +82,7 @@ var (
 	sponsoredCounter        = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/sponsored", nil))
 	skippedSponsoredCounter = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/sponsored/skipped", nil))
 	bundleCounter           = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/bundles", nil))
+	rolledBackBundleCounter = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/bundles/rolledBack", nil))
 
 	effectiveBundleGasHistogram = utils.MetricsHistogramWrapper(utils.NewPrometheusHistogram(prometheus.HistogramOpts{
 		Name:    "chain_bundle_gas_effective",
@@ -344,6 +345,7 @@ func consensusCallbackBeginBlockFn(
 					es.Rules,
 					chainCfg,
 					randao,
+					rolledBackBundleCounter,
 				)
 				executionStart := time.Now()
 

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -31,6 +31,7 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/scc/cert"
 	scc_node "github.com/0xsoniclabs/sonic/scc/node"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/dag"
@@ -77,6 +78,16 @@ var (
 
 	confirmedEventsMeter = metrics.GetOrRegisterMeter("chain/events/confirmed", nil) // events received from lachesis
 	spilledEventsMeter   = metrics.GetOrRegisterMeter("chain/events/spilled", nil)   // tx excluded because of MaxBlockGas
+
+	sponsoredCounter        = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/sponsored", nil))
+	skippedSponsoredCounter = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/sponsored/skipped", nil))
+	bundleCounter           = utils.MetricsCounter(metrics.GetOrRegisterCounter("chain/bundles", nil))
+
+	effectiveBundleGasHistogram = utils.MetricsHistogramWrapper(utils.NewPrometheusHistogram(prometheus.HistogramOpts{
+		Name:    "chain_bundle_gas_effective",
+		Help:    "Effective gas usage percentage for a bundle transactions",
+		Buckets: prometheus.LinearBuckets(0.00, 0.01, 100), // Buckets [0.00, 0.01, ..., 0.99, +inf]
+	}))
 )
 
 type ExtendedTxPosition struct {
@@ -646,7 +657,57 @@ func processUserTransactions(
 		}
 	}
 
+	updateTransactionMetrics(orderedTxs, summary, upgrades, sponsoredCounter, skippedSponsoredCounter, bundleCounter)
+
 	return summary.CausedBy
+}
+
+func updateTransactionMetrics(inputTransactions []*types.Transaction, summary evmcore.ProcessSummary, upgrades opera.Upgrades,
+	sponsoredTxCounter, skippedSponsoredTxCounter, bundleTxCounter utils.MetricsCounter) {
+
+	processed := make(map[common.Hash]*types.Receipt, len(summary.ProcessedTransactions))
+	for _, tx := range summary.ProcessedTransactions {
+		processed[tx.Transaction.Hash()] = tx.Receipt
+	}
+
+	bundleTxs := []common.Hash{}
+	for _, tx := range inputTransactions {
+		txHash := tx.Hash()
+		if upgrades.Brio && upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
+			bundleTxs = append(bundleTxs, txHash)
+			bundleTxCounter.Inc(1)
+		} else if upgrades.Allegro && upgrades.GasSubsidies && tx.GasPrice().BitLen() == 0 {
+			sponsoredTxCounter.Inc(1)
+			if receipt, found := processed[txHash]; found && receipt == nil {
+				skippedSponsoredTxCounter.Inc(1)
+			}
+		}
+	}
+
+	updateBundleEfficiencyHistogram(summary, bundleTxs, effectiveBundleGasHistogram)
+}
+
+func updateBundleEfficiencyHistogram(summary evmcore.ProcessSummary, bundleTxs []common.Hash, histogram utils.MetricsHistogramWrapper) {
+	for _, envelopeHash := range bundleTxs {
+		var gasUsed uint64
+		var totalExecCost core_types.ExecutionCost
+
+		for _, processed := range summary.ProcessedTransactions {
+			txHash := processed.Transaction.Hash()
+			if origin, ok := summary.CausedBy[txHash]; ok && origin == envelopeHash {
+				if processed.Receipt != nil {
+					gasUsed += processed.Receipt.GasUsed
+				}
+				totalExecCost += summary.ExecutionCost[txHash]
+			}
+		}
+
+		if totalExecCost == 0 {
+			continue
+		}
+		efficiency := float64(gasUsed) / float64(totalExecCost)
+		histogram.Update(efficiency)
+	}
 }
 
 // resolveRandaoMix computes the randao mix to be used by the block processor

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -690,7 +690,6 @@ func updateTransactionMetrics(inputTransactions []*types.Transaction, summary ev
 func updateBundleEfficiencyHistogram(summary evmcore.ProcessSummary, bundleTxs []common.Hash, histogram utils.MetricsHistogramWrapper) {
 	for _, envelopeHash := range bundleTxs {
 		var gasUsed uint64
-		var totalExecCost core_types.ExecutionCost
 
 		for _, processed := range summary.ProcessedTransactions {
 			txHash := processed.Transaction.Hash()
@@ -698,10 +697,10 @@ func updateBundleEfficiencyHistogram(summary evmcore.ProcessSummary, bundleTxs [
 				if processed.Receipt != nil {
 					gasUsed += processed.Receipt.GasUsed
 				}
-				totalExecCost += summary.ExecutionCost[txHash]
 			}
 		}
 
+		totalExecCost := summary.ExecutionCost[envelopeHash]
 		if totalExecCost == 0 {
 			continue
 		}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -87,7 +87,7 @@ var (
 
 	effectiveBundleGasHistogram = utils.MetricsHistogramWrapper(utils.NewPrometheusHistogram(prometheus.HistogramOpts{
 		Name:    "chain_bundle_gas_effective",
-		Help:    "Effective gas usage ratio for a bundle transactions",
+		Help:    "Effective gas usage ratio for a bundle transaction",
 		Buckets: prometheus.LinearBuckets(0.00, 0.01, 100), // Buckets [0.00, 0.01, ..., 0.99, +inf]
 	}))
 )

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/verwatcher"
 	"github.com/0xsoniclabs/sonic/gossip/emitter"
 	"github.com/0xsoniclabs/sonic/gossip/evmstore"
@@ -86,7 +87,7 @@ var (
 
 	effectiveBundleGasHistogram = utils.MetricsHistogramWrapper(utils.NewPrometheusHistogram(prometheus.HistogramOpts{
 		Name:    "chain_bundle_gas_effective",
-		Help:    "Effective gas usage percentage for a bundle transactions",
+		Help:    "Effective gas usage ratio for a bundle transactions",
 		Buckets: prometheus.LinearBuckets(0.00, 0.01, 100), // Buckets [0.00, 0.01, ..., 0.99, +inf]
 	}))
 )
@@ -678,7 +679,7 @@ func updateTransactionMetrics(inputTransactions []*types.Transaction, summary ev
 		if upgrades.Brio && upgrades.TransactionBundles && bundle.IsEnvelope(tx) {
 			bundleTxs = append(bundleTxs, txHash)
 			bundleTxCounter.Inc(1)
-		} else if upgrades.Allegro && upgrades.GasSubsidies && tx.GasPrice().BitLen() == 0 {
+		} else if upgrades.Allegro && upgrades.GasSubsidies && subsidies.IsSponsorshipRequest(tx) {
 			sponsoredTxCounter.Inc(1)
 			if receipt, found := processed[txHash]; found && receipt == nil {
 				skippedSponsoredTxCounter.Inc(1)
@@ -690,25 +691,27 @@ func updateTransactionMetrics(inputTransactions []*types.Transaction, summary ev
 }
 
 func updateBundleEfficiencyHistogram(summary evmcore.ProcessSummary, bundleTxs []common.Hash, histogram utils.MetricsHistogramWrapper) {
-	for _, envelopeHash := range bundleTxs {
-		var gasUsed uint64
-
-		for _, processed := range summary.ProcessedTransactions {
-			txHash := processed.Transaction.Hash()
-			if origin, ok := summary.CausedBy[txHash]; ok && origin == envelopeHash {
-				if processed.Receipt != nil {
-					gasUsed += processed.Receipt.GasUsed
-				}
-			}
+	gasUsedByEnvelope := make(map[common.Hash]uint64, len(bundleTxs))
+	for _, processed := range summary.ProcessedTransactions {
+		if processed.Receipt == nil {
+			continue
 		}
-
-		totalExecCost := summary.ExecutionCost[envelopeHash]
+		txHash := processed.Transaction.Hash()
+		origin, ok := summary.CausedBy[txHash]
+		if !ok {
+			continue
+		}
+		gasUsedByEnvelope[origin] += processed.Receipt.GasUsed
+	}
+	for _, envelopeHash := range bundleTxs {
+		totalExecCost := summary.ExecutionCosts[envelopeHash]
 		if totalExecCost == 0 {
 			continue
 		}
-		efficiency := float64(gasUsed) / float64(totalExecCost)
+		efficiency := float64(gasUsedByEnvelope[envelopeHash]) / float64(totalExecCost)
 		histogram.Update(efficiency)
 	}
+
 }
 
 // resolveRandaoMix computes the randao mix to be used by the block processor

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1632,9 +1632,15 @@ func (p *fakePayload) GasPowerUsed() uint64 {
 func TestUpdateTransactionMetrics_CountsBundleAndSponsoredTransactions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
 	bundleAddr := bundle.BundleProcessor
 	envelopeTx := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 1})
-	sponsoredTx := types.NewTx(&types.LegacyTx{Nonce: 2, GasPrice: big.NewInt(0)})
+	sponsoredTx := types.MustSignNewTx(key, signer, &types.LegacyTx{To: &common.Address{}, Nonce: 2, GasPrice: big.NewInt(0)})
 	regularTx := types.NewTx(&types.LegacyTx{Nonce: 3, GasPrice: big.NewInt(1)})
 
 	inputTransactions := []*types.Transaction{envelopeTx, sponsoredTx, regularTx}
@@ -1664,7 +1670,13 @@ func TestUpdateTransactionMetrics_CountsBundleAndSponsoredTransactions(t *testin
 func TestUpdateTransactionMetrics_CountsSkippedSponsoredTransactions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	sponsoredTx := types.NewTx(&types.LegacyTx{Nonce: 1, GasPrice: big.NewInt(0)})
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	sponsoredTx := types.MustSignNewTx(key, signer, &types.LegacyTx{To: &common.Address{}, Nonce: 2, GasPrice: big.NewInt(0)})
 
 	inputTransactions := []*types.Transaction{sponsoredTx}
 

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1728,8 +1728,7 @@ func TestUpdateBundleEfficiencyHistogram_ComputesEfficiencyForBundles(t *testing
 			{Transaction: innerTx2, Receipt: &types.Receipt{GasUsed: 30_000}},
 		},
 		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
-			innerTx1.Hash(): 100_000,
-			innerTx2.Hash(): 100_000,
+			envelopeTx.Hash(): 200_000,
 		},
 		CausedBy: map[common.Hash]common.Hash{
 			innerTx1.Hash(): envelopeTx.Hash(),
@@ -1737,7 +1736,7 @@ func TestUpdateBundleEfficiencyHistogram_ComputesEfficiencyForBundles(t *testing
 		},
 	}
 
-	// efficiency = (50_000 + 30_000) / (100_000 + 100_000) = 0.4
+	// efficiency = (50_000 + 30_000) / 200_000 = 0.4
 	histogram.EXPECT().Update(0.4)
 
 	updateBundleEfficiencyHistogram(summary, []common.Hash{envelopeTx.Hash()}, histogram)
@@ -1759,8 +1758,8 @@ func TestUpdateBundleEfficiencyHistogram_HandlesMultipleBundles(t *testing.T) {
 			{Transaction: innerTx2, Receipt: &types.Receipt{GasUsed: 20_000}},
 		},
 		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
-			innerTx1.Hash(): 100_000,
-			innerTx2.Hash(): 100_000,
+			envelope1.Hash(): 100_000,
+			envelope2.Hash(): 100_000,
 		},
 		CausedBy: map[common.Hash]common.Hash{
 			innerTx1.Hash(): envelope1.Hash(),
@@ -1791,8 +1790,7 @@ func TestUpdateBundleEfficiencyHistogram_SkippedInnerTransactionsContributeOnlyT
 			{Transaction: innerTx2, Receipt: nil}, // skipped, no gas used but has exec cost
 		},
 		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
-			innerTx1.Hash(): 100_000,
-			innerTx2.Hash(): 100_000,
+			envelopeTx.Hash(): 200_000,
 		},
 		CausedBy: map[common.Hash]common.Hash{
 			innerTx1.Hash(): envelopeTx.Hash(),
@@ -1800,7 +1798,7 @@ func TestUpdateBundleEfficiencyHistogram_SkippedInnerTransactionsContributeOnlyT
 		},
 	}
 
-	// efficiency = 50_000 / (100_000 + 100_000) = 0.25
+	// efficiency = 50_000 / 200_000 = 0.25
 	histogram.EXPECT().Update(0.25)
 
 	updateBundleEfficiencyHistogram(summary, []common.Hash{envelopeTx.Hash()}, histogram)

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1756,7 +1756,7 @@ func TestUpdateBundleEfficiencyHistogram_ComputesEfficiencyForBundles(t *testing
 			{Transaction: innerTx1, Receipt: &types.Receipt{GasUsed: 50_000}},
 			{Transaction: innerTx2, Receipt: &types.Receipt{GasUsed: 30_000}},
 		},
-		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
+		ExecutionCosts: map[common.Hash]core_types.ExecutionCost{
 			envelopeTx.Hash(): 200_000,
 		},
 		CausedBy: map[common.Hash]common.Hash{
@@ -1786,7 +1786,7 @@ func TestUpdateBundleEfficiencyHistogram_HandlesMultipleBundles(t *testing.T) {
 			{Transaction: innerTx1, Receipt: &types.Receipt{GasUsed: 80_000}},
 			{Transaction: innerTx2, Receipt: &types.Receipt{GasUsed: 20_000}},
 		},
-		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
+		ExecutionCosts: map[common.Hash]core_types.ExecutionCost{
 			envelope1.Hash(): 100_000,
 			envelope2.Hash(): 100_000,
 		},
@@ -1818,7 +1818,7 @@ func TestUpdateBundleEfficiencyHistogram_SkippedInnerTransactionsContributeOnlyT
 			{Transaction: innerTx1, Receipt: &types.Receipt{GasUsed: 50_000}},
 			{Transaction: innerTx2, Receipt: nil}, // skipped, no gas used but has exec cost
 		},
-		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
+		ExecutionCosts: map[common.Hash]core_types.ExecutionCost{
 			envelopeTx.Hash(): 200_000,
 		},
 		CausedBy: map[common.Hash]common.Hash{

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -1627,3 +1627,181 @@ func (p *fakePayload) Sig() inter.Signature {
 func (p *fakePayload) GasPowerUsed() uint64 {
 	return p.gasUsed
 }
+
+func TestUpdateTransactionMetrics_CountsBundleAndSponsoredTransactions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	bundleAddr := bundle.BundleProcessor
+	envelopeTx := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 1})
+	sponsoredTx := types.NewTx(&types.LegacyTx{Nonce: 2, GasPrice: big.NewInt(0)})
+	regularTx := types.NewTx(&types.LegacyTx{Nonce: 3, GasPrice: big.NewInt(1)})
+
+	inputTransactions := []*types.Transaction{envelopeTx, sponsoredTx, regularTx}
+
+	summary := evmcore.ProcessSummary{
+		ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: envelopeTx, Receipt: &types.Receipt{}},
+			{Transaction: sponsoredTx, Receipt: &types.Receipt{}},
+			{Transaction: regularTx, Receipt: &types.Receipt{}},
+		},
+	}
+
+	upgrades := opera.Upgrades{Allegro: true, Brio: true, GasSubsidies: true, TransactionBundles: true}
+
+	sponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	skippedSponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	bundleCounter := utils.NewMockMetricsCounter(ctrl)
+
+	// Expect bundle and sponsored counters to be incremented
+	bundleCounter.EXPECT().Inc(int64(1))
+	sponsoredCounter.EXPECT().Inc(int64(1))
+	// No skipped counters should be called since all have successful receipts
+
+	updateTransactionMetrics(inputTransactions, summary, upgrades, sponsoredCounter, skippedSponsoredCounter, bundleCounter)
+}
+
+func TestUpdateTransactionMetrics_CountsSkippedSponsoredTransactions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	sponsoredTx := types.NewTx(&types.LegacyTx{Nonce: 1, GasPrice: big.NewInt(0)})
+
+	inputTransactions := []*types.Transaction{sponsoredTx}
+
+	summary := evmcore.ProcessSummary{
+		ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: sponsoredTx, Receipt: nil}, // skipped
+		},
+	}
+
+	upgrades := opera.Upgrades{Allegro: true, Brio: true, GasSubsidies: true, TransactionBundles: true}
+
+	sponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	skippedSponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	bundleCounter := utils.NewMockMetricsCounter(ctrl)
+
+	sponsoredCounter.EXPECT().Inc(int64(1))
+	skippedSponsoredCounter.EXPECT().Inc(int64(1))
+
+	updateTransactionMetrics(inputTransactions, summary, upgrades, sponsoredCounter, skippedSponsoredCounter, bundleCounter)
+}
+
+func TestUpdateTransactionMetrics_DoesNotCountWithoutUpgrades(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	bundleAddr := bundle.BundleProcessor
+	envelopeTx := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 1})
+	sponsoredTx := types.NewTx(&types.LegacyTx{Nonce: 2, GasPrice: big.NewInt(0)})
+
+	inputTransactions := []*types.Transaction{envelopeTx, sponsoredTx}
+
+	summary := evmcore.ProcessSummary{
+		ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: envelopeTx, Receipt: nil},
+			{Transaction: sponsoredTx, Receipt: nil},
+		},
+	}
+
+	// Without upgrades, no counters should be touched
+	upgrades := opera.Upgrades{}
+
+	sponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	skippedSponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	bundleCounter := utils.NewMockMetricsCounter(ctrl)
+
+	// No expectations set — any call would fail the test
+
+	updateTransactionMetrics(inputTransactions, summary, upgrades, sponsoredCounter, skippedSponsoredCounter, bundleCounter)
+}
+
+func TestUpdateBundleEfficiencyHistogram_ComputesEfficiencyForBundles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	histogram := utils.NewMockMetricsHistogramWrapper(ctrl)
+
+	bundleAddr := bundle.BundleProcessor
+	envelopeTx := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 1})
+	innerTx1 := types.NewTx(&types.LegacyTx{Nonce: 10})
+	innerTx2 := types.NewTx(&types.LegacyTx{Nonce: 11})
+
+	summary := evmcore.ProcessSummary{
+		ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: innerTx1, Receipt: &types.Receipt{GasUsed: 50_000}},
+			{Transaction: innerTx2, Receipt: &types.Receipt{GasUsed: 30_000}},
+		},
+		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
+			innerTx1.Hash(): 100_000,
+			innerTx2.Hash(): 100_000,
+		},
+		CausedBy: map[common.Hash]common.Hash{
+			innerTx1.Hash(): envelopeTx.Hash(),
+			innerTx2.Hash(): envelopeTx.Hash(),
+		},
+	}
+
+	// efficiency = (50_000 + 30_000) / (100_000 + 100_000) = 0.4
+	histogram.EXPECT().Update(0.4)
+
+	updateBundleEfficiencyHistogram(summary, []common.Hash{envelopeTx.Hash()}, histogram)
+}
+
+func TestUpdateBundleEfficiencyHistogram_HandlesMultipleBundles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	histogram := utils.NewMockMetricsHistogramWrapper(ctrl)
+
+	bundleAddr := bundle.BundleProcessor
+	envelope1 := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 1})
+	envelope2 := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 2})
+	innerTx1 := types.NewTx(&types.LegacyTx{Nonce: 10})
+	innerTx2 := types.NewTx(&types.LegacyTx{Nonce: 20})
+
+	summary := evmcore.ProcessSummary{
+		ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: innerTx1, Receipt: &types.Receipt{GasUsed: 80_000}},
+			{Transaction: innerTx2, Receipt: &types.Receipt{GasUsed: 20_000}},
+		},
+		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
+			innerTx1.Hash(): 100_000,
+			innerTx2.Hash(): 100_000,
+		},
+		CausedBy: map[common.Hash]common.Hash{
+			innerTx1.Hash(): envelope1.Hash(),
+			innerTx2.Hash(): envelope2.Hash(),
+		},
+	}
+
+	// Bundle 1: 80_000 / 100_000 = 0.8
+	// Bundle 2: 20_000 / 100_000 = 0.2
+	histogram.EXPECT().Update(0.8)
+	histogram.EXPECT().Update(0.2)
+
+	updateBundleEfficiencyHistogram(summary, []common.Hash{envelope1.Hash(), envelope2.Hash()}, histogram)
+}
+
+func TestUpdateBundleEfficiencyHistogram_SkippedInnerTransactionsContributeOnlyToExecutionCost(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	histogram := utils.NewMockMetricsHistogramWrapper(ctrl)
+
+	bundleAddr := bundle.BundleProcessor
+	envelopeTx := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 1})
+	innerTx1 := types.NewTx(&types.LegacyTx{Nonce: 10})
+	innerTx2 := types.NewTx(&types.LegacyTx{Nonce: 11})
+
+	summary := evmcore.ProcessSummary{
+		ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: innerTx1, Receipt: &types.Receipt{GasUsed: 50_000}},
+			{Transaction: innerTx2, Receipt: nil}, // skipped, no gas used but has exec cost
+		},
+		ExecutionCost: map[common.Hash]core_types.ExecutionCost{
+			innerTx1.Hash(): 100_000,
+			innerTx2.Hash(): 100_000,
+		},
+		CausedBy: map[common.Hash]common.Hash{
+			innerTx1.Hash(): envelopeTx.Hash(),
+			innerTx2.Hash(): envelopeTx.Hash(),
+		},
+	}
+
+	// efficiency = 50_000 / (100_000 + 100_000) = 0.25
+	histogram.EXPECT().Update(0.25)
+
+	updateBundleEfficiencyHistogram(summary, []common.Hash{envelopeTx.Hash()}, histogram)
+}

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -285,8 +285,8 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 
 				evmModule := blockproc.NewMockEVM(ctrl)
 				evmModule.EXPECT().
-					Start(_any, _any, _any, _any, _any, _any, _any).
-					DoAndReturn(func(block iblockproc.BlockCtx, _, _, _, _, _, _ any) blockproc.EVMProcessor {
+					Start(_any, _any, _any, _any, _any, _any, _any, _any).
+					DoAndReturn(func(block iblockproc.BlockCtx, _, _, _, _, _, _, _ any) blockproc.EVMProcessor {
 						require.Equal(t, test.blockTime, block.Time)
 						return evmProcessor
 					})
@@ -1269,6 +1269,7 @@ func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransa
 		opera.Rules{},
 		&params.ChainConfig{},
 		common.Hash{},
+		nil, // no need to track rolled back bundles in this test
 	)
 	blockBuilder := inter.NewBlockBuilder()
 
@@ -1681,6 +1682,34 @@ func TestUpdateTransactionMetrics_CountsSkippedSponsoredTransactions(t *testing.
 
 	sponsoredCounter.EXPECT().Inc(int64(1))
 	skippedSponsoredCounter.EXPECT().Inc(int64(1))
+
+	updateTransactionMetrics(inputTransactions, summary, upgrades, sponsoredCounter, skippedSponsoredCounter, bundleCounter)
+}
+
+func TestUpdateTransactionMetrics_CountsRolledbackBundleTransactions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	bundleAddr := bundle.BundleProcessor
+	envelopeTx := types.NewTx(&types.LegacyTx{To: &bundleAddr, Nonce: 1})
+
+	inputTransactions := []*types.Transaction{envelopeTx}
+
+	// A rolled-back bundle has no processed inner transactions and no receipt
+	// for the envelope itself, but it still counts as a bundle attempt.
+	summary := evmcore.ProcessSummary{
+		ProcessedTransactions: []evmcore.ProcessedTransaction{
+			{Transaction: envelopeTx, Receipt: nil}, // rolled back
+		},
+	}
+
+	upgrades := opera.Upgrades{Allegro: true, Brio: true, GasSubsidies: true, TransactionBundles: true}
+
+	sponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	skippedSponsoredCounter := utils.NewMockMetricsCounter(ctrl)
+	bundleCounter := utils.NewMockMetricsCounter(ctrl)
+
+	// The bundle counter is still incremented for rolled-back bundles
+	bundleCounter.EXPECT().Inc(int64(1))
 
 	updateTransactionMetrics(inputTransactions, summary, upgrades, sponsoredCounter, skippedSponsoredCounter, bundleCounter)
 }

--- a/gossip/emitter/scheduler/processor.go
+++ b/gossip/emitter/scheduler/processor.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -99,8 +100,13 @@ func (p *evmProcessor) run(tx *types.Transaction) (bool, uint64) {
 		}
 	}
 
-	if summary.ExecutionCost == 0 ||
-		float64(gasUsed)/float64(summary.ExecutionCost) < evmcore.MinBundleEfficiency {
+	totalExecCost := core_types.ExecutionCost(0)
+	for _, cost := range summary.ExecutionCost {
+		totalExecCost += cost
+	}
+
+	if totalExecCost == 0 ||
+		float64(gasUsed)/float64(totalExecCost) < evmcore.MinBundleEfficiency {
 		p.stateDb.RevertToInterTxSnapshot(snapshot)
 		return false, 0
 	}

--- a/gossip/emitter/scheduler/processor.go
+++ b/gossip/emitter/scheduler/processor.go
@@ -18,7 +18,6 @@ package scheduler
 
 import (
 	"github.com/0xsoniclabs/sonic/evmcore"
-	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -100,10 +99,7 @@ func (p *evmProcessor) run(tx *types.Transaction) (bool, uint64) {
 		}
 	}
 
-	totalExecCost := core_types.ExecutionCost(0)
-	for _, cost := range summary.ExecutionCost {
-		totalExecCost += cost
-	}
+	totalExecCost := summary.TotalExecutionCost()
 
 	if totalExecCost == 0 ||
 		float64(gasUsed)/float64(totalExecCost) < evmcore.MinBundleEfficiency {

--- a/gossip/emitter/scheduler/processor_test.go
+++ b/gossip/emitter/scheduler/processor_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -55,7 +56,7 @@ func TestEvmProcessor_Run_IfExecutionSucceeds_ReportsSuccessAndGasUsage(t *testi
 				GasUsed: 10,
 			},
 		}},
-		ExecutionCost: core_types.ExecutionCost(10),
+		ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 10},
 	})
 
 	processor := &evmProcessor{processor: runner, stateDb: stateDb}
@@ -76,7 +77,7 @@ func TestEvmProcessor_Run_IfExecutionProducesMultipleProcessedTransactions_SumsU
 			{Receipt: nil}, // skipped transaction
 			{Receipt: &types.Receipt{GasUsed: 20}},
 		},
-		ExecutionCost: core_types.ExecutionCost(30),
+		ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 30},
 	})
 
 	processor := &evmProcessor{processor: runner, stateDb: stateDb}
@@ -97,7 +98,7 @@ func TestEvmProcessor_Run_IfRequestedTransactionIsNotExecuted_TheTransactionIsSt
 			Transaction: &types.Transaction{}, // different transaction
 			Receipt:     &types.Receipt{GasUsed: 10},
 		}},
-		ExecutionCost: core_types.ExecutionCost(10),
+		ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 10},
 	})
 
 	processor := &evmProcessor{processor: runner, stateDb: stateDb}
@@ -118,7 +119,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 			tx: nil,
 			summary: evmcore.ProcessSummary{
 				ProcessedTransactions: []evmcore.ProcessedTransaction{},
-				ExecutionCost:         core_types.ExecutionCost(0),
+				ExecutionCost:         map[common.Hash]core_types.ExecutionCost{},
 			},
 			expectAccept: false,
 		},
@@ -126,7 +127,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 			tx: tx,
 			summary: evmcore.ProcessSummary{
 				ProcessedTransactions: []evmcore.ProcessedTransaction{},
-				ExecutionCost:         core_types.ExecutionCost(0),
+				ExecutionCost:         map[common.Hash]core_types.ExecutionCost{},
 			},
 			expectAccept: false,
 		},
@@ -136,7 +137,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 				ProcessedTransactions: []evmcore.ProcessedTransaction{
 					{Transaction: tx, Receipt: nil},
 				},
-				ExecutionCost: core_types.ExecutionCost(100),
+				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: false,
 		},
@@ -146,7 +147,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 				ProcessedTransactions: []evmcore.ProcessedTransaction{
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100*evmcore.MinBundleEfficiency - 1}},
 				},
-				ExecutionCost: core_types.ExecutionCost(100),
+				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: false,
 		},
@@ -157,7 +158,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency - 1}},
 					{Transaction: otherTx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency - 1}},
 				},
-				ExecutionCost: core_types.ExecutionCost(100),
+				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: false,
 		},
@@ -167,7 +168,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 				ProcessedTransactions: []evmcore.ProcessedTransaction{
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100*evmcore.MinBundleEfficiency + 1}},
 				},
-				ExecutionCost: core_types.ExecutionCost(100),
+				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: true,
 		},
@@ -178,7 +179,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency + 1}},
 					{Transaction: otherTx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency + 1}},
 				},
-				ExecutionCost: core_types.ExecutionCost(100),
+				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: true,
 		},

--- a/gossip/emitter/scheduler/processor_test.go
+++ b/gossip/emitter/scheduler/processor_test.go
@@ -56,7 +56,7 @@ func TestEvmProcessor_Run_IfExecutionSucceeds_ReportsSuccessAndGasUsage(t *testi
 				GasUsed: 10,
 			},
 		}},
-		ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 10},
+		ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 10},
 	})
 
 	processor := &evmProcessor{processor: runner, stateDb: stateDb}
@@ -77,7 +77,7 @@ func TestEvmProcessor_Run_IfExecutionProducesMultipleProcessedTransactions_SumsU
 			{Receipt: nil}, // skipped transaction
 			{Receipt: &types.Receipt{GasUsed: 20}},
 		},
-		ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 30},
+		ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 30},
 	})
 
 	processor := &evmProcessor{processor: runner, stateDb: stateDb}
@@ -98,7 +98,7 @@ func TestEvmProcessor_Run_IfRequestedTransactionIsNotExecuted_TheTransactionIsSt
 			Transaction: &types.Transaction{}, // different transaction
 			Receipt:     &types.Receipt{GasUsed: 10},
 		}},
-		ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 10},
+		ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 10},
 	})
 
 	processor := &evmProcessor{processor: runner, stateDb: stateDb}
@@ -119,7 +119,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 			tx: nil,
 			summary: evmcore.ProcessSummary{
 				ProcessedTransactions: []evmcore.ProcessedTransaction{},
-				ExecutionCost:         map[common.Hash]core_types.ExecutionCost{},
+				ExecutionCosts:        map[common.Hash]core_types.ExecutionCost{},
 			},
 			expectAccept: false,
 		},
@@ -127,7 +127,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 			tx: tx,
 			summary: evmcore.ProcessSummary{
 				ProcessedTransactions: []evmcore.ProcessedTransaction{},
-				ExecutionCost:         map[common.Hash]core_types.ExecutionCost{},
+				ExecutionCosts:        map[common.Hash]core_types.ExecutionCost{},
 			},
 			expectAccept: false,
 		},
@@ -137,7 +137,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 				ProcessedTransactions: []evmcore.ProcessedTransaction{
 					{Transaction: tx, Receipt: nil},
 				},
-				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
+				ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: false,
 		},
@@ -147,7 +147,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 				ProcessedTransactions: []evmcore.ProcessedTransaction{
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100*evmcore.MinBundleEfficiency - 1}},
 				},
-				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
+				ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: false,
 		},
@@ -158,7 +158,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency - 1}},
 					{Transaction: otherTx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency - 1}},
 				},
-				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
+				ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: false,
 		},
@@ -168,7 +168,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 				ProcessedTransactions: []evmcore.ProcessedTransaction{
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100*evmcore.MinBundleEfficiency + 1}},
 				},
-				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
+				ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: true,
 		},
@@ -179,7 +179,7 @@ func TestEvmProcessor_Run_IfExecutionFailed_ReportsAFailedExecutionAndRevertsSta
 					{Transaction: tx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency + 1}},
 					{Transaction: otherTx, Receipt: &types.Receipt{GasUsed: 100/2*evmcore.MinBundleEfficiency + 1}},
 				},
-				ExecutionCost: map[common.Hash]core_types.ExecutionCost{{}: 100},
+				ExecutionCosts: map[common.Hash]core_types.ExecutionCost{{}: 100},
 			},
 			expectAccept: true,
 		},

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -267,6 +267,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 		es.Rules,
 		chainConfig,
 		common.Hash{0x01}, // non-zero PrevRandao necessary to enable Cancun
+		nil,               // no need to track rolled back bundles since there should be no reverts in genesis transactions
 	)
 
 	// Execute genesis transactions


### PR DESCRIPTION
This PR adds counters for sponsored transactions and bundles as well as a histogram for effective gas of a bundle.
The summary execution gas had to be changed to hold information about the execution cost per transaction.