### PR TITLE
Fail with distinct error code

### DIFF
--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime/debug"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -70,15 +71,16 @@ func (l *ErrorLock) Permanent(err error) {
 			"originalErr", err,
 			"writeErr", writeErr,
 		)
-
-		os.Exit(74) // distinct exit code to indicate a write error and avoid silent restart
+	} else {
+		// User facing error message, so we want to provide a clear message.
+		fmt.Fprintf(os.Stderr, "Node is permanently stopping due to an issue. Please"+
+			" fix the issue and then delete file \"%s\". Error message:\n%s",
+			eLockPath, err.Error())
 	}
+	debug.PrintStack()
 
-	// This is a user-facing error, so we want to provide a clear message.
-	//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
-	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix"+
-		" the issue and then delete file \"%s\". Error message:\n%s",
-		eLockPath, err.Error()))
+	// distinct exit code to avoid silently restarting into the same unsafe state
+	os.Exit(74)
 }
 
 func readAll(reader io.Reader, max int) ([]byte, error) {

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -71,12 +71,12 @@ func (l *ErrorLock) Permanent(err error) {
 			"originalErr", err,
 			"writeErr", writeErr,
 		)
-	} else {
-		// User facing error message, so we want to provide a clear message.
-		fmt.Fprintf(os.Stderr, "Node is permanently stopping due to an issue. Please"+
-			" fix the issue and then delete file \"%s\". Error message:\n%s",
-			eLockPath, err.Error())
 	}
+
+	// User facing error message, so we want to provide a clear message.
+	fmt.Fprintf(os.Stderr, "Node is permanently stopping due to an issue. Please"+
+		" fix the issue and then delete file \"%s\". Error message:\n%s",
+		eLockPath, err.Error())
 	debug.PrintStack()
 
 	// distinct exit code to avoid silently restarting into the same unsafe state

--- a/utils/errlock/errlock.go
+++ b/utils/errlock/errlock.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/ethereum/go-ethereum/log"
+
 	"github.com/0xsoniclabs/sonic/utils/caution"
 )
 
@@ -59,7 +61,19 @@ func (l *ErrorLock) Check() error {
 
 // Permanent error
 func (l *ErrorLock) Permanent(err error) {
-	eLockPath, _ := write(l.dataDir, err.Error())
+	eLockPath, writeErr := write(l.dataDir, err.Error())
+	if writeErr != nil {
+		log.Error("errlock: failed to write halt-lock file; terminating"+
+			" with distinct exit code so the node is not silently restarted"+
+			" into the same unsafe state that triggered Permanent()",
+			"path", eLockPath,
+			"originalErr", err,
+			"writeErr", writeErr,
+		)
+
+		os.Exit(74) // distinct exit code to indicate a write error and avoid silent restart
+	}
+
 	// This is a user-facing error, so we want to provide a clear message.
 	//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
 	panic(fmt.Errorf("Node is permanently stopping due to an issue. Please fix"+

--- a/utils/errlock/errlock_test.go
+++ b/utils/errlock/errlock_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package errlock
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Environment variables used to drive Permanent() inside a re-executed test
+// subprocess. Permanent() terminates the process via os.Exit, so it cannot be
+// exercised in-process; the test re-runs its own binary and inspects the exit
+// code and stderr of the child.
+const (
+	envRunPermanent = "ERRLOCK_TEST_RUN_PERMANENT"
+	envPermanentDir = "ERRLOCK_TEST_PERMANENT_DIR"
+)
+
+// TestMain intercepts the re-executed subprocess and invokes Permanent() with
+// the data directory provided by the parent. In the normal (parent) case it
+// just runs the test suite.
+func TestMain(m *testing.M) {
+	if os.Getenv(envRunPermanent) == "1" {
+		New(os.Getenv(envPermanentDir)).Permanent(errors.New("boom: triggering permanent halt"))
+		// Permanent() must not return; if it does the test fails via the
+		// unexpected exit code observed by the parent.
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// runPermanentInSubprocess re-executes the test binary so that TestMain calls
+// Permanent() with the given data directory, and returns the child's exit code
+// and captured stderr.
+func runPermanentInSubprocess(t *testing.T, dir string) (exitCode int, stderr string) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0])
+	cmd.Env = append(os.Environ(),
+		envRunPermanent+"=1",
+		envPermanentDir+"="+dir,
+	)
+	var buf bytes.Buffer
+	cmd.Stderr = &buf
+	err := cmd.Run()
+
+	if err == nil {
+		return 0, buf.String()
+	}
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "expected the subprocess to exit with a non-zero status")
+	return exitErr.ExitCode(), buf.String()
+}
+
+func TestPermanent_WriteSucceeds_WritesLockFileExitsWith74AndPrintsStack(t *testing.T) {
+	dir := t.TempDir()
+
+	exitCode, stderr := runPermanentInSubprocess(t, dir)
+
+	require.Equal(t, 74, exitCode, "Permanent must exit with the distinct code 74")
+
+	// The halt-lock file must be written with the original error message so a
+	// restart is refused by Check().
+	data, err := os.ReadFile(path.Join(dir, "errlock"))
+	require.NoError(t, err, "the halt-lock file should have been written")
+	require.Contains(t, string(data), "boom: triggering permanent halt")
+
+	// The stack trace must be printed so the crash location is recorded.
+	require.Contains(t, stderr, "errlock.(*ErrorLock).Permanent",
+		"the stack trace must include the Permanent call site")
+}
+
+func TestPermanent_WriteFails_ExitsWith74AndPrintsStack(t *testing.T) {
+	// Use a regular file as the "data directory" so that writing
+	// <dir>/errlock fails (the path component is not a directory).
+	f, err := os.CreateTemp(t.TempDir(), "not-a-dir")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	exitCode, stderr := runPermanentInSubprocess(t, f.Name())
+
+	require.Equal(t, 74, exitCode,
+		"Permanent must exit with 74 even when the halt-lock file cannot be written")
+
+	// The stack trace must be printed independently of the write result.
+	require.Contains(t, stderr, "errlock.(*ErrorLock).Permanent",
+		"the stack trace must be printed even when writing the lock file fails")
+
+	// No lock file should have been created at the (invalid) location.
+	_, statErr := os.Stat(path.Join(f.Name(), "errlock"))
+	require.Error(t, statErr)
+}


### PR DESCRIPTION
In case permanent lock can not be written, sonic should fail with a distinct error code to ensure scripted runners do not restart automatically.

Part of the fixes for the internal audit.