### PR TITLE
Disable acceptance of temporary blocked transactions in TxPool

### DIFF
--- a/evmcore/tx_validation.go
+++ b/evmcore/tx_validation.go
@@ -538,7 +538,7 @@ func validateBundleTransactionsInternal(
 
 	// Check that the bundle is executable.
 	state := bundleEvaluator.GetBundleState(getBundleStateAdaptor{chainState}, stateDb, tx)
-	if !state.Executable && !state.TemporarilyBlocked {
+	if !state.Executable {
 		err := ErrBundleNonExecutable
 		for _, reason := range state.Reasons {
 			err = errors.Join(err, errors.New(reason))

--- a/evmcore/tx_validation_test.go
+++ b/evmcore/tx_validation_test.go
@@ -2097,12 +2097,12 @@ func Test_validateBundleTransactionsInternal_EvaluatesBundleUsingGetBundleState(
 			},
 			expectedErr: nil,
 		},
-		"bundle temporarily not executable is accepted": {
+		"bundle temporarily not executable is rejected": {
 			bundleState: BundleState{
 				Executable:         false,
 				TemporarilyBlocked: true,
 			},
-			expectedErr: nil,
+			expectedErr: ErrBundleNonExecutable,
 		},
 		"bundle non-ever executable": {
 			bundleState: BundleState{

--- a/tests/bundles/non_executable_bundles_test.go
+++ b/tests/bundles/non_executable_bundles_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package bundles
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundle_NonExecutableBundlesAreRejected(t *testing.T) {
+	net := GetIntegrationTestNetWithBundlesEnabled(t)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	signer := types.LatestSignerForChainID(net.GetChainId())
+	sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+	recipient := common.Address{0x01}
+
+	// Submit a bundle with nonce 0 and verify that it executes successfully.
+	firstEnvelope, _, firstPlan := bundle.NewBuilder().
+		WithSigner(signer).
+		AllOf(Step(t, net, sender, &types.AccessListTx{
+			To:    &recipient,
+			Nonce: 0,
+		})).
+		BuildEnvelopeBundleAndPlan()
+
+	_, err = net.Send(firstEnvelope)
+	require.NoError(t, err)
+
+	firstInfo, err := WaitForBundleExecution(t.Context(), client.Client(), firstPlan.Hash())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, firstInfo.Count)
+
+	// Build another bundle with nonce 2 while nonce 1 is still missing.
+	// The bundle should be rejected as non-executable.
+	secondEnvelope := bundle.NewBuilder().
+		WithSigner(signer).
+		AllOf(Step(t, net, sender, &types.AccessListTx{
+			To:    &recipient,
+			Nonce: 2,
+		})).
+		Build()
+
+	_, err = net.Send(secondEnvelope)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "bundle is not executable")
+}

--- a/tests/bundles/stress_test.go
+++ b/tests/bundles/stress_test.go
@@ -34,7 +34,15 @@ func TestBundle_StressWithManyNonceBlockedBundles(t *testing.T) {
 	// Increase this number for profiling to increase load on the system.
 	const N = 2 // Number of blocked bundles
 
-	net := GetIntegrationTestNetWithBundlesEnabled(t)
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionBundles = true
+
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+		ClientExtraArguments: []string{
+			"--disable-txPool-validation",
+		},
+	})
 
 	client, err := net.GetClient()
 	require.NoError(t, err)

--- a/tests/rpcs/bundle_test.go
+++ b/tests/rpcs/bundle_test.go
@@ -64,7 +64,7 @@ func TestBundleRPCFunctions(t *testing.T) {
 	gasPrice, err := client.SuggestGasPrice(t.Context())
 	require.NoError(err)
 
-	blockFirst := hexutil.EncodeUint64(blockNum + 1)
+	blockFirst := hexutil.EncodeUint64(blockNum)
 	senderAddress := sender.Address().Hex()
 	contract := receipt.ContractAddress.Hex()
 	gasP := hexutil.EncodeBig(gasPrice)


### PR DESCRIPTION
This PR disables bundles from being accepted when they can not be immediately processed on the chain.