### PR TITLE
Fix Service/Handler race condition

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -496,6 +496,11 @@ func (h *handler) Stop() {
 	// After this send has completed, no new peers will be accepted.
 	close(h.quitSync)
 
+	// Disconnect existing sessions.
+	// This also closes the gate for any new registrations on the peer set.
+	// sessions which are already established but not added to h.peers yet
+	// will exit when they try to register.
+	h.peers.Close()
 	// Signal that we are stopping and wait for all peer Run goroutines.
 	h.peerCond.L.Lock()
 	h.stopping = true
@@ -503,12 +508,6 @@ func (h *handler) Stop() {
 		h.peerCond.Wait()
 	}
 	h.peerCond.L.Unlock()
-
-	// Disconnect existing sessions.
-	// This also closes the gate for any new registrations on the peer set.
-	// sessions which are already established but not added to h.peers yet
-	// will exit when they try to register.
-	h.peers.Close()
 
 	// Wait for all peer handler goroutines to come down.
 	h.peerWG.Wait()

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -161,10 +161,15 @@ type handler struct {
 	txsyncCh chan *txsync
 	quitSync chan struct{}
 
+	// peerCond protects the stopping flag and running peer count.
+	// Stop() sets stopping=true and waits for runningPeers to reach 0.
+	peerCond     *sync.Cond
+	stopping     bool
+	runningPeers int
+
 	// wait group is used for graceful shutdowns during downloading
 	// and processing
 	loopsWg sync.WaitGroup
-	wg      sync.WaitGroup
 	peerWG  sync.WaitGroup
 	started sync.WaitGroup
 
@@ -210,6 +215,7 @@ func newHandler(
 
 		Instance: logger.New("PM"),
 	}
+	h.peerCond = sync.NewCond(&sync.Mutex{})
 	h.started.Add(1)
 
 	h.dagFetcher = itemsfetcher.New(h.config.Protocol.DagFetcher, itemsfetcher.Callback{
@@ -490,6 +496,14 @@ func (h *handler) Stop() {
 	// After this send has completed, no new peers will be accepted.
 	close(h.quitSync)
 
+	// Signal that we are stopping and wait for all peer Run goroutines.
+	h.peerCond.L.Lock()
+	h.stopping = true
+	for h.runningPeers > 0 {
+		h.peerCond.Wait()
+	}
+	h.peerCond.L.Unlock()
+
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.
 	// sessions which are already established but not added to h.peers yet
@@ -497,10 +511,29 @@ func (h *handler) Stop() {
 	h.peers.Close()
 
 	// Wait for all peer handler goroutines to come down.
-	h.wg.Wait()
 	h.peerWG.Wait()
 
 	log.Info("Sonic protocol stopped")
+}
+
+// acquireRunSlot atomically checks whether the handler is shutting down and,
+// if not, increments the running peer count so Stop will wait for this goroutine.
+func (h *handler) acquireRunSlot() bool {
+	h.peerCond.L.Lock()
+	defer h.peerCond.L.Unlock()
+	if h.stopping {
+		return false
+	}
+	h.runningPeers++
+	return true
+}
+
+// releaseRunSlot decrements the running peer count and signals Stop if waiting.
+func (h *handler) releaseRunSlot() {
+	h.peerCond.L.Lock()
+	h.runningPeers--
+	h.peerCond.L.Unlock()
+	h.peerCond.Signal()
 }
 
 func (h *handler) myProgress() PeerProgress {

--- a/gossip/handler_runslot_test.go
+++ b/gossip/handler_runslot_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gossip
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAcquireRunSlot_SucceedsWhenNotStopping(t *testing.T) {
+	h := newTestHandler()
+
+	require.True(t, h.acquireRunSlot())
+	require.Equal(t, 1, h.runningPeers)
+
+	require.True(t, h.acquireRunSlot())
+	require.Equal(t, 2, h.runningPeers)
+
+	h.releaseRunSlot()
+	h.releaseRunSlot()
+	require.Equal(t, 0, h.runningPeers)
+}
+
+func TestAcquireRunSlot_FailsAfterStopping(t *testing.T) {
+	h := newTestHandler()
+
+	h.peerCond.L.Lock()
+	h.stopping = true
+	h.peerCond.L.Unlock()
+
+	require.False(t, h.acquireRunSlot())
+	require.Equal(t, 0, h.runningPeers)
+}
+
+func TestStop_BlocksUntilRunSlotsReleased(t *testing.T) {
+	h := newTestHandler()
+
+	// Simulate a peer holding a run slot.
+	require.True(t, h.acquireRunSlot())
+
+	stopDone := make(chan struct{})
+	go func() {
+		stopLogic(h, stopDone)
+	}()
+
+	// Stop should not complete while the slot is held.
+	select {
+	case <-stopDone:
+		t.Fatal("stop completed while run slot is still held")
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+
+	// Release the slot — Stop should now unblock.
+	h.releaseRunSlot()
+
+	select {
+	case <-stopDone:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("stop did not complete after releasing run slot")
+	}
+}
+
+func TestStop_BlocksUntilAllRunSlotsReleased(t *testing.T) {
+	h := newTestHandler()
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		require.True(t, h.acquireRunSlot())
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		stopLogic(h, stopDone)
+	}()
+
+	// Release slots one by one; stop should not complete until all are gone.
+	for i := 0; i < n-1; i++ {
+		h.releaseRunSlot()
+		select {
+		case <-stopDone:
+			t.Fatal("stop completed with slots still held")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	// Release the last slot.
+	h.releaseRunSlot()
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not complete after all slots released")
+	}
+}
+
+func TestAcquireRunSlot_ConcurrentWithStop(t *testing.T) {
+	// Hammer acquireRunSlot and releaseRunSlot from many goroutines
+	// while triggering a stop, verifying no panics or deadlocks.
+	h := newTestHandler()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	ready := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ready
+			if h.acquireRunSlot() {
+				// Simulate some work.
+				time.Sleep(time.Millisecond)
+				h.releaseRunSlot()
+			}
+		}()
+	}
+
+	// Let all goroutines race.
+	close(ready)
+
+	// Give some goroutines time to acquire slots.
+	time.Sleep(5 * time.Millisecond)
+
+	// Trigger stop.
+	stopLogic(h, make(chan struct{}))
+
+	// All goroutines must finish.
+	wg.Wait()
+	require.Equal(t, 0, h.runningPeers)
+}
+
+// newTestHandler creates a minimal handler with only the peerCond
+// initialized, sufficient for testing acquireRunSlot/releaseRunSlot.
+func newTestHandler() *handler {
+	h := &handler{}
+	h.peerCond = sync.NewCond(&sync.Mutex{})
+	return h
+}
+
+// stopLogic replicates the Stop() shutdown logic in isolation.
+func stopLogic(h *handler, stopDone chan struct{}) {
+	h.peerCond.L.Lock()
+	h.stopping = true
+	for h.runningPeers > 0 {
+		h.peerCond.Wait()
+	}
+	h.peerCond.L.Unlock()
+	close(stopDone)
+}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -501,14 +501,11 @@ func MakeProtocols(svc *Service, backend *handler, disc enode.Iterator) ([]p2p.P
 				peer := newPeer(version, p, rw, backend.config.Protocol.PeerCache)
 				defer peer.Close()
 
-				select {
-				case <-backend.quitSync:
+				if !backend.acquireRunSlot() {
 					return p2p.DiscQuitting
-				default:
-					backend.wg.Add(1)
-					defer backend.wg.Done()
-					return backend.handle(peer)
 				}
+				defer backend.releaseRunSlot()
+				return backend.handle(peer)
 			},
 			NodeInfo: func() interface{} {
 				return backend.NodeInfo()


### PR DESCRIPTION
This PR fixes https://github.com/0xsoniclabs/sonic-admin/issues/407

**The problem:**
Given the right heavy load conditions, a services spawned by [p2p protocol](https://github.com/0xsoniclabs/sonic/blob/main/gossip/service.go#L508) could call `wg.Add(1)` after the handler already started shutting down (aka, call [wg.Wait](https://github.com/0xsoniclabs/sonic/blob/main/gossip/handler.go#L500)). To the runtime race detection, this is interpreted as a race condition.
It is also an anti-pattern or misuse of the [`WaitGroup`](https://pkg.go.dev/sync#WaitGroup).

**The proposed solution:**
Since there is no real control of when the task will be started, instead of using a wait group, this PR proposes to use a [Condition variable](https://pkg.go.dev/sync#Cond) with a mutex.