### PR TITLE
Migrate linter to github actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,18 +8,16 @@ on:
 
 permissions:
   contents: read
-  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
-          go-version: stable
+          go-version: '1.26'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           go-version: '1.26'
 
-      - name: Static lints
-        run: make lint
-
       - name: License Check
         run: make license-check
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,12 +42,6 @@ pipeline {
             }
         }
 
-        stage('Static analysis') {
-            steps {
-                sh 'make lint'
-            }
-        }
-
         stage('Build') {
             steps {
                 sh 'make'

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,6 @@ coverage:
 clean:
 	rm -fr ./build/*
 
-# Linting
-
-.PHONY: lint
-lint: 
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.1
-	@golangci-lint run ./...
-
 .PHONY: license-check
 license-check:
 	go run ./scripts/license/add_license_header.go --check -dir ./

--- a/scripts/license/add_license_header.go
+++ b/scripts/license/add_license_header.go
@@ -91,7 +91,7 @@ func processFiles(dir, ext, prefix, license string, checkOnly bool) error {
 			return nil
 		}
 		// build files should not be checked
-		if shouldIgnore(path, []string{"/build/", "_mock.go", ".pb.go"}) {
+		if shouldIgnore(path, []string{"/build/", "_mock.go", ".pb.go", ".github/"}) {
 			return nil
 		}
 		if matchPattern(path, ext) {


### PR DESCRIPTION
This PR modernizes the infrastructure and uses github actions to run linters, with all the goodies, like for example caching golang and linter installations. 

The code is the example provided by https://github.com/golangci/golangci-lint-action