### PR TITLE
Fix pre-Brio fee attribution for subsidized transactions

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -646,6 +646,10 @@ func processUserTransactions(
 		}
 	}
 
+	// Pre-Brio: return nil to preserve the pre-Brio fee attribution behavior.
+	if !upgrades.Brio {
+		return nil
+	}
 	return summary.CausedBy
 }
 

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -487,7 +487,7 @@ func consensusCallbackBeginBlockFn(
 					// call OnNewReceipt
 					for i, r := range allReceipts {
 						originTx := r.TxHash
-						if origin, found := txCausedBy[r.TxHash]; found {
+						if origin, found := txCausedBy[r.TxHash]; found && es.Rules.Upgrades.Brio {
 							originTx = origin
 						}
 						creator := txPositions[originTx].EventCreator
@@ -646,10 +646,6 @@ func processUserTransactions(
 		}
 	}
 
-	// Pre-Brio: return nil to preserve the pre-Brio fee attribution behavior.
-	if !upgrades.Brio {
-		return nil
-	}
 	return summary.CausedBy
 }
 

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -487,8 +487,10 @@ func consensusCallbackBeginBlockFn(
 					// call OnNewReceipt
 					for i, r := range allReceipts {
 						originTx := r.TxHash
-						if origin, found := txCausedBy[r.TxHash]; found && es.Rules.Upgrades.Brio {
-							originTx = origin
+						if es.Rules.Upgrades.Brio {
+							if origin, found := txCausedBy[r.TxHash]; found {
+								originTx = origin
+							}
 						}
 						creator := txPositions[originTx].EventCreator
 						if creator != 0 && es.Validators.Get(creator) == 0 {


### PR DESCRIPTION
Fixes incompatibility of the main branch with v2.1.6 discovered in Norma testing.

  After #988 merged processUserTransactionsNoLimits into the unified
  processUserTransactions, the causedBy map began propagating in non-Brio
  mode. This caused payment transactions generated by GasSubsidies
  sponsorships to be attributed to the originating validator, whereas the
  old code left them unattributed (txCausedBy was nil).