### PR TITLE
Update max code size to eth Amsterdam values

### DIFF
--- a/opera/vm_config.go
+++ b/opera/vm_config.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	SonicPostAllegroMaxCodeSize     = 1<<15 + 1<<14                   // 48 KiB
-	SonicPostAllegroMaxInitCodeSize = SonicPostAllegroMaxCodeSize * 2 // 96 KiB
+	SonicPostAllegroMaxCodeSize     = 1 << 16                         // 64 KiB
+	SonicPostAllegroMaxInitCodeSize = SonicPostAllegroMaxCodeSize * 2 // 128 KiB
 )
 
 // sonicVmConfig is the initial Ethereum VM configuration used for processing


### PR DESCRIPTION
[EIP-7954](https://eips.ethereum.org/EIPS/eip-7954) has increased the max contract code size and max init code size again. To already support ethereum's next update these values are adjusted.