### PR TITLE
Make rule-copy operation nil-safe

### DIFF
--- a/opera/rules.go
+++ b/opera/rules.go
@@ -484,12 +484,14 @@ func DefaultGasPowerRules() GasPowerRules {
 
 func (r Rules) Copy() Rules {
 	cp := r
-	cp.Economy.MinGasPrice = new(big.Int).Set(r.Economy.MinGasPrice)
+	if r.Economy.MinGasPrice != nil {
+		cp.Economy.MinGasPrice = new(big.Int).Set(r.Economy.MinGasPrice)
+	}
 
 	// there is a bug in pre-Allegro versions that MinBaseFee is not deep copied.
 	// Since switching to deep-copy is not possible in a network running combination
 	// of Allegro and pre-Allegro versions, we need to enable this fix only when Allegro is applied.
-	if cp.Upgrades.Allegro {
+	if cp.Upgrades.Allegro && r.Economy.MinBaseFee != nil {
 		cp.Economy.MinBaseFee = new(big.Int).Set(r.Economy.MinBaseFee)
 	}
 

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -235,6 +235,43 @@ func TestRules_MinBaseFee_NoCopy_PreAllegro(t *testing.T) {
 	}
 }
 
+func TestRules_Copy_WorksForNilEntries(t *testing.T) {
+	tests := map[string]func(*Rules){
+		"MinGasPrice is nil": func(rules *Rules) {
+			rules.Economy.MinGasPrice = nil
+		},
+		"MinBaseFee is nil": func(rules *Rules) {
+			rules.Economy.MinBaseFee = nil
+		},
+		"MinGasPrice and MinBaseFee are nil": func(rules *Rules) {
+			rules.Economy.MinGasPrice = nil
+			rules.Economy.MinBaseFee = nil
+		},
+	}
+
+	for name, update := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			defaultRules := FakeNetRules(GetAllegroUpgrades())
+			require.NotNil(defaultRules.Economy.MinGasPrice)
+			require.NotNil(defaultRules.Economy.MinBaseFee)
+
+			original := defaultRules.Copy()
+			update(&original)
+			require.True(
+				original.Economy.MinGasPrice == nil ||
+					original.Economy.MinBaseFee == nil,
+			)
+
+			copy := original.Copy()
+			require.Equal(original, copy)
+
+			require.Equal(original.Economy.MinGasPrice, copy.Economy.MinGasPrice)
+			require.Equal(original.Economy.MinBaseFee, copy.Economy.MinBaseFee)
+		})
+	}
+}
+
 func TestCreateTransientEvmChainConfig_ContainsUpgradesBasedOnConstructionTimeBlockHeigh(t *testing.T) {
 
 	chainID := uint64(12345)


### PR DESCRIPTION
This change avoids a panic when cloning rules with nil-values in it.