### PR TITLE
Recover panics in P2P message handling

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"math"
 	"math/rand/v2"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -538,7 +539,21 @@ func isUseless(node *enode.Node, name string) bool {
 
 // handle is the callback invoked to manage the life cycle of a peer. When
 // this function terminates, the peer is disconnected.
-func (h *handler) handle(p *peer) error {
+//
+// A panic anywhere in the message-handling loop below (e.g. a decode or
+// processing bug triggered by attacker-controlled peer input) is recovered
+// here and turned into a returned error, which disconnects only this peer,
+// instead of crashing the whole node: an unrecovered panic in any goroutine
+// terminates the entire process, regardless of where it originated.
+func (h *handler) handle(p *peer) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.Log().Error("Recovered from panic while handling peer, disconnecting",
+				"peer", p.ID(), "name", p.Name(), "panic", r, "stack", string(debug.Stack()))
+			err = fmt.Errorf("panic while handling peer %s: %v", p.ID(), r)
+		}
+	}()
+
 	p.Log().Trace("Connecting peer", "peer", p.ID(), "name", p.Name())
 
 	useless := isUseless(p.Node(), p.Name())
@@ -589,7 +604,7 @@ func (h *handler) handle(p *peer) error {
 	// after this will be sent via broadcasts.
 	h.syncTransactions(p, h.txpool.SampleHashes(h.config.Protocol.MaxInitialTxHashesSend))
 
-	// Handle incoming messages until the connection is torn down
+	// Handle incoming messages until the connection is torn down.
 	for {
 		if err := h.handleMsg(p); err != nil {
 			level := slog.LevelWarn

--- a/gossip/handler_fuzz_test.go
+++ b/gossip/handler_fuzz_test.go
@@ -19,31 +19,55 @@ package gossip
 import (
 	"bytes"
 	"errors"
+	"io"
 	"math/big"
 	"math/rand/v2"
 	"sync"
 	"testing"
 
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/dag"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/gossip/protocols/dag/dagstream"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
 )
 
-func FuzzGossipHandler(f *testing.F) {
+var fuzzMsgCodes = []uint64{
+	HandshakeMsg,
+	ProgressMsg,
+	EvmTxsMsg,
+	NewEvmTxHashesMsg,
+	GetEvmTxsMsg,
+	NewEventIDsMsg,
+	GetEventsMsg,
+	EventsMsg,
+	RequestEventsStream,
+	EventsStreamResponse,
+	GetPeerInfosMsg,
+	PeerInfosMsg,
+	GetEndPointMsg,
+	EndPointUpdateMsg,
+}
+
+func FuzzGossipHandlePeer(f *testing.F) {
+	addHandlerMessageCorpus(f)
 
 	// Note: this fuzzer has large memory requirements.
 	// at the time of this message, one iteration requires 1.5 GiB of memory.
 	//
 	// To avoid OOM situations, use -parallel
-	// > go test -fuzz FuzzGossipHandler ./gossip/ -v -parallel=6
+	// > go test -fuzz FuzzGossipHandlePeer ./gossip/ -v -parallel=6
 	f.Fuzz(func(t *testing.T, data []byte) {
 		handler, err := makeFuzzedHandler(t)
 		if err != nil {
@@ -55,17 +79,19 @@ func FuzzGossipHandler(f *testing.F) {
 			t.Skip("input data is not a message, skip this run")
 		}
 
-		input := &fuzzMsgReadWriter{msg}
-		other := &peer{
-			version: 1,
-			Peer:    p2p.NewPeer(randomID(), "fake-node-1", []p2p.Cap{}),
-			rw:      input,
+		peerCfg := DefaultPeerCacheConfig(cachescale.Identity)
+		input := &fuzzHandleReadWriter{
+			networkID: handler.NetworkID,
+			genesis:   common.Hash(handler.store.GetGenesisID()),
+			version:   1,
+			msg:       msg,
 		}
 
-		// errors are ok, we are fuzzing for crash
-		// therefore we are interested in inputs that can both
-		// be processed or generate an error
-		_ = handler.handleMsg(other)
+		// Keep a Sonic-like name to avoid early rejection by isUseless.
+		other := newPeer(1, p2p.NewPeer(randomID(), "Sonic/fuzz-peer", []p2p.Cap{}), input, peerCfg)
+
+		// errors are ok, we are fuzzing for crash.
+		_ = handler.handle(other)
 	})
 }
 
@@ -161,24 +187,157 @@ type fuzzMsgReadWriter struct {
 	msg *p2p.Msg
 }
 
+type fuzzHandleReadWriter struct {
+	networkID uint64
+	genesis   common.Hash
+	version   uint
+	msg       *p2p.Msg
+
+	mu        sync.Mutex
+	readCount int
+}
+
+func addHandlerMessageCorpus(f *testing.F) {
+	singleTx := makeSeedTx()
+	singleHash := common.BytesToHash([]byte{1})
+	singleEventID := hash.Event{1}
+	nilTxEvent, okNilTxEvent := makeSeedEventSafe(nil)
+	emptyTxEvent, okEmptyTxEvent := makeSeedEventSafe(types.Transactions{})
+	singleTxEvent, okSingleTxEvent := makeSeedEventSafe(types.Transactions{singleTx})
+
+	var nilTxs types.Transactions
+	addCorpusInput(f, HandshakeMsg, &handshakeData{ProtocolVersion: 1, NetworkID: 1, Genesis: common.Hash{1}})
+	addCorpusInput(f, ProgressMsg, &PeerProgress{})
+	addCorpusInput(f, EvmTxsMsg, nilTxs)
+	addCorpusInput(f, EvmTxsMsg, types.Transactions{})
+	addCorpusInput(f, EvmTxsMsg, types.Transactions{singleTx})
+
+	var nilTxHashes []common.Hash
+	addCorpusInput(f, NewEvmTxHashesMsg, nilTxHashes)
+	addCorpusInput(f, NewEvmTxHashesMsg, []common.Hash{})
+	addCorpusInput(f, NewEvmTxHashesMsg, []common.Hash{singleHash})
+	addCorpusInput(f, GetEvmTxsMsg, nilTxHashes)
+	addCorpusInput(f, GetEvmTxsMsg, []common.Hash{})
+	addCorpusInput(f, GetEvmTxsMsg, []common.Hash{singleHash})
+
+	var nilEventIDs hash.Events
+	addCorpusInput(f, NewEventIDsMsg, nilEventIDs)
+	addCorpusInput(f, NewEventIDsMsg, hash.Events{})
+	addCorpusInput(f, NewEventIDsMsg, hash.Events{singleEventID})
+	addCorpusInput(f, GetEventsMsg, nilEventIDs)
+	addCorpusInput(f, GetEventsMsg, hash.Events{})
+	addCorpusInput(f, GetEventsMsg, hash.Events{singleEventID})
+
+	var nilEvents inter.EventPayloads
+	addCorpusInput(f, EventsMsg, nilEvents)
+	addCorpusInput(f, EventsMsg, inter.EventPayloads{})
+	if okNilTxEvent {
+		addCorpusInput(f, EventsMsg, inter.EventPayloads{nilTxEvent})
+	}
+	if okEmptyTxEvent {
+		addCorpusInput(f, EventsMsg, inter.EventPayloads{emptyTxEvent})
+	}
+	if okSingleTxEvent {
+		addCorpusInput(f, EventsMsg, inter.EventPayloads{singleTxEvent})
+	}
+
+	addCorpusInput(f, RequestEventsStream, dagstream.Request{})
+	addCorpusInput(f, RequestEventsStream, dagstream.Request{
+		Session: dagstream.Session{ID: 1, Start: []byte{0x01}, Stop: []byte{0x02}},
+		Type:    dagstream.RequestEvents,
+		Limit:   dag.Metric{Num: 1, Size: 1024},
+	})
+
+	addCorpusInput(f, EventsStreamResponse, dagChunk{SessionID: 1, Done: true})
+	addCorpusInput(f, EventsStreamResponse, dagChunk{SessionID: 1, IDs: hash.Events{singleEventID}})
+	if okNilTxEvent {
+		addCorpusInput(f, EventsStreamResponse, dagChunk{SessionID: 1, Events: inter.EventPayloads{nilTxEvent}})
+	}
+	if okSingleTxEvent {
+		addCorpusInput(f, EventsStreamResponse, dagChunk{SessionID: 1, Events: inter.EventPayloads{singleTxEvent}})
+	}
+
+	f.Add(makeFuzzInput(GetPeerInfosMsg, nil))
+	addCorpusInput(f, PeerInfosMsg, peerInfoMsg{Peers: []peerInfo{}})
+	addCorpusInput(f, PeerInfosMsg, peerInfoMsg{Peers: []peerInfo{{Enode: "enode://invalid@127.0.0.1:30303"}}})
+	f.Add(makeFuzzInput(GetEndPointMsg, nil))
+	addCorpusInput(f, EndPointUpdateMsg, "")
+	addCorpusInput(f, EndPointUpdateMsg, "enode://invalid@127.0.0.1:30303")
+}
+
+func makeSeedTx() *types.Transaction {
+	var to common.Address
+	to[0] = 1
+	return types.NewTx(&types.LegacyTx{
+		Nonce:    1,
+		To:       &to,
+		Value:    big.NewInt(1),
+		Gas:      21_000,
+		GasPrice: big.NewInt(1),
+	})
+}
+
+func makeSeedEvent(txs types.Transactions) *inter.EventPayload {
+	b := inter.MutableEventPayload{}
+	b.SetEpoch(1)
+	b.SetCreator(1)
+	b.SetLamport(1)
+	b.SetSeq(1)
+	b.SetCreationTime(1)
+	b.SetTxs(txs)
+	return b.Build()
+}
+
+func makeSeedEventSafe(txs types.Transactions) (event *inter.EventPayload, ok bool) {
+	defer func() {
+		if recover() != nil {
+			event = nil
+			ok = false
+		}
+	}()
+	return makeSeedEvent(txs), true
+}
+
+func addCorpusInput(f *testing.F, code uint64, payload interface{}) {
+	if input, ok := fuzzInput(code, payload); ok {
+		f.Add(input)
+	}
+}
+
+func fuzzInput(code uint64, payload interface{}) ([]byte, bool) {
+	if payload == nil {
+		return makeFuzzInput(code, nil), true
+	}
+	defer func() {
+		_ = recover()
+	}()
+	encoded, err := rlp.EncodeToBytes(payload)
+	if err != nil {
+		return nil, false
+	}
+	return makeFuzzInput(code, encoded), true
+}
+
+func makeFuzzInput(code uint64, payload []byte) []byte {
+	selector := byte(0)
+	for i, c := range fuzzMsgCodes {
+		if c == code {
+			selector = byte(i)
+			break
+		}
+	}
+	out := make([]byte, 1+len(payload))
+	out[0] = selector
+	copy(out[1:], payload)
+	return out
+}
+
 func newFuzzMsg(data []byte) (*p2p.Msg, error) {
 	if len(data) < 1 {
 		return nil, errors.New("empty data")
 	}
 
-	var (
-		codes = []uint64{
-			HandshakeMsg,
-			EvmTxsMsg,
-			ProgressMsg,
-			NewEventIDsMsg,
-			GetEventsMsg,
-			EventsMsg,
-			RequestEventsStream,
-			EventsStreamResponse,
-		}
-		code = codes[int(data[0])%len(codes)]
-	)
+	code := fuzzMsgCodes[int(data[0])%len(fuzzMsgCodes)]
 	data = data[1:]
 
 	return &p2p.Msg{
@@ -193,5 +352,38 @@ func (rw *fuzzMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 }
 
 func (rw *fuzzMsgReadWriter) WriteMsg(p2p.Msg) error {
+	return nil
+}
+
+func (rw *fuzzHandleReadWriter) ReadMsg() (p2p.Msg, error) {
+	rw.mu.Lock()
+	n := rw.readCount
+	rw.readCount++
+	rw.mu.Unlock()
+
+	if n == 0 {
+		encoded, err := rlp.EncodeToBytes(&handshakeData{
+			ProtocolVersion: uint32(rw.version),
+			NetworkID:       rw.networkID,
+			Genesis:         rw.genesis,
+		})
+		if err != nil {
+			return p2p.Msg{}, err
+		}
+		return p2p.Msg{
+			Code:    HandshakeMsg,
+			Size:    uint32(len(encoded)),
+			Payload: bytes.NewReader(encoded),
+		}, nil
+	}
+
+	if n == 1 {
+		return *rw.msg, nil
+	}
+
+	return p2p.Msg{}, io.EOF
+}
+
+func (rw *fuzzHandleReadWriter) WriteMsg(p2p.Msg) error {
 	return nil
 }

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -18,6 +18,7 @@ package gossip
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/eventcheck"
@@ -30,6 +31,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/Fantom-foundation/lachesis-base/utils/cachescale"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover/discfilter"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -172,6 +174,68 @@ func TestHandleMsgEventsStreamResponse(t *testing.T) {
 		err := sendChunk(dagChunk{SessionID: 1, Done: true, IDs: hash.Events{hash.Event{}}})
 		require.NoError(t, err)
 	})
+}
+
+// TestHandlePanicRecovery verifies that a panic anywhere inside handle()'s
+// message loop is caught by its defer/recover and returned as an error,
+// disconnecting only the offending peer rather than crashing the node.
+func TestHandlePanicRecovery(t *testing.T) {
+	h, err := makeFuzzedHandler(t)
+	require.NoError(t, err)
+
+	peerCfg := DefaultPeerCacheConfig(cachescale.Identity)
+	rw := &handshakeThenPanicReadWriter{
+		networkID: h.NetworkID,
+		genesis:   common.Hash(h.store.GetGenesisID()),
+		version:   1,
+	}
+	// Peer name must contain "sonic" or "opera" to not be rejected as useless
+	// by isUseless() before the message loop is even reached.
+	p := newPeer(1, p2p.NewPeer(randomID(), "Sonic/v1.0.0-test/linux-amd64/go1.25", []p2p.Cap{}), rw, peerCfg)
+
+	err = h.handle(p)
+	require.ErrorContains(t, err, "panic while handling peer")
+}
+
+// handshakeThenPanicReadWriter satisfies p2p.MsgReadWriter. It returns a valid
+// HandshakeMsg on the first ReadMsg call so that peer.Handshake() succeeds,
+// then panics on subsequent calls to simulate a bug triggered by peer input.
+type handshakeThenPanicReadWriter struct {
+	networkID uint64
+	genesis   common.Hash
+	version   uint
+
+	mu        sync.Mutex
+	readCount int
+}
+
+func (rw *handshakeThenPanicReadWriter) ReadMsg() (p2p.Msg, error) {
+	rw.mu.Lock()
+	n := rw.readCount
+	rw.readCount++
+	rw.mu.Unlock()
+
+	if n == 0 {
+		encoded, err := rlp.EncodeToBytes(&handshakeData{
+			ProtocolVersion: uint32(rw.version),
+			NetworkID:       rw.networkID,
+			Genesis:         rw.genesis,
+		})
+		if err != nil {
+			panic(err)
+		}
+		return p2p.Msg{
+			Code:    HandshakeMsg,
+			Size:    uint32(len(encoded)),
+			Payload: bytes.NewReader(encoded),
+		}, nil
+	}
+
+	panic("simulated peer-input panic")
+}
+
+func (rw *handshakeThenPanicReadWriter) WriteMsg(p2p.Msg) error {
+	return nil
 }
 
 func TestIsUseless(t *testing.T) {

--- a/gossip/handler_test.go
+++ b/gossip/handler_test.go
@@ -18,6 +18,7 @@ package gossip
 
 import (
 	"bytes"
+	"io"
 	"sync"
 	"testing"
 
@@ -195,6 +196,131 @@ func TestHandlePanicRecovery(t *testing.T) {
 
 	err = h.handle(p)
 	require.ErrorContains(t, err, "panic while handling peer")
+}
+
+func TestHandlePeerInputResilience(t *testing.T) {
+	h, err := makeFuzzedHandler(t)
+	require.NoError(t, err)
+
+	peerCfg := DefaultPeerCacheConfig(cachescale.Identity)
+	newTestPeer := func(rw p2p.MsgReadWriter) *peer {
+		return newPeer(
+			1,
+			p2p.NewPeer(randomID(), "Sonic/resilience-test", []p2p.Cap{}),
+			rw,
+			peerCfg,
+		)
+	}
+
+	makeMsg := func(code uint64, payload interface{}) *p2p.Msg {
+		t.Helper()
+		if payload == nil {
+			return &p2p.Msg{Code: code, Size: 0, Payload: bytes.NewReader(nil)}
+		}
+		encoded, err := rlp.EncodeToBytes(payload)
+		require.NoError(t, err)
+		return &p2p.Msg{Code: code, Size: uint32(len(encoded)), Payload: bytes.NewReader(encoded)}
+	}
+
+	handshake := makeMsg(HandshakeMsg, &handshakeData{
+		ProtocolVersion: 1,
+		NetworkID:       h.NetworkID,
+		Genesis:         common.Hash(h.store.GetGenesisID()),
+	})
+
+	tests := []struct {
+		name            string
+		steps           []readStep
+		wantErrContains string
+	}{
+		{
+			name: "invalid handshake code as first message",
+			steps: []readStep{
+				{msg: makeMsg(ProgressMsg, &PeerProgress{})},
+			},
+			wantErrContains: "No status message",
+		},
+		{
+			name: "invalid handshake payload",
+			steps: []readStep{
+				{msg: &p2p.Msg{Code: HandshakeMsg, Size: 1, Payload: bytes.NewReader([]byte{0xff})}},
+			},
+			wantErrContains: "Invalid message",
+		},
+		{
+			name: "successful handshake then malformed events payload",
+			steps: []readStep{
+				{msg: handshake},
+				{msg: &p2p.Msg{Code: EventsMsg, Size: 1, Payload: bytes.NewReader([]byte{0xff})}},
+			},
+			wantErrContains: "Invalid message",
+		},
+		{
+			name: "successful handshake then events containing nil event pointer",
+			steps: []readStep{
+				{msg: handshake},
+				{msg: makeMsg(EventsMsg, inter.EventPayloads{nil})},
+			},
+			wantErrContains: "Invalid message",
+		},
+		{
+			name: "successful handshake then event stream response with nil event pointer",
+			steps: []readStep{
+				{msg: handshake},
+				{msg: makeMsg(EventsStreamResponse, dagChunk{SessionID: 1, Events: inter.EventPayloads{nil}})},
+			},
+			wantErrContains: "Invalid message",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := &scriptedReadWriter{steps: tc.steps}
+			p := newTestPeer(rw)
+
+			var gotErr error
+			require.NotPanics(t, func() {
+				gotErr = h.handle(p)
+			})
+			require.Error(t, gotErr)
+			if tc.wantErrContains != "" {
+				require.ErrorContains(t, gotErr, tc.wantErrContains)
+			}
+		})
+	}
+}
+
+type readStep struct {
+	msg *p2p.Msg
+	err error
+}
+
+type scriptedReadWriter struct {
+	mu    sync.Mutex
+	steps []readStep
+	pos   int
+}
+
+func (rw *scriptedReadWriter) ReadMsg() (p2p.Msg, error) {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+
+	if rw.pos >= len(rw.steps) {
+		return p2p.Msg{}, io.EOF
+	}
+	step := rw.steps[rw.pos]
+	rw.pos++
+	if step.err != nil {
+		return p2p.Msg{}, step.err
+	}
+	if step.msg == nil {
+		return p2p.Msg{}, io.EOF
+	}
+	return *step.msg, nil
+}
+
+func (rw *scriptedReadWriter) WriteMsg(p2p.Msg) error {
+	return nil
 }
 
 // handshakeThenPanicReadWriter satisfies p2p.MsgReadWriter. It returns a valid

--- a/gossip/main_test.go
+++ b/gossip/main_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gossip
+
+import (
+	"flag"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// TestMain is the entry point for the gossip test suite.
+// It silences the go-ethereum global logger by default to keep test output clean.
+func TestMain(m *testing.M) {
+	var enableLogs bool
+	flag.BoolVar(&enableLogs, "gossip.logs", false, "enable go-ethereum global logger output in gossip tests")
+	flag.Parse()
+
+	if !enableLogs {
+		log.SetDefault(log.NewLogger(log.NewTerminalHandler(io.Discard, false)))
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
P2P hardening - if panic in P2P occurs, disconnect the peer, don't crash the node.