### PR TITLE
Add own `HexToBytes` and `BytesToHex`

### DIFF
--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -25,6 +25,7 @@ import (
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
 	"github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/utils/caution"
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -32,7 +33,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 var (

--- a/cmd/sonictool/chain/export_events.go
+++ b/cmd/sonictool/chain/export_events.go
@@ -36,8 +36,8 @@ import (
 )
 
 var (
-	eventsFileHeader  = hexutils.HexToBytes("7e995678")
-	eventsFileVersion = hexutils.HexToBytes("00010001")
+	eventsFileHeader  = hexutils.MustHexToBytes("7e995678")
+	eventsFileVersion = hexutils.MustHexToBytes("00010001")
 )
 
 // statsReportLimit is the time limit during import and export after which we

--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -34,13 +34,13 @@ import (
 	emitter_config "github.com/0xsoniclabs/sonic/gossip/emitter/config"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/utils/caution"
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/0xsoniclabs/sonic/utils/ioread"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/status-im/keycard-go/hexutils"
 	"gopkg.in/urfave/cli.v1"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/status-im/keycard-go v0.3.2
 	github.com/stretchr/testify v1.11.1
 	github.com/supranational/blst v0.3.16
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
@@ -129,6 +128,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
+	github.com/status-im/keycard-go v0.3.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/urfave/cli/v2 v2.27.7 // indirect

--- a/gossip/blockproc/subsidies/proxy/proxy.go
+++ b/gossip/blockproc/subsidies/proxy/proxy.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	_ "embed"
 
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 //go:generate solc --optimize --optimize-runs 200 --bin --bin-runtime proxy.sol --abi proxy.sol -o build --overwrite

--- a/gossip/blockproc/subsidies/proxy/proxy.go
+++ b/gossip/blockproc/subsidies/proxy/proxy.go
@@ -44,4 +44,4 @@ func GetCode() []byte {
 
 //go:embed proxy_contract.bin
 var proxyCodeInHex string
-var proxyCode []byte = hexutils.HexToBytes(proxyCodeInHex)
+var proxyCode []byte = hexutils.MustHexToBytes(proxyCodeInHex)

--- a/gossip/blockproc/subsidies/registry/registry.go
+++ b/gossip/blockproc/subsidies/registry/registry.go
@@ -20,9 +20,9 @@ import (
 	"bytes"
 	_ "embed"
 
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 //go:generate solc --optimize --optimize-runs 200 --bin --bin-runtime subsidies_registry.sol --abi subsidies_registry.sol -o build --overwrite

--- a/gossip/blockproc/subsidies/registry/registry.go
+++ b/gossip/blockproc/subsidies/registry/registry.go
@@ -64,4 +64,4 @@ var contractAddress = hexutil.MustDecode("0x7d0E23398b6CA0eC7Cdb5b5Aad7F1b112150
 
 //go:embed subsidies_contract.bin
 var registryCodeInHex string
-var registryCode []byte = hexutils.HexToBytes(registryCodeInHex)
+var registryCode []byte = hexutils.MustHexToBytes(registryCodeInHex)

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -23,6 +23,7 @@ import (
 	"github.com/0xsoniclabs/sonic/gossip"
 	"github.com/0xsoniclabs/sonic/utils/adapters/vecmt2dagidx"
 	"github.com/0xsoniclabs/sonic/utils/caution"
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/0xsoniclabs/sonic/vecmt"
 	"github.com/Fantom-foundation/lachesis-base/abft"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -32,7 +33,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 var (

--- a/integration/assembly.go
+++ b/integration/assembly.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	MetadataPrefix = hexutils.HexToBytes("0068c2927bf842c3e9e2f1364494a33a752db334b9a819534bc9f17d2c3b4e5970008ff519d35a86f29fcaa5aae706b75dee871f65f174fcea1747f2915fc92158f6bfbf5eb79f65d16225738594bffb")
+	MetadataPrefix = hexutils.MustHexToBytes("0068c2927bf842c3e9e2f1364494a33a752db334b9a819534bc9f17d2c3b4e5970008ff519d35a86f29fcaa5aae706b75dee871f65f174fcea1747f2915fc92158f6bfbf5eb79f65d16225738594bffb")
 	FlushIDKey     = append(common.CopyBytes(MetadataPrefix), 0x0c)
 	TablesKey      = append(common.CopyBytes(MetadataPrefix), 0x0d)
 )

--- a/opera/genesisstore/disk.go
+++ b/opera/genesisstore/disk.go
@@ -25,10 +25,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/status-im/keycard-go/hexutils"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/0xsoniclabs/sonic/opera/genesis"

--- a/opera/genesisstore/disk.go
+++ b/opera/genesisstore/disk.go
@@ -39,8 +39,8 @@ import (
 )
 
 var (
-	FileHeader  = hexutils.HexToBytes("641b00ac")
-	FileVersion = hexutils.HexToBytes("00020001")
+	FileHeader  = hexutils.MustHexToBytes("641b00ac")
+	FileVersion = hexutils.MustHexToBytes("00020001")
 )
 
 const (

--- a/utils/dbutil/autocompact/store.go
+++ b/utils/dbutil/autocompact/store.go
@@ -19,9 +19,9 @@ package autocompact
 import (
 	"sync"
 
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 // Store implements automatic compacting of recently inserted/erased data according to provided strategy

--- a/utils/dbutil/compactdb/log.go
+++ b/utils/dbutil/compactdb/log.go
@@ -21,9 +21,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 type loggedCompacter struct {

--- a/utils/hexutils/hexutils.go
+++ b/utils/hexutils/hexutils.go
@@ -20,13 +20,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"regexp"
+	"strings"
 )
 
 // HexToBytes converts a hex string to a byte sequence.
 // The hex string can have spaces between bytes.
 func HexToBytes(s string) []byte {
-	s = regexp.MustCompile(" ").ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, " ", "")
 	b := make([]byte, hex.DecodedLen(len(s)))
 	_, err := hex.Decode(b, []byte(s))
 	if err != nil {

--- a/utils/hexutils/hexutils.go
+++ b/utils/hexutils/hexutils.go
@@ -19,20 +19,30 @@ package hexutils
 import (
 	"encoding/hex"
 	"fmt"
-	"log"
 	"strings"
 )
 
+// MustHexToBytes converts a hex string to a byte sequence.
+// The hex string can have spaces between bytes.
+// MustHexToBytes is a helper that panics if the hex string is invalid.
+func MustHexToBytes(s string) []byte {
+	b, err := HexToBytes(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
 // HexToBytes converts a hex string to a byte sequence.
 // The hex string can have spaces between bytes.
-func HexToBytes(s string) []byte {
+func HexToBytes(s string) ([]byte, error) {
 	s = strings.ReplaceAll(s, " ", "")
 	b := make([]byte, hex.DecodedLen(len(s)))
 	_, err := hex.Decode(b, []byte(s))
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("cannot convert invalid hex string '%s' to bytes: %w", s, err)
 	}
-	return b[:]
+	return b[:], nil
 }
 
 // BytesToHex returns a hex string of b.

--- a/utils/hexutils/hexutils.go
+++ b/utils/hexutils/hexutils.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package hexutils
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+	"regexp"
+)
+
+// HexToBytes convert a hex string to a byte sequence.
+// The hex string can have spaces between bytes.
+func HexToBytes(s string) []byte {
+	s = regexp.MustCompile(" ").ReplaceAllString(s, "")
+	b := make([]byte, hex.DecodedLen(len(s)))
+	_, err := hex.Decode(b, []byte(s))
+	if err != nil {
+		log.Fatal(err)
+	}
+	return b[:]
+}
+
+// BytesToHex returns an hex string of b.
+func BytesToHex(b []byte) string {
+	return fmt.Sprintf("%X", b)
+}

--- a/utils/hexutils/hexutils.go
+++ b/utils/hexutils/hexutils.go
@@ -23,7 +23,7 @@ import (
 	"regexp"
 )
 
-// HexToBytes convert a hex string to a byte sequence.
+// HexToBytes converts a hex string to a byte sequence.
 // The hex string can have spaces between bytes.
 func HexToBytes(s string) []byte {
 	s = regexp.MustCompile(" ").ReplaceAllString(s, "")
@@ -35,7 +35,7 @@ func HexToBytes(s string) []byte {
 	return b[:]
 }
 
-// BytesToHex returns an hex string of b.
+// BytesToHex returns a hex string of b.
 func BytesToHex(b []byte) string {
 	return fmt.Sprintf("%X", b)
 }

--- a/utils/hexutils/hexutils_test.go
+++ b/utils/hexutils/hexutils_test.go
@@ -17,8 +17,6 @@
 package hexutils
 
 import (
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -89,24 +87,90 @@ func TestHexToBytes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := HexToBytes(tt.input)
+			result := MustHexToBytes(tt.input)
 			require.Equal(t, tt.expected, result)
 		})
 	}
 }
 
 func TestHexToBytes_InvalidInput(t *testing.T) {
-	if os.Getenv("TEST_FATAL") == "1" {
-		HexToBytes("zz")
-		return
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "non-hex characters", input: "zz"},
+		{name: "odd length", input: "abc"},
+		{name: "special characters", input: "!@#$"},
+		{name: "0x prefix", input: "0xdeadbeef"},
+		{name: "newline in string", input: "de\nad"},
+		{name: "tab in string", input: "de\tad"},
+		{name: "single non-hex char", input: "g"},
+		{name: "valid prefix invalid suffix", input: "deadbegf"},
+		{name: "unicode characters", input: "café"},
+		{name: "trailing garbage", input: "deadbeef!!"},
 	}
-	cmd := exec.Command(os.Args[0], "-test.run=TestHexToBytes_InvalidInput")
-	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
-	err := cmd.Run()
-	require.Error(t, err)
-	exitErr, ok := err.(*exec.ExitError)
-	require.True(t, ok)
-	require.False(t, exitErr.Success())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := HexToBytes(tt.input)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestMustHexToBytes_Panics(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "non-hex characters", input: "zz"},
+		{name: "odd length", input: "abc"},
+		{name: "special characters", input: "!@#$"},
+		{name: "0x prefix", input: "0xdeadbeef"},
+		{name: "newline in string", input: "de\nad"},
+		{name: "tab in string", input: "de\tad"},
+		{name: "single non-hex char", input: "g"},
+		{name: "valid prefix invalid suffix", input: "deadbegf"},
+		{name: "unicode characters", input: "café"},
+		{name: "trailing garbage", input: "deadbeef!!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Panics(t, func() {
+				MustHexToBytes(tt.input)
+			})
+		})
+	}
+}
+
+func TestMustHexToBytes_DoesNotPanic(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []byte
+	}{
+		{name: "spaces only", input: "   ", expected: []byte{}},
+		{name: "space-separated single byte", input: " ff ", expected: []byte{0xff}},
+		{name: "space inside byte pair", input: "d e a d", expected: []byte{0xde, 0xad}},
+		{name: "lowercase a-f", input: "abcdef", expected: []byte{0xab, 0xcd, 0xef}},
+		{name: "digits only", input: "0123456789", expected: []byte{0x01, 0x23, 0x45, 0x67, 0x89}},
+		{name: "32 bytes (address-like)", input: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", expected: []byte{
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				result := MustHexToBytes(tt.input)
+				require.Equal(t, tt.expected, result)
+			})
+		})
+	}
 }
 
 func TestBytesToHex(t *testing.T) {
@@ -180,7 +244,7 @@ func TestRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := HexToBytes(tt.hex)
+			b := MustHexToBytes(tt.hex)
 			result := BytesToHex(b)
 			require.Equal(t, tt.hex, result)
 		})
@@ -202,7 +266,7 @@ func TestRoundTripBytesToHexToBytes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hexStr := BytesToHex(tt.input)
-			result := HexToBytes(hexStr)
+			result := MustHexToBytes(hexStr)
 			require.Equal(t, tt.input, result)
 		})
 	}

--- a/utils/hexutils/hexutils_test.go
+++ b/utils/hexutils/hexutils_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package hexutils
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHexToBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []byte
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []byte{},
+		},
+		{
+			name:     "single byte",
+			input:    "ff",
+			expected: []byte{0xff},
+		},
+		{
+			name:     "multiple bytes",
+			input:    "deadbeef",
+			expected: []byte{0xde, 0xad, 0xbe, 0xef},
+		},
+		{
+			name:     "uppercase hex",
+			input:    "DEADBEEF",
+			expected: []byte{0xde, 0xad, 0xbe, 0xef},
+		},
+		{
+			name:     "mixed case",
+			input:    "DeAdBeEf",
+			expected: []byte{0xde, 0xad, 0xbe, 0xef},
+		},
+		{
+			name:     "with spaces between bytes",
+			input:    "de ad be ef",
+			expected: []byte{0xde, 0xad, 0xbe, 0xef},
+		},
+		{
+			name:     "with multiple spaces",
+			input:    "de  ad  be  ef",
+			expected: []byte{0xde, 0xad, 0xbe, 0xef},
+		},
+		{
+			name:     "all zeros",
+			input:    "00000000",
+			expected: []byte{0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:     "all ones",
+			input:    "ffffffff",
+			expected: []byte{0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:     "single zero byte",
+			input:    "00",
+			expected: []byte{0x00},
+		},
+		{
+			name:     "long input",
+			input:    "0123456789abcdef0123456789abcdef",
+			expected: []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HexToBytes(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHexToBytes_InvalidInput(t *testing.T) {
+	if os.Getenv("TEST_FATAL") == "1" {
+		HexToBytes("zz")
+		return
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=TestHexToBytes_InvalidInput")
+	cmd.Env = append(os.Environ(), "TEST_FATAL=1")
+	err := cmd.Run()
+	require.Error(t, err)
+	exitErr, ok := err.(*exec.ExitError)
+	require.True(t, ok)
+	require.False(t, exitErr.Success())
+}
+
+func TestBytesToHex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "empty slice",
+			input:    []byte{},
+			expected: "",
+		},
+		{
+			name:     "single byte",
+			input:    []byte{0xff},
+			expected: "FF",
+		},
+		{
+			name:     "multiple bytes",
+			input:    []byte{0xde, 0xad, 0xbe, 0xef},
+			expected: "DEADBEEF",
+		},
+		{
+			name:     "all zeros",
+			input:    []byte{0x00, 0x00, 0x00, 0x00},
+			expected: "00000000",
+		},
+		{
+			name:     "all ones",
+			input:    []byte{0xff, 0xff, 0xff, 0xff},
+			expected: "FFFFFFFF",
+		},
+		{
+			name:     "single zero byte",
+			input:    []byte{0x00},
+			expected: "00",
+		},
+		{
+			name:     "sequential bytes",
+			input:    []byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
+			expected: "0123456789ABCDEF",
+		},
+		{
+			name:     "nil slice",
+			input:    nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BytesToHex(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		hex  string
+	}{
+		{name: "deadbeef", hex: "DEADBEEF"},
+		{name: "empty", hex: ""},
+		{name: "single byte", hex: "AB"},
+		{name: "all zeros", hex: "00000000"},
+		{name: "all ones", hex: "FFFFFFFF"},
+		{name: "long value", hex: "0123456789ABCDEF0123456789ABCDEF"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := HexToBytes(tt.hex)
+			result := BytesToHex(b)
+			require.Equal(t, tt.hex, result)
+		})
+	}
+}
+
+func TestRoundTripBytesToHexToBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{name: "deadbeef", input: []byte{0xde, 0xad, 0xbe, 0xef}},
+		{name: "empty", input: []byte{}},
+		{name: "single byte", input: []byte{0xab}},
+		{name: "all zeros", input: []byte{0x00, 0x00, 0x00, 0x00}},
+		{name: "sequential", input: []byte{0x01, 0x02, 0x03, 0x04, 0x05}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hexStr := BytesToHex(tt.input)
+			result := HexToBytes(hexStr)
+			require.Equal(t, tt.input, result)
+		})
+	}
+}

--- a/utils/signers/internaltx/internaltx_test.go
+++ b/utils/signers/internaltx/internaltx_test.go
@@ -20,9 +20,9 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/utils/hexutils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/status-im/keycard-go/hexutils"
 	"github.com/stretchr/testify/require"
 )
 

--- a/utils/signers/internaltx/internaltx_test.go
+++ b/utils/signers/internaltx/internaltx_test.go
@@ -45,7 +45,7 @@ func TestIsInternal(t *testing.T) {
 	require.True(t, IsInternal(types.NewTx(&types.LegacyTx{
 		V: new(big.Int),
 		R: new(big.Int),
-		S: new(big.Int).SetBytes(hexutils.HexToBytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
+		S: new(big.Int).SetBytes(hexutils.MustHexToBytes("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")),
 	})))
 	require.False(t, IsInternal(types.NewTx(&types.LegacyTx{
 		V: big.NewInt(1),


### PR DESCRIPTION
Implements https://github.com/0xsoniclabs/sonic-admin/issues/765

Introduces a dedicated `hexutils` package under `utils` providing two utility functions for bytes and strings conversions, and migrates existing usages across the codebase to use them.
- `HexToBytes`: decodes a hex string to bytes, stripping spaces between byte pairs; calls `log.Fatal` on invalid input.
- `BytesToHex`: encodes a byte slice to an uppercase hex string.