### PR TITLE
Drop sponsored transaction if post-tx fail

### DIFF
--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -468,6 +468,26 @@ func (r *transactionRunner) runSponsoredTransactionInternal(
 		return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid
 	}
 
+	// Starting with Brio, the sponsored transaction and all its post-transactions
+	// are treated as an atomic unit. If any post-transaction fails or is skipped,
+	// everything is rolled back via an inter-tx snapshot.
+	var (
+		interTxSnapshotId int
+		savedGasPool      *core.GasPool
+		savedUsedGas      uint64
+	)
+	if ctxt.upgrades.Brio {
+		interTxSnapshotId = ctxt.statedb.InterTxSnapshot()
+		savedGasPool = ctxt.gasPool.Snapshot()
+		savedUsedGas = *ctxt.usedGas
+	}
+	rollback := func() ([]ProcessedTransaction, core_types.TransactionResult) {
+		ctxt.statedb.RevertToInterTxSnapshot(interTxSnapshotId)
+		ctxt.gasPool.Set(savedGasPool)
+		*ctxt.usedGas = savedUsedGas
+		return []ProcessedTransaction{{Transaction: tx}}, core_types.TransactionResultInvalid
+	}
+
 	// Run the sponsored transaction.
 	processed := r.evm.runWithoutBaseFeeCheck(ctxt, tx, txIndex)
 	if processed.Receipt == nil {
@@ -490,10 +510,13 @@ func (r *transactionRunner) runSponsoredTransactionInternal(
 
 	postTxs, err := getPostTransactions(sponsorship, ctxt.statedb, gasUsed, ctxt.baseFee)
 	if err != nil {
-		// Note: at this point the sponsored transaction has been executed, but we
-		// are not able to build the post-execution transaction. We can not undo
-		// the sponsored transaction, and we can not abort the block formation.
 		log.Warn("Failed to create post-execution transaction", "sponsored-tx", tx.Hash().Hex(), "err", err)
+		if ctxt.upgrades.Brio {
+			return rollback()
+		}
+		// Pre-Brio: at this point the sponsored transaction has been executed, but
+		// we are not able to build the post-execution transaction. The fee was not
+		// properly settled, but we cannot abort the block formation.
 		return []ProcessedTransaction{processed}, status
 	}
 
@@ -501,10 +524,17 @@ func (r *transactionRunner) runSponsoredTransactionInternal(
 	out := []ProcessedTransaction{processed}
 	for _, postTx := range postTxs {
 		processedPost := r.evm.runWithoutBaseFeeCheck(ctxt, postTx, txIndex)
-		if processedPost.Receipt == nil {
-			log.Warn("Post-execution transaction was skipped", "sponsored-tx", tx.Hash().Hex())
-		} else if processedPost.Receipt.Status == types.ReceiptStatusFailed {
-			log.Warn("Post-execution transaction failed", "sponsored-tx", tx.Hash().Hex())
+		if processedPost.Receipt == nil || processedPost.Receipt.Status == types.ReceiptStatusFailed {
+			if ctxt.upgrades.Brio {
+				log.Warn("Post-execution transaction failed or was skipped, rolling back sponsored transaction",
+					"sponsored-tx", tx.Hash().Hex())
+				return rollback()
+			}
+			if processedPost.Receipt == nil {
+				log.Warn("Post-execution transaction was skipped", "sponsored-tx", tx.Hash().Hex())
+			} else {
+				log.Warn("Post-execution transaction failed", "sponsored-tx", tx.Hash().Hex())
+			}
 		}
 		out = append(out, processedPost)
 		if processedPost.Receipt != nil {

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -524,17 +524,17 @@ func (r *transactionRunner) runSponsoredTransactionInternal(
 	out := []ProcessedTransaction{processed}
 	for _, postTx := range postTxs {
 		processedPost := r.evm.runWithoutBaseFeeCheck(ctxt, postTx, txIndex)
-		if processedPost.Receipt == nil || processedPost.Receipt.Status == types.ReceiptStatusFailed {
-			if ctxt.upgrades.Brio {
+		if ctxt.upgrades.Brio {
+			if processedPost.Receipt == nil || processedPost.Receipt.Status != types.ReceiptStatusSuccessful {
 				log.Warn("Post-execution transaction failed or was skipped, rolling back sponsored transaction",
 					"sponsored-tx", tx.Hash().Hex())
 				return rollback()
 			}
-			if processedPost.Receipt == nil {
-				log.Warn("Post-execution transaction was skipped", "sponsored-tx", tx.Hash().Hex())
-			} else {
-				log.Warn("Post-execution transaction failed", "sponsored-tx", tx.Hash().Hex())
-			}
+		}
+		if processedPost.Receipt == nil {
+			log.Warn("Post-execution transaction was skipped", "sponsored-tx", tx.Hash().Hex())
+		} else if processedPost.Receipt.Status == types.ReceiptStatusFailed {
+			log.Warn("Post-execution transaction failed", "sponsored-tx", tx.Hash().Hex())
 		}
 		out = append(out, processedPost)
 		if processedPost.Receipt != nil {

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2622,6 +2622,272 @@ func TestRunSponsoredTransaction_ProcessesAllPostTransactionsInOrder(t *testing.
 	}
 }
 
+func TestRunSponsoredTransaction_Brio_FailedPostTx_RollsBackAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	mockEvm := NewMock_evm(ctrl)
+
+	tx := getSponsorshipRequest(t)
+	postTx := &types.Transaction{}
+
+	any := gomock.Any()
+
+	// IsCovered query runs in a regular snapshot.
+	stateDb.EXPECT().Snapshot().Return(1)
+	stateDb.EXPECT().RevertToSnapshot(1)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil) // getGasConfig
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil) // chooseFund → mode 1
+
+	// Brio: inter-tx snapshot is taken before the sponsored tx executes.
+	const snapshotId = 42
+	stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
+
+	// Track initial gas state to verify it is fully restored after rollback.
+	const initialGasInPool = uint64(1_000_000)
+	gasPool := core.NewGasPool(initialGasInPool)
+	usedGas := uint64(50_000)
+
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).
+		DoAndReturn(func(ctxt *runContext, _ *types.Transaction, _ int) ProcessedTransaction {
+			_ = ctxt.gasPool.SubGas(21_000)
+			*ctxt.usedGas += 21_000
+			return ProcessedTransaction{
+				Transaction: tx,
+				Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
+			}
+		})
+
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).
+		DoAndReturn(func(ctxt *runContext, _ *types.Transaction, _ int) ProcessedTransaction {
+			_ = ctxt.gasPool.SubGas(1_000)
+			*ctxt.usedGas += 1_000
+			return ProcessedTransaction{
+				Transaction: postTx,
+				Receipt:     &types.Receipt{Status: types.ReceiptStatusFailed, GasUsed: 1_000},
+			}
+		})
+
+	// Brio: state, gas pool, and usedGas are all rolled back via inter-tx snapshot.
+	stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
+
+	ctxt := &runContext{
+		statedb:  stateDb,
+		signer:   types.LatestSignerForChainID(nil),
+		baseFee:  big.NewInt(1),
+		gasPool:  gasPool,
+		usedGas:  &usedGas,
+		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
+	}
+
+	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
+		return []*types.Transaction{postTx}, nil
+	}
+
+	runner := &transactionRunner{evm: mockEvm}
+	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
+
+	require.Equal(t, core_types.TransactionResultInvalid, status)
+	require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
+	require.Equal(t, initialGasInPool, gasPool.Gas(), "gas pool must be restored to pre-execution state")
+	require.Equal(t, uint64(50_000), usedGas, "usedGas must be restored to pre-execution state")
+}
+
+func TestRunSponsoredTransaction_Brio_SkippedPostTx_RollsBackAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	mockEvm := NewMock_evm(ctrl)
+
+	tx := getSponsorshipRequest(t)
+	postTx := &types.Transaction{}
+
+	any := gomock.Any()
+
+	stateDb.EXPECT().Snapshot().Return(1)
+	stateDb.EXPECT().RevertToSnapshot(1)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
+
+	const snapshotId = 7
+	stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
+
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(ProcessedTransaction{
+		Transaction: tx,
+		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
+	})
+
+	// Post-tx is skipped (nil receipt).
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).Return(ProcessedTransaction{
+		Transaction: postTx,
+		Receipt:     nil,
+	})
+
+	stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
+
+	ctxt := &runContext{
+		statedb:  stateDb,
+		signer:   types.LatestSignerForChainID(nil),
+		baseFee:  big.NewInt(1),
+		gasPool:  core.NewGasPool(1_000_000),
+		usedGas:  new(uint64),
+		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
+	}
+
+	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
+		return []*types.Transaction{postTx}, nil
+	}
+
+	runner := &transactionRunner{evm: mockEvm}
+	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
+
+	require.Equal(t, core_types.TransactionResultInvalid, status)
+	require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
+}
+
+func TestRunSponsoredTransaction_Brio_BuildErrorForPostTx_RollsBackAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	mockEvm := NewMock_evm(ctrl)
+
+	tx := getSponsorshipRequest(t)
+
+	any := gomock.Any()
+
+	stateDb.EXPECT().Snapshot().Return(1)
+	stateDb.EXPECT().RevertToSnapshot(1)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
+
+	const snapshotId = 5
+	stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
+
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(ProcessedTransaction{
+		Transaction: tx,
+		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
+	})
+
+	stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
+
+	ctxt := &runContext{
+		statedb:  stateDb,
+		signer:   types.LatestSignerForChainID(nil),
+		baseFee:  big.NewInt(1),
+		gasPool:  core.NewGasPool(1_000_000),
+		usedGas:  new(uint64),
+		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
+	}
+
+	buildErr := fmt.Errorf("cannot build post-tx")
+	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
+		return nil, buildErr
+	}
+
+	runner := &transactionRunner{evm: mockEvm}
+	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
+
+	require.Equal(t, core_types.TransactionResultInvalid, status)
+	require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
+}
+
+func TestRunSponsoredTransaction_Brio_SuccessfulPostTxs_NoRollback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	mockEvm := NewMock_evm(ctrl)
+
+	tx := getSponsorshipRequest(t)
+	postTx := &types.Transaction{}
+
+	any := gomock.Any()
+
+	stateDb.EXPECT().Snapshot().Return(1)
+	stateDb.EXPECT().RevertToSnapshot(1)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
+
+	// Snapshot is taken but never reverted (all post-txs succeed).
+	stateDb.EXPECT().InterTxSnapshot().Return(99)
+
+	processedSponsored := ProcessedTransaction{
+		Transaction: tx,
+		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
+	}
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(processedSponsored)
+
+	processedPost := ProcessedTransaction{
+		Transaction: postTx,
+		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 1_000},
+	}
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).Return(processedPost)
+
+	ctxt := &runContext{
+		statedb:  stateDb,
+		signer:   types.LatestSignerForChainID(nil),
+		baseFee:  big.NewInt(1),
+		gasPool:  core.NewGasPool(1_000_000),
+		usedGas:  new(uint64),
+		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
+	}
+
+	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
+		return []*types.Transaction{postTx}, nil
+	}
+
+	runner := &transactionRunner{evm: mockEvm}
+	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
+
+	require.Equal(t, core_types.TransactionResultSuccessful, status)
+	require.Equal(t, []ProcessedTransaction{processedSponsored, processedPost}, got)
+}
+
+func TestRunSponsoredTransaction_PreBrio_FailedPostTx_NeverRollsBack(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stateDb := state.NewMockStateDB(ctrl)
+	mockEvm := NewMock_evm(ctrl)
+
+	tx := getSponsorshipRequest(t)
+	postTx := &types.Transaction{}
+
+	any := gomock.Any()
+
+	stateDb.EXPECT().Snapshot().Return(1)
+	stateDb.EXPECT().RevertToSnapshot(1)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
+	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
+
+	// No InterTxSnapshot or RevertToInterTxSnapshot calls expected for pre-Brio.
+
+	processedSponsored := ProcessedTransaction{
+		Transaction: tx,
+		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
+	}
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(processedSponsored)
+
+	processedPost := ProcessedTransaction{
+		Transaction: postTx,
+		Receipt:     &types.Receipt{Status: types.ReceiptStatusFailed, GasUsed: 1_000},
+	}
+	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).Return(processedPost)
+
+	ctxt := &runContext{
+		statedb:  stateDb,
+		signer:   types.LatestSignerForChainID(nil),
+		baseFee:  big.NewInt(1),
+		gasPool:  core.NewGasPool(1_000_000),
+		usedGas:  new(uint64),
+		upgrades: opera.Upgrades{GasSubsidies: true, Brio: false},
+	}
+
+	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
+		return []*types.Transaction{postTx}, nil
+	}
+
+	runner := &transactionRunner{evm: mockEvm}
+	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
+
+	// Pre-Brio: sponsored tx is included despite failing post-tx.
+	require.Equal(t, core_types.TransactionResultSuccessful, status)
+	require.Equal(t, []ProcessedTransaction{processedSponsored, processedPost}, got)
+}
+
 func TestRunSponsoredTransaction_CoveredTransaction_ProcessesTwoTransactionsSuccessfully(t *testing.T) {
 	// This test is an integration test covering the combination of the state
 	// processor's runTransaction function, the subsidies package's utility

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -2622,270 +2622,165 @@ func TestRunSponsoredTransaction_ProcessesAllPostTransactionsInOrder(t *testing.
 	}
 }
 
-func TestRunSponsoredTransaction_Brio_FailedPostTx_RollsBackAll(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	stateDb := state.NewMockStateDB(ctrl)
-	mockEvm := NewMock_evm(ctrl)
-
-	tx := getSponsorshipRequest(t)
+// TestRunSponsoredTransaction_PostTxOutcome_DeterminesRollbackUnderBrio covers
+// the 2 × 3 matrix of [Brio on/off] × [post-tx skipped/failed/success].
+// When Brio is enabled and the post-tx is not successful, the entire group is
+// rolled back (sponsored tx disappears from the block, gas pool and usedGas
+// are restored). In all other cases the full result list is returned.
+func TestRunSponsoredTransaction_PostTxOutcome_DeterminesRollbackUnderBrio(t *testing.T) {
 	postTx := &types.Transaction{}
 
-	any := gomock.Any()
+	tests := map[string]struct {
+		brio          bool
+		postTxReceipt *types.Receipt
+		wantRollback  bool
+	}{
+		"brio on / post-tx failed":   {true, &types.Receipt{Status: types.ReceiptStatusFailed}, true},
+		"brio on / post-tx skipped":  {true, nil, true},
+		"brio on / post-tx success":  {true, &types.Receipt{Status: types.ReceiptStatusSuccessful}, false},
+		"brio off / post-tx failed":  {false, &types.Receipt{Status: types.ReceiptStatusFailed}, false},
+		"brio off / post-tx skipped": {false, nil, false},
+		"brio off / post-tx success": {false, &types.Receipt{Status: types.ReceiptStatusSuccessful}, false},
+	}
 
-	// IsCovered query runs in a regular snapshot.
-	stateDb.EXPECT().Snapshot().Return(1)
-	stateDb.EXPECT().RevertToSnapshot(1)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil) // getGasConfig
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil) // chooseFund → mode 1
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			stateDb := state.NewMockStateDB(ctrl)
+			mockEvm := NewMock_evm(ctrl)
 
-	// Brio: inter-tx snapshot is taken before the sponsored tx executes.
-	const snapshotId = 42
-	stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
+			tx := getSponsorshipRequest(t)
+			any := gomock.Any()
 
-	// Track initial gas state to verify it is fully restored after rollback.
-	const initialGasInPool = uint64(1_000_000)
-	gasPool := core.NewGasPool(initialGasInPool)
-	usedGas := uint64(50_000)
+			stateDb.EXPECT().Snapshot().Return(1)
+			stateDb.EXPECT().RevertToSnapshot(1)
+			mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil) // getGasConfig
+			mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil) // chooseFund → mode 1
 
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).
-		DoAndReturn(func(ctxt *runContext, _ *types.Transaction, _ int) ProcessedTransaction {
-			_ = ctxt.gasPool.SubGas(21_000)
-			*ctxt.usedGas += 21_000
-			return ProcessedTransaction{
+			const snapshotId = 42
+			if test.brio {
+				stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
+			}
+			if test.wantRollback {
+				stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
+			}
+
+			const initialGasInPool = uint64(1_000_000)
+			gasPool := core.NewGasPool(initialGasInPool)
+			usedGas := uint64(50_000)
+
+			processedSponsored := ProcessedTransaction{
 				Transaction: tx,
 				Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
 			}
-		})
+			mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).
+				DoAndReturn(func(ctxt *runContext, _ *types.Transaction, _ int) ProcessedTransaction {
+					_ = ctxt.gasPool.SubGas(21_000)
+					*ctxt.usedGas += 21_000
+					return processedSponsored
+				})
 
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).
-		DoAndReturn(func(ctxt *runContext, _ *types.Transaction, _ int) ProcessedTransaction {
-			_ = ctxt.gasPool.SubGas(1_000)
-			*ctxt.usedGas += 1_000
-			return ProcessedTransaction{
-				Transaction: postTx,
-				Receipt:     &types.Receipt{Status: types.ReceiptStatusFailed, GasUsed: 1_000},
+			processedPost := ProcessedTransaction{Transaction: postTx, Receipt: test.postTxReceipt}
+			mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).
+				DoAndReturn(func(ctxt *runContext, _ *types.Transaction, _ int) ProcessedTransaction {
+					_ = ctxt.gasPool.SubGas(1_000)
+					*ctxt.usedGas += 1_000
+					return processedPost
+				})
+
+			ctxt := &runContext{
+				statedb:  stateDb,
+				signer:   types.LatestSignerForChainID(nil),
+				baseFee:  big.NewInt(1),
+				gasPool:  gasPool,
+				usedGas:  &usedGas,
+				upgrades: opera.Upgrades{GasSubsidies: true, Brio: test.brio},
+			}
+
+			getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
+				return []*types.Transaction{postTx}, nil
+			}
+
+			runner := &transactionRunner{evm: mockEvm}
+			got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
+
+			if test.wantRollback {
+				require.Equal(t, core_types.TransactionResultInvalid, status)
+				require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
+				require.Equal(t, initialGasInPool, gasPool.Gas(), "gas pool must be restored")
+				require.Equal(t, uint64(50_000), usedGas, "usedGas must be restored")
+			} else {
+				require.Equal(t, core_types.TransactionResultSuccessful, status)
+				require.Equal(t, []ProcessedTransaction{processedSponsored, processedPost}, got)
 			}
 		})
-
-	// Brio: state, gas pool, and usedGas are all rolled back via inter-tx snapshot.
-	stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
-
-	ctxt := &runContext{
-		statedb:  stateDb,
-		signer:   types.LatestSignerForChainID(nil),
-		baseFee:  big.NewInt(1),
-		gasPool:  gasPool,
-		usedGas:  &usedGas,
-		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
 	}
-
-	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
-		return []*types.Transaction{postTx}, nil
-	}
-
-	runner := &transactionRunner{evm: mockEvm}
-	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
-
-	require.Equal(t, core_types.TransactionResultInvalid, status)
-	require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
-	require.Equal(t, initialGasInPool, gasPool.Gas(), "gas pool must be restored to pre-execution state")
-	require.Equal(t, uint64(50_000), usedGas, "usedGas must be restored to pre-execution state")
 }
 
-func TestRunSponsoredTransaction_Brio_SkippedPostTx_RollsBackAll(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	stateDb := state.NewMockStateDB(ctrl)
-	mockEvm := NewMock_evm(ctrl)
-
-	tx := getSponsorshipRequest(t)
-	postTx := &types.Transaction{}
-
-	any := gomock.Any()
-
-	stateDb.EXPECT().Snapshot().Return(1)
-	stateDb.EXPECT().RevertToSnapshot(1)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
-
-	const snapshotId = 7
-	stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
-
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(ProcessedTransaction{
-		Transaction: tx,
-		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
-	})
-
-	// Post-tx is skipped (nil receipt).
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).Return(ProcessedTransaction{
-		Transaction: postTx,
-		Receipt:     nil,
-	})
-
-	stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
-
-	ctxt := &runContext{
-		statedb:  stateDb,
-		signer:   types.LatestSignerForChainID(nil),
-		baseFee:  big.NewInt(1),
-		gasPool:  core.NewGasPool(1_000_000),
-		usedGas:  new(uint64),
-		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
+// TestRunSponsoredTransaction_PostTxBuildError_DeterminesRollbackUnderBrio
+// covers the [Brio on/off] × build-error matrix: when Brio is enabled and the
+// post-transaction cannot be constructed, the sponsored transaction is rolled
+// back; pre-Brio the sponsored transaction is kept.
+func TestRunSponsoredTransaction_PostTxBuildError_DeterminesRollbackUnderBrio(t *testing.T) {
+	tests := map[string]struct {
+		brio         bool
+		wantRollback bool
+	}{
+		"brio on":  {brio: true, wantRollback: true},
+		"brio off": {brio: false, wantRollback: false},
 	}
 
-	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
-		return []*types.Transaction{postTx}, nil
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			stateDb := state.NewMockStateDB(ctrl)
+			mockEvm := NewMock_evm(ctrl)
+
+			tx := getSponsorshipRequest(t)
+			any := gomock.Any()
+
+			stateDb.EXPECT().Snapshot().Return(1)
+			stateDb.EXPECT().RevertToSnapshot(1)
+			mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
+			mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
+
+			const snapshotId = 42
+			if test.brio {
+				stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
+				stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
+			}
+
+			processedSponsored := ProcessedTransaction{
+				Transaction: tx,
+				Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
+			}
+			mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(processedSponsored)
+
+			ctxt := &runContext{
+				statedb:  stateDb,
+				signer:   types.LatestSignerForChainID(nil),
+				baseFee:  big.NewInt(1),
+				gasPool:  core.NewGasPool(1_000_000),
+				usedGas:  new(uint64),
+				upgrades: opera.Upgrades{GasSubsidies: true, Brio: test.brio},
+			}
+
+			getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
+				return nil, fmt.Errorf("cannot build post-tx")
+			}
+
+			runner := &transactionRunner{evm: mockEvm}
+			got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
+
+			if test.wantRollback {
+				require.Equal(t, core_types.TransactionResultInvalid, status)
+				require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
+			} else {
+				require.Equal(t, core_types.TransactionResultSuccessful, status)
+				require.Equal(t, []ProcessedTransaction{processedSponsored}, got)
+			}
+		})
 	}
-
-	runner := &transactionRunner{evm: mockEvm}
-	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
-
-	require.Equal(t, core_types.TransactionResultInvalid, status)
-	require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
-}
-
-func TestRunSponsoredTransaction_Brio_BuildErrorForPostTx_RollsBackAll(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	stateDb := state.NewMockStateDB(ctrl)
-	mockEvm := NewMock_evm(ctrl)
-
-	tx := getSponsorshipRequest(t)
-
-	any := gomock.Any()
-
-	stateDb.EXPECT().Snapshot().Return(1)
-	stateDb.EXPECT().RevertToSnapshot(1)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
-
-	const snapshotId = 5
-	stateDb.EXPECT().InterTxSnapshot().Return(snapshotId)
-
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(ProcessedTransaction{
-		Transaction: tx,
-		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
-	})
-
-	stateDb.EXPECT().RevertToInterTxSnapshot(snapshotId)
-
-	ctxt := &runContext{
-		statedb:  stateDb,
-		signer:   types.LatestSignerForChainID(nil),
-		baseFee:  big.NewInt(1),
-		gasPool:  core.NewGasPool(1_000_000),
-		usedGas:  new(uint64),
-		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
-	}
-
-	buildErr := fmt.Errorf("cannot build post-tx")
-	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
-		return nil, buildErr
-	}
-
-	runner := &transactionRunner{evm: mockEvm}
-	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
-
-	require.Equal(t, core_types.TransactionResultInvalid, status)
-	require.Equal(t, []ProcessedTransaction{{Transaction: tx}}, got)
-}
-
-func TestRunSponsoredTransaction_Brio_SuccessfulPostTxs_NoRollback(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	stateDb := state.NewMockStateDB(ctrl)
-	mockEvm := NewMock_evm(ctrl)
-
-	tx := getSponsorshipRequest(t)
-	postTx := &types.Transaction{}
-
-	any := gomock.Any()
-
-	stateDb.EXPECT().Snapshot().Return(1)
-	stateDb.EXPECT().RevertToSnapshot(1)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
-
-	// Snapshot is taken but never reverted (all post-txs succeed).
-	stateDb.EXPECT().InterTxSnapshot().Return(99)
-
-	processedSponsored := ProcessedTransaction{
-		Transaction: tx,
-		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
-	}
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(processedSponsored)
-
-	processedPost := ProcessedTransaction{
-		Transaction: postTx,
-		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 1_000},
-	}
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).Return(processedPost)
-
-	ctxt := &runContext{
-		statedb:  stateDb,
-		signer:   types.LatestSignerForChainID(nil),
-		baseFee:  big.NewInt(1),
-		gasPool:  core.NewGasPool(1_000_000),
-		usedGas:  new(uint64),
-		upgrades: opera.Upgrades{GasSubsidies: true, Brio: true},
-	}
-
-	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
-		return []*types.Transaction{postTx}, nil
-	}
-
-	runner := &transactionRunner{evm: mockEvm}
-	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
-
-	require.Equal(t, core_types.TransactionResultSuccessful, status)
-	require.Equal(t, []ProcessedTransaction{processedSponsored, processedPost}, got)
-}
-
-func TestRunSponsoredTransaction_PreBrio_FailedPostTx_NeverRollsBack(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	stateDb := state.NewMockStateDB(ctrl)
-	mockEvm := NewMock_evm(ctrl)
-
-	tx := getSponsorshipRequest(t)
-	postTx := &types.Transaction{}
-
-	any := gomock.Any()
-
-	stateDb.EXPECT().Snapshot().Return(1)
-	stateDb.EXPECT().RevertToSnapshot(1)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{95: 0}, uint64(0), nil)
-	mockEvm.EXPECT().Call(any, any, any, any, any).Return([]byte{31: 1}, uint64(0), nil)
-
-	// No InterTxSnapshot or RevertToInterTxSnapshot calls expected for pre-Brio.
-
-	processedSponsored := ProcessedTransaction{
-		Transaction: tx,
-		Receipt:     &types.Receipt{Status: types.ReceiptStatusSuccessful, GasUsed: 21_000},
-	}
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, tx, any).Return(processedSponsored)
-
-	processedPost := ProcessedTransaction{
-		Transaction: postTx,
-		Receipt:     &types.Receipt{Status: types.ReceiptStatusFailed, GasUsed: 1_000},
-	}
-	mockEvm.EXPECT().runWithoutBaseFeeCheck(any, postTx, any).Return(processedPost)
-
-	ctxt := &runContext{
-		statedb:  stateDb,
-		signer:   types.LatestSignerForChainID(nil),
-		baseFee:  big.NewInt(1),
-		gasPool:  core.NewGasPool(1_000_000),
-		usedGas:  new(uint64),
-		upgrades: opera.Upgrades{GasSubsidies: true, Brio: false},
-	}
-
-	getPostTxs := func(subsidies.Sponsorship, subsidies.NonceSource, uint64, *big.Int) ([]*types.Transaction, error) {
-		return []*types.Transaction{postTx}, nil
-	}
-
-	runner := &transactionRunner{evm: mockEvm}
-	got, status := runner.runSponsoredTransactionInternal(ctxt, tx, 0, math.MaxUint64, getPostTxs)
-
-	// Pre-Brio: sponsored tx is included despite failing post-tx.
-	require.Equal(t, core_types.TransactionResultSuccessful, status)
-	require.Equal(t, []ProcessedTransaction{processedSponsored, processedPost}, got)
 }
 
 func TestRunSponsoredTransaction_CoveredTransaction_ProcessesTwoTransactionsSuccessfully(t *testing.T) {

--- a/tests/contracts/failing_post_tx_registry/gen.go
+++ b/tests/contracts/failing_post_tx_registry/gen.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package failing_post_tx_registry
+
+//go:generate solc --bin registry.sol --abi registry.sol -o build --overwrite
+//go:generate abigen --bin=build/FailingPostTxRegistry.bin --abi=build/FailingPostTxRegistry.abi --pkg=failing_post_tx_registry --out=registry.go

--- a/tests/contracts/failing_post_tx_registry/registry.go
+++ b/tests/contracts/failing_post_tx_registry/registry.go
@@ -1,0 +1,366 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package failing_post_tx_registry
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// FailingPostTxRegistryMetaData contains all meta data concerning the FailingPostTxRegistry contract.
+var FailingPostTxRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"chooseFund\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"mode\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"payload\",\"type\":\"bytes32\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"deductFees\",\"outputs\":[],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getGasConfig\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"gasLimitForChooseFund\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimitForDeductFees\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"gasLimitForTrack\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"overheadChargeForFundBackedSponsorships\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"overheadChargeForNetworkSponsorshipsWithTracking\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"track\",\"outputs\":[],\"stateMutability\":\"pure\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f80fd5b506106298061001c5f395ff3fe608060405234801561000f575f80fd5b506004361061004a575f3560e01c8063399f59ca1461004e5780634b5c54c01461007f578063b9ed9f26146100a1578063bf70eb15146100bd575b5f80fd5b610068600480360381019061006391906102b6565b6100d9565b604051610076929190610387565b60405180910390f35b6100876100f4565b6040516100989594939291906103ae565b60405180910390f35b6100bb60048036038101906100b69190610429565b61014a565b005b6100d760048036038101906100d29190610429565b610185565b005b5f80600363deadbeef5f1b9150915097509795505050505050565b5f805f805f8061c3509050620186a0955061ea60945062013880935080858761011d9190610494565b6101279190610494565b92508084876101369190610494565b6101409190610494565b9150509091929394565b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040161017c90610547565b60405180910390fd5b6040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016101b7906105af565b60405180910390fd5b5f80fd5b5f80fd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6101f1826101c8565b9050919050565b610201816101e7565b811461020b575f80fd5b50565b5f8135905061021c816101f8565b92915050565b5f819050919050565b61023481610222565b811461023e575f80fd5b50565b5f8135905061024f8161022b565b92915050565b5f80fd5b5f80fd5b5f80fd5b5f8083601f84011261027657610275610255565b5b8235905067ffffffffffffffff81111561029357610292610259565b5b6020830191508360018202830111156102af576102ae61025d565b5b9250929050565b5f805f805f805f60c0888a0312156102d1576102d06101c0565b5b5f6102de8a828b0161020e565b97505060206102ef8a828b0161020e565b96505060406103008a828b01610241565b95505060606103118a828b01610241565b945050608088013567ffffffffffffffff811115610332576103316101c4565b5b61033e8a828b01610261565b935093505060a06103518a828b01610241565b91505092959891949750929550565b61036981610222565b82525050565b5f819050919050565b6103818161036f565b82525050565b5f60408201905061039a5f830185610360565b6103a76020830184610378565b9392505050565b5f60a0820190506103c15f830188610360565b6103ce6020830187610360565b6103db6040830186610360565b6103e86060830185610360565b6103f56080830184610360565b9695505050505050565b6104088161036f565b8114610412575f80fd5b50565b5f81359050610423816103ff565b92915050565b5f806040838503121561043f5761043e6101c0565b5b5f61044c85828601610415565b925050602061045d85828601610241565b9150509250929050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61049e82610222565b91506104a983610222565b92508282019050808211156104c1576104c0610467565b5b92915050565b5f82825260208201905092915050565b7f646564756374466565732073686f756c64206e6f742062652063616c6c6564205f8201527f666f72206d6f6465203300000000000000000000000000000000000000000000602082015250565b5f610531602a836104c7565b915061053c826104d7565b604082019050919050565b5f6020820190508181035f83015261055e81610525565b9050919050565b7f747261636b20616c77617973206661696c7300000000000000000000000000005f82015250565b5f6105996012836104c7565b91506105a482610565565b602082019050919050565b5f6020820190508181035f8301526105c68161058d565b905091905056fea2646970667358221220132db73ba2035efdd67e1afff740241737bb449dd339f506894ccb185e3619b864736f6c637828302e382e32352d646576656c6f702e323032342e322e32342b636f6d6d69742e64626137353465630059",
+}
+
+// FailingPostTxRegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use FailingPostTxRegistryMetaData.ABI instead.
+var FailingPostTxRegistryABI = FailingPostTxRegistryMetaData.ABI
+
+// FailingPostTxRegistryBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use FailingPostTxRegistryMetaData.Bin instead.
+var FailingPostTxRegistryBin = FailingPostTxRegistryMetaData.Bin
+
+// DeployFailingPostTxRegistry deploys a new Ethereum contract, binding an instance of FailingPostTxRegistry to it.
+func DeployFailingPostTxRegistry(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *FailingPostTxRegistry, error) {
+	parsed, err := FailingPostTxRegistryMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(FailingPostTxRegistryBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &FailingPostTxRegistry{FailingPostTxRegistryCaller: FailingPostTxRegistryCaller{contract: contract}, FailingPostTxRegistryTransactor: FailingPostTxRegistryTransactor{contract: contract}, FailingPostTxRegistryFilterer: FailingPostTxRegistryFilterer{contract: contract}}, nil
+}
+
+// FailingPostTxRegistry is an auto generated Go binding around an Ethereum contract.
+type FailingPostTxRegistry struct {
+	FailingPostTxRegistryCaller     // Read-only binding to the contract
+	FailingPostTxRegistryTransactor // Write-only binding to the contract
+	FailingPostTxRegistryFilterer   // Log filterer for contract events
+}
+
+// FailingPostTxRegistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type FailingPostTxRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FailingPostTxRegistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type FailingPostTxRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FailingPostTxRegistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FailingPostTxRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FailingPostTxRegistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FailingPostTxRegistrySession struct {
+	Contract     *FailingPostTxRegistry // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts          // Call options to use throughout this session
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// FailingPostTxRegistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FailingPostTxRegistryCallerSession struct {
+	Contract *FailingPostTxRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                // Call options to use throughout this session
+}
+
+// FailingPostTxRegistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FailingPostTxRegistryTransactorSession struct {
+	Contract     *FailingPostTxRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                // Transaction auth options to use throughout this session
+}
+
+// FailingPostTxRegistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type FailingPostTxRegistryRaw struct {
+	Contract *FailingPostTxRegistry // Generic contract binding to access the raw methods on
+}
+
+// FailingPostTxRegistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FailingPostTxRegistryCallerRaw struct {
+	Contract *FailingPostTxRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// FailingPostTxRegistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FailingPostTxRegistryTransactorRaw struct {
+	Contract *FailingPostTxRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFailingPostTxRegistry creates a new instance of FailingPostTxRegistry, bound to a specific deployed contract.
+func NewFailingPostTxRegistry(address common.Address, backend bind.ContractBackend) (*FailingPostTxRegistry, error) {
+	contract, err := bindFailingPostTxRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &FailingPostTxRegistry{FailingPostTxRegistryCaller: FailingPostTxRegistryCaller{contract: contract}, FailingPostTxRegistryTransactor: FailingPostTxRegistryTransactor{contract: contract}, FailingPostTxRegistryFilterer: FailingPostTxRegistryFilterer{contract: contract}}, nil
+}
+
+// NewFailingPostTxRegistryCaller creates a new read-only instance of FailingPostTxRegistry, bound to a specific deployed contract.
+func NewFailingPostTxRegistryCaller(address common.Address, caller bind.ContractCaller) (*FailingPostTxRegistryCaller, error) {
+	contract, err := bindFailingPostTxRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FailingPostTxRegistryCaller{contract: contract}, nil
+}
+
+// NewFailingPostTxRegistryTransactor creates a new write-only instance of FailingPostTxRegistry, bound to a specific deployed contract.
+func NewFailingPostTxRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*FailingPostTxRegistryTransactor, error) {
+	contract, err := bindFailingPostTxRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FailingPostTxRegistryTransactor{contract: contract}, nil
+}
+
+// NewFailingPostTxRegistryFilterer creates a new log filterer instance of FailingPostTxRegistry, bound to a specific deployed contract.
+func NewFailingPostTxRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*FailingPostTxRegistryFilterer, error) {
+	contract, err := bindFailingPostTxRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FailingPostTxRegistryFilterer{contract: contract}, nil
+}
+
+// bindFailingPostTxRegistry binds a generic wrapper to an already deployed contract.
+func bindFailingPostTxRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := FailingPostTxRegistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FailingPostTxRegistry *FailingPostTxRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FailingPostTxRegistry.Contract.FailingPostTxRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FailingPostTxRegistry *FailingPostTxRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FailingPostTxRegistry.Contract.FailingPostTxRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FailingPostTxRegistry *FailingPostTxRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FailingPostTxRegistry.Contract.FailingPostTxRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FailingPostTxRegistry *FailingPostTxRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FailingPostTxRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FailingPostTxRegistry *FailingPostTxRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FailingPostTxRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FailingPostTxRegistry *FailingPostTxRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FailingPostTxRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// ChooseFund is a free data retrieval call binding the contract method 0x399f59ca.
+//
+// Solidity: function chooseFund(address , address , uint256 , uint256 , bytes , uint256 ) pure returns(uint256 mode, bytes32 payload)
+func (_FailingPostTxRegistry *FailingPostTxRegistryCaller) ChooseFund(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (struct {
+	Mode    *big.Int
+	Payload [32]byte
+}, error) {
+	var out []interface{}
+	err := _FailingPostTxRegistry.contract.Call(opts, &out, "chooseFund", arg0, arg1, arg2, arg3, arg4, arg5)
+
+	outstruct := new(struct {
+		Mode    *big.Int
+		Payload [32]byte
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Mode = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Payload = *abi.ConvertType(out[1], new([32]byte)).(*[32]byte)
+
+	return *outstruct, err
+
+}
+
+// ChooseFund is a free data retrieval call binding the contract method 0x399f59ca.
+//
+// Solidity: function chooseFund(address , address , uint256 , uint256 , bytes , uint256 ) pure returns(uint256 mode, bytes32 payload)
+func (_FailingPostTxRegistry *FailingPostTxRegistrySession) ChooseFund(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (struct {
+	Mode    *big.Int
+	Payload [32]byte
+}, error) {
+	return _FailingPostTxRegistry.Contract.ChooseFund(&_FailingPostTxRegistry.CallOpts, arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// ChooseFund is a free data retrieval call binding the contract method 0x399f59ca.
+//
+// Solidity: function chooseFund(address , address , uint256 , uint256 , bytes , uint256 ) pure returns(uint256 mode, bytes32 payload)
+func (_FailingPostTxRegistry *FailingPostTxRegistryCallerSession) ChooseFund(arg0 common.Address, arg1 common.Address, arg2 *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (struct {
+	Mode    *big.Int
+	Payload [32]byte
+}, error) {
+	return _FailingPostTxRegistry.Contract.ChooseFund(&_FailingPostTxRegistry.CallOpts, arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+// DeductFees is a free data retrieval call binding the contract method 0xb9ed9f26.
+//
+// Solidity: function deductFees(bytes32 , uint256 ) pure returns()
+func (_FailingPostTxRegistry *FailingPostTxRegistryCaller) DeductFees(opts *bind.CallOpts, arg0 [32]byte, arg1 *big.Int) error {
+	var out []interface{}
+	err := _FailingPostTxRegistry.contract.Call(opts, &out, "deductFees", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// DeductFees is a free data retrieval call binding the contract method 0xb9ed9f26.
+//
+// Solidity: function deductFees(bytes32 , uint256 ) pure returns()
+func (_FailingPostTxRegistry *FailingPostTxRegistrySession) DeductFees(arg0 [32]byte, arg1 *big.Int) error {
+	return _FailingPostTxRegistry.Contract.DeductFees(&_FailingPostTxRegistry.CallOpts, arg0, arg1)
+}
+
+// DeductFees is a free data retrieval call binding the contract method 0xb9ed9f26.
+//
+// Solidity: function deductFees(bytes32 , uint256 ) pure returns()
+func (_FailingPostTxRegistry *FailingPostTxRegistryCallerSession) DeductFees(arg0 [32]byte, arg1 *big.Int) error {
+	return _FailingPostTxRegistry.Contract.DeductFees(&_FailingPostTxRegistry.CallOpts, arg0, arg1)
+}
+
+// GetGasConfig is a free data retrieval call binding the contract method 0x4b5c54c0.
+//
+// Solidity: function getGasConfig() pure returns(uint256 gasLimitForChooseFund, uint256 gasLimitForDeductFees, uint256 gasLimitForTrack, uint256 overheadChargeForFundBackedSponsorships, uint256 overheadChargeForNetworkSponsorshipsWithTracking)
+func (_FailingPostTxRegistry *FailingPostTxRegistryCaller) GetGasConfig(opts *bind.CallOpts) (struct {
+	GasLimitForChooseFund                            *big.Int
+	GasLimitForDeductFees                            *big.Int
+	GasLimitForTrack                                 *big.Int
+	OverheadChargeForFundBackedSponsorships          *big.Int
+	OverheadChargeForNetworkSponsorshipsWithTracking *big.Int
+}, error) {
+	var out []interface{}
+	err := _FailingPostTxRegistry.contract.Call(opts, &out, "getGasConfig")
+
+	outstruct := new(struct {
+		GasLimitForChooseFund                            *big.Int
+		GasLimitForDeductFees                            *big.Int
+		GasLimitForTrack                                 *big.Int
+		OverheadChargeForFundBackedSponsorships          *big.Int
+		OverheadChargeForNetworkSponsorshipsWithTracking *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.GasLimitForChooseFund = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.GasLimitForDeductFees = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.GasLimitForTrack = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.OverheadChargeForFundBackedSponsorships = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.OverheadChargeForNetworkSponsorshipsWithTracking = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetGasConfig is a free data retrieval call binding the contract method 0x4b5c54c0.
+//
+// Solidity: function getGasConfig() pure returns(uint256 gasLimitForChooseFund, uint256 gasLimitForDeductFees, uint256 gasLimitForTrack, uint256 overheadChargeForFundBackedSponsorships, uint256 overheadChargeForNetworkSponsorshipsWithTracking)
+func (_FailingPostTxRegistry *FailingPostTxRegistrySession) GetGasConfig() (struct {
+	GasLimitForChooseFund                            *big.Int
+	GasLimitForDeductFees                            *big.Int
+	GasLimitForTrack                                 *big.Int
+	OverheadChargeForFundBackedSponsorships          *big.Int
+	OverheadChargeForNetworkSponsorshipsWithTracking *big.Int
+}, error) {
+	return _FailingPostTxRegistry.Contract.GetGasConfig(&_FailingPostTxRegistry.CallOpts)
+}
+
+// GetGasConfig is a free data retrieval call binding the contract method 0x4b5c54c0.
+//
+// Solidity: function getGasConfig() pure returns(uint256 gasLimitForChooseFund, uint256 gasLimitForDeductFees, uint256 gasLimitForTrack, uint256 overheadChargeForFundBackedSponsorships, uint256 overheadChargeForNetworkSponsorshipsWithTracking)
+func (_FailingPostTxRegistry *FailingPostTxRegistryCallerSession) GetGasConfig() (struct {
+	GasLimitForChooseFund                            *big.Int
+	GasLimitForDeductFees                            *big.Int
+	GasLimitForTrack                                 *big.Int
+	OverheadChargeForFundBackedSponsorships          *big.Int
+	OverheadChargeForNetworkSponsorshipsWithTracking *big.Int
+}, error) {
+	return _FailingPostTxRegistry.Contract.GetGasConfig(&_FailingPostTxRegistry.CallOpts)
+}
+
+// Track is a free data retrieval call binding the contract method 0xbf70eb15.
+//
+// Solidity: function track(bytes32 , uint256 ) pure returns()
+func (_FailingPostTxRegistry *FailingPostTxRegistryCaller) Track(opts *bind.CallOpts, arg0 [32]byte, arg1 *big.Int) error {
+	var out []interface{}
+	err := _FailingPostTxRegistry.contract.Call(opts, &out, "track", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// Track is a free data retrieval call binding the contract method 0xbf70eb15.
+//
+// Solidity: function track(bytes32 , uint256 ) pure returns()
+func (_FailingPostTxRegistry *FailingPostTxRegistrySession) Track(arg0 [32]byte, arg1 *big.Int) error {
+	return _FailingPostTxRegistry.Contract.Track(&_FailingPostTxRegistry.CallOpts, arg0, arg1)
+}
+
+// Track is a free data retrieval call binding the contract method 0xbf70eb15.
+//
+// Solidity: function track(bytes32 , uint256 ) pure returns()
+func (_FailingPostTxRegistry *FailingPostTxRegistryCallerSession) Track(arg0 [32]byte, arg1 *big.Int) error {
+	return _FailingPostTxRegistry.Contract.Track(&_FailingPostTxRegistry.CallOpts, arg0, arg1)
+}

--- a/tests/contracts/failing_post_tx_registry/registry.sol
+++ b/tests/contracts/failing_post_tx_registry/registry.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+// FailingPostTxRegistry is a test registry that approves all sponsorships
+// using mode 3 (network sponsored with on-chain tracking) so the txpool
+// pre-check passes, but whose track() function always reverts.
+// This allows integration tests to verify that a failing post-transaction
+// causes the sponsored transaction to be rolled back under the Brio rules.
+contract FailingPostTxRegistry {
+
+    function getGasConfig() public pure returns (
+        uint256 gasLimitForChooseFund,
+        uint256 gasLimitForDeductFees,
+        uint256 gasLimitForTrack,
+        uint256 overheadChargeForFundBackedSponsorships,
+        uint256 overheadChargeForNetworkSponsorshipsWithTracking
+    ) {
+        uint256 getGasConfigCosts = 50_000;
+        gasLimitForChooseFund = 100_000;
+        gasLimitForDeductFees = 60_000;
+        gasLimitForTrack = 80_000;
+        overheadChargeForFundBackedSponsorships = gasLimitForChooseFund + gasLimitForDeductFees + getGasConfigCosts;
+        overheadChargeForNetworkSponsorshipsWithTracking = gasLimitForChooseFund + gasLimitForTrack + getGasConfigCosts;
+    }
+
+    function chooseFund(
+        address /*from*/,
+        address /*to*/,
+        uint256 /*value*/,
+        uint256 /*nonce*/,
+        bytes calldata /*callData*/,
+        uint256 /*fee*/
+    ) public pure returns (uint256 mode, bytes32 payload) {
+        // Mode 3: network sponsored with tracking.
+        return (3, bytes32(uint256(0xdeadbeef)));
+    }
+
+    function deductFees(bytes32 /*fundId*/, uint256 /*fee*/) public pure {
+        revert("deductFees should not be called for mode 3");
+    }
+
+    function track(bytes32 /*trackingId*/, uint256 /*fee*/) public pure {
+        revert("track always fails");
+    }
+}

--- a/tests/gas_subsidies/post_tx_rollback_test.go
+++ b/tests/gas_subsidies/post_tx_rollback_test.go
@@ -17,6 +17,7 @@
 package gas_subsidies
 
 import (
+	"context"
 	"testing"
 	"time"
 

--- a/tests/gas_subsidies/post_tx_rollback_test.go
+++ b/tests/gas_subsidies/post_tx_rollback_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gas_subsidies
+
+import (
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/proxy"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/tests/contracts/counter"
+	"github.com/0xsoniclabs/sonic/tests/contracts/failing_post_tx_registry"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGasSubsidies_Brio_FailedPostTx_RollsBackSponsoredTransaction verifies
+// that under the Brio rules, a sponsored transaction whose post-transaction
+// (track) always reverts is fully rolled back: the state change made by the
+// sponsored transaction is undone and no receipt is ever produced.
+func TestGasSubsidies_Brio_FailedPostTx_RollsBackSponsoredTransaction(t *testing.T) {
+	net := startNetWithSubsidies(t)
+	installFailingRegistry(t, net)
+
+	_, counterReceipt, err := tests.DeployContract(net, counter.DeployCounter)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, counterReceipt.Status)
+	counterAddr := counterReceipt.ContractAddress
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Build the sponsored transaction: sponsee calls counter.IncrementCounter().
+	calldata, err := buildIncrementCounterCalldata()
+	require.NoError(t, err)
+
+	sponsee := tests.NewAccount()
+	sponsoredTx := makeSponsorRequestTransaction(t, &types.LegacyTx{
+		To:   &counterAddr,
+		Gas:  100_000,
+		Data: calldata,
+	}, net.GetChainId(), sponsee)
+
+	// Submit the sponsored transaction; the txpool accepts it because
+	// IsCovered returns a valid sponsorship (the failing registry only
+	// fails during the post-transaction execution, not during chooseFund).
+	require.NoError(t, client.SendTransaction(t.Context(), sponsoredTx))
+
+	// Advance one epoch to guarantee that blocks were produced after the
+	// sponsored transaction entered the mempool.
+	net.AdvanceEpoch(t, 1)
+
+	// The state change (counter increment) must be absent: the Brio rollback
+	// undoes both the sponsored transaction and the failing post-transaction.
+	boundCounter, err := counter.NewCounter(counterAddr, client)
+	require.NoError(t, err)
+	count, err := boundCounter.GetCount(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count.Int64(),
+		"counter must remain at 0: the sponsored tx was rolled back due to the failing post-tx")
+
+	// No receipt should ever be produced for the sponsored transaction.
+	_, err = net.TryGetReceipt(3*time.Second, sponsoredTx.Hash())
+	require.Error(t, err,
+		"sponsored tx must not have a receipt: it was rolled back")
+}
+
+// TestGasSubsidies_PreBrio_FailedPostTx_SponsoredTransactionIsIncluded verifies
+// that before the Brio upgrade a sponsored transaction is still included in the
+// block even when its post-transaction fails: no rollback occurs and the state
+// change from the sponsored transaction persists.
+func TestGasSubsidies_PreBrio_FailedPostTx_SponsoredTransactionIsIncluded(t *testing.T) {
+	// Start a pre-Brio network with gas subsidies enabled.
+	upgrades := opera.GetAllegroUpgrades()
+	upgrades.GasSubsidies = true
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
+	installFailingRegistry(t, net)
+
+	_, counterReceipt, err := tests.DeployContract(net, counter.DeployCounter)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, counterReceipt.Status)
+	counterAddr := counterReceipt.ContractAddress
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	calldata, err := buildIncrementCounterCalldata()
+	require.NoError(t, err)
+
+	sponsee := tests.NewAccount()
+	sponsoredTx := makeSponsorRequestTransaction(t, &types.LegacyTx{
+		To:   &counterAddr,
+		Gas:  100_000,
+		Data: calldata,
+	}, net.GetChainId(), sponsee)
+
+	require.NoError(t, client.SendTransaction(t.Context(), sponsoredTx))
+
+	// Wait for the sponsored transaction to be included in a block.
+	// Pre-Brio: the sponsored tx is committed despite the failing post-tx.
+	receipt, err := net.GetReceipt(sponsoredTx.Hash())
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status,
+		"sponsored tx should be included and succeed pre-Brio")
+
+	// The counter increment must have persisted (no rollback pre-Brio).
+	boundCounter, err := counter.NewCounter(counterAddr, client)
+	require.NoError(t, err)
+	count, err := boundCounter.GetCount(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count.Int64(),
+		"counter must be 1: pre-Brio does not roll back on a failing post-tx")
+
+	// Verify that the post-transaction (track) is present in the block and
+	// has a failed receipt.
+	block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
+	require.NoError(t, err)
+
+	found := false
+	for i, tx := range block.Transactions() {
+		if tx.Hash() != sponsoredTx.Hash() {
+			continue
+		}
+		found = true
+		require.Less(t, i+1, len(block.Transactions()),
+			"track post-tx must follow the sponsored tx in the block")
+		trackTx := block.Transactions()[i+1]
+		require.True(t, subsidies.IsTrackTransaction(trackTx),
+			"next tx must be an IsTrackTransaction post-tx")
+		trackReceipt, err := net.GetReceipt(trackTx.Hash())
+		require.NoError(t, err)
+		require.Equal(t, types.ReceiptStatusFailed, trackReceipt.Status,
+			"pre-Brio: failing track post-tx has a failed receipt but the sponsored tx is not rolled back")
+		break
+	}
+	require.True(t, found, "sponsored tx must be present in the block pre-Brio")
+}
+
+// installFailingRegistry deploys a FailingPostTxRegistry and sets it as the
+// active implementation in the subsidies proxy. The failing registry approves
+// all sponsorships (mode 3, network-with-tracking) so the txpool pre-check
+// passes, but its track() function always reverts, making every post-tx fail.
+func installFailingRegistry(t *testing.T, net *tests.IntegrationTestNet) {
+	t.Helper()
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, receipt, err := tests.DeployContract(net, failing_post_tx_registry.DeployFailingPostTxRegistry)
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	contractAddr := receipt.ContractAddress
+
+	proxyContract, err := proxy.NewProxy(registry.GetAddress(), client)
+	require.NoError(t, err)
+
+	updateReceipt, err := net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return proxyContract.Update(opts, contractAddr)
+	})
+	require.NoError(t, err)
+	require.Equal(t, types.ReceiptStatusSuccessful, updateReceipt.Status)
+}
+
+// buildIncrementCounterCalldata returns the ABI-encoded calldata for Counter.incrementCounter().
+func buildIncrementCounterCalldata() ([]byte, error) {
+	abi, err := counter.CounterMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return abi.Pack("incrementCounter")
+}

--- a/tests/gas_subsidies/post_tx_rollback_test.go
+++ b/tests/gas_subsidies/post_tx_rollback_test.go
@@ -80,7 +80,7 @@ func TestGasSubsidies_Brio_FailedPostTx_RollsBackSponsoredTransaction(t *testing
 
 	// No receipt should ever be produced for the sponsored transaction.
 	_, err = net.TryGetReceipt(3*time.Second, sponsoredTx.Hash())
-	require.Error(t, err,
+	require.ErrorIs(t, err, context.DeadlineExceeded,
 		"sponsored tx must not have a receipt: it was rolled back")
 }
 


### PR DESCRIPTION
This PR introduces an extension of the sponsored transaction execution semantic such that sponsored transactions that require a fee deduction or tracking call are rolled back if the fee deduction or the tracking call fails or is skipped.

This change is guarded by the Brio flag and only enabled with it, to preserve backward compatibility.