### PR TITLE
Disable legacy debug methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: sonicd sonictool
 
 GOPROXY ?= "https://proxy.golang.org,direct"
-.PHONY: sonicd sonictool
+.PHONY: sonicd sonictool sonicd-debug
 sonicd:
 	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
@@ -24,6 +24,21 @@ sonictool:
 	    -o build/sonictool \
 	    ./cmd/sonictool && \
 	    ./build/sonictool --version
+
+# Builds with go-ethereum's internal debug RPC methods enabled (file-write
+# endpoints such as debug_startCPUProfile are active). For development and
+# diagnostics only — do NOT use in production or on public-facing nodes.
+sonicd-debug:
+	GIT_COMMIT=`git rev-list -1 HEAD 2>/dev/null || echo ""` && \
+	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
+	GOPROXY=$(GOPROXY) \
+	go build \
+	    -tags enable_debug \
+	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/version.gitCommit=$${GIT_COMMIT} \
+	                    -X github.com/0xsoniclabs/sonic/version.gitDate=$${GIT_DATE}" \
+	    -o build/sonicd-debug \
+	    ./cmd/sonicd && \
+	    ./build/sonicd-debug version
 
 TAG ?= "latest"
 .PHONY: sonic-image

--- a/api/ethapi/debugOverride.go
+++ b/api/ethapi/debugOverride.go
@@ -1,5 +1,3 @@
-//go:build !enable_debug
-
 // Copyright 2026 Sonic Operations Ltd
 // This file is part of the Sonic Client
 //
@@ -15,6 +13,8 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !enable_debug
 
 package ethapi
 

--- a/api/ethapi/debugOverride.go
+++ b/api/ethapi/debugOverride.go
@@ -1,3 +1,5 @@
+//go:build !enable_debug
+
 // Copyright 2026 Sonic Operations Ltd
 // This file is part of the Sonic Client
 //

--- a/api/ethapi/debugOverride.go
+++ b/api/ethapi/debugOverride.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package ethapi
+
+import (
+	"errors"
+	"runtime"
+	"runtime/debug"
+)
+
+var errMethodNotEnabled = errors.New("this method is not enabled")
+
+// The following methods shadow the identically-named endpoints from
+// go-ethereum's internal/debug.Handler, Registering them here under
+// the same debug namespace ensures callers receive an error.
+
+func (api *PublicDebugAPI) Verbosity(level int) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) Vmodule(pattern string) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) MemStats() (*runtime.MemStats, error) {
+	return nil, errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) GcStats() (*debug.GCStats, error) {
+	return nil, errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) CpuProfile(file string, nsec uint) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) StartCPUProfile(file string) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) StopCPUProfile() error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) GoTrace(file string, nsec uint) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) StartGoTrace(file string) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) StopGoTrace() error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) BlockProfile(file string, nsec uint) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) SetBlockProfileRate(rate int) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) WriteBlockProfile(file string) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) MutexProfile(file string, nsec uint) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) SetMutexProfileFraction(rate int) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) WriteMutexProfile(file string) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) WriteMemProfile(file string) error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) Stacks(filter *string) (string, error) {
+	return "", errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) FreeOSMemory() error {
+	return errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) SetGCPercent(v int) (int, error) {
+	return 0, errMethodNotEnabled
+}
+
+func (api *PublicDebugAPI) SetMemoryLimit(limit int64) (int64, error) {
+	return 0, errMethodNotEnabled
+}

--- a/tests/rpcs/debug_test.go
+++ b/tests/rpcs/debug_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package rpcs
+
+import (
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugMethods_notEnabled(t *testing.T) {
+	net := tests.StartIntegrationTestNet(t)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	const wantErr = "this method is not enabled"
+	var result interface{}
+
+	cases := []struct {
+		method string
+		args   []any
+	}{
+		{"debug_verbosity", []any{1}},
+		{"debug_vmodule", []any{"p2p=5"}},
+		{"debug_memStats", []any{}},
+		{"debug_gcStats", []any{}},
+		{"debug_cpuProfile", []any{"cpu.out", 1}},
+		{"debug_startCPUProfile", []any{"cpu.out"}},
+		{"debug_stopCPUProfile", []any{}},
+		{"debug_goTrace", []any{"trace.out", 1}},
+		{"debug_startGoTrace", []any{"trace.out"}},
+		{"debug_stopGoTrace", []any{}},
+		{"debug_blockProfile", []any{"block.out", 1}},
+		{"debug_setBlockProfileRate", []any{1}},
+		{"debug_writeBlockProfile", []any{"block.out"}},
+		{"debug_mutexProfile", []any{"mutex.out", 1}},
+		{"debug_setMutexProfileFraction", []any{1}},
+		{"debug_writeMutexProfile", []any{"mutex.out"}},
+		{"debug_writeMemProfile", []any{"mem.out"}},
+		{"debug_stacks", []any{nil}},
+		{"debug_freeOSMemory", []any{}},
+		{"debug_setGCPercent", []any{100}},
+		{"debug_setMemoryLimit", []any{int64(1 << 30)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			err := client.Client().Call(&result, tc.method, tc.args...)
+			require.EqualError(t, err, wantErr)
+		})
+	}
+}


### PR DESCRIPTION
This PR overrides lagacy debug methods for the RPC. This allows custom debug namespace methods be available in the RPC interface, while original are not enabled.
There is a still option to build sonic client with the legacy debug methods enabled with tag `enable_debug`.