### PR TITLE
[SONIC-003] Preserve group-level TolerateFailures flag in prepareBundle

### DIFF
--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -386,10 +386,11 @@ func convertProposalToPlanInternal(signer types.Signer, proposalStep any) (bundl
 			return steps[0], nil
 		}
 
-		return bundle.NewGroupStep(
-			step.OneOf,
-			steps...,
-		), nil
+		group := bundle.NewGroupStep(step.OneOf, steps...)
+		if step.TolerateFailures {
+			group = group.WithFlags(bundle.EF_TolerateFailed)
+		}
+		return group, nil
 	}
 
 	return empty, fmt.Errorf("invalid execution proposal level: must have either executionStep or group")

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -1234,6 +1234,57 @@ func Test_convertProposalToPlan(t *testing.T) {
 				).
 				BuildBundle().Plan,
 		},
+		"group TolerateFailures flag is preserved": {
+			proposal: RPCExecutionProposal{
+				BlockRange: &RPCRange{
+					First:  *rpctest.ToHexUint64(0),
+					Length: *rpctest.ToHexUint64(1023),
+				},
+				RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+					Steps: []any{
+						RPCExecutionPlanGroup{
+							TolerateFailures: true,
+							Steps: []any{
+								RPCExecutionStepProposal{
+									TransactionArgs: ethapi.TransactionArgs{
+										From:  &address1,
+										To:    &common.Address{123},
+										Nonce: rpctest.ToHexUint64(1),
+										Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
+									},
+								},
+								RPCExecutionStepProposal{
+									TransactionArgs: ethapi.TransactionArgs{
+										From:  &address2,
+										To:    &common.Address{1},
+										Nonce: rpctest.ToHexUint64(2),
+										Gas:   rpctest.ToHexUint64(21000 + bundleMarkerCost),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			plan: bundle.NewBuilder().
+				SetEarliest(0).SetRangeLength(1023).
+				WithSigner(signer).
+				With(
+					bundle.AllOf(
+						bundle.Step(key1, &types.AccessListTx{
+							To:    &common.Address{123},
+							Nonce: 1,
+							Gas:   21000,
+						}),
+						bundle.Step(key2, &types.AccessListTx{
+							To:    &common.Address{1},
+							Nonce: 2,
+							Gas:   21000,
+						}),
+					).WithFlags(bundle.EF_TolerateFailed),
+				).
+				BuildBundle().Plan,
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
convertProposalToPlanInternal built the execution plan group via bundle.NewGroupStep without applying EF_TolerateFailed when the proposal group had TolerateFailures=true. The symmetric path in execution_plan.go correctly called group.WithFlags(EF_TolerateFailed), but the proposal conversion path was missing the same step.

Result: a prepared bundle was stricter than requested — any failed transaction in the group would invalidate the whole bundle even though the caller explicitly set tolerateFailures=true.

Fix: mirror the execution_plan.go pattern after NewGroupStep:
  group = group.WithFlags(bundle.EF_TolerateFailed)

Add test case 'group TolerateFailures flag is preserved' to Test_convertProposalToPlan, which would have caught this regression.