### PR TITLE
Bound execution-plan JSON nesting depth

### DIFF
--- a/api/sonicapi/execution_plan.go
+++ b/api/sonicapi/execution_plan.go
@@ -178,7 +178,7 @@ func (t *RPCExecutionPlanComposable) UnmarshalJSON(data []byte) error {
 	t.TolerateFailures = raw.TolerateFailures
 	t.Steps = make([]any, len(raw.Steps))
 	for i, rawStep := range raw.Steps {
-		step, empty, err := unmarshalBundleGroup[RPCExecutionStepComposable](rawStep)
+		step, empty, err := unmarshalBundleGroup[RPCExecutionStepComposable](rawStep, 0)
 		if err != nil {
 			return err
 		}

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -440,7 +440,13 @@ func toTransactionForBundles(step ethapi.TransactionArgs) (*types.Transaction, e
 func transform(
 	proposal RPCExecutionProposal,
 	fn func(step RPCExecutionStepProposal) (RPCExecutionStepProposal, error),
+	depth int,
 ) (RPCExecutionProposal, error) {
+	if depth > bundle.MaxGroupNestingDepth {
+		return proposal, fmt.Errorf(
+			"execution plan exceeds maximum nesting depth of %d", bundle.MaxGroupNestingDepth)
+	}
+
 	if proposal.Steps == nil {
 		return proposal, nil
 	}
@@ -459,9 +465,9 @@ func transform(
 			result, err := transform(RPCExecutionProposal{
 				BlockRange:            proposal.BlockRange,
 				RPCExecutionPlanGroup: step,
-			}, fn)
+			}, fn, depth+1)
 			if err != nil {
-				return result, err
+				return RPCExecutionProposal{}, err
 			}
 			resultSteps = append(resultSteps, result.RPCExecutionPlanGroup)
 

--- a/api/sonicapi/execution_proposal.go
+++ b/api/sonicapi/execution_proposal.go
@@ -104,7 +104,7 @@ func (p *RPCExecutionProposal) UnmarshalJSON(data []byte) error {
 	p.TolerateFailures = raw.TolerateFailures
 	p.Steps = make([]any, len(raw.Steps))
 	for i, rawStep := range raw.Steps {
-		step, empty, err := unmarshalBundleGroup[RPCExecutionStepProposal](rawStep)
+		step, empty, err := unmarshalBundleGroup[RPCExecutionStepProposal](rawStep, 0)
 		if err != nil {
 			return err
 		}
@@ -136,8 +136,24 @@ func (s *RPCExecutionStepProposal) UnmarshalJSON(data []byte) error {
 // no "steps" key) and a group (RPCExecutionPlanGroup, has "steps" key).
 // This function returns the unmarshaled element, a boolean indicating whenever the
 // element can be optimized away and an error if the JSON is invalid. The optimization
-// boolean is used to indicate to the caller that the resulting group is empty
-func unmarshalBundleGroup[LeafType any](data []byte) (any, bool, error) {
+// boolean is used to indicate to the caller that the resulting group is empty.
+//
+// depth is the "steps" nesting depth of data, with 0 for the root proposal's
+// direct children (matching the root-is-depth-0 convention of validateStep,
+// gossip/blockproc/bundle/validate.go). It is checked against
+// bundle.MaxGroupNestingDepth before any parsing of data is attempted, so
+// maliciously deep input is rejected cheaply instead of costing quadratic
+// decode time (every recursion level re-parses the still fully nested
+// remainder of the input). Reusing MaxGroupNestingDepth directly, rather than
+// a separate decode-time constant, still leaves one level of slack versus the
+// precise rule validateStep enforces later: a transparent single-child
+// wrapper group collapses away in convertProposalToPlanInternal and so does
+// not count against MaxGroupNestingDepth in the final validated plan.
+func unmarshalBundleGroup[LeafType any](data []byte, depth int) (any, bool, error) {
+	if depth > bundle.MaxGroupNestingDepth {
+		return nil, false, fmt.Errorf(
+			"execution plan exceeds maximum nesting depth of %d", bundle.MaxGroupNestingDepth)
+	}
 	var probe struct {
 		Steps *json.RawMessage `json:"steps"`
 	}
@@ -155,7 +171,7 @@ func unmarshalBundleGroup[LeafType any](data []byte) (any, bool, error) {
 		}
 		children := make([]any, len(rawGroup.Steps))
 		for i, raw := range rawGroup.Steps {
-			child, empty, err := unmarshalBundleGroup[LeafType](raw)
+			child, empty, err := unmarshalBundleGroup[LeafType](raw, depth+1)
 			if err != nil {
 				return nil, false, err
 			}

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -1531,39 +1531,37 @@ func Test_RPCExecutionProposal_UnmarshalJSON_FailsOnInvalidFirstLevelStep(t *tes
 	}
 }
 
-// Test_RPCExecutionProposal_UnmarshalJSON_RejectsExcessivelyDeepNesting ensures
-// that a maliciously deep proposal is rejected by the depth guard in
-// unmarshalBundleGroup instead of being decoded at a cost quadratic in its
-// nesting depth (see unmarshalBundleGroup's depth parameter). Depth 4999 is
-// roughly the deepest input encoding/json's own 10000-token nesting limit lets
-// through. nestedStepsProposalJSON(D) puts its leaf at recursion depth D-1,
-// so D = bundle.MaxGroupNestingDepth+2 is the smallest rejected depth.
 func Test_RPCExecutionProposal_UnmarshalJSON_RejectsExcessivelyDeepNesting(t *testing.T) {
-	for _, depth := range []int{bundle.MaxGroupNestingDepth + 2, 1000, 4999} {
-		var proposal RPCExecutionProposal
-		err := json.Unmarshal(nestedStepsProposalJSON(depth), &proposal)
-		require.ErrorContains(t, err, "nesting depth")
+	for _, depth := range []int{
+		bundle.MaxGroupNestingDepth + 1,
+		bundle.MaxGroupNestingDepth + 2,
+		1000,
+		4998, // maximum depth that encoding/json will accept
+	} {
+		t.Run(fmt.Sprintf("depth=%d", depth), func(t *testing.T) {
+			var proposal RPCExecutionProposal
+			rawJSON := nestedStepsProposalJSON(depth)
+			err := json.Unmarshal(rawJSON, &proposal)
+			require.ErrorContains(t, err, "nesting depth")
+		})
 	}
 }
 
-// Test_RPCExecutionProposal_UnmarshalJSON_AcceptsNestingAtLimit ensures the
-// decode-time depth guard does not reject a proposal nested exactly to the
-// permitted limit (D = bundle.MaxGroupNestingDepth+1, see
-// Test_RPCExecutionProposal_UnmarshalJSON_RejectsExcessivelyDeepNesting).
 func Test_RPCExecutionProposal_UnmarshalJSON_AcceptsNestingAtLimit(t *testing.T) {
 	var proposal RPCExecutionProposal
-	require.NoError(t, json.Unmarshal(nestedStepsProposalJSON(bundle.MaxGroupNestingDepth+1), &proposal))
+	require.NoError(t, json.Unmarshal(nestedStepsProposalJSON(bundle.MaxGroupNestingDepth), &proposal))
 }
 
 // nestedStepsProposalJSON builds a JSON execution-proposal document with
 // `depth` levels of nested "steps" groups wrapping a single leaf transaction step.
 func nestedStepsProposalJSON(depth int) []byte {
+	// depth +1 levels are created because the empty proposal is already a group.
 	var b strings.Builder
-	for range depth {
+	for range depth + 1 {
 		b.WriteString(`{"steps":[`)
 	}
 	b.WriteString(`{"from":"0x0000000000000000000000000000000000000001"}`)
-	for range depth {
+	for range depth + 1 {
 		b.WriteString(`]}`)
 	}
 	return []byte(b.String())

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -914,7 +914,7 @@ func Test_transform_AppliesFunctionToAllLeaves(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			result, err := transform(tt.proposal, markTolerateFailed)
+			result, err := transform(tt.proposal, markTolerateFailed, 0)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, result)
 		})
@@ -986,7 +986,7 @@ func Test_transform_ReturnsErrors(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := transform(tt.proposal, alwaysFails)
+			_, err := transform(tt.proposal, alwaysFails, 0)
 			require.Error(t, err)
 		})
 	}

--- a/api/sonicapi/execution_proposal_test.go
+++ b/api/sonicapi/execution_proposal_test.go
@@ -1531,6 +1531,44 @@ func Test_RPCExecutionProposal_UnmarshalJSON_FailsOnInvalidFirstLevelStep(t *tes
 	}
 }
 
+// Test_RPCExecutionProposal_UnmarshalJSON_RejectsExcessivelyDeepNesting ensures
+// that a maliciously deep proposal is rejected by the depth guard in
+// unmarshalBundleGroup instead of being decoded at a cost quadratic in its
+// nesting depth (see unmarshalBundleGroup's depth parameter). Depth 4999 is
+// roughly the deepest input encoding/json's own 10000-token nesting limit lets
+// through. nestedStepsProposalJSON(D) puts its leaf at recursion depth D-1,
+// so D = bundle.MaxGroupNestingDepth+2 is the smallest rejected depth.
+func Test_RPCExecutionProposal_UnmarshalJSON_RejectsExcessivelyDeepNesting(t *testing.T) {
+	for _, depth := range []int{bundle.MaxGroupNestingDepth + 2, 1000, 4999} {
+		var proposal RPCExecutionProposal
+		err := json.Unmarshal(nestedStepsProposalJSON(depth), &proposal)
+		require.ErrorContains(t, err, "nesting depth")
+	}
+}
+
+// Test_RPCExecutionProposal_UnmarshalJSON_AcceptsNestingAtLimit ensures the
+// decode-time depth guard does not reject a proposal nested exactly to the
+// permitted limit (D = bundle.MaxGroupNestingDepth+1, see
+// Test_RPCExecutionProposal_UnmarshalJSON_RejectsExcessivelyDeepNesting).
+func Test_RPCExecutionProposal_UnmarshalJSON_AcceptsNestingAtLimit(t *testing.T) {
+	var proposal RPCExecutionProposal
+	require.NoError(t, json.Unmarshal(nestedStepsProposalJSON(bundle.MaxGroupNestingDepth+1), &proposal))
+}
+
+// nestedStepsProposalJSON builds a JSON execution-proposal document with
+// `depth` levels of nested "steps" groups wrapping a single leaf transaction step.
+func nestedStepsProposalJSON(depth int) []byte {
+	var b strings.Builder
+	for range depth {
+		b.WriteString(`{"steps":[`)
+	}
+	b.WriteString(`{"from":"0x0000000000000000000000000000000000000001"}`)
+	for range depth {
+		b.WriteString(`]}`)
+	}
+	return []byte(b.String())
+}
+
 func Test_RPCExecutionProposal_UnmarshalJSON_FailsOnInvalidNestedLevelStep(t *testing.T) {
 	tests := map[string]string{
 		"nested group contains non-object element": `{

--- a/api/sonicapi/prepare_bundle.go
+++ b/api/sonicapi/prepare_bundle.go
@@ -110,6 +110,7 @@ func (a *PublicBundleAPI) PrepareBundle(
 				TransactionArgs: step.TransactionArgs,
 			}, nil
 		},
+		0,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set proposed transactions defaults: %w", err)
@@ -166,6 +167,7 @@ func flattenTransactions(args RPCExecutionProposal) ([]ethapi.TransactionArgs, m
 			}
 			return tx, nil
 		},
+		0,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to flatten transactions: %w", err)

--- a/api/sonicapi/prepare_bundle_test.go
+++ b/api/sonicapi/prepare_bundle_test.go
@@ -17,8 +17,10 @@
 package sonicapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/api/ethapi"
@@ -1200,5 +1202,66 @@ func Test_PrepareBundle_GasEstimationCompatibility(t *testing.T) {
 				require.NotNil(t, result)
 			}
 		})
+	}
+}
+
+func TestPrepareBundle_ReturnsError_WhenProposalDepthExceedsMaximum(t *testing.T) {
+	for _, depth := range []int{
+		1,
+		2,
+		bundle.MaxGroupNestingDepth - 1,
+		bundle.MaxGroupNestingDepth,
+		bundle.MaxGroupNestingDepth + 1,
+		1024,
+		4998, // maximum json encodable nesting, with 10k nested json groups
+	} {
+		t.Run(fmt.Sprintf("depth=%d", depth), func(t *testing.T) {
+
+			addr1 := common.Address{1}
+			addr2 := common.Address{2}
+			gas := hexutil.Uint64(21000)
+
+			be := rpctest.NewBackendBuilder(t).
+				WithAccount(addr1, rpctest.AccountState{Balance: big.NewInt(1e18)}).
+				Build()
+			api := NewPublicBundleAPI(be)
+
+			proposal := makeNestedBundleProposal(
+				depth,
+				ethapi.TransactionArgs{
+					From:  &addr1,
+					To:    &addr2,
+					Nonce: rpctest.ToHexUint64(0),
+					Gas:   &gas,
+				})
+
+			rawJSON, err := json.MarshalIndent(proposal, "", "  ")
+			require.NoError(t, err)
+			err = os.WriteFile(fmt.Sprintf("/tmp/prepare_bundle_depth_%d.json", depth), rawJSON, 0o644)
+			require.NoError(t, err)
+
+			_, err = api.PrepareBundle(t.Context(), proposal)
+			if depth <= bundle.MaxGroupNestingDepth {
+				require.NoError(t, err, "expected no error for depth %d", depth)
+			} else {
+				require.ErrorContains(t, err, fmt.Sprintf("execution plan exceeds maximum nesting depth of %d", bundle.MaxGroupNestingDepth))
+			}
+		})
+	}
+}
+
+func makeNestedBundleProposal(
+	depth int,
+	tx ethapi.TransactionArgs,
+) RPCExecutionProposal {
+	step := any(txEntry(tx))
+	for range depth {
+		step = groupEntry(step)
+	}
+
+	return RPCExecutionProposal{
+		RPCExecutionPlanGroup: RPCExecutionPlanGroup{
+			Steps: []any{step},
+		},
 	}
 }


### PR DESCRIPTION
Fix of finding from AI audit:

`unmarshalBundleGroup` recursed once per "steps" nesting level with no depth limit, and every recursive call re-parsed the still fully-nested remainder of the input, making decode cost quadratic in nesting depth. A ~60KB `sonic_prepareBundle/sonic_submitBundle` request nested to 4999 levels (near encoding/json's own 10000-token nesting cap) took 2.4+ CPU-seconds to decode, and a ~5MB request built from several such branches could occupy a core for minutes -- unauthenticated, since these methods are in the default RPC module list.

Add a nesting-depth guard checked before any parsing at a given level, mirroring the existing RLP-side guard (checkStepEncodingDepth) for the same execution-plan structure.