### PR TITLE
Make rule usage consistent throughout a block

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -189,9 +189,12 @@ func consensusCallbackBeginBlockFn(
 			},
 			EndBlock: func() (newValidators *pos.Validators) {
 
+				// Fix the rules to be used by this block.
+				thisBlocksRules := es.Rules.Copy()
+
 				// sort events by Lamport time
 				sort.Sort(confirmedEvents)
-				maxBlockGas := es.Rules.Blocks.MaxBlockGas
+				maxBlockGas := thisBlocksRules.Blocks.MaxBlockGas
 				blockEvents := spillBlockEvents(confirmedEvents, maxBlockGas,
 					func(id hash.Event) inter.EventPayloadI {
 						// Note: currently, GetEventPayload returns a pointer to struct,
@@ -212,7 +215,7 @@ func consensusCallbackBeginBlockFn(
 
 				randao := computePrevRandao(confirmedEvents)
 				chainCfg := opera.CreateTransientEvmChainConfig(
-					es.Rules.NetworkID,
+					thisBlocksRules.NetworkID,
 					store.GetUpgradeHeights(),
 					idx.Block(number),
 				)
@@ -238,7 +241,7 @@ func consensusCallbackBeginBlockFn(
 					ParentHash: lastBlockHeader.Hash,
 				}
 				blockTime := atroposTime
-				if es.Rules.Upgrades.SingleProposerBlockFormation {
+				if thisBlocksRules.Upgrades.SingleProposerBlockFormation {
 					if proposed, proposer, time := extractProposalForNextBlock(lastBlockHeader, blockEvents, log.Root()); proposed != nil {
 						proposal = *proposed
 						blockTime = time
@@ -252,7 +255,7 @@ func consensusCallbackBeginBlockFn(
 
 						userTransactionGasLimit = inter.GetEffectiveGasLimit(
 							blockTime.Time().Sub(lastBlockHeader.Time.Time()),
-							es.Rules.Economy.ShortGasPower.AllocPerSec,
+							thisBlocksRules.Economy.ShortGasPower.AllocPerSec,
 							maxBlockGas,
 						)
 					}
@@ -267,12 +270,12 @@ func consensusCallbackBeginBlockFn(
 						unorderedTxs = append(unorderedTxs, e.Transactions()...)
 					}
 
-					proposal.Transactions = scrambler.GetExecutionOrder(unorderedTxs, signer, es.Rules.Upgrades.Sonic)
+					proposal.Transactions = scrambler.GetExecutionOrder(unorderedTxs, signer, thisBlocksRules.Upgrades.Sonic)
 				}
 
 				// Filter invalid transactions from the proposal.
 				proposal.Transactions = filterNonPermissibleTransactions(
-					proposal.Transactions, &es.Rules, signer, log.Root(), invalidTxsMeter,
+					proposal.Transactions, &thisBlocksRules, signer, log.Root(), invalidTxsMeter,
 				)
 
 				// Make sure the new block time is after the last block time.
@@ -297,7 +300,7 @@ func consensusCallbackBeginBlockFn(
 				skipBlock := atroposDegenerate
 				// Check if empty block should be pruned
 				emptyBlock := confirmedEvents.Len() == 0 && cBlock.Cheaters.Len() == 0
-				if es.Rules.Upgrades.SingleProposerBlockFormation {
+				if thisBlocksRules.Upgrades.SingleProposerBlockFormation {
 					// Just checking for the number of confirmed events is not
 					// enough in the SingleProposer mode, because proposals may
 					// be empty or may have been found invalid (wrong block
@@ -310,7 +313,7 @@ func consensusCallbackBeginBlockFn(
 					// in general be skipped.
 					emptyBlock = cBlock.Cheaters.Len() == 0 && len(proposal.Transactions) == 0
 				}
-				skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+es.Rules.Blocks.MaxEmptyBlockSkipPeriod)
+				skipBlock = skipBlock || (emptyBlock && blockCtx.Time < bs.LastBlock.Time+thisBlocksRules.Blocks.MaxEmptyBlockSkipPeriod)
 				// Finalize the progress of eventProcessor
 				bs = eventProcessor.Finalize(blockCtx, skipBlock) // TODO: refactor to not mutate the bs, it is unclear
 				if skipBlock {
@@ -344,7 +347,7 @@ func consensusCallbackBeginBlockFn(
 					statedb,
 					evmStateReader,
 					onNewLogAll,
-					es.Rules,
+					thisBlocksRules,
 					chainCfg,
 					randao,
 					sonicFeaturesMetrics,
@@ -412,7 +415,7 @@ func consensusCallbackBeginBlockFn(
 					// (8054923) in which the gas limit was adapted. To support
 					// this one-time exception, we add a special case for
 					// this block here to ensure backward compatibility.
-					if es.Rules.NetworkID == 146 && number == 8054923 {
+					if thisBlocksRules.NetworkID == 146 && number == 8054923 {
 						blockBuilder.WithGasLimit(es.Rules.Blocks.MaxBlockGas)
 					}
 
@@ -448,7 +451,7 @@ func consensusCallbackBeginBlockFn(
 						blockBuilder,
 						proposal.Transactions,
 						userTransactionGasLimit,
-						es.Rules.Upgrades,
+						thisBlocksRules.Upgrades,
 					)
 
 					evmBlock, numSkippedTxs, allReceipts := evmProcessor.Finalize()
@@ -502,7 +505,7 @@ func consensusCallbackBeginBlockFn(
 					// call OnNewReceipt
 					for i, r := range allReceipts {
 						originTx := r.TxHash
-						if es.Rules.Upgrades.Brio {
+						if thisBlocksRules.Upgrades.Brio {
 							if origin, found := txCausedBy[r.TxHash]; found {
 								originTx = origin
 							}

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -337,6 +337,342 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 	}
 }
 
+// TestConsensusCallback_UsesBlockStartRulesAcrossEpochSealing verifies that a
+// block which seals an epoch is processed using the network rules that were in
+// effect at the start of the block, even though sealing the epoch installs a
+// different set of rules into the epoch state.
+//
+// This is a regression test for the fix that captures a copy of the rules at
+// the beginning of EndBlock (thisBlocksRules) instead of reading es.Rules
+// directly: after SealEpoch reassigns es, the body of the block (the blockFn
+// closure) must still observe the block's original rules.
+//
+// The observable signal is the size limit passed to EVMProcessor.Execute for
+// the user transactions: with the Brio upgrade enabled the limit is the finite
+// block-size budget, while without Brio it is math.MaxUint64. The block starts
+// with Brio enabled and the sealed epoch disables it; therefore observing the
+// finite, Brio-derived limit proves the start rules were used.
+func TestConsensusCallback_UsesBlockStartRulesAcrossEpochSealing(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	const maxEmptyBlockSkipPeriod = inter.Timestamp(10_000)
+	const lastBlockTime = inter.Timestamp(1000)
+	// Beyond the skip period so the block is produced rather than skipped.
+	const blockTime = lastBlockTime + maxEmptyBlockSkipPeriod + 1
+
+	// Start the block with the Brio rules enabled, using single-proposer mode.
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.SingleProposerBlockFormation = true
+	store := newInMemoryStoreWithGenesisData(t, upgrades, 1, 2)
+
+	// Create an event carrying a (valid, empty) proposal for the next block,
+	// plus the atropos event of the block.
+	proposalBuilder := inter.MutableEventPayload{}
+	proposalBuilder.SetVersion(3)
+	proposalBuilder.SetEpoch(2)
+	proposalBuilder.SetMedianTime(blockTime)
+	proposalBuilder.SetPayload(inter.Payload{
+		Proposal: &inter.Proposal{
+			Number:     1,
+			ParentHash: store.GetBlock(0).Hash(),
+		},
+	})
+	proposalEvent := proposalBuilder.Build()
+
+	atroposBuilder := inter.MutableEventPayload{}
+	atroposBuilder.SetVersion(3)
+	atroposBuilder.SetEpoch(2)
+	atroposBuilder.SetMedianTime(blockTime)
+	atropos := atroposBuilder.Build()
+
+	events := []*inter.EventPayload{proposalEvent, atropos}
+	for _, event := range events {
+		store.SetEvent(event)
+	}
+
+	// Update block and epoch state to match the test conditions.
+	bs := store.GetBlockState()
+	bs.LastBlock = iblockproc.BlockCtx{Time: lastBlockTime}
+	es := store.GetEpochState()
+	es.Rules.Blocks.MaxEmptyBlockSkipPeriod = maxEmptyBlockSkipPeriod
+	store.SetBlockEpochState(bs, es)
+
+	// The epoch state installed by sealing the epoch deliberately uses a
+	// different set of rules than the block started with: Brio is disabled.
+	sealedEpochState := store.GetEpochState().Copy()
+	sealedEpochState.Rules.Upgrades.Brio = false
+
+	ctrl := gomock.NewController(t)
+	_any := gomock.Any()
+
+	confirmedEventProcessor := blockproc.NewMockConfirmedEventsProcessor(ctrl)
+	confirmedEventProcessor.EXPECT().Finalize(_any, _any).Return(iblockproc.BlockState{})
+	confirmedEventProcessor.EXPECT().ProcessConfirmedEvent(_any).AnyTimes()
+	eventsModule := blockproc.NewMockConfirmedEventsModule(ctrl)
+	eventsModule.EXPECT().Start(_any, _any).Return(confirmedEventProcessor)
+
+	// Record the size limit of every EVMProcessor.Execute call.
+	var mu sync.Mutex
+	var executeSizeLimits []uint64
+	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+	evmProcessor.EXPECT().Execute(_any, _any, _any).
+		DoAndReturn(func(_ types.Transactions, _ uint64, sizeLimit uint64) evmcore.ProcessSummary {
+			mu.Lock()
+			defer mu.Unlock()
+			executeSizeLimits = append(executeSizeLimits, sizeLimit)
+			return evmcore.ProcessSummary{}
+		}).MinTimes(1)
+	evmProcessor.EXPECT().Finalize().Return(&evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{
+			BaseFee: big.NewInt(0),
+			TxHash:  common.Hash{1, 2, 3},
+		},
+	}, 0, nil)
+	evmModule := blockproc.NewMockEVM(ctrl)
+	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
+
+	// Sealer reports that this block seals the epoch and returns the sealed
+	// epoch state carrying the changed rules.
+	sealer := blockproc.NewMockSealerProcessor(ctrl)
+	sealer.EXPECT().EpochSealing().Return(true)
+	sealer.EXPECT().Update(_any, _any)
+	sealer.EXPECT().SealEpoch(_any, _any, _any).
+		Return(iblockproc.BlockState{}, sealedEpochState)
+	sealerModule := blockproc.NewMockSealerModule(ctrl)
+	sealerModule.EXPECT().Start(_any, _any, _any).Return(sealer)
+
+	txListener := blockproc.NewMockTxListener(ctrl)
+	txListener.EXPECT().Finalize().Return(iblockproc.BlockState{}).AnyTimes()
+	txListener.EXPECT().Update(_any, _any).AnyTimes()
+	txListener.EXPECT().OnNewReceipt(_any, _any, _any, _any, _any).AnyTimes()
+	txListenerModule := blockproc.NewMockTxListenerModule(ctrl)
+	txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
+
+	txTransactor := blockproc.NewMockTxTransactor(ctrl)
+	txTransactor.EXPECT().PopInternalTxs(_any, _any, _any, _any, _any).
+		Return(types.Transactions{}).AnyTimes()
+
+	proc := BlockProc{
+		EventsModule:     eventsModule,
+		SealerModule:     sealerModule,
+		TxListenerModule: txListenerModule,
+		EVMModule:        evmModule,
+		PreTxTransactor:  txTransactor,
+		PostTxTransactor: txTransactor,
+	}
+
+	// Worker group running the (possibly asynchronous) block processing.
+	stop := make(chan struct{})
+	var workerWaitGroup sync.WaitGroup
+	workers := workers.New(&workerWaitGroup, stop, 1)
+	workers.Start(1)
+	defer func() {
+		close(stop)
+		workerWaitGroup.Wait()
+	}()
+
+	var callbackWaitGroup sync.WaitGroup
+	bootstrapping := false
+	blockBusyFlag := uint32(0)
+	emitters := []*emitter.Emitter{}
+	beginBlock := consensusCallbackBeginBlockFn(
+		workers, &callbackWaitGroup, &blockBusyFlag, store, proc, false, nil, &emitters, nil, &bootstrapping, nil,
+	)
+
+	callbacks := beginBlock(&lachesis.Block{Atropos: atropos.ID()})
+	for _, event := range events {
+		callbacks.ApplyEvent(event)
+	}
+	callbacks.EndBlock()
+	callbackWaitGroup.Wait()
+
+	// The user-transaction execution must use the Brio block-size limit derived
+	// from the block's start rules. With the buggy (post-seal) rules Brio would
+	// be disabled and every Execute call would use math.MaxUint64 instead.
+	mu.Lock()
+	defer mu.Unlock()
+	wantBrioSizeLimit := uint64(params.MaxBlockSize - rlpEncodedMaxHeaderSizeInBytes)
+	require.Contains(executeSizeLimits, wantBrioSizeLimit,
+		"user transactions must be executed with the block's start rules (Brio enabled), got size limits %v", executeSizeLimits)
+}
+
+// TestConsensusCallback_UsesBlockStartRulesForReceiptOriginTracking verifies
+// that the receipt origin tracking performed at the end of block processing
+// uses the network rules in effect at the start of the block, even though
+// sealing the epoch installs a different set of rules.
+//
+// This is a regression test for the same fix as
+// TestConsensusCallback_UsesBlockStartRulesAcrossEpochSealing, targeting the
+// other rule-dependent site inside the blockFn closure: origin tracking is only
+// performed when the Brio upgrade is enabled. With Brio, a receipt's transaction
+// is resolved to the transaction that caused it (via the CausedBy map), and the
+// originator reported to the TxListener is the creator of the event containing
+// that origin transaction. Without Brio, the receipt's own transaction is used.
+//
+// The block starts with Brio enabled and the sealed epoch disables it. The
+// origin transaction is carried by an event created by validator 1, while the
+// receipt's own transaction is not part of any event. Therefore observing
+// validator 1 as the reported originator proves the start rules were used; the
+// buggy (post-seal) behavior would report validator 0.
+func TestConsensusCallback_UsesBlockStartRulesForReceiptOriginTracking(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	const maxEmptyBlockSkipPeriod = inter.Timestamp(10_000)
+	const lastBlockTime = inter.Timestamp(1000)
+	const blockTime = lastBlockTime + maxEmptyBlockSkipPeriod + 1
+
+	const originCreator = idx.ValidatorID(1)
+
+	// Start the block with the Brio rules enabled, using single-proposer mode.
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.SingleProposerBlockFormation = true
+	store := newInMemoryStoreWithGenesisData(t, upgrades, 1, 2)
+
+	// The origin transaction is carried (via the block proposal) by a confirmed
+	// event created by validator 1; the receipt's own transaction is not part of
+	// any event.
+	originTx := types.NewTx(&types.LegacyTx{Nonce: 1})
+	receiptTx := types.NewTx(&types.LegacyTx{Nonce: 2})
+
+	// An event carrying a proposal with the origin transaction, created by
+	// validator 1.
+	originBuilder := inter.MutableEventPayload{}
+	originBuilder.SetVersion(3)
+	originBuilder.SetEpoch(2)
+	originBuilder.SetMedianTime(blockTime)
+	originBuilder.SetCreator(originCreator)
+	originBuilder.SetPayload(inter.Payload{
+		Proposal: &inter.Proposal{
+			Number:       1,
+			ParentHash:   store.GetBlock(0).Hash(),
+			Transactions: types.Transactions{originTx},
+		},
+	})
+	originEvent := originBuilder.Build()
+
+	// The atropos event of the block.
+	atroposBuilder := inter.MutableEventPayload{}
+	atroposBuilder.SetVersion(3)
+	atroposBuilder.SetEpoch(2)
+	atroposBuilder.SetMedianTime(blockTime)
+	atropos := atroposBuilder.Build()
+
+	events := []*inter.EventPayload{originEvent, atropos}
+	for _, event := range events {
+		store.SetEvent(event)
+	}
+
+	bs := store.GetBlockState()
+	bs.LastBlock = iblockproc.BlockCtx{Time: lastBlockTime}
+	es := store.GetEpochState()
+	es.Rules.Blocks.MaxEmptyBlockSkipPeriod = maxEmptyBlockSkipPeriod
+	store.SetBlockEpochState(bs, es)
+
+	// Sealing the epoch installs rules with Brio disabled.
+	sealedEpochState := store.GetEpochState().Copy()
+	sealedEpochState.Rules.Upgrades.Brio = false
+
+	ctrl := gomock.NewController(t)
+	_any := gomock.Any()
+
+	confirmedEventProcessor := blockproc.NewMockConfirmedEventsProcessor(ctrl)
+	confirmedEventProcessor.EXPECT().Finalize(_any, _any).Return(iblockproc.BlockState{})
+	confirmedEventProcessor.EXPECT().ProcessConfirmedEvent(_any).AnyTimes()
+	eventsModule := blockproc.NewMockConfirmedEventsModule(ctrl)
+	eventsModule.EXPECT().Start(_any, _any).Return(confirmedEventProcessor)
+
+	// The user-transaction execution reports that receiptTx was caused by
+	// originTx. This mapping is only consulted when Brio is enabled.
+	evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
+	evmProcessor.EXPECT().Execute(_any, _any, _any).
+		Return(evmcore.ProcessSummary{
+			CausedBy: map[common.Hash]common.Hash{
+				receiptTx.Hash(): originTx.Hash(),
+			},
+		}).AnyTimes()
+	evmProcessor.EXPECT().Finalize().Return(&evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{
+			BaseFee: big.NewInt(0),
+			TxHash:  common.Hash{1, 2, 3},
+		},
+		Transactions: types.Transactions{receiptTx},
+	}, 0, types.Receipts{
+		&types.Receipt{TxHash: receiptTx.Hash(), Status: 1},
+	})
+	evmModule := blockproc.NewMockEVM(ctrl)
+	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
+
+	sealer := blockproc.NewMockSealerProcessor(ctrl)
+	sealer.EXPECT().EpochSealing().Return(true)
+	sealer.EXPECT().Update(_any, _any)
+	sealer.EXPECT().SealEpoch(_any, _any, _any).
+		Return(iblockproc.BlockState{}, sealedEpochState)
+	sealerModule := blockproc.NewMockSealerModule(ctrl)
+	sealerModule.EXPECT().Start(_any, _any, _any).Return(sealer)
+
+	// Capture the originator reported to the TxListener for the single receipt.
+	var mu sync.Mutex
+	var reportedOriginators []idx.ValidatorID
+	txListener := blockproc.NewMockTxListener(ctrl)
+	txListener.EXPECT().Finalize().Return(iblockproc.BlockState{}).AnyTimes()
+	txListener.EXPECT().Update(_any, _any).AnyTimes()
+	txListener.EXPECT().OnNewReceipt(_any, _any, _any, _any, _any).
+		Do(func(_ *types.Transaction, _ *types.Receipt, originator idx.ValidatorID, _, _ *big.Int) {
+			mu.Lock()
+			defer mu.Unlock()
+			reportedOriginators = append(reportedOriginators, originator)
+		}).AnyTimes()
+	txListenerModule := blockproc.NewMockTxListenerModule(ctrl)
+	txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
+
+	txTransactor := blockproc.NewMockTxTransactor(ctrl)
+	txTransactor.EXPECT().PopInternalTxs(_any, _any, _any, _any, _any).
+		Return(types.Transactions{}).AnyTimes()
+
+	proc := BlockProc{
+		EventsModule:     eventsModule,
+		SealerModule:     sealerModule,
+		TxListenerModule: txListenerModule,
+		EVMModule:        evmModule,
+		PreTxTransactor:  txTransactor,
+		PostTxTransactor: txTransactor,
+	}
+
+	stop := make(chan struct{})
+	var workerWaitGroup sync.WaitGroup
+	workers := workers.New(&workerWaitGroup, stop, 1)
+	workers.Start(1)
+	defer func() {
+		close(stop)
+		workerWaitGroup.Wait()
+	}()
+
+	var callbackWaitGroup sync.WaitGroup
+	bootstrapping := false
+	blockBusyFlag := uint32(0)
+	emitters := []*emitter.Emitter{}
+	beginBlock := consensusCallbackBeginBlockFn(
+		workers, &callbackWaitGroup, &blockBusyFlag, store, proc, false, nil, &emitters, nil, &bootstrapping, nil,
+	)
+
+	callbacks := beginBlock(&lachesis.Block{Atropos: atropos.ID()})
+	for _, event := range events {
+		callbacks.ApplyEvent(event)
+	}
+	callbacks.EndBlock()
+	callbackWaitGroup.Wait()
+
+	// With the block's start rules (Brio enabled), the receipt is attributed to
+	// the origin transaction's event creator. With the buggy (post-seal) rules,
+	// Brio would be disabled, origin tracking skipped, and validator 0 reported.
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal([]idx.ValidatorID{originCreator}, reportedOriginators,
+		"receipt origin must be tracked using the block's start rules (Brio enabled)")
+}
+
 func TestExtractProposalForNextBlock_NoEvents_ReturnsNoProposal(t *testing.T) {
 	last := &evmcore.EvmHeader{
 		Number: big.NewInt(100),


### PR DESCRIPTION
This PR fixes an inconsistency in rule usage throughout a sealing block. Before this PR, most parts use the rules of the previous epoch, while some parts of the block processing use the rules of the new epoch. In particular:

Old rule usage:
 - determining the block's gas limit [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L194)
 - determining the block formation protocol [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L241)
 - determining the block's effective gas limit [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L255)
 - enabling transaction scrambling [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L270)
- filtering non-permissible transactions [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L275)
- determining the maximum skipped block duration [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L313)
- initializing the EVM processor [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L347)

New rule usage:
- for determining the MaxBlockGas for a legacy bug [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L416)
- enabling the restriction of the max block size in Brio [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L451)
- enabling the indirect tracking of transaction origins [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L505)

This PR aligns the rule usage such that the entire block makes its decision based on the old epoch -- except for the legacy bug [here](https://github.com/0xsoniclabs/sonic/blob/d0e00fafb44965a26443deff1ae983d68230a4d5/gossip/c_block_callbacks.go#L416) -- which is the epoch considered by the validators while preparing the block.