### PR TITLE
Add debug namespace test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -153,6 +153,6 @@ require (
 	pgregory.net/rand v1.0.2 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe
+replace github.com/ethereum/go-ethereum => github.com/0xsoniclabs/go-ethereum v0.0.0-20260608092519-9146d4108fe9
 
 replace github.com/Fantom-foundation/lachesis-base => github.com/Fantom-foundation/lachesis-base-sonic v0.0.0-20260429065829-930ae462cd09

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4 h1:HF2gKas3kyQx28LDcN4jn1yafxa4+gsy+UXUEnli2Kc=
 github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe h1:JPiyJPZ1oBzRwsRW0BER76wChPg7rOxKwk1W5YUkKlE=
-github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20260608092519-9146d4108fe9 h1:v3J1Ay0pvI/UvJBtbn3ibW45ZfcBjgtMxoN1SYFjV90=
+github.com/0xsoniclabs/go-ethereum v0.0.0-20260608092519-9146d4108fe9/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42/go.mod h1:iXtx7i9R25Oc5SD/xGI7aamdnF0nCteBpulZGIOIYJI=
 github.com/0xsoniclabs/tracy v0.0.0-20251027125423-00a5ab7968fb h1:mb6rPN+DpA/N2QWrQrLQEG2uzrYgy061PPauifstXNM=

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -86,6 +86,21 @@ func TestRPCApis(t *testing.T) {
 	require.Zero(t, len(missing), "missing namespaces %v", missing)
 }
 
+func TestDebugOverride_CoversAllHandlerMethods(t *testing.T) {
+
+	// methods on go-ethereum's debug.Handler (HandlerT)
+	ethDebugMethods := parseAPIs(rpc_test_utils.GetDebugHandlerApis())
+
+	// methods on sonic's PublicDebugAPI (debug namespace)
+	sonicDebugMethods := parseAPIs(getNodeService(t).APIs())
+
+	// all go-ethereum debug.Handler methods must be present in sonic's debug API
+	// (either implemented or shadowed in debugOverride.go)
+	missing := findMissingMethods(ethDebugMethods, sonicDebugMethods)
+	require.Zero(t, len(missing),
+		"go-ethereum debug.Handler has methods not shadowed in sonic's PublicDebugAPI: %v", missing)
+}
+
 // getNodeService returns a gossip service
 // which includes initialization of RPC APIs for Sonic
 func getNodeService(t *testing.T) *gossip.Service {


### PR DESCRIPTION
This PR adds regression test for the debug namespace. It is checking, if all debug RPC methods are implemented shadowed in the Sonic client.