### PR TITLE
Add new RPC function eth_sendRawTransactionSync

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2207,8 +2207,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 }
 
 const (
-	defaultSendRawSyncTimeout = 2 * time.Second
-	sendRawSyncPollInterval   = 100 * time.Millisecond
+	sendRawSyncPollInterval = 100 * time.Millisecond
 )
 
 // SendRawTransactionSync submits a signed transaction and waits synchronously
@@ -2235,9 +2234,15 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 	txHash := tx.Hash()
 
 	// 2. Determine timeout.
-	timeout := defaultSendRawSyncTimeout
+	timeout := s.b.RPCTxSyncDefaultTimeout()
 	if timeoutMs != nil {
+		defautlMaxTimeout := s.b.RPCTxSyncMaxTimeout()
+
+		if *timeoutMs > hexutil.Uint64(defautlMaxTimeout.Milliseconds()) {
+			timeout = defautlMaxTimeout
+		} else {
 		timeout = time.Duration(*timeoutMs) * time.Millisecond
+		}
 	}
 
 	// 3. Nonce gap check (EIP-7966 Code 6): reject before pool submission.

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2241,7 +2241,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 		if *timeoutMs > hexutil.Uint64(defautlMaxTimeout.Milliseconds()) {
 			timeout = defautlMaxTimeout
 		} else {
-		timeout = time.Duration(*timeoutMs) * time.Millisecond
+			timeout = time.Duration(*timeoutMs) * time.Millisecond
 		}
 	}
 
@@ -2261,7 +2261,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 
 	// 4. Submit transaction (validates fee, EIP-155, adds to pool).
 	if _, err := SubmitTransaction(ctx, s.b, tx); err != nil {
-		return nil, err
+		return nil, errSendRawSyncRejected(txHash, err)
 	}
 
 	// 5. Poll for confirmation with deadline context.
@@ -2292,10 +2292,6 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 		// Wait for next poll tick or deadline.
 		select {
 		case <-deadlineCtx.Done():
-			// Distinguish Code 5 vs Code 4 by checking if tx is still in pool.
-			if s.b.GetPoolTransaction(txHash) != nil {
-				return nil, errSendRawSyncQueued(txHash)
-			}
 			return nil, errSendRawSyncTimeout(txHash)
 		case <-ticker.C:
 			// Poll again.

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2279,7 +2279,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 			}
 			receipts := s.b.FetchReceiptsForBlock(block)
 			if receipts == nil || receipts.Len() <= int(index) {
-				return nil, nil
+				return nil, fmt.Errorf("confirmed transaction %s found in block %d but receipt is unavailable or transaction index %d is out of range", txHash, blockNumber, index)
 			}
 			return s.formatTxReceipt(block.Header(), confirmedTx, index, receipts[index]), nil
 		}

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2286,8 +2286,11 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 		}
 		if confirmedTx != nil {
 			block, err := s.b.BlockByNumber(deadlineCtx, rpc.BlockNumber(blockNumber))
-			if block == nil || err != nil {
+			if err != nil {
 				return nil, err
+			}
+			if block == nil {
+				return nil, fmt.Errorf("confirmed transaction %s found in block %d but the block is unavailable", txHash, blockNumber)
 			}
 			receipts := s.b.FetchReceiptsForBlock(block)
 			if receipts == nil || receipts.Len() <= int(index) {

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2217,7 +2217,9 @@ const (
 //   - encodedTx: hex-encoded RLP signed transaction
 //   - timeoutMs: optional max wait time for tx processing in milliseconds
 //
-// Returns receipt on success. On failure, returns a typed JSON-RPC error:
+// Returns the transaction receipt on success, in the same format as
+// eth_getTransactionReceipt (see formatTxReceipt).
+// On failure, returns a typed JSON-RPC error:
 //   - Code 4: timeout, tx was submitted but not confirmed in time and is no longer in the pool (status unknown)
 //   - Code 5: timeout, tx was submitted and is still in the pool
 //   - Code 6: nonce gap detected, tx was NOT submitted to the pool

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2219,8 +2219,8 @@ const (
 //   - timeoutMs: optional max wait time in milliseconds (default: 2000ms)
 //
 // Returns receipt on success. On failure, returns a typed JSON-RPC error:
-//   - Code 4: timeout, tx was submitted but not confirmed in time
-//   - Code 5: timeout, tx is still in the pool (queued/unknown)
+//   - Code 4: timeout, tx was submitted but not confirmed in time and is no longer in the pool (status unknown)
+//   - Code 5: timeout, tx was submitted and is still in the pool
 //   - Code 6: nonce gap detected, tx was NOT submitted to the pool
 func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 	ctx context.Context,

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2215,7 +2215,7 @@ const (
 //
 // Parameters:
 //   - encodedTx: hex-encoded RLP signed transaction
-//   - timeoutMs: optional max wait time in milliseconds (default: 2000ms)
+//   - timeoutMs: optional max wait time for tx processing in milliseconds
 //
 // Returns receipt on success. On failure, returns a typed JSON-RPC error:
 //   - Code 4: timeout, tx was submitted but not confirmed in time and is no longer in the pool (status unknown)

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2206,6 +2206,98 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	return SubmitTransaction(ctx, s.b, tx)
 }
 
+const (
+	defaultSendRawSyncTimeout = 2 * time.Second
+	sendRawSyncPollInterval   = 100 * time.Millisecond
+)
+
+// SendRawTransactionSync submits a signed transaction and waits synchronously
+// for it to be included in a block, returning the receipt. Implements EIP-7966.
+//
+// Parameters:
+//   - encodedTx: hex-encoded RLP signed transaction
+//   - timeoutMs: optional max wait time in milliseconds (default: 2000ms)
+//
+// Returns receipt on success. On failure, returns a typed JSON-RPC error:
+//   - Code 4: timeout, tx was submitted but not confirmed in time
+//   - Code 5: timeout, tx is still in the pool (queued/unknown)
+//   - Code 6: nonce gap detected, tx was NOT submitted to the pool
+func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
+	ctx context.Context,
+	encodedTx hexutil.Bytes,
+	timeoutMs *hexutil.Uint64,
+) (map[string]interface{}, error) {
+	// 1. Decode the transaction.
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(encodedTx); err != nil {
+		return nil, err
+	}
+	txHash := tx.Hash()
+
+	// 2. Determine timeout.
+	timeout := defaultSendRawSyncTimeout
+	if timeoutMs != nil {
+		timeout = time.Duration(*timeoutMs) * time.Millisecond
+	}
+
+	// 3. Nonce gap check (EIP-7966 Code 6): reject before pool submission.
+	signer := types.LatestSignerForChainID(s.b.ChainID())
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		return nil, err
+	}
+	expectedNonce, err := s.b.GetPoolNonce(ctx, from)
+	if err != nil {
+		return nil, err
+	}
+	if tx.Nonce() > expectedNonce {
+		return nil, errSendRawSyncNonceGap(txHash, expectedNonce)
+	}
+
+	// 4. Submit transaction (validates fee, EIP-155, adds to pool).
+	if _, err := SubmitTransaction(ctx, s.b, tx); err != nil {
+		return nil, err
+	}
+
+	// 5. Poll for confirmation with deadline context.
+	deadlineCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(sendRawSyncPollInterval)
+	defer ticker.Stop()
+
+	for {
+		// Check for immediate confirmation (fast path, also handles already-confirmed).
+		confirmedTx, blockNumber, index, err := s.b.GetTransaction(deadlineCtx, txHash)
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		if confirmedTx != nil {
+			block, err := s.b.BlockByNumber(deadlineCtx, rpc.BlockNumber(blockNumber))
+			if block == nil || err != nil {
+				return nil, err
+			}
+			receipts := s.b.FetchReceiptsForBlock(block)
+			if receipts == nil || receipts.Len() <= int(index) {
+				return nil, nil
+			}
+			return s.formatTxReceipt(block.Header(), confirmedTx, index, receipts[index]), nil
+		}
+
+		// Wait for next poll tick or deadline.
+		select {
+		case <-deadlineCtx.Done():
+			// Distinguish Code 5 vs Code 4 by checking if tx is still in pool.
+			if s.b.GetPoolTransaction(txHash) != nil {
+				return nil, errSendRawSyncQueued(txHash)
+			}
+			return nil, errSendRawSyncTimeout(txHash)
+		case <-ticker.C:
+			// Poll again.
+		}
+	}
+}
+
 // Sign calculates an ECDSA signature for:
 // keccack256("\x19Ethereum Signed Message:\n" + len(message) + message).
 //

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2219,10 +2219,10 @@ const (
 //
 // Returns the transaction receipt on success, in the same format as
 // eth_getTransactionReceipt (see formatTxReceipt).
-// On failure, returns a typed JSON-RPC error:
-//   - Code 4: timeout, tx was submitted but not confirmed in time and is no longer in the pool (status unknown)
-//   - Code 5: timeout, tx was submitted and is still in the pool
-//   - Code 6: nonce gap detected, tx was NOT submitted to the pool
+// On failure, returns a typed JSON-RPC error (EIP-7966):
+//   - Code 4: tx was added to the pool but not processed within the timeout (data: tx hash)
+//   - Code 5: tx was NOT added to the pool, rejected for a reason other than a nonce gap (data: tx hash)
+//   - Code 6: tx was NOT added to the pool, nonce gap detected (data: expected nonce)
 func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 	ctx context.Context,
 	encodedTx hexutil.Bytes,

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2236,12 +2236,17 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 	// 2. Determine timeout.
 	timeout := s.b.RPCTxSyncDefaultTimeout()
 	if timeoutMs != nil {
-		defautlMaxTimeout := s.b.RPCTxSyncMaxTimeout()
-
-		if *timeoutMs > hexutil.Uint64(defautlMaxTimeout.Milliseconds()) {
-			timeout = defautlMaxTimeout
-		} else {
-			timeout = time.Duration(*timeoutMs) * time.Millisecond
+		if *timeoutMs == 0 {
+			return nil, errors.New("timeout must be greater than zero")
+		}
+		// Convert without overflowing time.Duration (int64 nanoseconds).
+		requested := time.Duration(math.MaxInt64)
+		if *timeoutMs < hexutil.Uint64(requested/time.Millisecond) {
+			requested = time.Duration(*timeoutMs) * time.Millisecond
+		}
+		timeout = requested
+		if maxTimeout := s.b.RPCTxSyncMaxTimeout(); maxTimeout > 0 && timeout > maxTimeout {
+			timeout = maxTimeout
 		}
 	}
 

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2251,7 +2251,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransactionSync(
 		return nil, err
 	}
 	if tx.Nonce() > expectedNonce {
-		return nil, errSendRawSyncNonceGap(txHash, expectedNonce)
+		return nil, errSendRawSyncNonceGap(expectedNonce)
 	}
 
 	// 4. Submit transaction (validates fee, EIP-155, adds to pool).

--- a/api/ethapi/backend.go
+++ b/api/ethapi/backend.go
@@ -66,6 +66,8 @@ type Backend interface {
 	UnprotectedAllowed() bool     // allows only for EIP155 transactions.
 	CalcBlockExtApi() bool
 	HistoryPruningCutoff() uint64 // block height at which pruning was done
+	RPCTxSyncDefaultTimeout() time.Duration
+	RPCTxSyncMaxTimeout() time.Duration
 
 	// Blockchain API
 	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*evmcore.EvmHeader, error)

--- a/api/ethapi/backend_mock.go
+++ b/api/ethapi/backend_mock.go
@@ -36,7 +36,6 @@ import (
 type MockBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockBackendMockRecorder is the mock recorder for MockBackend.
@@ -71,18 +70,18 @@ func (mr *MockBackendMockRecorder) AccountManager() *gomock.Call {
 }
 
 // BlockByHash mocks base method.
-func (m *MockBackend) BlockByHash(ctx context.Context, arg1 common.Hash) (*evmcore.EvmBlock, error) {
+func (m *MockBackend) BlockByHash(ctx context.Context, hash common.Hash) (*evmcore.EvmBlock, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockByHash", ctx, arg1)
+	ret := m.ctrl.Call(m, "BlockByHash", ctx, hash)
 	ret0, _ := ret[0].(*evmcore.EvmBlock)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockByHash indicates an expected call of BlockByHash.
-func (mr *MockBackendMockRecorder) BlockByHash(ctx, arg1 any) *gomock.Call {
+func (mr *MockBackendMockRecorder) BlockByHash(ctx, hash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockBackend)(nil).BlockByHash), ctx, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockBackend)(nil).BlockByHash), ctx, hash)
 }
 
 // BlockByNumber mocks base method.
@@ -215,9 +214,9 @@ func (mr *MockBackendMockRecorder) GetDowntime(ctx, vid any) *gomock.Call {
 }
 
 // GetEVM mocks base method.
-func (m *MockBackend) GetEVM(ctx context.Context, arg1 vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
+func (m *MockBackend) GetEVM(ctx context.Context, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEVM", ctx, arg1, header, vmConfig, blockContext)
+	ret := m.ctrl.Call(m, "GetEVM", ctx, state, header, vmConfig, blockContext)
 	ret0, _ := ret[0].(*vm.EVM)
 	ret1, _ := ret[1].(func() error)
 	ret2, _ := ret[2].(error)
@@ -225,9 +224,9 @@ func (m *MockBackend) GetEVM(ctx context.Context, arg1 vm.StateDB, header *evmco
 }
 
 // GetEVM indicates an expected call of GetEVM.
-func (mr *MockBackendMockRecorder) GetEVM(ctx, arg1, header, vmConfig, blockContext any) *gomock.Call {
+func (mr *MockBackendMockRecorder) GetEVM(ctx, state, header, vmConfig, blockContext any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEVM", reflect.TypeOf((*MockBackend)(nil).GetEVM), ctx, arg1, header, vmConfig, blockContext)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEVM", reflect.TypeOf((*MockBackend)(nil).GetEVM), ctx, state, header, vmConfig, blockContext)
 }
 
 // GetEpochBlockState mocks base method.
@@ -441,18 +440,18 @@ func (mr *MockBackendMockRecorder) GetUptime(ctx, vid any) *gomock.Call {
 }
 
 // HeaderByHash mocks base method.
-func (m *MockBackend) HeaderByHash(ctx context.Context, arg1 common.Hash) (*evmcore.EvmHeader, error) {
+func (m *MockBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*evmcore.EvmHeader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HeaderByHash", ctx, arg1)
+	ret := m.ctrl.Call(m, "HeaderByHash", ctx, hash)
 	ret0, _ := ret[0].(*evmcore.EvmHeader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HeaderByHash indicates an expected call of HeaderByHash.
-func (mr *MockBackendMockRecorder) HeaderByHash(ctx, arg1 any) *gomock.Call {
+func (mr *MockBackendMockRecorder) HeaderByHash(ctx, hash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByHash", reflect.TypeOf((*MockBackend)(nil).HeaderByHash), ctx, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByHash", reflect.TypeOf((*MockBackend)(nil).HeaderByHash), ctx, hash)
 }
 
 // HeaderByNumber mocks base method.
@@ -566,6 +565,34 @@ func (m *MockBackend) RPCTxFeeCap() float64 {
 func (mr *MockBackendMockRecorder) RPCTxFeeCap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxFeeCap", reflect.TypeOf((*MockBackend)(nil).RPCTxFeeCap))
+}
+
+// RPCTxSyncDefaultTimeout mocks base method.
+func (m *MockBackend) RPCTxSyncDefaultTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RPCTxSyncDefaultTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// RPCTxSyncDefaultTimeout indicates an expected call of RPCTxSyncDefaultTimeout.
+func (mr *MockBackendMockRecorder) RPCTxSyncDefaultTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxSyncDefaultTimeout", reflect.TypeOf((*MockBackend)(nil).RPCTxSyncDefaultTimeout))
+}
+
+// RPCTxSyncMaxTimeout mocks base method.
+func (m *MockBackend) RPCTxSyncMaxTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RPCTxSyncMaxTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// RPCTxSyncMaxTimeout indicates an expected call of RPCTxSyncMaxTimeout.
+func (mr *MockBackendMockRecorder) RPCTxSyncMaxTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxSyncMaxTimeout", reflect.TypeOf((*MockBackend)(nil).RPCTxSyncMaxTimeout))
 }
 
 // ResolveRpcBlockNumberOrHash mocks base method.

--- a/api/ethapi/errors.go
+++ b/api/ethapi/errors.go
@@ -126,10 +126,10 @@ func errSendRawSyncTimeout(hash common.Hash) error {
 	}
 }
 
-func errSendRawSyncQueued(hash common.Hash) error {
+func errSendRawSyncRejected(hash common.Hash, err error) error {
 	return &sendRawSyncError{
 		code:    errCodeSendRawSyncQueued,
-		message: "transaction unknown or still queued after timeout",
+		message: fmt.Sprintf("transaction was rejected: %v", err),
 		data:    hash,
 	}
 }

--- a/api/ethapi/errors.go
+++ b/api/ethapi/errors.go
@@ -134,8 +134,7 @@ func errSendRawSyncQueued(hash common.Hash) error {
 	}
 }
 
-func errSendRawSyncNonceGap(hash common.Hash, expectedNonce uint64) error {
-	_ = hash // hash included for EIP-7966 compatibility but not used in data per spec
+func errSendRawSyncNonceGap(expectedNonce uint64) error {
 	return &sendRawSyncError{
 		code:    errCodeSendRawSyncNonceGap,
 		message: fmt.Sprintf("nonce gap: expected nonce %d", expectedNonce),

--- a/api/ethapi/errors.go
+++ b/api/ethapi/errors.go
@@ -18,7 +18,10 @@ package ethapi
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 )
@@ -38,6 +41,11 @@ const (
 	errCodeSenderIsNotEOA          = -38024
 	errCodeMaxInitCodeSizeExceeded = -38025
 	errCodeClientLimitExceeded     = -38026
+
+	// EIP-7966 error codes (positive, distinct from standard JSON-RPC negative codes)
+	errCodeSendRawSyncTimeout  = 4
+	errCodeSendRawSyncQueued   = 5
+	errCodeSendRawSyncNonceGap = 6
 )
 
 // simInvalidTxError is an error type for invalid transactions
@@ -95,5 +103,42 @@ func simTxValidationError(err error) *simInvalidTxError {
 			Message: err.Error(),
 			Code:    errCodeInternalError,
 		}
+	}
+}
+
+// sendRawSyncError is a JSON-RPC error for eth_sendRawTransactionSync (EIP-7966).
+// It carries both an ErrorCode and an ErrorData field.
+type sendRawSyncError struct {
+	code    int
+	message string
+	data    interface{}
+}
+
+func (e *sendRawSyncError) Error() string          { return e.message }
+func (e *sendRawSyncError) ErrorCode() int         { return e.code }
+func (e *sendRawSyncError) ErrorData() interface{} { return e.data }
+
+func errSendRawSyncTimeout(hash common.Hash) error {
+	return &sendRawSyncError{
+		code:    errCodeSendRawSyncTimeout,
+		message: "transaction not confirmed within timeout",
+		data:    hash,
+	}
+}
+
+func errSendRawSyncQueued(hash common.Hash) error {
+	return &sendRawSyncError{
+		code:    errCodeSendRawSyncQueued,
+		message: "transaction unknown or still queued after timeout",
+		data:    hash,
+	}
+}
+
+func errSendRawSyncNonceGap(hash common.Hash, expectedNonce uint64) error {
+	_ = hash // hash included for EIP-7966 compatibility but not used in data per spec
+	return &sendRawSyncError{
+		code:    errCodeSendRawSyncNonceGap,
+		message: fmt.Sprintf("nonce gap: expected nonce %d", expectedNonce),
+		data:    hexutil.Uint64(expectedNonce),
 	}
 }

--- a/api/ethapi/errors.go
+++ b/api/ethapi/errors.go
@@ -44,7 +44,7 @@ const (
 
 	// EIP-7966 error codes (positive, distinct from standard JSON-RPC negative codes)
 	errCodeSendRawSyncTimeout  = 4
-	errCodeSendRawSyncQueued   = 5
+	errCodeSendRawSyncRejected = 5
 	errCodeSendRawSyncNonceGap = 6
 )
 
@@ -128,7 +128,7 @@ func errSendRawSyncTimeout(hash common.Hash) error {
 
 func errSendRawSyncRejected(hash common.Hash, err error) error {
 	return &sendRawSyncError{
-		code:    errCodeSendRawSyncQueued,
+		code:    errCodeSendRawSyncRejected,
 		message: fmt.Sprintf("transaction was rejected: %v", err),
 		data:    hash,
 	}

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -113,6 +113,47 @@ func TestSendRawTransactionSync_ReturnsReceipt(t *testing.T) {
 	require.Equal(t, hexutil.Uint64(receipt.GasUsed), result["gasUsed"])
 }
 
+func TestSendRawTransactionSync_ConfirmedOnSecondPoll_ReturnsReceipt(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t, 5*time.Second, 10*time.Second)
+
+	tx, encoded := newTestTx(t, 0, nil)
+	txHash := tx.Hash()
+
+	block := &evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{Number: big.NewInt(1)},
+	}
+	receipt := &types.Receipt{
+		Status:  types.ReceiptStatusSuccessful,
+		TxHash:  txHash,
+		GasUsed: 21000,
+	}
+
+	expectSuccessfulSubmission(mockBackend)
+	// First poll: not yet confirmed; second poll (one tick later): confirmed.
+	firstPoll := mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).
+		Return(nil, uint64(0), uint64(0), nil)
+	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).
+		Return(tx, uint64(1), uint64(0), nil).
+		After(firstPoll)
+	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
+	mockBackend.EXPECT().FetchReceiptsForBlock(block).Return(types.Receipts{receipt})
+	mockBackend.EXPECT().ChainConfig(gomock.Any()).Return(&params.ChainConfig{ChainID: big.NewInt(1)}).AnyTimes()
+
+	start := time.Now()
+	result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, hexutil.Uint(receipt.Status), result["status"])
+	require.Equal(t, receipt.TxHash, result["transactionHash"])
+	// The second poll happens only after one ticker interval, and the result
+	// must arrive well before the 5s timeout — proving the loop polled again
+	// rather than timing out or succeeding on the fast path.
+	require.GreaterOrEqual(t, elapsed, sendRawSyncPollInterval)
+	require.Less(t, elapsed, 5*time.Second)
+}
+
 // TestSendRawTransactionSync_ErrorCases covers all pre-confirmation failure
 // paths: request validation, nonce checks, and pool submission errors.
 func TestSendRawTransactionSync_ErrorCases(t *testing.T) {

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -241,7 +241,7 @@ func TestSendRawTransactionSync_SendTxError_ReturnsCode5(t *testing.T) {
 	require.Error(t, err)
 	var syncErr *sendRawSyncError
 	require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
-	require.Equal(t, errCodeSendRawSyncQueued, syncErr.ErrorCode())
+	require.Equal(t, errCodeSendRawSyncRejected, syncErr.ErrorCode())
 	require.Equal(t, tx.Hash(), syncErr.ErrorData())
 	require.Contains(t, syncErr.Error(), poolErr.Error())
 }

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -36,6 +36,7 @@ import (
 
 // newTestTx creates a signed EIP-155 transaction for use in tests.
 // chainID defaults to 1 if nil.
+// it returns a transaction and its marshalling.
 func newTestTx(t *testing.T, nonce uint64, chainID *big.Int) (*types.Transaction, hexutil.Bytes) {
 	t.Helper()
 	if chainID == nil {
@@ -107,7 +108,9 @@ func TestSendRawTransactionSync_ReturnsReceipt(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Equal(t, hexutil.Uint(types.ReceiptStatusSuccessful), result["status"])
+	require.Equal(t, hexutil.Uint(receipt.Status), result["status"])
+	require.Equal(t, receipt.TxHash, result["transactionHash"])
+	require.Equal(t, hexutil.Uint64(receipt.GasUsed), result["gasUsed"])
 }
 
 func TestSendRawTransactionSync_NonceGap_ReturnsCode6(t *testing.T) {

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+var (
+	now   = time.Now
+	since = time.Since
+)
+
+// newTestTx creates a signed EIP-155 transaction for use in tests.
+// chainID defaults to 1 if nil.
+func newTestTx(t *testing.T, nonce uint64, chainID *big.Int) (*types.Transaction, hexutil.Bytes) {
+	t.Helper()
+	if chainID == nil {
+		chainID = big.NewInt(1)
+	}
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := crypto.PubkeyToAddress(key.PublicKey)
+	tx, err := types.SignTx(
+		types.NewTx(&types.LegacyTx{
+			Nonce:    nonce,
+			Gas:      21000,
+			GasPrice: big.NewInt(1e9),
+			To:       &to,
+		}),
+		types.NewEIP155Signer(chainID),
+		key,
+	)
+	require.NoError(t, err)
+	encoded, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	return tx, hexutil.Bytes(encoded)
+}
+
+// setupSendRawSyncAPI creates a mock backend and PublicTransactionPoolAPI for unit tests.
+func setupSendRawSyncAPI(t *testing.T) (*MockBackend, *PublicTransactionPoolAPI) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockBackend := NewMockBackend(ctrl)
+	mockBackend.EXPECT().ChainID().Return(big.NewInt(1)).AnyTimes()
+	api := NewPublicTransactionPoolAPI(mockBackend, &AddrLocker{})
+	return mockBackend, api
+}
+
+func TestSendRawTransactionSync_ReturnsReceipt(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t)
+
+	tx, encoded := newTestTx(t, 0, nil)
+	txHash := tx.Hash()
+
+	block := &evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{Number: big.NewInt(1)},
+	}
+	receipt := &types.Receipt{
+		Status:  types.ReceiptStatusSuccessful,
+		TxHash:  txHash,
+		GasUsed: 21000,
+	}
+
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(tx, uint64(1), uint64(0), nil)
+	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
+	mockBackend.EXPECT().FetchReceiptsForBlock(block).Return(types.Receipts{receipt})
+	mockBackend.EXPECT().ChainConfig(gomock.Any()).Return(&params.ChainConfig{ChainID: big.NewInt(1)}).AnyTimes()
+
+	result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, hexutil.Uint(types.ReceiptStatusSuccessful), result["status"])
+}
+
+func TestSendRawTransactionSync_NonceGap_ReturnsCode6(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t)
+
+	// tx has nonce=5 but pool expects nonce=0 → gap
+	_, encoded := newTestTx(t, 5, nil)
+
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	// SendTx must NOT be called on nonce gap
+
+	result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	var syncErr *sendRawSyncError
+	require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
+	require.Equal(t, errCodeSendRawSyncNonceGap, syncErr.ErrorCode())
+	require.Equal(t, hexutil.Uint64(0), syncErr.ErrorData())
+}
+
+func TestSendRawTransactionSync_Timeout_TxInPool_ReturnsCode5(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t)
+
+	tx, encoded := newTestTx(t, 0, nil)
+	txHash := tx.Hash()
+	timeoutMs := hexutil.Uint64(10) // very short, 10ms
+
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+	// GetTransaction always returns nil (not confirmed)
+	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(nil, uint64(0), uint64(0), nil).AnyTimes()
+	// tx still in pool after timeout
+	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(tx)
+
+	result, err := api.SendRawTransactionSync(context.Background(), encoded, &timeoutMs)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	var syncErr *sendRawSyncError
+	require.True(t, errors.As(err, &syncErr))
+	require.Equal(t, errCodeSendRawSyncQueued, syncErr.ErrorCode())
+}
+
+func TestSendRawTransactionSync_Timeout_TxNotInPool_ReturnsCode4(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t)
+
+	tx, encoded := newTestTx(t, 0, nil)
+	txHash := tx.Hash()
+	timeoutMs := hexutil.Uint64(10) // very short, 10ms
+
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+	// GetTransaction always returns nil
+	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(nil, uint64(0), uint64(0), nil).AnyTimes()
+	// tx not in pool after timeout
+	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(nil)
+
+	result, err := api.SendRawTransactionSync(context.Background(), encoded, &timeoutMs)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	var syncErr *sendRawSyncError
+	require.True(t, errors.As(err, &syncErr))
+	require.Equal(t, errCodeSendRawSyncTimeout, syncErr.ErrorCode())
+}
+
+func TestSendRawTransactionSync_SendTxError_PropagatesError(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t)
+
+	_, encoded := newTestTx(t, 0, nil)
+	poolErr := errors.New("insufficient funds")
+
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(poolErr)
+
+	result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
+
+	require.Nil(t, result)
+	require.ErrorIs(t, err, poolErr)
+}
+
+func TestSendRawTransactionSync_InvalidRLP_ReturnsDecodeError(t *testing.T) {
+	_, api := setupSendRawSyncAPI(t)
+
+	invalidEncoded := hexutil.Bytes([]byte{0xde, 0xad, 0xbe, 0xef})
+
+	result, err := api.SendRawTransactionSync(context.Background(), invalidEncoded, nil)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	// No backend calls expected — gomock will fail the test if any are made
+}
+
+func TestSendRawTransactionSync_CustomTimeout_IsHonored(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t)
+
+	tx, encoded := newTestTx(t, 0, nil)
+	txHash := tx.Hash()
+	timeoutMs := hexutil.Uint64(50) // 50ms, well under the 2s default
+
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(nil, uint64(0), uint64(0), nil).AnyTimes()
+	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(nil)
+
+	start := now()
+	_, err := api.SendRawTransactionSync(context.Background(), encoded, &timeoutMs)
+	elapsed := since(start)
+
+	require.Error(t, err)
+	// Should return well before the 2s default timeout
+	require.Less(t, elapsed.Milliseconds(), int64(1500), "should have returned before default 2s timeout")
+}
+
+func TestSendRawTransactionSync_ContextCanceled_ReturnsError(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t)
+
+	tx, encoded := newTestTx(t, 0, nil)
+	txHash := tx.Hash()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).DoAndReturn(
+		func(ctx context.Context, _ common.Hash) (*types.Transaction, uint64, uint64, error) {
+			cancel() // cancel the parent context on first poll
+			return nil, 0, 0, nil
+		},
+	).AnyTimes()
+	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(nil).AnyTimes()
+
+	_, err := api.SendRawTransactionSync(ctx, encoded, nil)
+
+	require.Error(t, err)
+}

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -113,23 +113,90 @@ func TestSendRawTransactionSync_ReturnsReceipt(t *testing.T) {
 	require.Equal(t, hexutil.Uint64(receipt.GasUsed), result["gasUsed"])
 }
 
-func TestSendRawTransactionSync_NonceGap_ReturnsCode6(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
+// TestSendRawTransactionSync_ErrorCases covers all pre-confirmation failure
+// paths: request validation, nonce checks, and pool submission errors.
+func TestSendRawTransactionSync_ErrorCases(t *testing.T) {
+	poolErr := errors.New("insufficient funds")
+	nonceErr := errors.New("pool nonce lookup failed")
+	zero := hexutil.Uint64(0)
 
-	// tx has nonce=5 but pool expects nonce=0 → gap
-	_, encoded := newTestTx(t, 5, nil)
+	tests := map[string]struct {
+		txNonce    uint64
+		invalidRLP bool
+		timeoutMs  *hexutil.Uint64
+		setupMocks func(*MockBackend)
+		// wantCode/wantData checked only when wantCode != 0; wantData
+		// receives the submitted tx to derive expected error data.
+		wantCode    int
+		wantData    func(tx *types.Transaction) interface{}
+		wantErrText string
+	}{
+		"invalid RLP returns decode error before any backend call": {
+			invalidRLP:  true,
+			wantErrText: "rlp: value size exceeds available input length",
+		},
+		"zero timeout is rejected before submission": {
+			timeoutMs:   &zero,
+			wantErrText: "timeout must be greater than zero",
+		},
+		"pool nonce lookup error is propagated": {
+			setupMocks: func(mockBackend *MockBackend) {
+				mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nonceErr)
+			},
+			wantErrText: nonceErr.Error(),
+		},
+		"nonce gap returns code 6 without pool submission": {
+			// tx has nonce=5 but pool expects nonce=0 → gap;
+			// SendTx must NOT be called.
+			txNonce: 5,
+			setupMocks: func(mockBackend *MockBackend) {
+				mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+			},
+			wantCode: errCodeSendRawSyncNonceGap,
+			wantData: func(*types.Transaction) interface{} {
+				return hexutil.Uint64(0)
+			},
+			wantErrText: "nonce gap",
+		},
+		"pool rejection returns code 5": {
+			setupMocks: func(mockBackend *MockBackend) {
+				mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+				mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+				mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+				mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(poolErr)
+			},
+			wantCode: errCodeSendRawSyncRejected,
+			wantData: func(tx *types.Transaction) interface{} {
+				return tx.Hash()
+			},
+			wantErrText: poolErr.Error(),
+		},
+	}
 
-	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	// SendTx must NOT be called on nonce gap
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockBackend, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
+			if test.setupMocks != nil {
+				test.setupMocks(mockBackend)
+			}
 
-	result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
+			tx, encoded := newTestTx(t, test.txNonce, nil)
+			if test.invalidRLP {
+				encoded = hexutil.Bytes([]byte{0xde, 0xad, 0xbe, 0xef})
+			}
 
-	require.Nil(t, result)
-	require.Error(t, err)
-	var syncErr *sendRawSyncError
-	require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
-	require.Equal(t, errCodeSendRawSyncNonceGap, syncErr.ErrorCode())
-	require.Equal(t, hexutil.Uint64(0), syncErr.ErrorData())
+			result, err := api.SendRawTransactionSync(context.Background(), encoded, test.timeoutMs)
+
+			require.Nil(t, result)
+			require.ErrorContains(t, err, test.wantErrText)
+			if test.wantCode != 0 {
+				var syncErr *sendRawSyncError
+				require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
+				require.Equal(t, test.wantCode, syncErr.ErrorCode())
+				require.Equal(t, test.wantData(tx), syncErr.ErrorData())
+			}
+		})
+	}
 }
 
 func TestSendRawTransactionSync_TimeoutHandling(t *testing.T) {
@@ -210,42 +277,6 @@ func TestSendRawTransactionSync_TimeoutHandling(t *testing.T) {
 	}
 }
 
-func TestSendRawTransactionSync_ZeroTimeout_IsRejected(t *testing.T) {
-	_, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
-
-	_, encoded := newTestTx(t, 0, nil)
-	zero := hexutil.Uint64(0)
-
-	// No submission-related backend calls expected — the request must be
-	// rejected before the transaction reaches the pool.
-	result, err := api.SendRawTransactionSync(context.Background(), encoded, &zero)
-
-	require.Nil(t, result)
-	require.ErrorContains(t, err, "timeout must be greater than zero")
-}
-
-func TestSendRawTransactionSync_SendTxError_ReturnsCode5(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
-
-	tx, encoded := newTestTx(t, 0, nil)
-	poolErr := errors.New("insufficient funds")
-
-	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
-	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
-	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(poolErr)
-
-	result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
-
-	require.Nil(t, result)
-	require.Error(t, err)
-	var syncErr *sendRawSyncError
-	require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
-	require.Equal(t, errCodeSendRawSyncRejected, syncErr.ErrorCode())
-	require.Equal(t, tx.Hash(), syncErr.ErrorData())
-	require.Contains(t, syncErr.Error(), poolErr.Error())
-}
-
 func TestSendRawTransactionSync_BlockUnavailable_ReturnsError(t *testing.T) {
 	blockErr := errors.New("block lookup failed")
 
@@ -283,18 +314,6 @@ func TestSendRawTransactionSync_BlockUnavailable_ReturnsError(t *testing.T) {
 			require.ErrorContains(t, err, test.wantErr)
 		})
 	}
-}
-
-func TestSendRawTransactionSync_InvalidRLP_ReturnsDecodeError(t *testing.T) {
-	_, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
-
-	invalidEncoded := hexutil.Bytes([]byte{0xde, 0xad, 0xbe, 0xef})
-
-	result, err := api.SendRawTransactionSync(context.Background(), invalidEncoded, nil)
-
-	require.Nil(t, result)
-	require.Error(t, err)
-	// No backend calls expected — gomock will fail the test if any are made
 }
 
 func TestSendRawTransactionSync_ContextCanceled_ReturnsTimeoutError(t *testing.T) {

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -246,6 +246,45 @@ func TestSendRawTransactionSync_SendTxError_ReturnsCode5(t *testing.T) {
 	require.Contains(t, syncErr.Error(), poolErr.Error())
 }
 
+func TestSendRawTransactionSync_BlockUnavailable_ReturnsError(t *testing.T) {
+	blockErr := errors.New("block lookup failed")
+
+	tests := map[string]struct {
+		block   *evmcore.EvmBlock
+		err     error
+		wantErr string
+	}{
+		"lookup error is propagated": {
+			block:   nil,
+			err:     blockErr,
+			wantErr: blockErr.Error(),
+		},
+		"missing block yields explicit error": {
+			block:   nil,
+			err:     nil,
+			wantErr: "block is unavailable",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockBackend, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
+
+			tx, encoded := newTestTx(t, 0, nil)
+			txHash := tx.Hash()
+
+			expectSuccessfulSubmission(mockBackend)
+			mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(tx, uint64(1), uint64(0), nil)
+			mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(test.block, test.err)
+
+			result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
+
+			require.Nil(t, result)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
 func TestSendRawTransactionSync_InvalidRLP_ReturnsDecodeError(t *testing.T) {
 	_, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
 

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -33,11 +33,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var (
-	now   = time.Now
-	since = time.Since
-)
-
 // newTestTx creates a signed EIP-155 transaction for use in tests.
 // chainID defaults to 1 if nil.
 func newTestTx(t *testing.T, nonce uint64, chainID *big.Int) (*types.Transaction, hexutil.Bytes) {
@@ -64,18 +59,30 @@ func newTestTx(t *testing.T, nonce uint64, chainID *big.Int) (*types.Transaction
 	return tx, hexutil.Bytes(encoded)
 }
 
-// setupSendRawSyncAPI creates a mock backend and PublicTransactionPoolAPI for unit tests.
-func setupSendRawSyncAPI(t *testing.T) (*MockBackend, *PublicTransactionPoolAPI) {
+// setupSendRawSyncAPI creates a mock backend and PublicTransactionPoolAPI for
+// unit tests, with the given default and maximum sync-wait timeouts.
+func setupSendRawSyncAPI(t *testing.T, defaultTimeout, maxTimeout time.Duration) (*MockBackend, *PublicTransactionPoolAPI) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	mockBackend := NewMockBackend(ctrl)
 	mockBackend.EXPECT().ChainID().Return(big.NewInt(1)).AnyTimes()
+	mockBackend.EXPECT().RPCTxSyncDefaultTimeout().Return(defaultTimeout).AnyTimes()
+	mockBackend.EXPECT().RPCTxSyncMaxTimeout().Return(maxTimeout).AnyTimes()
 	api := NewPublicTransactionPoolAPI(mockBackend, &AddrLocker{})
 	return mockBackend, api
 }
 
+// expectSuccessfulSubmission registers the backend expectations for a
+// transaction that passes the nonce check and is accepted by the pool.
+func expectSuccessfulSubmission(mockBackend *MockBackend) {
+	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
+	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
+	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
+	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+}
+
 func TestSendRawTransactionSync_ReturnsReceipt(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t)
+	mockBackend, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
 
 	tx, encoded := newTestTx(t, 0, nil)
 	txHash := tx.Hash()
@@ -89,10 +96,7 @@ func TestSendRawTransactionSync_ReturnsReceipt(t *testing.T) {
 		GasUsed: 21000,
 	}
 
-	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
-	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
-	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+	expectSuccessfulSubmission(mockBackend)
 	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(tx, uint64(1), uint64(0), nil)
 	mockBackend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(block, nil)
 	mockBackend.EXPECT().FetchReceiptsForBlock(block).Return(types.Receipts{receipt})
@@ -106,7 +110,7 @@ func TestSendRawTransactionSync_ReturnsReceipt(t *testing.T) {
 }
 
 func TestSendRawTransactionSync_NonceGap_ReturnsCode6(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t)
+	mockBackend, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
 
 	// tx has nonce=5 but pool expects nonce=0 → gap
 	_, encoded := newTestTx(t, 5, nil)
@@ -124,60 +128,88 @@ func TestSendRawTransactionSync_NonceGap_ReturnsCode6(t *testing.T) {
 	require.Equal(t, hexutil.Uint64(0), syncErr.ErrorData())
 }
 
-func TestSendRawTransactionSync_Timeout_TxInPool_ReturnsCode5(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t)
+func TestSendRawTransactionSync_TimeoutHandling(t *testing.T) {
+	uint64Ptr := func(v uint64) *hexutil.Uint64 {
+		u := hexutil.Uint64(v)
+		return &u
+	}
 
-	tx, encoded := newTestTx(t, 0, nil)
-	txHash := tx.Hash()
-	timeoutMs := hexutil.Uint64(10) // very short, 10ms
+	tests := map[string]struct {
+		defaultTimeout time.Duration
+		maxTimeout     time.Duration
+		timeoutMs      *hexutil.Uint64
+		// effective timeout the implementation is expected to apply
+		wantTimeout time.Duration
+	}{
+		"nil timeout uses default": {
+			defaultTimeout: 200 * time.Millisecond,
+			maxTimeout:     10 * time.Second,
+			timeoutMs:      nil,
+			wantTimeout:    200 * time.Millisecond,
+		},
+		"custom timeout below max is honored": {
+			defaultTimeout: 10 * time.Second,
+			maxTimeout:     10 * time.Second,
+			timeoutMs:      uint64Ptr(100),
+			wantTimeout:    100 * time.Millisecond,
+		},
+		"custom timeout equal to max is honored": {
+			defaultTimeout: 10 * time.Second,
+			maxTimeout:     300 * time.Millisecond,
+			timeoutMs:      uint64Ptr(300),
+			wantTimeout:    300 * time.Millisecond,
+		},
+		"custom timeout above max is clamped to max": {
+			defaultTimeout: 10 * time.Second,
+			maxTimeout:     200 * time.Millisecond,
+			timeoutMs:      uint64Ptr(60_000),
+			wantTimeout:    200 * time.Millisecond,
+		},
+		"zero timeout expires immediately": {
+			defaultTimeout: 10 * time.Second,
+			maxTimeout:     10 * time.Second,
+			timeoutMs:      uint64Ptr(0),
+			wantTimeout:    0,
+		},
+	}
 
-	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
-	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
-	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
-	// GetTransaction always returns nil (not confirmed)
-	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(nil, uint64(0), uint64(0), nil).AnyTimes()
-	// tx still in pool after timeout
-	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(tx)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockBackend, api := setupSendRawSyncAPI(t, test.defaultTimeout, test.maxTimeout)
 
-	result, err := api.SendRawTransactionSync(context.Background(), encoded, &timeoutMs)
+			tx, encoded := newTestTx(t, 0, nil)
+			txHash := tx.Hash()
 
-	require.Nil(t, result)
-	require.Error(t, err)
-	var syncErr *sendRawSyncError
-	require.True(t, errors.As(err, &syncErr))
-	require.Equal(t, errCodeSendRawSyncQueued, syncErr.ErrorCode())
+			expectSuccessfulSubmission(mockBackend)
+			// GetTransaction always reports not-yet-confirmed, so the call
+			// can only end by hitting the effective timeout.
+			mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(nil, uint64(0), uint64(0), nil).AnyTimes()
+
+			start := time.Now()
+			result, err := api.SendRawTransactionSync(context.Background(), encoded, test.timeoutMs)
+			elapsed := time.Since(start)
+
+			require.Nil(t, result)
+			require.Error(t, err)
+			var syncErr *sendRawSyncError
+			require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
+			require.Equal(t, errCodeSendRawSyncTimeout, syncErr.ErrorCode())
+			require.Equal(t, txHash, syncErr.ErrorData())
+
+			require.GreaterOrEqual(t, elapsed, test.wantTimeout,
+				"returned before the effective timeout elapsed")
+			// Generous upper bound: well below the not-chosen timeouts
+			// (default/max of 10s) while tolerating scheduling jitter.
+			require.Less(t, elapsed, test.wantTimeout+2*time.Second,
+				"did not return close to the effective timeout")
+		})
+	}
 }
 
-func TestSendRawTransactionSync_Timeout_TxNotInPool_ReturnsCode4(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t)
+func TestSendRawTransactionSync_SendTxError_ReturnsCode5(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
 
 	tx, encoded := newTestTx(t, 0, nil)
-	txHash := tx.Hash()
-	timeoutMs := hexutil.Uint64(10) // very short, 10ms
-
-	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
-	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
-	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
-	// GetTransaction always returns nil
-	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(nil, uint64(0), uint64(0), nil).AnyTimes()
-	// tx not in pool after timeout
-	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(nil)
-
-	result, err := api.SendRawTransactionSync(context.Background(), encoded, &timeoutMs)
-
-	require.Nil(t, result)
-	require.Error(t, err)
-	var syncErr *sendRawSyncError
-	require.True(t, errors.As(err, &syncErr))
-	require.Equal(t, errCodeSendRawSyncTimeout, syncErr.ErrorCode())
-}
-
-func TestSendRawTransactionSync_SendTxError_PropagatesError(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t)
-
-	_, encoded := newTestTx(t, 0, nil)
 	poolErr := errors.New("insufficient funds")
 
 	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
@@ -188,11 +220,16 @@ func TestSendRawTransactionSync_SendTxError_PropagatesError(t *testing.T) {
 	result, err := api.SendRawTransactionSync(context.Background(), encoded, nil)
 
 	require.Nil(t, result)
-	require.ErrorIs(t, err, poolErr)
+	require.Error(t, err)
+	var syncErr *sendRawSyncError
+	require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
+	require.Equal(t, errCodeSendRawSyncQueued, syncErr.ErrorCode())
+	require.Equal(t, tx.Hash(), syncErr.ErrorData())
+	require.Contains(t, syncErr.Error(), poolErr.Error())
 }
 
 func TestSendRawTransactionSync_InvalidRLP_ReturnsDecodeError(t *testing.T) {
-	_, api := setupSendRawSyncAPI(t)
+	_, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
 
 	invalidEncoded := hexutil.Bytes([]byte{0xde, 0xad, 0xbe, 0xef})
 
@@ -203,50 +240,31 @@ func TestSendRawTransactionSync_InvalidRLP_ReturnsDecodeError(t *testing.T) {
 	// No backend calls expected — gomock will fail the test if any are made
 }
 
-func TestSendRawTransactionSync_CustomTimeout_IsHonored(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t)
-
-	tx, encoded := newTestTx(t, 0, nil)
-	txHash := tx.Hash()
-	timeoutMs := hexutil.Uint64(50) // 50ms, well under the 2s default
-
-	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
-	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
-	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
-	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).Return(nil, uint64(0), uint64(0), nil).AnyTimes()
-	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(nil)
-
-	start := now()
-	_, err := api.SendRawTransactionSync(context.Background(), encoded, &timeoutMs)
-	elapsed := since(start)
-
-	require.Error(t, err)
-	// Should return well before the 2s default timeout
-	require.Less(t, elapsed.Milliseconds(), int64(1500), "should have returned before default 2s timeout")
-}
-
-func TestSendRawTransactionSync_ContextCanceled_ReturnsError(t *testing.T) {
-	mockBackend, api := setupSendRawSyncAPI(t)
+func TestSendRawTransactionSync_ContextCanceled_ReturnsTimeoutError(t *testing.T) {
+	mockBackend, api := setupSendRawSyncAPI(t, 10*time.Second, 10*time.Second)
 
 	tx, encoded := newTestTx(t, 0, nil)
 	txHash := tx.Hash()
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	mockBackend.EXPECT().GetPoolNonce(gomock.Any(), gomock.Any()).Return(uint64(0), nil)
-	mockBackend.EXPECT().RPCTxFeeCap().Return(float64(0))
-	mockBackend.EXPECT().UnprotectedAllowed().Return(false)
-	mockBackend.EXPECT().SendTx(gomock.Any(), gomock.Any()).Return(nil)
+	expectSuccessfulSubmission(mockBackend)
 	mockBackend.EXPECT().GetTransaction(gomock.Any(), txHash).DoAndReturn(
 		func(ctx context.Context, _ common.Hash) (*types.Transaction, uint64, uint64, error) {
 			cancel() // cancel the parent context on first poll
 			return nil, 0, 0, nil
 		},
 	).AnyTimes()
-	mockBackend.EXPECT().GetPoolTransaction(txHash).Return(nil).AnyTimes()
 
-	_, err := api.SendRawTransactionSync(ctx, encoded, nil)
+	start := time.Now()
+	result, err := api.SendRawTransactionSync(ctx, encoded, nil)
+	elapsed := time.Since(start)
 
+	require.Nil(t, result)
 	require.Error(t, err)
+	var syncErr *sendRawSyncError
+	require.True(t, errors.As(err, &syncErr), "expected sendRawSyncError, got %T: %v", err, err)
+	require.Equal(t, errCodeSendRawSyncTimeout, syncErr.ErrorCode())
+	// Cancellation must interrupt the wait long before the 10s timeout.
+	require.Less(t, elapsed, 5*time.Second)
 }

--- a/api/ethapi/send_raw_transaction_sync_test.go
+++ b/api/ethapi/send_raw_transaction_sync_test.go
@@ -19,6 +19,7 @@ package ethapi
 import (
 	"context"
 	"errors"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -165,11 +166,11 @@ func TestSendRawTransactionSync_TimeoutHandling(t *testing.T) {
 			timeoutMs:      uint64Ptr(60_000),
 			wantTimeout:    200 * time.Millisecond,
 		},
-		"zero timeout expires immediately": {
+		"huge timeout does not overflow and is clamped to max": {
 			defaultTimeout: 10 * time.Second,
-			maxTimeout:     10 * time.Second,
-			timeoutMs:      uint64Ptr(0),
-			wantTimeout:    0,
+			maxTimeout:     200 * time.Millisecond,
+			timeoutMs:      uint64Ptr(math.MaxUint64),
+			wantTimeout:    200 * time.Millisecond,
 		},
 	}
 
@@ -204,6 +205,20 @@ func TestSendRawTransactionSync_TimeoutHandling(t *testing.T) {
 				"did not return close to the effective timeout")
 		})
 	}
+}
+
+func TestSendRawTransactionSync_ZeroTimeout_IsRejected(t *testing.T) {
+	_, api := setupSendRawSyncAPI(t, 1*time.Second, 2*time.Second)
+
+	_, encoded := newTestTx(t, 0, nil)
+	zero := hexutil.Uint64(0)
+
+	// No submission-related backend calls expected — the request must be
+	// rejected before the transaction reaches the pool.
+	result, err := api.SendRawTransactionSync(context.Background(), encoded, &zero)
+
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "timeout must be greater than zero")
 }
 
 func TestSendRawTransactionSync_SendTxError_ReturnsCode5(t *testing.T) {

--- a/api/sonicapi/backend_mock.go
+++ b/api/sonicapi/backend_mock.go
@@ -38,7 +38,6 @@ import (
 type MockBundleApiBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBundleApiBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockBundleApiBackendMockRecorder is the mock recorder for MockBundleApiBackend.
@@ -73,18 +72,18 @@ func (mr *MockBundleApiBackendMockRecorder) AccountManager() *gomock.Call {
 }
 
 // BlockByHash mocks base method.
-func (m *MockBundleApiBackend) BlockByHash(ctx context.Context, arg1 common.Hash) (*evmcore.EvmBlock, error) {
+func (m *MockBundleApiBackend) BlockByHash(ctx context.Context, hash common.Hash) (*evmcore.EvmBlock, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockByHash", ctx, arg1)
+	ret := m.ctrl.Call(m, "BlockByHash", ctx, hash)
 	ret0, _ := ret[0].(*evmcore.EvmBlock)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockByHash indicates an expected call of BlockByHash.
-func (mr *MockBundleApiBackendMockRecorder) BlockByHash(ctx, arg1 any) *gomock.Call {
+func (mr *MockBundleApiBackendMockRecorder) BlockByHash(ctx, hash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockBundleApiBackend)(nil).BlockByHash), ctx, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockBundleApiBackend)(nil).BlockByHash), ctx, hash)
 }
 
 // BlockByNumber mocks base method.
@@ -231,9 +230,9 @@ func (mr *MockBundleApiBackendMockRecorder) GetDowntime(ctx, vid any) *gomock.Ca
 }
 
 // GetEVM mocks base method.
-func (m *MockBundleApiBackend) GetEVM(ctx context.Context, arg1 vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
+func (m *MockBundleApiBackend) GetEVM(ctx context.Context, state vm.StateDB, header *evmcore.EvmHeader, vmConfig *vm.Config, blockContext *vm.BlockContext) (*vm.EVM, func() error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEVM", ctx, arg1, header, vmConfig, blockContext)
+	ret := m.ctrl.Call(m, "GetEVM", ctx, state, header, vmConfig, blockContext)
 	ret0, _ := ret[0].(*vm.EVM)
 	ret1, _ := ret[1].(func() error)
 	ret2, _ := ret[2].(error)
@@ -241,9 +240,9 @@ func (m *MockBundleApiBackend) GetEVM(ctx context.Context, arg1 vm.StateDB, head
 }
 
 // GetEVM indicates an expected call of GetEVM.
-func (mr *MockBundleApiBackendMockRecorder) GetEVM(ctx, arg1, header, vmConfig, blockContext any) *gomock.Call {
+func (mr *MockBundleApiBackendMockRecorder) GetEVM(ctx, state, header, vmConfig, blockContext any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEVM", reflect.TypeOf((*MockBundleApiBackend)(nil).GetEVM), ctx, arg1, header, vmConfig, blockContext)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEVM", reflect.TypeOf((*MockBundleApiBackend)(nil).GetEVM), ctx, state, header, vmConfig, blockContext)
 }
 
 // GetEpochBlockState mocks base method.
@@ -457,18 +456,18 @@ func (mr *MockBundleApiBackendMockRecorder) GetUptime(ctx, vid any) *gomock.Call
 }
 
 // HeaderByHash mocks base method.
-func (m *MockBundleApiBackend) HeaderByHash(ctx context.Context, arg1 common.Hash) (*evmcore.EvmHeader, error) {
+func (m *MockBundleApiBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*evmcore.EvmHeader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HeaderByHash", ctx, arg1)
+	ret := m.ctrl.Call(m, "HeaderByHash", ctx, hash)
 	ret0, _ := ret[0].(*evmcore.EvmHeader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HeaderByHash indicates an expected call of HeaderByHash.
-func (mr *MockBundleApiBackendMockRecorder) HeaderByHash(ctx, arg1 any) *gomock.Call {
+func (mr *MockBundleApiBackendMockRecorder) HeaderByHash(ctx, hash any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByHash", reflect.TypeOf((*MockBundleApiBackend)(nil).HeaderByHash), ctx, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByHash", reflect.TypeOf((*MockBundleApiBackend)(nil).HeaderByHash), ctx, hash)
 }
 
 // HeaderByNumber mocks base method.
@@ -582,6 +581,34 @@ func (m *MockBundleApiBackend) RPCTxFeeCap() float64 {
 func (mr *MockBundleApiBackendMockRecorder) RPCTxFeeCap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxFeeCap", reflect.TypeOf((*MockBundleApiBackend)(nil).RPCTxFeeCap))
+}
+
+// RPCTxSyncDefaultTimeout mocks base method.
+func (m *MockBundleApiBackend) RPCTxSyncDefaultTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RPCTxSyncDefaultTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// RPCTxSyncDefaultTimeout indicates an expected call of RPCTxSyncDefaultTimeout.
+func (mr *MockBundleApiBackendMockRecorder) RPCTxSyncDefaultTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxSyncDefaultTimeout", reflect.TypeOf((*MockBundleApiBackend)(nil).RPCTxSyncDefaultTimeout))
+}
+
+// RPCTxSyncMaxTimeout mocks base method.
+func (m *MockBundleApiBackend) RPCTxSyncMaxTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RPCTxSyncMaxTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// RPCTxSyncMaxTimeout indicates an expected call of RPCTxSyncMaxTimeout.
+func (mr *MockBundleApiBackendMockRecorder) RPCTxSyncMaxTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxSyncMaxTimeout", reflect.TypeOf((*MockBundleApiBackend)(nil).RPCTxSyncMaxTimeout))
 }
 
 // ResolveRpcBlockNumberOrHash mocks base method.

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -155,6 +155,8 @@ func initFlags() {
 		flags.RPCGlobalTimeoutFlag,
 		flags.RPCLogQueryParameterLimit,
 		flags.RPCLogQueryResultLimit,
+		flags.RPCTxSyncDefaultTimeoutFlag,
+		flags.RPCTxSyncMaxTimeoutFlag,
 		flags.BatchRequestLimit,
 		flags.BatchResponseMaxSize,
 		flags.MaxResponseSizeFlag,

--- a/config/config.go
+++ b/config/config.go
@@ -247,6 +247,12 @@ func gossipConfigWithFlags(ctx *cli.Context, src gossip.Config) gossip.Config {
 	if ctx.GlobalIsSet(flags.RPCGlobalTimeoutFlag.Name) {
 		cfg.RPCTimeout = ctx.GlobalDuration(flags.RPCGlobalTimeoutFlag.Name)
 	}
+	if ctx.GlobalIsSet(flags.RPCTxSyncDefaultTimeoutFlag.Name) {
+		cfg.TxSyncDefaultTimeout = ctx.GlobalDuration(flags.RPCTxSyncDefaultTimeoutFlag.Name)
+	}
+	if ctx.GlobalIsSet(flags.RPCTxSyncMaxTimeoutFlag.Name) {
+		cfg.TxSyncMaxTimeout = ctx.GlobalDuration(flags.RPCTxSyncMaxTimeoutFlag.Name)
+	}
 	if ctx.GlobalIsSet(flags.MaxResponseSizeFlag.Name) {
 		cfg.MaxResponseSize = ctx.GlobalInt(flags.MaxResponseSizeFlag.Name)
 	}

--- a/config/flags/flags.go
+++ b/config/flags/flags.go
@@ -28,6 +28,7 @@ import (
 	pcsclite "github.com/gballet/go-libpcsclite"
 	"gopkg.in/urfave/cli.v1"
 
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/node"
 )
 
@@ -313,6 +314,16 @@ var (
 		Name:  "rpc.log-query-result-limit",
 		Usage: "Maximum number of logs that can be returned in a single eth_getLogs query if the query covers a range of more than one block. For a single block, there is no limit (0 = no cap)",
 		Value: filters.DefaultConfig().LogQueryResultLimit,
+	}
+	RPCTxSyncDefaultTimeoutFlag = &cli.DurationFlag{
+		Name:  "rpc.txsync.defaulttimeout",
+		Usage: "Default timeout for eth_sendRawTransactionSync (e.g. 2s, 500ms)",
+		Value: ethconfig.Defaults.TxSyncDefaultTimeout,
+	}
+	RPCTxSyncMaxTimeoutFlag = &cli.DurationFlag{
+		Name:  "rpc.txsync.maxtimeout",
+		Usage: "Maximum allowed timeout for eth_sendRawTransactionSync (e.g. 5m)",
+		Value: ethconfig.Defaults.TxSyncMaxTimeout,
 	}
 	BatchRequestLimit = &cli.IntFlag{
 		Name:  "rpc.batch-request-limit",

--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,7 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/hashicorp/go-bexpr v0.1.16 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0 // indirect

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -101,6 +101,10 @@ type (
 		// RPCTimeout is a global time limit for RPC methods execution.
 		RPCTimeout time.Duration
 
+		// EIP-7966: eth_sendRawTransactionSync timeouts
+		TxSyncDefaultTimeout time.Duration `toml:",omitempty"`
+		TxSyncMaxTimeout     time.Duration `toml:",omitempty"`
+
 		// allows only for EIP155 transactions.
 		AllowUnprotectedTxs bool
 
@@ -224,6 +228,8 @@ func DefaultConfig(scale cachescale.Func) Config {
 		RPCGasCap:   50000000,
 		RPCTxFeeCap: 100, // 100 FTM
 		RPCTimeout:  5 * time.Second,
+
+		TxSyncDefaultTimeout: 5 * time.Second,
 
 		MaxResponseSize: 25 * 1024 * 1024,
 		StructLogLimit:  2000,

--- a/gossip/config.go
+++ b/gossip/config.go
@@ -230,6 +230,7 @@ func DefaultConfig(scale cachescale.Func) Config {
 		RPCTimeout:  5 * time.Second,
 
 		TxSyncDefaultTimeout: 5 * time.Second,
+		TxSyncMaxTimeout:     30 * time.Second,
 
 		MaxResponseSize: 25 * 1024 * 1024,
 		StructLogLimit:  2000,

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -544,6 +544,14 @@ func (b *EthAPIBackend) RPCTxFeeCap() float64 {
 	return b.svc.config.RPCTxFeeCap
 }
 
+func (b *EthAPIBackend) RPCTxSyncDefaultTimeout() time.Duration {
+	return b.svc.config.TxSyncDefaultTimeout
+}
+
+func (b *EthAPIBackend) RPCTxSyncMaxTimeout() time.Duration {
+	return b.svc.config.TxSyncMaxTimeout
+}
+
 func (b *EthAPIBackend) EvmLogIndex() topicsdb.Index {
 	return b.svc.store.evm.EvmLogs
 }

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -49,8 +49,7 @@ import (
 var (
 	knownMissingAPIs = namespaceMap{
 		"eth": {
-			"SendRawTransactionSync": struct{}{},
-			"GetStorageValues":       struct{}{},
+			"GetStorageValues": struct{}{},
 		},
 		"debug": {
 			"DbAncient":                   struct{}{},

--- a/tests/rpcs/send_raw_transaction_sync_test.go
+++ b/tests/rpcs/send_raw_transaction_sync_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package rpcs
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSendRawTransactionSync tests the eth_sendRawTransactionSync RPC endpoint (EIP-7966).
+func TestSendRawTransactionSync(t *testing.T) {
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{})
+
+	t.Run("happy_path_returns_receipt", func(t *testing.T) {
+		session := net.SpawnSession(t)
+
+		// Create and fund a sender account.
+		sender := tests.NewAccount()
+		_, err := session.EndowAccount(sender.Address(), big.NewInt(1e18))
+		require.NoError(t, err)
+
+		client, err := net.GetClient()
+		require.NoError(t, err)
+		defer client.Close()
+
+		chainID, err := client.ChainID(t.Context())
+		require.NoError(t, err)
+
+		nonce, err := client.PendingNonceAt(t.Context(), sender.Address())
+		require.NoError(t, err)
+
+		gasPrice, err := client.SuggestGasPrice(t.Context())
+		require.NoError(t, err)
+
+		receiver := tests.NewAccount()
+		tx := tests.SignTransaction(t, chainID, &types.LegacyTx{
+			Nonce:    nonce,
+			Gas:      21000,
+			GasPrice: gasPrice,
+			To:       addrPtr(receiver.Address()),
+			Value:    big.NewInt(1000),
+		}, sender)
+
+		encoded, err := tx.MarshalBinary()
+		require.NoError(t, err)
+
+		var receipt map[string]interface{}
+		err = client.Client().Call(&receipt, "eth_sendRawTransactionSync", hexutil.Bytes(encoded))
+		require.NoError(t, err, "eth_sendRawTransactionSync must succeed for a valid transaction")
+		require.NotNil(t, receipt, "receipt must not be nil")
+		require.Equal(t, "0x1", receipt["status"], "transaction must succeed")
+		require.Equal(t, tx.Hash().Hex(), receipt["transactionHash"], "receipt must match submitted tx hash")
+
+		// Verify receipt matches eth_getTransactionReceipt.
+		var expectedReceipt map[string]interface{}
+		err = client.Client().Call(&expectedReceipt, "eth_getTransactionReceipt", tx.Hash())
+		require.NoError(t, err)
+		require.Equal(t, expectedReceipt["transactionHash"], receipt["transactionHash"])
+		require.Equal(t, expectedReceipt["blockNumber"], receipt["blockNumber"])
+		require.Equal(t, expectedReceipt["status"], receipt["status"])
+	})
+
+	t.Run("nonce_gap_returns_code6_error", func(t *testing.T) {
+		// Fresh account — pool expects nonce=0, but we send nonce=5.
+		sender := tests.NewAccount()
+
+		client, err := net.GetClient()
+		require.NoError(t, err)
+		defer client.Close()
+
+		chainID, err := client.ChainID(t.Context())
+		require.NoError(t, err)
+
+		gasPrice, err := client.SuggestGasPrice(t.Context())
+		require.NoError(t, err)
+
+		receiver := tests.NewAccount()
+		tx := tests.SignTransaction(t, chainID, &types.LegacyTx{
+			Nonce:    5,
+			Gas:      21000,
+			GasPrice: gasPrice,
+			To:       addrPtr(receiver.Address()),
+			Value:    big.NewInt(0),
+		}, sender)
+
+		encoded, err := tx.MarshalBinary()
+		require.NoError(t, err)
+
+		var result map[string]interface{}
+		err = client.Client().Call(&result, "eth_sendRawTransactionSync", hexutil.Bytes(encoded))
+		require.Error(t, err, "nonce gap must return an error")
+
+		rpcErr, ok := err.(rpc.Error)
+		require.True(t, ok, "error must be an RPC error, got %T: %v", err, err)
+		require.Equal(t, 6, rpcErr.ErrorCode(), "nonce gap must return error code 6")
+	})
+
+	t.Run("short_timeout_returns_timeout_error", func(t *testing.T) {
+		session := net.SpawnSession(t)
+
+		sender := tests.NewAccount()
+		_, err := session.EndowAccount(sender.Address(), big.NewInt(1e18))
+		require.NoError(t, err)
+
+		client, err := net.GetClient()
+		require.NoError(t, err)
+		defer client.Close()
+
+		chainID, err := client.ChainID(t.Context())
+		require.NoError(t, err)
+
+		nonce, err := client.PendingNonceAt(t.Context(), sender.Address())
+		require.NoError(t, err)
+
+		gasPrice, err := client.SuggestGasPrice(t.Context())
+		require.NoError(t, err)
+
+		receiver := tests.NewAccount()
+		tx := tests.SignTransaction(t, chainID, &types.LegacyTx{
+			Nonce:    nonce,
+			Gas:      21000,
+			GasPrice: gasPrice,
+			To:       addrPtr(receiver.Address()),
+			Value:    big.NewInt(1000),
+		}, sender)
+
+		encoded, err := tx.MarshalBinary()
+		require.NoError(t, err)
+
+		// 1ms timeout — will almost certainly not confirm in time.
+		timeoutMs := hexutil.Uint64(1)
+
+		var result map[string]interface{}
+		err = client.Client().Call(&result, "eth_sendRawTransactionSync", hexutil.Bytes(encoded), timeoutMs)
+		require.Error(t, err, "very short timeout must return an error")
+
+		rpcErr, ok := err.(rpc.Error)
+		require.True(t, ok, "error must be an RPC error, got %T: %v", err, err)
+		// Code 4 (timeout, not in pool) or 5 (queued, tx still in pool).
+		require.True(t,
+			rpcErr.ErrorCode() == 4 || rpcErr.ErrorCode() == 5,
+			"short timeout must return error code 4 or 5, got %d", rpcErr.ErrorCode(),
+		)
+	})
+}
+
+// addrPtr returns a pointer to the given address value.
+func addrPtr[T any](v T) *T { return &v }


### PR DESCRIPTION
This PR introduces new RPC function `eth_sendRawTransactionSync`. This method submits a signed transaction and waits synchronously for it to be included in a block, returning the receipt or a typed error (per EIP-7966).