### PR TITLE
Reframe bundle examples around trading cards instead of NFTs

### DIFF
--- a/docs/bundles/01-what-are-bundles.md
+++ b/docs/bundles/01-what-are-bundles.md
@@ -8,7 +8,7 @@ Sonic **transaction bundles** address both problems -- the friction of repeated 
 
 ## Problem One: The Multi-Signature Tax
 
-Consider buying a matched set of five NFTs. Each purchase is its own transaction. By the time you confirm the fourth, the fifth item may have sold out or the seller may have changed the price. You are now the proud owner of four-fifths of a set you no longer want, with no clean way to undo the preceding purchases.
+Consider buying a complete five-card set of onchain collectible cards. Each purchase is its own transaction. By the time you confirm the fourth, the fifth item may have sold out or the seller may have changed the price. You are now the proud owner of four-fifths of a set you no longer want (an incomplete set is worth far less than the cards in it cost), with no clean way to undo the preceding purchases.
 
 The same pattern appears throughout DeFi. Moving a loan from one protocol to another typically requires at least five steps. Each step is a separate transaction. Each transaction is a separate confirmation. Each confirmation is a moment where the market can move, a price can spike, or liquidity can disappear.
 
@@ -46,15 +46,15 @@ An **AllOf** group succeeds only if every step inside it succeeds. If any step f
 
 ```
 AllOf(
-  buy_nft_1,
-  buy_nft_2,
-  buy_nft_3,
-  buy_nft_4,
-  buy_nft_5
+  buy_card_1,
+  buy_card_2,
+  buy_card_3,
+  buy_card_4,
+  buy_card_5
 )
 ```
 
-If `buy_nft_3` reverts because the item sold out, the purchases of NFTs 1 and 2 are also undone. You either get the complete set or nothing.
+If `buy_card_3` reverts because the item sold out, the purchases of cards 1 and 2 are also undone. You either get the complete set or nothing.
 
 ### OneOf -- First Success Wins
 
@@ -99,7 +99,7 @@ Both motivation stories -- the UX friction and the interleaving risk -- are reso
 
 Because the entire bundle executes atomically:
 
-- A collector can buy a full set of NFTs with a single on-chain commitment, knowing they either get everything or spend nothing.
+- A collector can buy a full set of cards with a single on-chain commitment, knowing they either get everything or spend nothing.
 - A borrower can refinance across protocols without any moment of unsafe exposure in between.
 - A trader can express a ranked list of preferred execution venues and be guaranteed that at most one trade fires, regardless of how the market moves in the same block.
 

--- a/docs/bundles/02-builders-guide.md
+++ b/docs/bundles/02-builders-guide.md
@@ -66,7 +66,7 @@ Integrating bundles involves three RPC calls: **prepare**, **submit**, and optio
 
 ### Step 1 -- Prepare: `sonic_prepareBundle`
 
-Call `sonic_prepareBundle` with your unsigned transactions and the structure you want. The node estimates gas limits, suggests gas prices, computes the plan hash, and injects the BundleOnly marker into each transaction's access list. It returns the transactions ready to sign.
+Call `sonic_prepareBundle` with your unsigned transactions and the structure you want. The node estimates gas limits, suggests gas prices, computes the plan hash, and injects the BundleOnly marker into each transaction's access list. It returns the transactions ready to sign. (The example below buys onchain collectible cards.)
 
 **Request:**
 
@@ -79,16 +79,16 @@ Call `sonic_prepareBundle` with your unsigned transactions and the structure you
   "steps": [
     {
       "from": "0xAlice",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x5",
-      "data": "0xbuyNFT42...",
+      "data": "0xbuyCard42...",
       "chainId": "0xfa"
     },
     {
       "from": "0xAlice",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x6",
-      "data": "0xbuyNFT43...",
+      "data": "0xbuyCard43...",
       "chainId": "0xfa"
     }
   ]
@@ -125,9 +125,9 @@ Group steps use a different shape:
   "transactions": [
     {
       "from": "0xAlice",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x5",
-      "data": "0xbuyNFT42...",
+      "data": "0xbuyCard42...",
       "gas": "0x8d20",
       "maxFeePerGas": "0x...",
       "accessList": [

--- a/docs/bundles/03-bundles-in-action.md
+++ b/docs/bundles/03-bundles-in-action.md
@@ -10,9 +10,9 @@ The two guarantees that bundles provide -- **atomic execution** and **no interle
 
 ### The Problem
 
-A collector wants to buy a team of five player NFTs as a complete set. They find all five listed on a marketplace, check the total price, and start purchasing.
+A collector wants to buy a complete five-card set of onchain collectible cards, such as a team of five player cards. They find all five listed on a marketplace, check the total price, and start purchasing.
 
-With individual transactions, each purchase settles independently. By the time the third or fourth confirmation lands, the fifth item might have sold to another buyer, or the seller might have raised the price. The collector is now stuck with an incomplete set that cost them most of the budget.
+With individual transactions, each purchase settles independently. By the time the third or fourth confirmation lands, the fifth item might have sold to another buyer, or the seller might have raised the price. The collector is now stuck with an incomplete set that cost them most of the budget but is worth a fraction of a complete one.
 
 The natural response -- "I'll be fast" -- is not a solution. Even if the collector submits all five transactions in the same block, there is no guarantee all five succeed. One reverting transaction does not undo the others.
 
@@ -24,11 +24,11 @@ Wrap all five purchases in an **AllOf** group:
 {
   "blockRange": { "first": "0x1234", "length": "0x0a" },
   "steps": [
-    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x10", "data": "0x<buyNFT_1>" },
-    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x11", "data": "0x<buyNFT_2>" },
-    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x12", "data": "0x<buyNFT_3>" },
-    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x13", "data": "0x<buyNFT_4>" },
-    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x14", "data": "0x<buyNFT_5>" }
+    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x10", "data": "0x<buyCard_1>" },
+    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x11", "data": "0x<buyCard_2>" },
+    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x12", "data": "0x<buyCard_3>" },
+    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x13", "data": "0x<buyCard_4>" },
+    { "from": "0xCollector", "to": "0xMarket", "nonce": "0x14", "data": "0x<buyCard_5>" }
   ]
 }
 ```

--- a/docs/bundles/04-one-signature.md
+++ b/docs/bundles/04-one-signature.md
@@ -40,14 +40,14 @@ The user's single signature is not a blank cheque. It is a precise commitment to
 
 ## Walkthrough: Perfect Set Acquisition
 
-Let us trace through the full workflow for the NFT set purchase from [Article 3](./03-bundles-in-action.md), using the temporary account pattern.
+Let us trace through the full workflow for the card set purchase (onchain collectible cards) from [Article 3](./03-bundles-in-action.md), using the temporary account pattern.
 
 ### Setup
 
 The web service maintains a pool of temporary signing keys, or generates a fresh one per request. Call this address `0xTemp`.
 
 The web service also knows:
-- Which NFTs the user wants (IDs 1–5 on `0xNFTMarket`)
+- Which cards the user wants (IDs 1–5 on `0xCardMarket`)
 - The total price for all five (e.g. $5)
 - The user's address (`0xUser`)
 
@@ -68,74 +68,74 @@ The web service calls `sonic_prepareBundle` with a proposal that describes the f
       "chainId": "0xfa"
     },
 
-    // Phase 2: temporary account buys all five NFTs
+    // Phase 2: temporary account buys all five cards
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x00",
-      "data": "0x<buyNFT(1)>"
+      "data": "0x<buyCard(1)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x01",
-      "data": "0x<buyNFT(2)>"
+      "data": "0x<buyCard(2)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x02",
-      "data": "0x<buyNFT(3)>"
+      "data": "0x<buyCard(3)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x03",
-      "data": "0x<buyNFT(4)>"
+      "data": "0x<buyCard(4)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x04",
-      "data": "0x<buyNFT(5)>"
+      "data": "0x<buyCard(5)>"
     },
 
-    // Phase 3: temporary account transfers all five NFTs to the user
+    // Phase 3: temporary account transfers all five cards to the user
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x05",
-      "data": "0x<transferNFT(1, 0xUser)>"
+      "data": "0x<transferCard(1, 0xUser)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x06",
-      "data": "0x<transferNFT(2, 0xUser)>"
+      "data": "0x<transferCard(2, 0xUser)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x07",
-      "data": "0x<transferNFT(3, 0xUser)>"
+      "data": "0x<transferCard(3, 0xUser)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x08",
-      "data": "0x<transferNFT(4, 0xUser)>"
+      "data": "0x<transferCard(4, 0xUser)>"
     },
     {
       "from": "0xTemp",
-      "to": "0xNFTMarket",
+      "to": "0xCardMarket",
       "nonce": "0x09",
-      "data": "0x<transferNFT(5, 0xUser)>"
+      "data": "0x<transferCard(5, 0xUser)>"
     }
   ]
 }
 ```
 
-The structure is simple: first the user funds the temporary account, then the temporary account buys each NFT, then it transfers each NFT to the user. All of this is one flat AllOf sequence -- if any step fails, nothing happens.
+The structure is simple: first the user funds the temporary account, then the temporary account buys each card, then it transfers each card to the user. All of this is one flat AllOf sequence. If any step fails, nothing happens.
 
 ### Presenting the Plan to the User
 
@@ -143,7 +143,7 @@ The structure is simple: first the user funds the temporary account, then the te
 - A flat list of 11 prepared transactions, each with the plan hash in its access list.
 - The execution plan (a structured description of what will happen).
 
-The web service presents the plan to the user -- ideally rendered in a human-readable form by the wallet UI. The user can see exactly what they are authorizing: the amounts, the recipients, the NFT IDs.
+The web service presents the plan to the user, ideally rendered in a human-readable form by the wallet UI. The user can see exactly what they are authorizing: the amounts, the recipients, the card IDs.
 
 The user signs **one transaction**: the first one, which sends $5 to `0xTemp`. They approve this in their wallet, and the web service receives the signed transaction.
 
@@ -174,7 +174,7 @@ The node wraps everything in an envelope, submits it to the mempool, and returns
 From the user's perspective:
 1. They see a single confirmation request in their wallet showing the payment of $5.
 2. They confirm it.
-3. After the bundle executes, all five NFTs appear in their wallet.
+3. After the bundle executes, all five cards appear in their wallet.
 
 One click. One signature. Complete set.
 
@@ -185,7 +185,7 @@ One click. One signature. Complete set.
 The temporary account pattern is trustless in a precise sense:
 
 - The user's signed transaction commits them to the **exact plan hash** that was shown to them.
-- The web service cannot change any step -- including the transfer destinations, the NFT IDs, or the amounts -- without producing a different plan hash, which would render the user's signature invalid.
+- The web service cannot change any step (including the transfer destinations, the card IDs, or the amounts) without producing a different plan hash, which would render the user's signature invalid.
 - The bundle's AllOf semantics mean the web service cannot run only the fund-transfer step without also completing the purchases and transfers. All steps succeed together or none of them do.
 - The web service cannot take the user's signed transaction and submit it outside a bundle, or inside a different bundle, to collect the funds without fulfilling its obligations. The BundleOnly marker in the user's transaction tells the network to reject it in any context other than the specific bundle it was prepared for.
 
@@ -193,7 +193,7 @@ The web service can fail to submit the bundle, or submit it and have it expire w
 
 ---
 
-## Beyond NFTs: Where This Pattern Applies
+## Beyond Cards: Where This Pattern Applies
 
 The temporary account pattern is general. Anywhere a workflow requires:
 - **Actions on behalf of the user** -- buying, swapping, bridging, staking


### PR DESCRIPTION
## Summary

This is a framing swap, not a rewrite. It replaces the NFT-collecting example with an onchain trading-card (TCG) example across the four bundle articles, so the content reads current to the 2026 trading-card market. The underlying teaching is unchanged: you buy a complete set, it is all-or-nothing, and any item can sell out or reprice between steps.

Scoped to `docs/bundles/` only:
- `01-what-are-bundles.md`
- `02-builders-guide.md`
- `03-bundles-in-action.md`
- `04-one-signature.md`

### What changed
- NFT references reframed as a complete card set (e.g. "a matched set of five NFTs" becomes "a complete five-card set"), with a short clarifier on first mention so readers picture digital, onchain cards rather than physical ones.
- Example identifiers renamed consistently: `buy_nft_*` to `buy_card_*`, `0xNFTMarket` to `0xCardMarket`, `buyNFT(...)` to `buyCard(...)`, `transferNFT(...)` to `transferCard(...)`. Nonces, addresses, structure, and all other values are identical.
- The "Perfect Set Acquisition" use case (03) and the set-purchase walkthrough (04) are kept consistent with the example in 01 so the through-line holds.
- One small economic clarification added to reinforce the existing all-or-nothing lesson: an incomplete set is worth far less than the cards in it cost.
- No em dashes introduced; existing em dashes on edited lines were converted to commas/periods/parentheses.

### What did NOT change
Bundle mechanics, API descriptions, flags, limits, the refinancing example (Use Case 2), and the fallback-trading example (Use Case 3) are all untouched.

## Test plan
- [ ] Original author review of the four `docs/bundles/` articles for tone and accuracy of the TCG framing
- [ ] Confirm the through-line is consistent across articles 01, 03, and 04

Made with [Cursor](https://cursor.com)