### PR TITLE
Allow blob transactions with BlobHashes to enable ethereum history replay

### DIFF
--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -1362,6 +1362,7 @@ func TestDebugTraceWithBlobTx(t *testing.T) {
 		blockCtx := vm.BlockContext{
 			BlockNumber: block.Number,
 			BaseFee:     big.NewInt(1_000),
+			BlobBaseFee: big.NewInt(1_000),
 			Transfer:    vm.TransferFunc(func(sd vm.StateDB, a1, a2 common.Address, i *uint256.Int, _ *params.Rules) {}),
 			CanTransfer: vm.CanTransferFunc(func(sd vm.StateDB, a1 common.Address, i *uint256.Int) bool { return true }),
 		}
@@ -1397,18 +1398,18 @@ func TestDebugTraceWithBlobTx(t *testing.T) {
 		}))
 		api := NewPublicDebugAPI(mockBackend, 10000, 10000)
 
-		// Replay the second transaction (includes replaying the first one to initialize the state)
+		// replay tx
 		_, err := api.TraceTransaction(context.Background(), common.Hash{}, &tracers.TraceConfig{})
 		require.NoError(t, err, "must be possible to trace the blob transaction")
 
-		// Replay the whole block
+		// replay complete block
 		res, err := api.TraceBlockByNumber(context.Background(), rpc.BlockNumber(5), &tracers.TraceConfig{})
 		require.NoError(t, err, "trace block must succeed")
 		require.Empty(t, res[0].Error, "tx must succeed")
 		require.Empty(t, res[1].Error, "tx must succeed")
 	})
 
-	t.Run("provides proper error for non-empty BlockHashes", func(t *testing.T) {
+	t.Run("succeed with non-empty BlockHashes", func(t *testing.T) {
 		mockBackend := prepareMockBackend(types.NewTx(&types.BlobTx{
 			Gas:        21000,
 			GasFeeCap:  uint256.NewInt(1_000_000_000_000),
@@ -1419,13 +1420,15 @@ func TestDebugTraceWithBlobTx(t *testing.T) {
 		}))
 		api := NewPublicDebugAPI(mockBackend, 10000, 10000)
 
-		// Replay the second transaction - initialization by replaing the first one is expected to fail
+		// replay tx
 		_, err := api.TraceTransaction(context.Background(), common.Hash{}, &tracers.TraceConfig{})
-		require.Equal(t, err.Error(), "tracing failed: blob data is not supported")
+		require.NoError(t, err, "must be possible to trace the blob transaction")
 
-		// Replay the whole block - should return errors for individual txs
-		_, err = api.TraceBlockByNumber(context.Background(), rpc.BlockNumber(5), &tracers.TraceConfig{})
-		require.Error(t, err, "tracing failed: blob data is not supported")
+		// replay complete block
+		res, err := api.TraceBlockByNumber(context.Background(), rpc.BlockNumber(5), &tracers.TraceConfig{})
+		require.NoError(t, err, "trace block must succeed")
+		require.Empty(t, res[0].Error, "tx must succeed")
+		require.Empty(t, res[1].Error, "tx must succeed")
 	})
 }
 

--- a/api/ethapi/transaction_args.go
+++ b/api/ethapi/transaction_args.go
@@ -269,6 +269,11 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, lo
 		blobGasFeeCap = args.BlobFeeCap.ToInt()
 	}
 
+	blobHashes := args.BlobHashes
+	if len(blobHashes) == 0 {
+		blobHashes = nil
+	}
+
 	return &core.Message{
 		From:                  addr,
 		To:                    args.To,
@@ -281,7 +286,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, lo
 		Data:                  data,
 		AccessList:            accessList,
 		BlobGasFeeCap:         blobGasFeeCap,
-		BlobHashes:            args.BlobHashes,
+		BlobHashes:            blobHashes,
 		SetCodeAuthorizations: args.AuthorizationList,
 		SkipNonceChecks:       true,
 		SkipTransactionChecks: true,

--- a/api/ethapi/transaction_args_test.go
+++ b/api/ethapi/transaction_args_test.go
@@ -21,11 +21,13 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/logger"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
@@ -101,7 +103,7 @@ func TestTransactionArgs_ToMessage_CapsGasToProvidedGlobalAndLogsWarning(t *test
 	t.Parallel()
 
 	args := TransactionArgs{
-		Gas: asPointer(hexutil.Uint64(150)),
+		Gas: new(hexutil.Uint64(150)),
 	}
 
 	ctrl := gomock.NewController(t)
@@ -147,11 +149,11 @@ func TestTransactionArgs_ToMessage_TrivialFieldsAreCopied(t *testing.T) {
 
 	txArgs := TransactionArgs{
 		To:    &common.Address{0x1},
-		Nonce: asPointer(hexutil.Uint64(0x2)),
+		Nonce: new(hexutil.Uint64(0x2)),
 		Value: (*hexutil.Big)(big.NewInt(0x3)),
-		Data:  asPointer(hexutil.Bytes([]byte{0x4})),
-		Gas:   asPointer(hexutil.Uint64(0x5)),
-		AccessList: asPointer(
+		Data:  new(hexutil.Bytes([]byte{0x4})),
+		Gas:   new(hexutil.Uint64(0x5)),
+		AccessList: new(
 			types.AccessList{
 				{
 					Address: common.Address{0x1},
@@ -453,11 +455,11 @@ func TestTransactionArgs_ToTransaction(t *testing.T) {
 		"legacy transaction": {
 			args: TransactionArgs{
 				To:       &common.Address{0x41},
-				Nonce:    asPointer(hexutil.Uint64(0x42)),
-				Gas:      asPointer(hexutil.Uint64(0x43)),
+				Nonce:    new(hexutil.Uint64(0x42)),
+				Gas:      new(hexutil.Uint64(0x43)),
 				GasPrice: (*hexutil.Big)(big.NewInt(0x44)),
 				Value:    (*hexutil.Big)(big.NewInt(0x45)),
-				Data:     asPointer(hexutil.Bytes{0x46}),
+				Data:     new(hexutil.Bytes{0x46}),
 			},
 			expected: types.NewTx(&types.LegacyTx{
 				To:       &common.Address{0x41},
@@ -471,12 +473,12 @@ func TestTransactionArgs_ToTransaction(t *testing.T) {
 		"accessList transaction": {
 			args: TransactionArgs{
 				To:       &common.Address{0x41},
-				Nonce:    asPointer(hexutil.Uint64(0x42)),
-				Gas:      asPointer(hexutil.Uint64(0x43)),
+				Nonce:    new(hexutil.Uint64(0x42)),
+				Gas:      new(hexutil.Uint64(0x43)),
 				GasPrice: (*hexutil.Big)(big.NewInt(0x44)),
 				Value:    (*hexutil.Big)(big.NewInt(0x45)),
-				Data:     asPointer(hexutil.Bytes{0x46}),
-				AccessList: asPointer(types.AccessList{
+				Data:     new(hexutil.Bytes{0x46}),
+				AccessList: new(types.AccessList{
 					{
 						Address: common.Address{0x01},
 						StorageKeys: []common.Hash{
@@ -507,13 +509,13 @@ func TestTransactionArgs_ToTransaction(t *testing.T) {
 		"dynamicFee transaction": {
 			args: TransactionArgs{
 				To:                   &common.Address{0x41},
-				Nonce:                asPointer(hexutil.Uint64(0x42)),
-				Gas:                  asPointer(hexutil.Uint64(0x43)),
+				Nonce:                new(hexutil.Uint64(0x42)),
+				Gas:                  new(hexutil.Uint64(0x43)),
 				MaxFeePerGas:         (*hexutil.Big)(big.NewInt(0x44)),
 				MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(0x45)),
 				Value:                (*hexutil.Big)(big.NewInt(0x46)),
-				Data:                 asPointer(hexutil.Bytes{0x47}),
-				AccessList: asPointer(types.AccessList{
+				Data:                 new(hexutil.Bytes{0x47}),
+				AccessList: new(types.AccessList{
 					{
 						Address: common.Address{0x01},
 					},
@@ -537,13 +539,13 @@ func TestTransactionArgs_ToTransaction(t *testing.T) {
 		"blob transaction": {
 			args: TransactionArgs{
 				To:                   &common.Address{0x41},
-				Nonce:                asPointer(hexutil.Uint64(0x42)),
-				Gas:                  asPointer(hexutil.Uint64(0x43)),
+				Nonce:                new(hexutil.Uint64(0x42)),
+				Gas:                  new(hexutil.Uint64(0x43)),
 				MaxFeePerGas:         (*hexutil.Big)(big.NewInt(0x44)),
 				MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(0x45)),
 				Value:                (*hexutil.Big)(big.NewInt(0x46)),
-				Data:                 asPointer(hexutil.Bytes{0x47}),
-				AccessList: asPointer(types.AccessList{
+				Data:                 new(hexutil.Bytes{0x47}),
+				AccessList: new(types.AccessList{
 					{
 						Address: common.Address{0x01},
 					},
@@ -577,13 +579,13 @@ func TestTransactionArgs_ToTransaction(t *testing.T) {
 		"setCode transaction": {
 			args: TransactionArgs{
 				To:                   &common.Address{0x41},
-				Nonce:                asPointer(hexutil.Uint64(0x42)),
-				Gas:                  asPointer(hexutil.Uint64(0x43)),
+				Nonce:                new(hexutil.Uint64(0x42)),
+				Gas:                  new(hexutil.Uint64(0x43)),
 				MaxFeePerGas:         (*hexutil.Big)(big.NewInt(0x44)),
 				MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(0x45)),
 				Value:                (*hexutil.Big)(big.NewInt(0x46)),
-				Data:                 asPointer(hexutil.Bytes{0x47}),
-				AccessList: asPointer(types.AccessList{
+				Data:                 new(hexutil.Bytes{0x47}),
+				AccessList: new(types.AccessList{
 					{
 						Address: common.Address{0x01},
 					},
@@ -915,8 +917,133 @@ func TestToTransaction_ReturnsErrors(t *testing.T) {
 	}
 }
 
-// asPointer is a helper function to convert a value to a pointer,
-// useful to inline hexutil types in tests.
-func asPointer[T any](v T) *T {
-	return &v
+func TestTransactionArgs_ToMessageIsEquivalentToEvmcoreToMessage(t *testing.T) {
+	t.Parallel()
+
+	// Verify tx args -> message conversion is equivalent to
+	// tx args -> transaction -> message conversion.
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	from := crypto.PubkeyToAddress(key.PublicKey)
+	to := common.Address{0xaa}
+	nonce := hexutil.Uint64(7)
+	gas := hexutil.Uint64(123_456)
+	chainID := (*hexutil.Big)(big.NewInt(1337))
+	gasPrice := (*hexutil.Big)(big.NewInt(21))
+	maxFeePerGas := (*hexutil.Big)(big.NewInt(100))
+	maxPriorityFeePerGas := (*hexutil.Big)(big.NewInt(3))
+	blobFeeCap := (*hexutil.Big)(big.NewInt(7))
+	baseFee := big.NewInt(2)
+	inputData := hexutil.Bytes{0x01, 0x02, 0x03}
+	accessList := types.AccessList{{Address: common.Address{0x01}}}
+
+	tests := map[string]TransactionArgs{
+		"legacy tx": {
+			From:     &from,
+			To:       &to,
+			Nonce:    &nonce,
+			Gas:      &gas,
+			GasPrice: gasPrice,
+			Value:    (*hexutil.Big)(big.NewInt(11)),
+			Input:    &inputData,
+		},
+		"access list tx": {
+			From:       &from,
+			To:         &to,
+			Nonce:      &nonce,
+			Gas:        &gas,
+			GasPrice:   gasPrice,
+			Value:      (*hexutil.Big)(big.NewInt(11)),
+			Input:      &inputData,
+			AccessList: &accessList,
+			ChainID:    chainID,
+		},
+		"dynamic fee tx": {
+			From:                 &from,
+			To:                   &to,
+			Nonce:                &nonce,
+			Gas:                  &gas,
+			Value:                (*hexutil.Big)(big.NewInt(11)),
+			Input:                &inputData,
+			AccessList:           &accessList,
+			ChainID:              chainID,
+			MaxFeePerGas:         maxFeePerGas,
+			MaxPriorityFeePerGas: maxPriorityFeePerGas,
+		},
+		"blob tx with blob hashes": {
+			From:                 &from,
+			To:                   &to,
+			Nonce:                &nonce,
+			Gas:                  &gas,
+			Value:                (*hexutil.Big)(big.NewInt(11)),
+			Input:                &inputData,
+			AccessList:           &accessList,
+			ChainID:              chainID,
+			MaxFeePerGas:         maxFeePerGas,
+			MaxPriorityFeePerGas: maxPriorityFeePerGas,
+			BlobFeeCap:           blobFeeCap,
+			BlobHashes: []common.Hash{
+				common.HexToHash("0x49"),
+				common.HexToHash("0x4a"),
+			},
+		},
+		"blob tx with empty blob hashes": {
+			From:                 &from,
+			To:                   &to,
+			Nonce:                &nonce,
+			Gas:                  &gas,
+			Value:                (*hexutil.Big)(big.NewInt(11)),
+			Input:                &inputData,
+			AccessList:           &accessList,
+			ChainID:              chainID,
+			MaxFeePerGas:         maxFeePerGas,
+			MaxPriorityFeePerGas: maxPriorityFeePerGas,
+			BlobFeeCap:           blobFeeCap,
+			BlobHashes:           []common.Hash{},
+		},
+		"set code tx": {
+			From:                 &from,
+			To:                   &to,
+			Nonce:                &nonce,
+			Gas:                  &gas,
+			Value:                (*hexutil.Big)(big.NewInt(11)),
+			Input:                &inputData,
+			AccessList:           &accessList,
+			ChainID:              chainID,
+			MaxFeePerGas:         maxFeePerGas,
+			MaxPriorityFeePerGas: maxPriorityFeePerGas,
+			AuthorizationList: []types.SetCodeAuthorization{
+				{
+					Address: common.Address{0x01},
+					Nonce:   0x02,
+					ChainID: *uint256.NewInt(0x03),
+				},
+			},
+		},
+	}
+
+	for name, args := range tests {
+		t.Run(name, func(t *testing.T) {
+			directMsg, err := args.ToMessage(0, baseFee, nil)
+			require.NoError(t, err)
+
+			tx, err := args.ToTransaction()
+			require.NoError(t, err)
+
+			signer := types.LatestSignerForChainID(args.ChainID.ToInt())
+			signedTx, err := types.SignTx(tx, signer, key)
+			require.NoError(t, err)
+
+			msgFromTx, err := evmcore.TxAsMessage(signedTx, signer, baseFee)
+			require.NoError(t, err)
+
+			// RPC messages usually skip checks; normalize to compare payload fields.
+			directMsg.SkipNonceChecks = false
+			directMsg.SkipTransactionChecks = false
+
+			require.Equal(t, directMsg, msgFromTx)
+		})
+	}
 }

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -70,8 +70,8 @@ func GetCoinbase() common.Address {
 }
 
 // GetBlobBaseFee returns the blob base fee to be used by blocks on Sonic networks.
-func GetBlobBaseFee() uint256.Int {
-	return uint256.Int{}
+func GetBlobBaseFee() *uint256.Int {
+	return uint256.NewInt(1)
 }
 
 // NewEvmBlock constructor.

--- a/evmcore/dummy_block.go
+++ b/evmcore/dummy_block.go
@@ -71,6 +71,14 @@ func GetCoinbase() common.Address {
 
 // GetBlobBaseFee returns the blob base fee to be used by blocks on Sonic networks.
 func GetBlobBaseFee() *uint256.Int {
+	// The reason is that https://eips.ethereum.org/EIPS/eip-4844 defines a formula for the computation of the blob-base-fee:
+	//
+	//    the function get_base_fee_per_blob_gas is defines as:
+	//    - BLOB_BASE_FEE = MIN_BASE_FEE_PER_BLOB_GAS * e ^ (header.excess_blob_gas / BLOB_BASE_FEE_UPDATE_FRACTION)
+	//    - MIN_BASE_FEE_PER_BLOB_GAS = 1
+	//    - BLOB_BASE_FEE_UPDATE_FRACTION = 3338477
+	//
+	// In sonic the excess_blob_gas is always 0, since Sonic does not offer blob gas this reduces to 1 * e^0 = 1.
 	return uint256.NewInt(1)
 }
 

--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -77,7 +77,8 @@ func NewEVMBlockContextWithDifficulty(
 		difficulty = big.NewInt(0)
 	}
 
-	blobBaseFee := big.NewInt(1) // default for Sonic networks, overridden by header if present
+	// default for Sonic networks, overridden by header if present
+	blobBaseFee := GetBlobBaseFee().ToBig()
 	if header.BlobBaseFee != nil {
 		blobBaseFee = new(big.Int).Set(header.BlobBaseFee)
 	}

--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -74,7 +74,7 @@ func NewEVMBlockContextWithDifficulty(
 	if header.PrevRandao.Cmp(common.Hash{}) != 0 {
 		random = &header.PrevRandao
 		// Difficulty must be set to 0 when PREVRANDAO is enabled.
-		difficulty = big.NewInt(0)
+		difficulty.SetUint64(0)
 	}
 
 	// default for Sonic networks, overridden by header if present

--- a/evmcore/evm.go
+++ b/evmcore/evm.go
@@ -60,6 +60,7 @@ func NewEVMBlockContextWithDifficulty(
 		baseFee     *big.Int
 		random      *common.Hash
 	)
+
 	// If we don't have an explicit author (i.e. not mining), extract from the header
 	if author == nil {
 		beneficiary = header.Coinbase
@@ -73,7 +74,12 @@ func NewEVMBlockContextWithDifficulty(
 	if header.PrevRandao.Cmp(common.Hash{}) != 0 {
 		random = &header.PrevRandao
 		// Difficulty must be set to 0 when PREVRANDAO is enabled.
-		difficulty.SetUint64(0)
+		difficulty = big.NewInt(0)
+	}
+
+	blobBaseFee := big.NewInt(1) // default for Sonic networks, overridden by header if present
+	if header.BlobBaseFee != nil {
+		blobBaseFee = new(big.Int).Set(header.BlobBaseFee)
 	}
 
 	return vm.BlockContext{
@@ -87,7 +93,7 @@ func NewEVMBlockContextWithDifficulty(
 		BaseFee:     baseFee,
 		GasLimit:    header.GasLimit,
 		Random:      random,
-		BlobBaseFee: big.NewInt(1), // TODO issue #147
+		BlobBaseFee: blobBaseFee,
 	}
 }
 

--- a/evmcore/evm_test.go
+++ b/evmcore/evm_test.go
@@ -140,10 +140,10 @@ func TestNewEVMBlockContextWithDifficulty_UsesHeaderParametersIfDefinedOrSonicDe
 	// an execution context which can process both recorded and live blocks,
 	// by correctly using header parameters when defined.
 	// The following parameters are tested:
-	// - Base is nil in sonic (at this stage), but it uses  the base fee from the header if defined.
-	// - BlobBaseFee is 1 by default, but it uses the value from the header if defined.
-	// - Coinbase is taken from the header if author parameter is nil, otherwise it uses the author.
-	// - PrevRandao is used if defined, and difficulty is set to 0 in that case. Otherwise, difficulty remains being the header value.
+	// - BaseFee is nil on Sonic (at this stage), but it uses the base fee from the header if defined.
+	// - BlobBaseFee defaults to 1, but it uses the value from the header if defined.
+	// - Coinbase is taken from the header if the author parameter is nil; otherwise it uses the author.
+	// - PrevRandao is used if defined and difficulty is set to 0 in that case; otherwise difficulty remains the header value.
 
 	const defaultBlobBaseFee int64 = 1
 

--- a/evmcore/evm_test.go
+++ b/evmcore/evm_test.go
@@ -133,3 +133,116 @@ func TestMustNewEVMTxContext_PanicsOnInvalidGasPrice(t *testing.T) {
 		func() { MustNewEVMTxContext(msg) },
 	)
 }
+
+func TestNewEVMBlockContextWithDifficulty_UsesHeaderParametersIfDefinedOrSonicDefaults(t *testing.T) {
+
+	// This test verifies that NewEVMBlockContextWithDifficulty can both be used to create
+	// an execution context which can process both recorded and live blocks,
+	// by correctly using header parameters when defined.
+	// The following parameters are tested:
+	// - Base is nil in sonic (at this stage), but it uses  the base fee from the header if defined.
+	// - BlobBaseFee is 1 by default, but it uses the value from the header if defined.
+	// - Coinbase is taken from the header if author parameter is nil, otherwise it uses the author.
+	// - PrevRandao is used if defined, and difficulty is set to 0 in that case. Otherwise, difficulty remains being the header value.
+
+	const defaultBlobBaseFee int64 = 1
+
+	someBaseFee := big.NewInt(7)
+	someBlobBaseFee := big.NewInt(123)
+	someDifficulty := big.NewInt(321)
+
+	tests := map[string]struct {
+		header      *EvmHeader
+		author      *common.Address
+		difficulty  *big.Int
+		expectation func(t testing.TB, ctx vm.BlockContext)
+	}{
+		"uses header.BaseFee when defined": {
+			header: &EvmHeader{
+				Number:  big.NewInt(1),
+				BaseFee: someBaseFee,
+			},
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.Equal(t, someBaseFee, ctx.BaseFee)
+				require.NotSame(t, someBaseFee, ctx.BaseFee, "BaseFee should be copied, not aliased")
+			},
+		},
+		"uses nil BaseFee when header.BaseFee is not defined": {
+			header: &EvmHeader{
+				Number: big.NewInt(1),
+			},
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.Nil(t, ctx.BaseFee)
+			},
+		},
+		"header.blockBaseFee overrides default": {
+			header: &EvmHeader{
+				Number:      big.NewInt(1),
+				BlobBaseFee: someBlobBaseFee,
+			},
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.Equal(t, someBlobBaseFee, ctx.BlobBaseFee)
+				require.NotSame(t, someBlobBaseFee, ctx.BlobBaseFee, "BlobBaseFee should be copied, not aliased")
+			},
+		},
+		"uses default blobBaseFee when header.blobBaseFee is not defined": {
+			header: &EvmHeader{
+				Number: big.NewInt(1),
+			},
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.Equal(t, defaultBlobBaseFee, ctx.BlobBaseFee.Int64())
+
+			},
+		},
+		"uses header coinbase when author is nil": {
+			header: &EvmHeader{
+				Number:   big.NewInt(1),
+				Coinbase: common.Address{0xAA},
+			},
+			author: nil,
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.Equal(t, common.Address{0xAA}, ctx.Coinbase)
+			},
+		},
+		"author overrides header coinbase": {
+			header: &EvmHeader{
+				Number:   big.NewInt(1),
+				Coinbase: common.Address{0xAA},
+			},
+			author: &common.Address{0xBB},
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.Equal(t, common.Address{0xBB}, ctx.Coinbase)
+			},
+		},
+		"uses header.prevRandao and 0 difficulty when prevRandao is set": {
+			header: &EvmHeader{
+				Number:     big.NewInt(1),
+				PrevRandao: common.Hash{0x01},
+			},
+			difficulty: someDifficulty,
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.NotNil(t, ctx.Random)
+				require.Equal(t, common.Hash{0x01}, *ctx.Random)
+				require.Equal(t, int64(0), ctx.Difficulty.Int64())
+			},
+		},
+		"keeps provided difficulty and nil random when prevRandao is zero": {
+			header: &EvmHeader{
+				Number:     big.NewInt(1),
+				PrevRandao: common.Hash{},
+			},
+			difficulty: someDifficulty,
+			expectation: func(t testing.TB, ctx vm.BlockContext) {
+				require.Nil(t, ctx.Random)
+				require.Equal(t, someDifficulty, ctx.Difficulty)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := NewEVMBlockContextWithDifficulty(test.header, nil, test.author, test.difficulty)
+			test.expectation(t, ctx)
+		})
+	}
+}

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -828,7 +828,20 @@ func (tp *TransactionProcessor) Run(i int, tx *types.Transaction) ProcessSummary
 // ApplyTransactionWithEVM attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment similar to ApplyTransaction. However,
 // this method takes an already created EVM instance as input.
-func ApplyTransactionWithEVM(msg *core.Message, config *params.ChainConfig, gp *core.GasPool, statedb state.StateDB, blockNumber *big.Int, blockHash common.Hash, tx *types.Transaction, usedGas *uint64, evm *vm.EVM) (receipt *types.Receipt, err error) {
+//
+// The primary use case for this method is to apply transactions from RPC calls or
+// traces.
+func ApplyTransactionWithEVM(
+	msg *core.Message,
+	config *params.ChainConfig,
+	gp *core.GasPool,
+	statedb state.StateDB,
+	blockNumber *big.Int,
+	blockHash common.Hash,
+	tx *types.Transaction,
+	usedGas *uint64,
+	evm *vm.EVM,
+) (receipt *types.Receipt, err error) {
 	if evm.Config.Tracer != nil && evm.Config.Tracer.OnTxStart != nil {
 		evm.Config.Tracer.OnTxStart(evm.GetVMContext(), tx, msg.From)
 		if evm.Config.Tracer.OnTxEnd != nil {
@@ -844,16 +857,6 @@ func ApplyTransactionWithEVM(msg *core.Message, config *params.ChainConfig, gp *
 		return nil, fmt.Errorf("failed to create EVM transaction context: %w", err)
 	}
 	evm.SetTxContext(txContext)
-
-	// For now, Sonic only supports Blob transactions without blob data.
-	if msg.BlobHashes != nil {
-		if len(msg.BlobHashes) > 0 {
-			statedb.EndTransaction()
-			return nil, fmt.Errorf("blob data is not supported")
-		}
-		// PreCheck requires non-nil blobHashes not to be empty
-		msg.BlobHashes = nil
-	}
 
 	// Apply the transaction to the current state (included in the env).
 	result, err := core.ApplyMessage(evm, msg, gp)
@@ -950,16 +953,6 @@ func applyTransaction(
 	// Skip checking of base fee limits for internal transactions.
 	evm.Config.NoBaseFee = evm.Config.NoBaseFee || msg.SkipNonceChecks
 
-	// For now, Sonic only supports Blob transactions without blob data.
-	if msg.BlobHashes != nil {
-		if len(msg.BlobHashes) > 0 {
-			statedb.EndTransaction()
-			return nil, 0, fmt.Errorf("blob data is not supported")
-		}
-		// PreCheck requires non-nil blobHashes not to be empty
-		msg.BlobHashes = nil
-	}
-
 	isAllegro := evm.ChainConfig().IsPrague(blockNumber, evm.Context.Time)
 	var snapshot int
 	if isAllegro {
@@ -1021,9 +1014,8 @@ func applyTransaction(
 }
 
 func TxAsMessage(tx *types.Transaction, signer types.Signer, baseFee *big.Int) (*core.Message, error) {
-	if !internaltx.IsInternal(tx) {
-		return core.TransactionToMessage(tx, signer, baseFee)
-	} else {
+	if internaltx.IsInternal(tx) {
+
 		return &core.Message{ // internal tx - no signature checking
 			From:                  internaltx.InternalSender(tx),
 			To:                    tx.To(),
@@ -1041,6 +1033,21 @@ func TxAsMessage(tx *types.Transaction, signer types.Signer, baseFee *big.Int) (
 			SkipTransactionChecks: true,
 		}, nil
 	}
+
+	msg, err := core.TransactionToMessage(tx, signer, baseFee)
+	if err != nil {
+		return nil, err
+	}
+
+	// Patch BlobHashes to allow execution of ethereum history and sonic semantics:
+	// - ethereum does not allow blob txs without BlobHashes, but preChecks will not
+	// check it if BlobHashes is nil
+	// - Sonic only allows blob txs if BlobHashes is empty
+	if len(msg.BlobHashes) == 0 {
+		msg.BlobHashes = nil
+	}
+
+	return msg, nil
 }
 
 // logger is an internal interface to enable the mocking of logging in tests.

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -5077,11 +5077,25 @@ func TestTxAsMessage_ConvertsUserTransactionsToMessage(t *testing.T) {
 	signer := types.LatestSignerForChainID(chainId)
 	sender := crypto.PubkeyToAddress(key.PublicKey)
 
+	accessList := types.AccessList{
+		{
+			Address:     common.Address{2},
+			StorageKeys: []common.Hash{{1}, {2}},
+		},
+	}
+
+	setCodeAuthorizations := []types.SetCodeAuthorization{
+		{
+			Address: common.Address{3},
+			Nonce:   1,
+		},
+	}
+
 	test := map[string]struct {
 		tx           types.TxData
 		expectations func(*testing.T, core.Message)
 	}{
-		"type 0: legacy transaction": {
+		"legacy transaction": {
 			tx: &types.LegacyTx{
 				Nonce:    0,
 				To:       &common.Address{1},
@@ -5091,83 +5105,38 @@ func TestTxAsMessage_ConvertsUserTransactionsToMessage(t *testing.T) {
 				Data:     []byte{0x01, 0x02},
 			},
 		},
-		"type 1: access list transaction": {
+		"access list transaction": {
 			tx: &types.AccessListTx{
-				Nonce:    0,
-				To:       &common.Address{1},
-				Gas:      21_000,
-				GasPrice: big.NewInt(1),
-				Value:    big.NewInt(100),
-				Data:     []byte{0x01, 0x02},
-				AccessList: types.AccessList{
-					{
-						Address:     common.Address{2},
-						StorageKeys: []common.Hash{{1}, {2}},
-					},
-				},
+				Nonce:      0,
+				To:         &common.Address{1},
+				Gas:        21_000,
+				GasPrice:   big.NewInt(1),
+				Value:      big.NewInt(100),
+				Data:       []byte{0x01, 0x02},
+				AccessList: accessList,
 			},
 			expectations: func(t *testing.T, msg core.Message) {
-				require.Equal(t,
-					types.AccessList{
-						{
-							Address:     common.Address{2},
-							StorageKeys: []common.Hash{{1}, {2}},
-						},
-					}, msg.AccessList)
+				require.Equal(t, accessList, msg.AccessList)
 			},
 		},
-		"type 2: dynamic fee transaction": {
+		"dynamic fee transaction": {
 			tx: &types.DynamicFeeTx{
-				Nonce:     0,
-				To:        &common.Address{1},
-				Gas:       21_000,
-				GasFeeCap: big.NewInt(1),
-				GasTipCap: big.NewInt(2),
-				Value:     big.NewInt(100),
-				Data:      []byte{0x01, 0x02},
+				Nonce:      0,
+				To:         &common.Address{1},
+				Gas:        21_000,
+				GasFeeCap:  big.NewInt(1),
+				GasTipCap:  big.NewInt(2),
+				Value:      big.NewInt(100),
+				Data:       []byte{0x01, 0x02},
+				AccessList: accessList,
 			},
 			expectations: func(t *testing.T, msg core.Message) {
 				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
 				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Equal(t, accessList, msg.AccessList)
 			},
 		},
-		"type 3: blob transaction with blob hashes": {
-			tx: &types.BlobTx{
-				Nonce:     0,
-				To:        common.Address{1},
-				Gas:       21_000,
-				GasFeeCap: uint256.NewInt(1),
-				GasTipCap: uint256.NewInt(2),
-				Value:     uint256.NewInt(100),
-				Data:      []byte{0x01, 0x02},
-				BlobHashes: []common.Hash{
-					{1}, {2},
-				},
-			},
-			expectations: func(t *testing.T, msg core.Message) {
-				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
-				require.Equal(t, big.NewInt(2), msg.GasTipCap)
-				require.Equal(t, msg.BlobHashes, []common.Hash{{1}, {2}},
-					"Sonic rejects blobTxs with non-empty blob hashes, but this layer allows them for history replays")
-			},
-		},
-		"type 3: blob transaction with nil blob hashes": {
-			tx: &types.BlobTx{
-				Nonce:     0,
-				To:        common.Address{1},
-				Gas:       21_000,
-				GasFeeCap: uint256.NewInt(1),
-				GasTipCap: uint256.NewInt(2),
-				Value:     uint256.NewInt(100),
-				Data:      []byte{0x01, 0x02},
-			},
-			expectations: func(t *testing.T, msg core.Message) {
-				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
-				require.Equal(t, big.NewInt(2), msg.GasTipCap)
-				require.Nil(t, msg.BlobHashes, "Sonic allows empty blob txs, go-ethereum allows processing nil")
-			},
-		},
-		"type 3: blob transaction with empty blob hashes": {
+		"blob transaction with blob hashes": {
 			tx: &types.BlobTx{
 				Nonce:      0,
 				To:         common.Address{1},
@@ -5176,12 +5145,85 @@ func TestTxAsMessage_ConvertsUserTransactionsToMessage(t *testing.T) {
 				GasTipCap:  uint256.NewInt(2),
 				Value:      uint256.NewInt(100),
 				Data:       []byte{0x01, 0x02},
+				AccessList: accessList,
+				BlobHashes: []common.Hash{
+					{1}, {2},
+				},
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
+				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Equal(t, accessList, msg.AccessList)
+				require.Equal(t, msg.BlobHashes, []common.Hash{{1}, {2}},
+					"Sonic rejects blobTxs with non-empty blob hashes, but this layer allows them for history replays")
+			},
+		},
+		"blob transaction with nil blob hashes": {
+			tx: &types.BlobTx{
+				Nonce:      0,
+				To:         common.Address{1},
+				Gas:        21_000,
+				GasFeeCap:  uint256.NewInt(1),
+				GasTipCap:  uint256.NewInt(2),
+				Value:      uint256.NewInt(100),
+				AccessList: accessList,
+				Data:       []byte{0x01, 0x02},
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
+				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Equal(t, accessList, msg.AccessList)
+				require.Nil(t, msg.BlobHashes, "Sonic allows empty blob txs, go-ethereum allows processing nil")
+			},
+		},
+		"blob transaction with empty blob hashes": {
+			tx: &types.BlobTx{
+				Nonce:      0,
+				To:         common.Address{1},
+				Gas:        21_000,
+				GasFeeCap:  uint256.NewInt(1),
+				GasTipCap:  uint256.NewInt(2),
+				Value:      uint256.NewInt(100),
+				Data:       []byte{0x01, 0x02},
+				AccessList: accessList,
 				BlobHashes: []common.Hash{},
 			},
 			expectations: func(t *testing.T, msg core.Message) {
 				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
 				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Equal(t, accessList, msg.AccessList)
 				require.Nil(t, msg.BlobHashes, "Sonic allows empty blob txs, go-ethereum allows processing nil")
+			},
+		},
+		"set code transaction": {
+			tx: &types.SetCodeTx{
+				Nonce:      0,
+				To:         common.Address{1},
+				Gas:        21_000,
+				Value:      uint256.NewInt(100),
+				Data:       []byte{0x01, 0x02},
+				AccessList: accessList,
+				AuthList:   setCodeAuthorizations,
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, common.Address{1}, *msg.To)
+				require.Equal(t, accessList, msg.AccessList)
+				require.Equal(t, setCodeAuthorizations, msg.SetCodeAuthorizations)
+			},
+		},
+		"set code transaction, empty auth list": {
+			tx: &types.SetCodeTx{
+				Nonce:      0,
+				To:         common.Address{1},
+				Gas:        21_000,
+				Value:      uint256.NewInt(100),
+				Data:       []byte{0x01, 0x02},
+				AccessList: accessList,
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, common.Address{1}, *msg.To)
+				require.Equal(t, accessList, msg.AccessList)
+				require.Empty(t, msg.SetCodeAuthorizations)
 			},
 		},
 	}

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -720,29 +720,6 @@ func TestApplyTransaction_FailsForTransactionWithInvalidGasPrice(t *testing.T) {
 	require.ErrorContains(t, err, "failed to create EVM transaction context")
 }
 
-func TestApplyTransaction_BlobHashesNotSupportedAndSkipped(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	state := state.NewMockStateDB(ctrl)
-	evm := vm.NewEVM(vm.BlockContext{}, state, &params.ChainConfig{}, vm.Config{})
-	gp := core.NewGasPool(1000000)
-
-	state.EXPECT().EndTransaction()
-
-	msg := &core.Message{
-		From:       common.Address{1},
-		To:         &common.Address{2},
-		GasLimit:   21000,
-		GasPrice:   big.NewInt(1),
-		BlobHashes: []common.Hash{{0x01}},
-	}
-	usedGas := uint64(0)
-	receipt, gasUsed, err :=
-		applyTransaction(msg, gp, state, big.NewInt(1), nil, &usedGas, evm, nil)
-	require.ErrorContains(t, err, "blob data is not supported")
-	require.Nil(t, receipt)
-	require.Equal(t, uint64(0), gasUsed)
-}
-
 func TestApplyTransaction_ApplyMessageError_RevertsSnapshotIfPrague(t *testing.T) {
 	versions := map[string]bool{
 		"pre prague": false,
@@ -3691,7 +3668,7 @@ func getRegularTransaction(t *testing.T) *types.Transaction {
 	})
 }
 
-func getSponsorshipRequestUnsigned(t *testing.T) *types.Transaction {
+func getSponsorshipRequestUnsigned(*testing.T) *types.Transaction {
 	return types.NewTx(&types.LegacyTx{
 		Nonce: 0, To: &common.Address{1}, Gas: 21_000,
 	})
@@ -5070,4 +5047,167 @@ func TestStateProcessor_MetricsAreEnabledInSingleBlockProposerMode(t *testing.T)
 
 	require.Equal(t, mockMetrics, tp.metrics,
 		"metrics must be forwarded from StateProcessor to TransactionProcessor via BeginBlock")
+}
+
+func TestTxAsMessage_ConvertsInternalTransactionToMessage(t *testing.T) {
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		To:       &common.Address{1},
+		Gas:      21_000,
+		GasPrice: big.NewInt(1),
+		Value:    big.NewInt(100),
+		Data:     []byte{0x01, 0x02},
+	})
+
+	msg, err := TxAsMessage(tx, nil, big.NewInt(1))
+	require.NoError(t, err)
+	require.Equal(t, common.Address{}, msg.From)
+	require.Equal(t, tx.To(), msg.To)
+	require.Equal(t, tx.Gas(), msg.GasLimit)
+	require.Equal(t, tx.GasPrice(), msg.GasPrice)
+	require.Equal(t, tx.Value(), msg.Value)
+	require.Equal(t, tx.Data(), msg.Data)
+}
+
+func TestTxAsMessage_ConvertsUserTransactionsToMessage(t *testing.T) {
+	chainId := big.NewInt(1)
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	signer := types.LatestSignerForChainID(chainId)
+	sender := crypto.PubkeyToAddress(key.PublicKey)
+
+	test := map[string]struct {
+		tx           types.TxData
+		expectations func(*testing.T, core.Message)
+	}{
+		"type 0: legacy transaction": {
+			tx: &types.LegacyTx{
+				Nonce:    0,
+				To:       &common.Address{1},
+				Gas:      21_000,
+				GasPrice: big.NewInt(1),
+				Value:    big.NewInt(100),
+				Data:     []byte{0x01, 0x02},
+			},
+		},
+		"type 1: access list transaction": {
+			tx: &types.AccessListTx{
+				Nonce:    0,
+				To:       &common.Address{1},
+				Gas:      21_000,
+				GasPrice: big.NewInt(1),
+				Value:    big.NewInt(100),
+				Data:     []byte{0x01, 0x02},
+				AccessList: types.AccessList{
+					{
+						Address:     common.Address{2},
+						StorageKeys: []common.Hash{{1}, {2}},
+					},
+				},
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t,
+					types.AccessList{
+						{
+							Address:     common.Address{2},
+							StorageKeys: []common.Hash{{1}, {2}},
+						},
+					}, msg.AccessList)
+			},
+		},
+		"type 2: dynamic fee transaction": {
+			tx: &types.DynamicFeeTx{
+				Nonce:     0,
+				To:        &common.Address{1},
+				Gas:       21_000,
+				GasFeeCap: big.NewInt(1),
+				GasTipCap: big.NewInt(2),
+				Value:     big.NewInt(100),
+				Data:      []byte{0x01, 0x02},
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
+				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Equal(t, []byte{0x01, 0x02}, msg.Data)
+			},
+		},
+		"type 3: blob transaction with blob hashes": {
+			tx: &types.BlobTx{
+				Nonce:     0,
+				To:        common.Address{1},
+				Gas:       21_000,
+				GasFeeCap: uint256.NewInt(1),
+				GasTipCap: uint256.NewInt(2),
+				Value:     uint256.NewInt(100),
+				Data:      []byte{0x01, 0x02},
+				BlobHashes: []common.Hash{
+					{1}, {2},
+				},
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
+				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Equal(t, msg.BlobHashes, []common.Hash{{1}, {2}})
+				require.Equal(t, msg.BlobHashes, []common.Hash{{1}, {2}},
+					"Sonic rejects blobTxs with non-empty blob hashes, but this layer allows them for history replays")
+			},
+		},
+		"type 3: blob transaction with nil blob hashes": {
+			tx: &types.BlobTx{
+				Nonce:     0,
+				To:        common.Address{1},
+				Gas:       21_000,
+				GasFeeCap: uint256.NewInt(1),
+				GasTipCap: uint256.NewInt(2),
+				Value:     uint256.NewInt(100),
+				Data:      []byte{0x01, 0x02},
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
+				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Nil(t, msg.BlobHashes, "Sonic allows empty blob txs, go-ethereum allows processing nil")
+			},
+		},
+		"type 3: blob transaction with empty blob hashes": {
+			tx: &types.BlobTx{
+				Nonce:      0,
+				To:         common.Address{1},
+				Gas:        21_000,
+				GasFeeCap:  uint256.NewInt(1),
+				GasTipCap:  uint256.NewInt(2),
+				Value:      uint256.NewInt(100),
+				Data:       []byte{0x01, 0x02},
+				BlobHashes: []common.Hash{},
+			},
+			expectations: func(t *testing.T, msg core.Message) {
+				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
+				require.Equal(t, big.NewInt(2), msg.GasTipCap)
+				require.Nil(t, msg.BlobHashes, "Sonic allows empty blob txs, go-ethereum allows processing nil")
+			},
+		},
+	}
+
+	for name, tc := range test {
+		t.Run(name, func(t *testing.T) {
+			basefee := big.NewInt(1)
+			tx := types.MustSignNewTx(key, signer, tc.tx)
+			msg, err := TxAsMessage(tx, signer, basefee)
+			require.NoError(t, err)
+			require.NotNil(t, msg)
+
+			require.Equal(t, sender, msg.From)
+			require.Equal(t, tx.To(), msg.To)
+			require.Equal(t, tx.GasPrice(), msg.GasPrice)
+			require.Equal(t, tx.GasFeeCap(), msg.GasFeeCap)
+			require.Equal(t, tx.GasTipCap(), msg.GasTipCap)
+			require.Equal(t, tx.Value(), msg.Value)
+			require.Equal(t, tx.Gas(), msg.GasLimit)
+			require.Equal(t, tx.Data(), msg.Data)
+
+			if tc.expectations != nil {
+				tc.expectations(t, *msg)
+			}
+		})
+	}
 }

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -5129,7 +5129,6 @@ func TestTxAsMessage_ConvertsUserTransactionsToMessage(t *testing.T) {
 			expectations: func(t *testing.T, msg core.Message) {
 				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
 				require.Equal(t, big.NewInt(2), msg.GasTipCap)
-				require.Equal(t, []byte{0x01, 0x02}, msg.Data)
 			},
 		},
 		"type 3: blob transaction with blob hashes": {
@@ -5148,7 +5147,6 @@ func TestTxAsMessage_ConvertsUserTransactionsToMessage(t *testing.T) {
 			expectations: func(t *testing.T, msg core.Message) {
 				require.Equal(t, big.NewInt(1), msg.GasFeeCap)
 				require.Equal(t, big.NewInt(2), msg.GasTipCap)
-				require.Equal(t, msg.BlobHashes, []common.Hash{{1}, {2}})
 				require.Equal(t, msg.BlobHashes, []common.Hash{{1}, {2}},
 					"Sonic rejects blobTxs with non-empty blob hashes, but this layer allows them for history replays")
 			},

--- a/gossip/emitter/proposals.go
+++ b/gossip/emitter/proposals.go
@@ -277,7 +277,7 @@ func makeProposal(
 			MixHash:     randaoMix,
 			Coinbase:    evmcore.GetCoinbase(),
 			BaseFee:     *baseFee256,
-			BlobBaseFee: evmcore.GetBlobBaseFee(),
+			BlobBaseFee: *evmcore.GetBlobBaseFee(),
 		},
 		candidates,
 		scheduler.Limits{

--- a/gossip/emitter/proposals_test.go
+++ b/gossip/emitter/proposals_test.go
@@ -383,7 +383,7 @@ func TestMakeProposal_ValidArguments_CreatesValidProposal(t *testing.T) {
 			GasLimit:    rules.Blocks.MaxBlockGas,
 			MixHash:     someRandao,
 			BaseFee:     *uint256.NewInt(100),
-			BlobBaseFee: *uint256.NewInt(0),
+			BlobBaseFee: *evmcore.GetBlobBaseFee(),
 		},
 		nil,
 		scheduler.Limits{
@@ -657,7 +657,7 @@ func TestMakeProposal_SchedulerIsRunWithCorrectBaseFee(t *testing.T) {
 			MixHash:     randaoMix,
 			Coinbase:    evmcore.GetCoinbase(),
 			BaseFee:     *uint256.MustFromBig(expectedBaseFee),
-			BlobBaseFee: evmcore.GetBlobBaseFee(),
+			BlobBaseFee: *evmcore.GetBlobBaseFee(),
 		},
 		gomock.Any(),
 		gomock.Any(),


### PR DESCRIPTION
This Change allows the state processor running ethereum history blob txs by enabling two components:

- forward blob hashes to state processor
- use blobBaseFee from block is available

## BlobBaseFee

BlobBase fee is used if available in the block. This PR targets history replays, Sonic does not have the capability of deciding how is this value computed, but it can be reused if the block is already known. 

The code would use two different BlobBasefees  depending on if it is being called via RPC or block processing, blobbasefee is now hardcoded to 1, which is the value used in the block processor and therefore committed to the history. 

## Blob Hashes
Sonic does not implement Blobs, but allows blob transactions as long as they contain no blobs. 
Ethereum does not allow bob transactions without blobs, but geth does not check nil list in the transaction pre-checks. This is used by sonic to execute empty blob txs. 

To enable history runs blob semantics have to be unified.  The system will now produce `BlobHashes` with hashes or nil to enable both semantics. 
The conversion was previously done in `applyTransaction` which is a function with unclear responsibilities and difficult to test. This PR minimizes changes by moving the patching of the blob transaction to  `TxAsMessage`, which is used by both the block processor and RPC calls and traces, therefore enabling the change for `ApplyTransactionWithEVM` as well (the entry point to the state processor from the RPC) 

## Checks
- [x] run bertha on eth
- [x] run bertha on sonic