### PR TITLE
Refactor state processor apply_transaction

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2548,6 +2548,7 @@ func (api *PublicDebugAPI) traceTx(
 
 	// Call SetTxContext to clear out the statedb access list
 	loggingStateDB.SetTxContext(txctx.TxHash, txctx.TxIndex)
+	defer loggingStateDB.EndTransaction()
 
 	// Run the transaction with tracing enabled.
 	_, err = evmcore.ApplyTransactionWithEVM(

--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -975,7 +975,7 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 	expectedCallsFromTxCall := func(mockState *state.MockStateDB) {
 		mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		mockState.EXPECT().Release().AnyTimes()
-		mockState.EXPECT().Snapshot()
+		mockState.EXPECT().Snapshot().AnyTimes()
 		mockState.EXPECT().GetBalance(sender).Return(uint256.NewInt(1e18))
 		mockState.EXPECT().GetNonce(sender).Return(uint64(0))
 		mockState.EXPECT().SetNonce(sender, uint64(1), gomock.Any())
@@ -987,7 +987,7 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 	}
 
 	expectedCallsFromHistoryStorageContract := func(mockState *state.MockStateDB) {
-		mockState.EXPECT().Snapshot()
+		mockState.EXPECT().Snapshot().AnyTimes()
 		mockState.EXPECT().AddAddressToAccessList(params.HistoryStorageAddress)
 		mockState.EXPECT().GetCode(params.HistoryStorageAddress).Return(params.HistoryStorageCode).Times(2)
 		mockState.EXPECT().GetCodeHash(params.HistoryStorageAddress).Return(common.Hash{})
@@ -1017,10 +1017,10 @@ func TestAPI_EIP2935_InvokesHistoryStorageContract(t *testing.T) {
 		mockState.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		mockState.EXPECT().SetNonce(sender, uint64(2), gomock.Any())
 		mockState.EXPECT().GetCode(recipient).Return([]byte{})
-		mockState.EXPECT().Snapshot()
+		mockState.EXPECT().Snapshot().AnyTimes()
 		mockState.EXPECT().Exist(recipient)
 		mockState.EXPECT().GetRefund().Times(2)
-		mockState.EXPECT().EndTransaction().Times(2)
+		mockState.EXPECT().EndTransaction().Times(1)
 		mockState.EXPECT().TxIndex()
 	}
 

--- a/api/ethapi/tx_trace.go
+++ b/api/ethapi/tx_trace.go
@@ -489,12 +489,10 @@ func (s *PublicTxTraceAPI) traceTx(
 	defer cancel()
 
 	statedb.SetTxContext(tx.Hash(), int(index))
+	defer statedb.EndTransaction()
+
 	chainConfig := s.b.ChainConfig(idx.Block(block.Number.Uint64()))
 	resultReceipt, err := evmcore.ApplyTransactionWithEVM(msg, chainConfig, core.NewGasPool(msg.GasLimit), statedb, block.Number, block.Hash, tx, &index, tracedEVM.vmenv)
-
-	traceActions := tracedEVM.txTracer.GetResult()
-	statedb.EndTransaction()
-
 	if err != nil {
 		errTrace := txtrace.GetErrorTraceFromMsg(msg, block.Hash, *block.Number, tx.Hash(), index, err)
 		at := []txtrace.ActionTrace{*errTrace}
@@ -503,6 +501,8 @@ func (s *PublicTxTraceAPI) traceTx(
 		}
 		return &at, nil
 	}
+
+	traceActions := tracedEVM.txTracer.GetResult()
 
 	if tracedEVM.vmenv.Cancelled() {
 		return nil, fmt.Errorf("EVM was cancelled when replaying tx")

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -703,15 +703,75 @@ func (e evm) _runTransaction(
 
 	e.Config.NoBaseFee = !checkBaseFee
 	ctxt.statedb.SetTxContext(tx.Hash(), txIndex)
-	receipt, _, err := applyTransaction(
-		msg, ctxt.gasPool, ctxt.statedb, ctxt.blockNumber, tx,
-		ctxt.usedGas, e.EVM, ctxt.onNewLog,
-	)
+	defer ctxt.statedb.EndTransaction()
+
+	result, err := applyMessage(msg, e.EVM, ctxt.statedb, ctxt.gasPool, ctxt.blockNumber)
 	if err != nil {
-		log.Debug("Failed to apply transaction", "tx", tx.Hash().Hex(), "err", err)
+		log.Debug("Failed to apply message", "tx", tx.Hash().Hex(), "err", err)
 		return ProcessedTransaction{Transaction: tx}
 	}
-	return ProcessedTransaction{Transaction: tx, Receipt: receipt}
+
+	logs := ctxt.statedb.GetLogs(tx.Hash(), common.Hash{})
+
+	// TODO: removed in https://github.com/0xsoniclabs/sonic/pull/1032
+	if ctxt.onNewLog != nil {
+		for _, l := range logs {
+			ctxt.onNewLog(core_types.CoreLogFromGethLog(l))
+		}
+	}
+
+	*ctxt.usedGas += result.UsedGas
+	receipt := CreateReceiptForTx(
+		msg.From,
+		tx,
+		*ctxt.usedGas,
+		result,
+		logs,
+		ctxt.blockNumber,
+		uint(ctxt.statedb.TxIndex()),
+	)
+	return ProcessedTransaction{
+		Transaction: tx,
+		Receipt:     receipt,
+	}
+}
+
+// applyMessage  wraps core.ApplyMessage with sonic specific logic:
+// - it creates the EVM transaction context from the message and sets it in the StateDB,
+// - if the Allegro upgrade is active, it takes a snapshot of the StateDB before
+// executing the message and reverts to it if the execution fails.
+func applyMessage(
+	msg *core.Message,
+	evm *vm.EVM,
+	statedb state.StateDB,
+	gasPool *core.GasPool,
+	blockNumber *big.Int,
+) (*core.ExecutionResult, error) {
+	txContext, err := NewEVMTxContext(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create EVM transaction context: %w", err)
+	}
+
+	evm.SetTxContext(txContext)
+
+	// Internal transactions bypass base-fee validation.
+	// This executes transactions used by genesis and driver internal txs.
+	evm.Config.NoBaseFee = evm.Config.NoBaseFee || msg.SkipNonceChecks
+
+	var snapshot int
+	isAllegro := evm.ChainConfig().IsPrague(blockNumber, evm.Context.Time)
+	if isAllegro {
+		snapshot = statedb.Snapshot()
+	}
+
+	result, err := core.ApplyMessage(evm, msg, gasPool)
+	if err != nil {
+		if isAllegro {
+			statedb.RevertToSnapshot(snapshot)
+		}
+		return nil, fmt.Errorf("failed to apply message: %w", err)
+	}
+	return result, nil
 }
 
 // ---
@@ -839,7 +899,7 @@ func ApplyTransactionWithEVM(
 	blockNumber *big.Int,
 	blockHash common.Hash,
 	tx *types.Transaction,
-	usedGas *uint64,
+	cumulatedGas *uint64,
 	evm *vm.EVM,
 ) (receipt *types.Receipt, err error) {
 	if evm.Config.Tracer != nil && evm.Config.Tracer.OnTxStart != nil {
@@ -850,55 +910,29 @@ func ApplyTransactionWithEVM(
 			}()
 		}
 	}
-	// Create a new context to be used in the EVM environment.
-	txContext, err := NewEVMTxContext(msg)
+
+	result, err := applyMessage(msg, evm, statedb, gp, blockNumber)
 	if err != nil {
-		statedb.EndTransaction()
-		return nil, fmt.Errorf("failed to create EVM transaction context: %w", err)
-	}
-	evm.SetTxContext(txContext)
-
-	// Apply the transaction to the current state (included in the env).
-	result, err := core.ApplyMessage(evm, msg, gp)
-	if err != nil {
-		statedb.EndTransaction()
-		return nil, err
+		return nil, fmt.Errorf("failed to apply message: %w", err)
 	}
 
-	// Update the state with pending changes.
-	statedb.EndTransaction()
-	*usedGas += result.UsedGas
+	*cumulatedGas += result.UsedGas
 
-	// Create a new receipt for the transaction, storing the intermediate root and gas used
-	// by the tx.
-	receipt = &types.Receipt{Type: tx.Type(), CumulativeGasUsed: *usedGas}
-	if result.Failed() {
-		receipt.Status = types.ReceiptStatusFailed
-	} else {
-		receipt.Status = types.ReceiptStatusSuccessful
-	}
-	receipt.TxHash = tx.Hash()
-	receipt.GasUsed = result.UsedGas
-
-	if tx.Type() == types.BlobTxType {
-		receipt.BlobGasUsed = uint64(len(tx.BlobHashes()) * params.BlobTxBlobGasPerBlob)
-		receipt.BlobGasPrice = evm.Context.BlobBaseFee // TODO issue #147
-	}
-
-	// If the transaction created a contract, store the creation address in the receipt.
-	if msg.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.Origin, tx.Nonce())
-	}
-
-	// Tracing doesn't need logs and bloom.
+	// with tracing enabled, logs are not reported
+	var logs []*types.Log
 	if evm.Config.Tracer == nil {
-		// Set the receipt logs and create the bloom filter.
-		receipt.Logs = statedb.GetLogs(tx.Hash(), blockHash) // don't store logs when tracing
-		receipt.Bloom = types.CreateBloom(receipt)
+		logs = statedb.GetLogs(tx.Hash(), blockHash)
 	}
-	receipt.BlockHash = blockHash
-	receipt.BlockNumber = blockNumber
-	receipt.TransactionIndex = uint(statedb.TxIndex())
+
+	receipt = CreateReceiptForTx(
+		msg.From,
+		tx,
+		*cumulatedGas,
+		result,
+		logs,
+		blockNumber,
+		uint(statedb.TxIndex()),
+	)
 	return receipt, err
 }
 
@@ -922,95 +956,6 @@ func ProcessParentBlockHash(prevHash common.Hash, evm *vm.EVM, stateDb state.Sta
 	_, _, _ = evm.Call(msg.From, *msg.To, msg.Data, 30_000_000, common.U2560)
 	stateDb.Finalise(true)
 	stateDb.EndTransaction()
-}
-
-// applyTransaction attempts to apply a transaction defined by the given message
-// to the provided EVM environment. If successful, a non-nil receipt and the
-// used gas is returned. If it fails, an error is returned and the receipt is
-// guaranteed to be nil.
-func applyTransaction(
-	msg *core.Message,
-	gp *core.GasPool,
-	statedb state.StateDB,
-	blockNumber *big.Int,
-	tx *types.Transaction,
-	usedGas *uint64,
-	evm *vm.EVM,
-	onNewLog func(*core_types.Log),
-) (
-	*types.Receipt,
-	uint64,
-	error,
-) {
-	// Create a new context to be used in the EVM environment.
-	txContext, err := NewEVMTxContext(msg)
-	if err != nil {
-		statedb.EndTransaction()
-		return nil, 0, fmt.Errorf("failed to create EVM transaction context: %w", err)
-	}
-	evm.SetTxContext(txContext)
-
-	// Skip checking of base fee limits for internal transactions.
-	evm.Config.NoBaseFee = evm.Config.NoBaseFee || msg.SkipNonceChecks
-
-	isAllegro := evm.ChainConfig().IsPrague(blockNumber, evm.Context.Time)
-	var snapshot int
-	if isAllegro {
-		snapshot = statedb.Snapshot()
-	}
-	// Apply the transaction to the current state (included in the env).
-	result, err := core.ApplyMessage(evm, msg, gp)
-	if err != nil {
-		if isAllegro {
-			statedb.RevertToSnapshot(snapshot)
-		}
-		statedb.EndTransaction()
-		return nil, 0, err
-	}
-	// Notify about logs with potential state changes.
-	// At this point the final block hash is not yet known, so we pass an empty
-	// hash. For the consumers of the log messages, as for instance the driver
-	// contract listener, only the sender, topics, and the data are relevant.
-	// The block hash is not used.
-	logs := statedb.GetLogs(tx.Hash(), common.Hash{})
-	if onNewLog != nil {
-		for _, l := range logs {
-			onNewLog(core_types.CoreLogFromGethLog(l))
-		}
-	}
-
-	// Update the state with pending changes.
-	statedb.EndTransaction()
-	*usedGas += result.UsedGas
-
-	// Create a new receipt for the transaction, storing the intermediate root and gas used
-	// by the tx.
-	receipt := &types.Receipt{Type: tx.Type(), CumulativeGasUsed: *usedGas}
-	if result.Failed() {
-		receipt.Status = types.ReceiptStatusFailed
-	} else {
-		receipt.Status = types.ReceiptStatusSuccessful
-	}
-	receipt.TxHash = tx.Hash()
-	receipt.GasUsed = result.UsedGas
-
-	// If the transaction created a contract, store the creation address in the receipt.
-	if msg.To == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.Origin, tx.Nonce())
-	}
-
-	// Set the receipt logs.
-	receipt.Logs = logs
-	receipt.Bloom = types.CreateBloom(receipt)
-	receipt.BlockNumber = blockNumber
-	receipt.TransactionIndex = uint(statedb.TxIndex())
-
-	// Set the effective gas price in the receipt. By registering it here, at
-	// the source, down-stream consumers of the receipts do not have to
-	// replicate the code for computing effective gas prices.
-	receipt.EffectiveGasPrice = msg.GasPrice
-
-	return receipt, result.UsedGas, nil
 }
 
 func TxAsMessage(tx *types.Transaction, signer types.Signer, baseFee *big.Int) (*core.Message, error) {

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -729,6 +729,8 @@ func (e evm) _runTransaction(
 		logs,
 		ctxt.blockNumber,
 		uint(ctxt.statedb.TxIndex()),
+		msg.GasPrice, // Conversion to msg with non-nil base fee ensures that the gas price the effective gas price
+		e.Context.BlobBaseFee,
 	)
 	return ProcessedTransaction{
 		Transaction: tx,
@@ -932,6 +934,8 @@ func ApplyTransactionWithEVM(
 		logs,
 		blockNumber,
 		uint(statedb.TxIndex()),
+		msg.GasPrice, // Conversion to msg with non-nil base fee ensures that the gas price the effective gas price
+		evm.Context.BlobBaseFee,
 	)
 	return receipt, err
 }
@@ -1005,6 +1009,8 @@ func CreateReceiptForTx(
 	logs []*types.Log,
 	blockNumber *big.Int,
 	txIndex uint,
+	effectiveGasPrice *big.Int,
+	blobGasPrice *big.Int,
 ) *types.Receipt {
 
 	receipt := &types.Receipt{
@@ -1014,6 +1020,10 @@ func CreateReceiptForTx(
 		TxHash:            tx.Hash(),
 		TransactionIndex:  txIndex,
 		GasUsed:           result.UsedGas,
+		EffectiveGasPrice: new(big.Int).Set(effectiveGasPrice),
+		BlobGasUsed:       uint64(len(tx.BlobHashes()) * params.BlobTxBlobGasPerBlob),
+		BlobGasPrice:      new(big.Int).Set(blobGasPrice),
+		Logs:              logs,
 	}
 	if result.Failed() {
 		receipt.Status = types.ReceiptStatusFailed
@@ -1027,13 +1037,7 @@ func CreateReceiptForTx(
 	}
 
 	// Set the receipt logs.
-	receipt.Logs = logs
 	receipt.Bloom = types.CreateBloom(receipt)
-
-	// Set the effective gas price in the receipt. By registering it here, at
-	// the source, down-stream consumers of the receipts do not have to
-	// replicate the code for computing effective gas prices.
-	receipt.EffectiveGasPrice = tx.GasFeeCap()
 
 	return receipt
 }

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -1050,6 +1050,49 @@ func TxAsMessage(tx *types.Transaction, signer types.Signer, baseFee *big.Int) (
 	return msg, nil
 }
 
+// CreateReceiptForTx creates a receipt for the given transaction based
+// on the execution result and logs.
+func CreateReceiptForTx(
+	from common.Address,
+	tx *types.Transaction,
+	cumulativeGas uint64,
+	result *core.ExecutionResult,
+	logs []*types.Log,
+	blockNumber *big.Int,
+	txIndex uint,
+) *types.Receipt {
+
+	receipt := &types.Receipt{
+		Type:              tx.Type(),
+		CumulativeGasUsed: cumulativeGas,
+		BlockNumber:       blockNumber,
+		TxHash:            tx.Hash(),
+		TransactionIndex:  txIndex,
+		GasUsed:           result.UsedGas,
+	}
+	if result.Failed() {
+		receipt.Status = types.ReceiptStatusFailed
+	} else {
+		receipt.Status = types.ReceiptStatusSuccessful
+	}
+
+	// If the transaction created a contract, store the creation address in the receipt.
+	if tx.To() == nil {
+		receipt.ContractAddress = crypto.CreateAddress(from, tx.Nonce())
+	}
+
+	// Set the receipt logs.
+	receipt.Logs = logs
+	receipt.Bloom = types.CreateBloom(receipt)
+
+	// Set the effective gas price in the receipt. By registering it here, at
+	// the source, down-stream consumers of the receipts do not have to
+	// replicate the code for computing effective gas prices.
+	receipt.EffectiveGasPrice = tx.GasFeeCap()
+
+	return receipt
+}
+
 // logger is an internal interface to enable the mocking of logging in tests.
 // This is in particular useful to make sure tests that trigger failing
 // conditions are actually triggering the correct condition.

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -670,197 +670,258 @@ func TestProcess_ForwardsCorrectIndexToTransactionProcessor(t *testing.T) {
 	}
 }
 
-func TestApplyTransaction_InternalTransactionsSkipBaseFeeCharges(t *testing.T) {
-	for _, internal := range []bool{true, false} {
-		t.Run("internal="+fmt.Sprint(internal), func(t *testing.T) {
-			ctxt := gomock.NewController(t)
-			state := state.NewMockStateDB(ctxt)
+func TestRunTransaction_CanBypassBaseFeeChecks(t *testing.T) {
+	ctrl := gomock.NewController(t)
 
-			any := gomock.Any()
-			state.EXPECT().GetBalance(any).Return(uint256.NewInt(0))
-			state.EXPECT().SubBalance(any, any, any)
-			state.EXPECT().EndTransaction()
-			if !internal {
-				state.EXPECT().GetNonce(any)
-				state.EXPECT().GetCode(any)
-			}
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	signer := types.FrontierSigner{}
 
-			evm := vm.NewEVM(vm.BlockContext{}, state, &params.ChainConfig{}, vm.Config{})
-			gp := core.NewGasPool(1000000)
+	regularTx := types.MustSignNewTx(key, signer, &types.LegacyTx{
+		Nonce:    0,
+		To:       &common.Address{0x01},
+		Gas:      21_000,
+		GasPrice: big.NewInt(3),
+	})
+	require.False(t, internaltx.IsInternal(regularTx))
+	internalTx := types.NewTx(&types.LegacyTx{
+		Nonce: 0,
+		To:    &common.Address{0x01},
+		Gas:   21_000,
+		// no gas price
+	})
+	require.True(t, internaltx.IsInternal(internalTx))
 
-			// The transaction will fail for various reasons, but for this test
-			// this is not relevant. We just want to check if the base fee
-			// configuration flag is updated to match the SkipAccountChecks flag.
-			_, _, err := applyTransaction(&core.Message{
-				SkipNonceChecks:       internal,
-				SkipTransactionChecks: internal,
-				GasPrice:              big.NewInt(0),
-				Value:                 big.NewInt(0),
-			}, gp, state, nil, nil, nil, evm, nil)
-			if err == nil {
-				t.Errorf("expected transaction to fail")
-			}
+	state := getStateDbMockForTransactions(ctrl, []*types.Transaction{regularTx, internalTx})
+	vmEvm := vm.NewEVM(vm.BlockContext{
+		BlockNumber: big.NewInt(100),
+		Time:        100,
+		BaseFee:     big.NewInt(2),
+		Random:      &common.Hash{0x01},
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+	}, state, &params.ChainConfig{}, vm.Config{})
+	runner := evm{vmEvm}
 
-			if want, got := internal, evm.Config.NoBaseFee; want != got {
-				t.Fatalf("want %v, got %v", want, got)
-			}
+	context := &runContext{
+		signer:      signer,
+		baseFee:     big.NewInt(2),
+		statedb:     state,
+		gasPool:     core.NewGasPool(1_000_000),
+		blockNumber: big.NewInt(100),
+		usedGas:     new(uint64),
+	}
+
+	tests := map[string]struct {
+		tx              *types.Transaction
+		run             func(*runContext, *types.Transaction, int) ProcessedTransaction
+		expectNoBaseFee bool
+	}{
+		"regular tx with base-fee check": {
+			tx:              regularTx,
+			run:             runner.runWithBaseFeeCheck,
+			expectNoBaseFee: false,
+		},
+		"regular tx without base-fee check": {
+			tx:              regularTx,
+			run:             runner.runWithoutBaseFeeCheck,
+			expectNoBaseFee: true,
+		},
+		"internal tx with base-fee check": {
+			tx:              internalTx,
+			run:             runner.runWithBaseFeeCheck,
+			expectNoBaseFee: true,
+		},
+		"internal tx without base-fee check": {
+			tx:              internalTx,
+			run:             runner.runWithoutBaseFeeCheck,
+			expectNoBaseFee: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			runner.Config.NoBaseFee = false
+			result := test.run(context, test.tx, 0)
+			require.Equal(t, test.tx, result.Transaction)
+			require.Equal(t, test.expectNoBaseFee, runner.Config.NoBaseFee,
+				"configuration used for running the transaction should disable base-fee checks")
+			require.NotNil(t, result.Receipt, "transactions in test are expected to not be skipped")
 		})
 	}
 }
 
-func TestApplyTransaction_FailsForTransactionWithInvalidGasPrice(t *testing.T) {
+func TestApplyMessage_FailsForTransactionWithInvalidGasPrice(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	stateDb := state.NewMockStateDB(ctrl)
-	stateDb.EXPECT().EndTransaction()
 
-	msg := &core.Message{
-		GasPrice: big.NewInt(-1),
-	}
-	_, _, err := applyTransaction(msg, nil, stateDb, nil, nil, nil, nil, nil)
+	evm := vm.NewEVM(vm.BlockContext{}, stateDb, &params.ChainConfig{}, vm.Config{})
+	msg := &core.Message{GasPrice: big.NewInt(-1)}
+
+	_, err := applyMessage(msg, evm, stateDb, core.NewGasPool(1), big.NewInt(0))
 	require.ErrorContains(t, err, "failed to create EVM transaction context")
 }
 
-func TestApplyTransaction_ApplyMessageError_RevertsSnapshotIfPrague(t *testing.T) {
-	versions := map[string]bool{
-		"pre prague": false,
-		"prague":     true,
+func TestApplyMessage_PragueFailure_CreatesAndRevertsSnapshot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := state.NewMockStateDB(ctrl)
+	any := gomock.Any()
+	state.EXPECT().GetBalance(any).Return(uint256.NewInt(math.MaxInt64)).AnyTimes()
+	state.EXPECT().SubBalance(any, any, any).AnyTimes()
+
+	pragueTime := uint64(0)
+	chainCfg := &params.ChainConfig{
+		LondonBlock:        new(big.Int).SetUint64(0),
+		MergeNetsplitBlock: new(big.Int).SetUint64(0),
+		ShanghaiTime:       new(uint64),
+		CancunTime:         new(uint64),
+		PragueTime:         &pragueTime,
 	}
 
-	for name, isPrague := range versions {
-		t.Run(name, func(t *testing.T) {
-			pragueTime := uint64(1000)
-			callToSnapshot := 0
-			if isPrague {
-				pragueTime = 0
-				callToSnapshot = 1
-			}
-			any := gomock.Any()
-			ctrl := gomock.NewController(t)
-			state := state.NewMockStateDB(ctrl)
-			evm := vm.NewEVM(vm.BlockContext{}, state, &params.ChainConfig{
-				LondonBlock:        new(big.Int).SetUint64(0),
-				MergeNetsplitBlock: new(big.Int).SetUint64(0),
-				ShanghaiTime:       new(uint64),
-				CancunTime:         new(uint64),
-				PragueTime:         &pragueTime,
-			}, vm.Config{})
-			gp := core.NewGasPool(1000000)
+	evm := vm.NewEVM(vm.BlockContext{
+		BlockNumber: big.NewInt(100),
+		Time:        100,
+		BaseFee:     big.NewInt(0),
+		Random:      &common.Hash{0x01},
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+	}, state, chainCfg, vm.Config{})
 
-			blockNumber := big.NewInt(100)
-			evm.Context.Random = &common.Hash{0x01} // triggers isMerge
-			evm.Context.BlockNumber = blockNumber   // triggers isMerge
-			evm.Context.Time = 100                  // triggers IsPrague
-
-			initCode := make([]byte, 50000) // large init code to trigger error
-			msg := &core.Message{
-				From:                  common.Address{1},
-				To:                    nil, // contract creation
-				GasLimit:              1000000,
-				GasPrice:              big.NewInt(1),
-				GasFeeCap:             big.NewInt(0),
-				GasTipCap:             big.NewInt(0),
-				Value:                 big.NewInt(0),
-				Data:                  initCode,
-				SkipNonceChecks:       true,
-				SkipTransactionChecks: true,
-			}
-
-			gomock.InOrder(
-				state.EXPECT().Snapshot().Return(42).Times(callToSnapshot),
-				state.EXPECT().GetBalance(msg.From).Return(uint256.NewInt(1000000)),
-				state.EXPECT().SubBalance(any, any, any),
-				state.EXPECT().RevertToSnapshot(42).Times(callToSnapshot),
-				state.EXPECT().EndTransaction(),
-			)
-
-			receipt, gasUsed, err :=
-				applyTransaction(msg, gp, state, blockNumber, nil, new(uint64), evm, nil)
-			require.ErrorContains(t, err, "max initcode size exceeded")
-			require.Nil(t, receipt)
-			require.Equal(t, uint64(0), gasUsed)
-		})
+	to := common.Address{0x02}
+	msg := &core.Message{
+		From:                  common.Address{0x01},
+		To:                    &to,
+		GasLimit:              21_000,
+		GasPrice:              big.NewInt(1),
+		GasFeeCap:             big.NewInt(1),
+		GasTipCap:             big.NewInt(0),
+		Value:                 big.NewInt(0),
+		SkipNonceChecks:       true,
+		SkipTransactionChecks: true,
 	}
+
+	gomock.InOrder(
+		state.EXPECT().Snapshot().Return(42),
+		state.EXPECT().RevertToSnapshot(42),
+	)
+
+	gasPool := core.NewGasPool(1)
+	_, err := applyMessage(msg, evm, state, gasPool, big.NewInt(100))
+	require.Error(t, err)
 }
 
-func TestApplyTransaction_SetsEffectiveGasPriceInReceipt(t *testing.T) {
-	gasPrices := []*big.Int{
-		big.NewInt(0),
-		big.NewInt(100),
-		big.NewInt(math.MaxInt64),
-		new(big.Int).Lsh(big.NewInt(1), 200),
+func TestApplyMessage_PragueSuccess_CreatesSnapshotWithoutRevertingIt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := state.NewMockStateDB(ctrl)
+	any := gomock.Any()
+
+	state.EXPECT().GetBalance(any).Return(uint256.NewInt(math.MaxInt64)).AnyTimes()
+	state.EXPECT().SubBalance(any, any, any).AnyTimes()
+	state.EXPECT().Prepare(any, any, any, any, any, any).AnyTimes()
+	state.EXPECT().GetNonce(any).Return(uint64(0)).AnyTimes()
+	state.EXPECT().SetNonce(any, any, any).AnyTimes()
+	state.EXPECT().GetCode(any).Return(nil).AnyTimes()
+	state.EXPECT().GetCodeHash(any).Return(types.EmptyCodeHash).AnyTimes()
+	state.EXPECT().GetStorageRoot(any).Return(types.EmptyRootHash).AnyTimes()
+	state.EXPECT().Exist(any).Return(true).AnyTimes()
+	state.EXPECT().AddBalance(any, any, any).AnyTimes()
+	state.EXPECT().GetRefund().Return(uint64(0)).AnyTimes()
+	state.EXPECT().AddRefund(any).AnyTimes()
+	state.EXPECT().SubRefund(any).AnyTimes()
+
+	snapshotCalls := 0
+	state.EXPECT().Snapshot().DoAndReturn(func() int {
+		snapshotCalls++
+		if snapshotCalls == 1 {
+			return 42
+		}
+		return 42 + snapshotCalls
+	}).AnyTimes()
+	state.EXPECT().RevertToSnapshot(42).Times(0)
+	state.EXPECT().RevertToSnapshot(gomock.Not(42)).AnyTimes()
+
+	pragueTime := uint64(0)
+	chainCfg := &params.ChainConfig{
+		LondonBlock:        new(big.Int).SetUint64(0),
+		MergeNetsplitBlock: new(big.Int).SetUint64(0),
+		ShanghaiTime:       new(uint64),
+		CancunTime:         new(uint64),
+		PragueTime:         &pragueTime,
 	}
 
-	for _, price := range gasPrices {
-		t.Run(fmt.Sprintf("%v", price), func(t *testing.T) {
-			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			state := state.NewMockStateDB(ctrl)
+	evm := vm.NewEVM(vm.BlockContext{
+		BlockNumber: big.NewInt(100),
+		Time:        100,
+		BaseFee:     big.NewInt(0),
+		Random:      &common.Hash{0x01},
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+	}, state, chainCfg, vm.Config{})
 
-			// -- setup to get a simple transaction to pass --
-
-			blockContext := vm.BlockContext{
-				BlockNumber: big.NewInt(123),
-				BaseFee:     big.NewInt(0),
-				Transfer: func(_ vm.StateDB, _ common.Address, _ common.Address, _ *uint256.Int, _ *params.Rules) {
-					// do nothing
-				},
-				CanTransfer: func(_ vm.StateDB, _ common.Address, _ *uint256.Int) bool {
-					return true
-				},
-				Random: &common.Hash{}, // < signals Revision >= Merge
-			}
-
-			evm := vm.NewEVM(blockContext, state, &params.ChainConfig{
-				LondonBlock:        new(big.Int).SetUint64(0),
-				MergeNetsplitBlock: new(big.Int).SetUint64(0),
-				ShanghaiTime:       new(uint64),
-				CancunTime:         new(uint64),
-			}, vm.Config{})
-
-			// accept everything else that is needed to get the transaction to run
-			any := gomock.Any()
-			balance := new(uint256.Int).Lsh(uint256.NewInt(1), 240)
-			state.EXPECT().GetBalance(any).Return(balance).AnyTimes()
-			state.EXPECT().SubBalance(any, any, any).AnyTimes()
-			state.EXPECT().Prepare(any, any, any, any, any, any).AnyTimes()
-			state.EXPECT().GetNonce(any).AnyTimes()
-			state.EXPECT().SetNonce(any, any, any).AnyTimes()
-			state.EXPECT().GetCode(any).AnyTimes()
-			state.EXPECT().Snapshot().AnyTimes()
-			state.EXPECT().Exist(any).Return(true).AnyTimes()
-			state.EXPECT().AddBalance(any, any, any).AnyTimes()
-			state.EXPECT().GetRefund().AnyTimes()
-			state.EXPECT().AddRefund(any).AnyTimes()
-			state.EXPECT().GetLogs(any, any).AnyTimes()
-			state.EXPECT().EndTransaction().AnyTimes()
-			state.EXPECT().TxIndex().AnyTimes()
-
-			gp := core.NewGasPool(1000000)
-			var usedGas uint64
-
-			blockNum := big.NewInt(12)
-
-			tx := types.NewTx(&types.LegacyTx{})
-
-			// -- end of setup --
-
-			// The only thing we really care of is that the GasPrice of the
-			// message is stored in the receipt.
-			msg := &core.Message{
-				GasPrice:  price,
-				GasFeeCap: new(big.Int).Add(price, big.NewInt(1000)),
-				GasTipCap: big.NewInt(100),
-				To:        &common.Address{},
-				Value:     big.NewInt(0),
-				GasLimit:  21_000,
-			}
-
-			receipt, _, err := applyTransaction(msg, gp, state, blockNum, tx, &usedGas, evm, nil)
-			require.NoError(err)
-
-			require.Equal(price, receipt.EffectiveGasPrice)
-		})
+	to := common.Address{0x02}
+	msg := &core.Message{
+		From:                  common.Address{0x01},
+		To:                    &to,
+		GasLimit:              21_000,
+		GasPrice:              big.NewInt(1),
+		GasFeeCap:             big.NewInt(1),
+		GasTipCap:             big.NewInt(0),
+		Value:                 big.NewInt(0),
+		SkipNonceChecks:       true,
+		SkipTransactionChecks: true,
 	}
+
+	gasPool := core.NewGasPool(1_000_000)
+	result, err := applyMessage(msg, evm, state, gasPool, big.NewInt(100))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.GreaterOrEqual(t, snapshotCalls, 1)
+}
+
+func TestApplyMessage_PrePrague_DoesNotCreateSnapshot(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	state := state.NewMockStateDB(ctrl)
+	any := gomock.Any()
+	state.EXPECT().GetBalance(any).Return(uint256.NewInt(math.MaxInt64)).AnyTimes()
+	state.EXPECT().SubBalance(any, any, any).AnyTimes()
+
+	pragueTime := uint64(1000)
+	chainCfg := &params.ChainConfig{
+		LondonBlock:        new(big.Int).SetUint64(0),
+		MergeNetsplitBlock: new(big.Int).SetUint64(0),
+		ShanghaiTime:       new(uint64),
+		CancunTime:         new(uint64),
+		PragueTime:         &pragueTime,
+	}
+
+	evm := vm.NewEVM(vm.BlockContext{
+		BlockNumber: big.NewInt(100),
+		Time:        100,
+		BaseFee:     big.NewInt(0),
+		Random:      &common.Hash{0x01},
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+	}, state, chainCfg, vm.Config{})
+
+	to := common.Address{0x02}
+	msg := &core.Message{
+		From:                  common.Address{0x01},
+		To:                    &to,
+		GasLimit:              21_000,
+		GasPrice:              big.NewInt(1),
+		GasFeeCap:             big.NewInt(1),
+		GasTipCap:             big.NewInt(0),
+		Value:                 big.NewInt(0),
+		SkipNonceChecks:       true,
+		SkipTransactionChecks: true,
+	}
+
+	state.EXPECT().Snapshot().Times(0)
+	state.EXPECT().RevertToSnapshot(gomock.Any()).Times(0)
+
+	gasPool := core.NewGasPool(1)
+	_, err := applyMessage(msg, evm, state, gasPool, big.NewInt(100))
+	require.Error(t, err)
 }
 
 // processFunction is a function type alias for the StateProcessor's Process
@@ -2242,8 +2303,8 @@ func TestRunSponsoredTransaction_CoveredTransaction_ProcessesTwoTransactionsSucc
 		state.EXPECT().SetTxContext(tx.Hash(), txIndex),
 		state.EXPECT().SetNonce(sender, uint64(1), tracing.NonceChangeEoACall),
 		state.EXPECT().Snapshot().Return(4), // < for the transaction processing
-		state.EXPECT().EndTransaction(),
 		state.EXPECT().TxIndex().Return(txIndex),
+		state.EXPECT().EndTransaction(),
 
 		// --- Preparation of the fee deduction transaction ---
 		state.EXPECT().GetNonce(zeroAddress).Return(uint64(123)),
@@ -2256,8 +2317,8 @@ func TestRunSponsoredTransaction_CoveredTransaction_ProcessesTwoTransactionsSucc
 		state.EXPECT().SetState(sfcAddress, any, any).AnyTimes(),      // < update of the total token supply
 		state.EXPECT().Snapshot().Return(7),                           // < transfer to account 0
 		state.EXPECT().SetState(registryAddress, any, any).AnyTimes(), // < update of the fund
-		state.EXPECT().EndTransaction(),
 		state.EXPECT().TxIndex().Return(txIndex+1),
+		state.EXPECT().EndTransaction(),
 	)
 
 	// StateDB interactions that are occurring, and need to be accounted for,

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -5376,6 +5376,9 @@ func TestCreateReceiptForTx_ConstructsReceiptsFromExecutedTransactions(t *testin
 		},
 	}
 
+	gasPrice := big.NewInt(123)
+	blobGasPrice := big.NewInt(321)
+
 	for txProperty, newTx := range txTypeCases {
 		for statusProperty, statusCase := range statusCases {
 			for targetProperty, to := range targetCases {
@@ -5406,6 +5409,8 @@ func TestCreateReceiptForTx_ConstructsReceiptsFromExecutedTransactions(t *testin
 								logs,
 								blockNumber,
 								txIndex,
+								gasPrice,
+								blobGasPrice,
 							)
 
 							require.NotNil(t, receipt)
@@ -5429,7 +5434,10 @@ func TestCreateReceiptForTx_ConstructsReceiptsFromExecutedTransactions(t *testin
 							}
 							require.Equal(t, expectedContractAddress, receipt.ContractAddress)
 
-							require.Equal(t, tx.GasFeeCap(), receipt.EffectiveGasPrice)
+							require.Equal(t, gasPrice, receipt.EffectiveGasPrice)
+							require.NotSame(t, gasPrice, receipt.EffectiveGasPrice)
+							require.Equal(t, blobGasPrice, receipt.BlobGasPrice)
+							require.NotSame(t, blobGasPrice, receipt.BlobGasPrice)
 						})
 					}
 				}

--- a/evmcore/state_processor_test.go
+++ b/evmcore/state_processor_test.go
@@ -5251,3 +5251,128 @@ func TestTxAsMessage_ConvertsUserTransactionsToMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateReceiptForTx_ConstructsReceiptsFromExecutedTransactions(t *testing.T) {
+	from := common.Address{0xaa}
+	cumulativeGas := uint64(99_999)
+	txIndex := uint(42)
+
+	statusCases := map[string]struct {
+		failed         bool
+		expectedStatus uint64
+	}{
+		"status=successful": {
+			failed:         false,
+			expectedStatus: types.ReceiptStatusSuccessful,
+		},
+		"status=failed": {
+			failed:         true,
+			expectedStatus: types.ReceiptStatusFailed,
+		},
+	}
+
+	targetCases := map[string]*common.Address{
+		"target=contract-call":     {0x01},
+		"target=contract-creation": nil,
+	}
+
+	logCases := map[string][]*types.Log{
+		"logs=empty": nil,
+		"logs=single": {
+			{
+				Address: common.Address{0x10},
+				Topics:  []common.Hash{{0x11}},
+				Data:    []byte{0xde, 0xad},
+			},
+		},
+	}
+
+	blockNumberCases := map[string]*big.Int{
+		"block-number=nil": nil,
+		"block-number=set": big.NewInt(777),
+	}
+
+	txTypeCases := map[string]func(to *common.Address) *types.Transaction{
+		"tx-type=legacy": func(to *common.Address) *types.Transaction {
+			return types.NewTx(&types.LegacyTx{
+				Nonce:    7,
+				To:       to,
+				Gas:      21_000,
+				GasPrice: big.NewInt(123),
+				Value:    big.NewInt(1),
+			})
+		},
+		"tx-type=dynamic-fee": func(to *common.Address) *types.Transaction {
+			return types.NewTx(&types.DynamicFeeTx{
+				ChainID:   big.NewInt(1),
+				Nonce:     7,
+				To:        to,
+				Gas:       21_000,
+				GasFeeCap: big.NewInt(456),
+				GasTipCap: big.NewInt(12),
+				Value:     big.NewInt(1),
+			})
+		},
+	}
+
+	for txProperty, newTx := range txTypeCases {
+		for statusProperty, statusCase := range statusCases {
+			for targetProperty, to := range targetCases {
+				for logsProperty, logs := range logCases {
+					for blockNumberProperty, blockNumber := range blockNumberCases {
+						name := fmt.Sprintf(
+							"%s,%s,%s,%s,%s",
+							txProperty,
+							statusProperty,
+							targetProperty,
+							logsProperty,
+							blockNumberProperty,
+						)
+
+						t.Run(name, func(t *testing.T) {
+							tx := newTx(to)
+
+							result := &core.ExecutionResult{UsedGas: 21_123}
+							if statusCase.failed {
+								result.Err = vm.ErrOutOfGas
+							}
+
+							receipt := CreateReceiptForTx(
+								from,
+								tx,
+								cumulativeGas,
+								result,
+								logs,
+								blockNumber,
+								txIndex,
+							)
+
+							require.NotNil(t, receipt)
+							require.Equal(t, tx.Type(), receipt.Type)
+							require.Equal(t, cumulativeGas, receipt.CumulativeGasUsed)
+							require.Equal(t, blockNumber, receipt.BlockNumber)
+							require.Equal(t, tx.Hash(), receipt.TxHash)
+							require.Equal(t, txIndex, receipt.TransactionIndex)
+							require.Equal(t, result.UsedGas, receipt.GasUsed)
+							require.Equal(t, statusCase.expectedStatus, receipt.Status)
+							require.Equal(t, logs, receipt.Logs)
+
+							expectedBloom := types.CreateBloom(&types.Receipt{
+								Logs: logs,
+							})
+							require.Equal(t, expectedBloom, receipt.Bloom)
+
+							var expectedContractAddress common.Address
+							if to == nil {
+								expectedContractAddress = crypto.CreateAddress(from, tx.Nonce())
+							}
+							require.Equal(t, expectedContractAddress, receipt.ContractAddress)
+
+							require.Equal(t, tx.GasFeeCap(), receipt.EffectiveGasPrice)
+						})
+					}
+				}
+			}
+		}
+	}
+}

--- a/evmcore/tx_validation_fuzzer_test.go
+++ b/evmcore/tx_validation_fuzzer_test.go
@@ -274,10 +274,7 @@ func FuzzValidateTransaction(f *testing.F) {
 		require.NoError(t, err)
 
 		gp := core.NewGasPool(maxGas)
-		var usedGas uint64
-		_, _, processorError := applyTransaction(msg, gp, state, big.NewInt(blockNum),
-			signedTx, &usedGas, evm, nil)
-
+		_, processorError := applyMessage(msg, evm, state, gp, big.NewInt(blockNum))
 		// validateTx should not reject transactions that the processor would accept
 		if processorError != nil && validateErr == nil {
 			// if the nonce is too high this is also acceptable for the validateTx


### PR DESCRIPTION
This refactors common code from `(e evm) _runTransaction` and `ApplyTransactionWithEVM` into better specified and scoped utilities, removing ambiguities and reducing the difference between the two implementations. 

The motivation is the following code smells:
- Duplicated code: the construction of the receipt was hardcoded in both cases, although producing a receipt is a stateless function on the transaction, some context and the execution result. This is a trivial function.
- Ambiguous parameters: Passing both `core.Message` and `types.Transaction` through the functions is redundant and the values do diverge during execution (i.e. blobHashes is set to nil in the message). Removing this pattern improves readability. 
- Unclear when to call `statedb.EndTransaction()`: this has been a problem [recently](https://github.com/0xsoniclabs/sonic/pull/969/changes#r3229568727), where some paths did not call the function. Transactions begin with `ctxt.statedb.SetTxContext(tx.Hash(), txIndex)`, it only makes sense to end the transaction at the same level. 
- passing context state by reference:  `*ctxt.usedGas` is updated inside the `apply_transaction` function while the context remains in `_runTransaction`, this is not needed and complicates the code. 
- different handling of blobFees in RPC (contemplated) than block processing (ignored) 

The code replaces `applyTransaction` with unclear responsibilities with `applyMessage` and `CreateReceiptForTx`, which scoped and specific roles. 
RPC transaction run and state_processor now share more code, divergent behaviors are minimized (i.e. RCP trace_tx would not snapshoot but runTransaction did after brio) 
