### PR TITLE
Internal audit cleanup changes

### DIFF
--- a/cmd/sonictool/db/heal.go
+++ b/cmd/sonictool/db/heal.go
@@ -190,7 +190,9 @@ func dropAllEpochDbs(producer kvdb.IterableDBProducer) error {
 			if err != nil {
 				return fmt.Errorf("unable to open db %s; %s", name, err)
 			}
-			_ = db.Close()
+			if err := db.Close(); err != nil {
+				log.Error("Failed to close db before drop", "name", name, "err", err)
+			}
 			db.Drop()
 		}
 	}

--- a/opera/genesisstore/disk.go
+++ b/opera/genesisstore/disk.go
@@ -167,6 +167,9 @@ func OpenGenesisStore(rawReader ReadAtSeekerCloser) (*Store, genesis.Hashes, err
 // getLoggerName provides a human-readable name of a unit for logging purposes
 func getLoggerName(name string) string {
 	scanfName := strings.ReplaceAll(name, "-", "")
+	if len(scanfName) == 0 {
+		return name
+	}
 	if scanfName[len(scanfName)-1] < '0' || scanfName[len(scanfName)-1] > '9' {
 		scanfName += "0"
 	}

--- a/opera/genesisstore/disk_test.go
+++ b/opera/genesisstore/disk_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package genesisstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLoggerName(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		// Malformed: dashes only — previously panicked with index out of range.
+		"only dashes":     {input: "-", expected: "-"},
+		"multiple dashes": {input: "---", expected: "---"},
+		// Empty string — degenerate case, must not panic.
+		"empty": {input: "", expected: ""},
+		// Known unit name patterns.
+		"brs0":  {input: "brs0", expected: "blocks unit 0"},
+		"brs1":  {input: "brs1", expected: "blocks unit 1"},
+		"brs-1": {input: "brs-1", expected: "blocks unit 1"},
+		"ers0":  {input: "ers0", expected: "epochs unit 0"},
+		"ers-2": {input: "ers-2", expected: "epochs unit 2"},
+		"evm0":  {input: "evm0", expected: "EVM unit 0"},
+		"evm-3": {input: "evm-3", expected: "EVM unit 3"},
+		// Unit name without trailing digit — suffix "0" is appended internally.
+		"brs no digit": {input: "brs", expected: "blocks unit 0"},
+		"ers no digit": {input: "ers", expected: "epochs unit 0"},
+		"evm no digit": {input: "evm", expected: "EVM unit 0"},
+		// Unrecognised names are returned unchanged.
+		"unknown":             {input: "unknown", expected: "unknown"},
+		"unknown with dashes": {input: "foo-bar", expected: "foo-bar"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				got := getLoggerName(tc.input)
+				require.Equal(t, tc.expected, got)
+			})
+		})
+	}
+}

--- a/opera/genesisstore/fileshash/filehash_test.go
+++ b/opera/genesisstore/fileshash/filehash_test.go
@@ -18,6 +18,7 @@ package fileshash
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -26,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/0xsoniclabs/sonic/utils/ioread"
@@ -237,4 +239,78 @@ func testFileHash_ReadWrite(t *testing.T, content []byte, expRoot hash.Hash, pie
 		err = ioread.ReadAll(oomReader, data)
 		require.Errorf(err, "hashed file requires too much memory")
 	}
+}
+
+// errTmp wraps a real file-backed TmpWriter and returns injected errors from
+// Close and Drop, so we can exercise the log branches in readFromTmp.
+type errTmp struct {
+	TmpWriter
+	closeErr error
+	dropErr  error
+}
+
+func (e *errTmp) Close() error {
+	_ = e.TmpWriter.Close()
+	return e.closeErr
+}
+
+func (e *errTmp) Drop() error {
+	_ = e.TmpWriter.Drop()
+	return e.dropErr
+}
+
+// captureLog redirects the default logger to a buffer for the duration of
+// the test and returns the buffer.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	orig := log.Root()
+	log.SetDefault(log.NewLogger(log.NewTerminalHandler(buf, false)))
+	t.Cleanup(func() { log.SetDefault(orig) })
+	return buf
+}
+
+func newFileTmp(t *testing.T, dir string, i int) TmpWriter {
+	t.Helper()
+	fh, err := os.OpenFile(path.Join(dir, fmt.Sprintf("tmp%d.dat", i)), os.O_CREATE|os.O_RDWR, 0600)
+	require.NoError(t, err)
+	return dropableFile{ReadWriteSeeker: fh, Closer: fh, path: fh.Name()}
+}
+
+func TestWriter_ReadFromTmp_CloseErrorIsLogged(t *testing.T) {
+	dir := t.TempDir()
+	outFile, err := os.CreateTemp(dir, "out")
+	require.NoError(t, err)
+	defer func() { _ = outFile.Close() }()
+
+	buf := captureLog(t)
+	w := WrapWriter(outFile, 2, func(i int) TmpWriter {
+		return &errTmp{TmpWriter: newFileTmp(t, dir, i), closeErr: errors.New("boom-close")}
+	})
+	_, err = w.Write([]byte{1, 2})
+	require.NoError(t, err)
+	_, err = w.Flush()
+	require.NoError(t, err)
+
+	require.Contains(t, buf.String(), "failed to close tmp piece")
+	require.Contains(t, buf.String(), "boom-close")
+}
+
+func TestWriter_ReadFromTmp_DropErrorIsLogged(t *testing.T) {
+	dir := t.TempDir()
+	outFile, err := os.CreateTemp(dir, "out")
+	require.NoError(t, err)
+	defer func() { _ = outFile.Close() }()
+
+	buf := captureLog(t)
+	w := WrapWriter(outFile, 2, func(i int) TmpWriter {
+		return &errTmp{TmpWriter: newFileTmp(t, dir, i), dropErr: errors.New("boom-drop")}
+	})
+	_, err = w.Write([]byte{1, 2})
+	require.NoError(t, err)
+	_, err = w.Flush()
+	require.NoError(t, err)
+
+	require.Contains(t, buf.String(), "failed to drop tmp piece")
+	require.Contains(t, buf.String(), "boom-drop")
 }

--- a/opera/genesisstore/fileshash/write_file.go
+++ b/opera/genesisstore/fileshash/write_file.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/0xsoniclabs/sonic/utils/ioread"
 )
@@ -127,9 +128,13 @@ func (w *Writer) readFromTmp(p []byte, destructive bool) error {
 	}
 	w.tmpReadPos += maxToRead
 	if w.tmpReadPos%w.pieceSize == 0 {
-		_ = w.tmps[tmpI].Close()
+		if err := w.tmps[tmpI].Close(); err != nil {
+			log.Error("failed to close tmp piece", "tmpI", tmpI, "err", err)
+		}
 		if destructive {
-			_ = w.tmps[tmpI].Drop()
+			if err := w.tmps[tmpI].Drop(); err != nil {
+				log.Error("failed to drop tmp piece", "tmpI", tmpI, "err", err)
+			}
 		}
 		w.tmps[tmpI].TmpWriter = nil
 	}

--- a/topicsdb/index.go
+++ b/topicsdb/index.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // index is a specialized indexes for log records storing and fetching.
@@ -47,8 +48,12 @@ func (tt *index) WrapTablesAsBatched() (unwrap func()) {
 	batchedLogrec := batched.Wrap(tt.table.Logrec)
 	tt.table.Logrec = batchedLogrec
 	return func() {
-		_ = batchedTopic.Flush()
-		_ = batchedLogrec.Flush()
+		if err := batchedTopic.Flush(); err != nil {
+			log.Error("Failed to flush topic batch", "err", err)
+		}
+		if err := batchedLogrec.Flush(); err != nil {
+			log.Error("Failed to flush logrec batch", "err", err)
+		}
 		tt.table = origTables
 	}
 }
@@ -104,6 +109,10 @@ func (tt *index) Push(recs ...*types.Log) error {
 }
 
 func (tt *index) Close() {
-	_ = tt.table.Topic.Close()
-	_ = tt.table.Logrec.Close()
+	if err := tt.table.Topic.Close(); err != nil {
+		log.Error("Failed to close topic table", "err", err)
+	}
+	if err := tt.table.Logrec.Close(); err != nil {
+		log.Error("Failed to close logrec table", "err", err)
+	}
 }

--- a/topicsdb/index_test.go
+++ b/topicsdb/index_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package topicsdb
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// captureLog redirects the default logger to a buffer for the test duration.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	orig := log.Root()
+	log.SetDefault(log.NewLogger(log.NewTerminalHandler(buf, false)))
+	t.Cleanup(func() { log.SetDefault(orig) })
+	return buf
+}
+
+// errOnCloseStore wraps a kvdb.Store whose Close always returns a fixed error.
+type errOnCloseStore struct {
+	kvdb.Store
+	closeErr error
+}
+
+func (e *errOnCloseStore) Close() error { return e.closeErr }
+
+func TestIndex_Close_LogsTopicAndLogrecErrors(t *testing.T) {
+	buf := captureLog(t)
+
+	idx := newIndex(memorydb.New())
+	idx.table.Topic = &errOnCloseStore{Store: memorydb.New(), closeErr: errors.New("boom-topic")}
+	idx.table.Logrec = &errOnCloseStore{Store: memorydb.New(), closeErr: errors.New("boom-logrec")}
+
+	idx.Close()
+
+	out := buf.String()
+	require.Contains(t, out, "Failed to close topic table")
+	require.Contains(t, out, "boom-topic")
+	require.Contains(t, out, "Failed to close logrec table")
+	require.Contains(t, out, "boom-logrec")
+}
+
+// errOnBatchWriteStore wraps a kvdb.Store whose batches always fail on Write.
+type errOnBatchWriteStore struct {
+	kvdb.Store
+	writeErr error
+}
+
+type errBatch struct {
+	kvdb.Batch
+	writeErr error
+}
+
+func (b *errBatch) Write() error { return b.writeErr }
+
+func (s *errOnBatchWriteStore) NewBatch() kvdb.Batch {
+	return &errBatch{Batch: s.Store.NewBatch(), writeErr: s.writeErr}
+}
+
+func TestIndex_WrapTablesAsBatched_UnwrapLogsFlushErrors(t *testing.T) {
+	buf := captureLog(t)
+
+	idx := newIndex(memorydb.New())
+	// Replace the tables so batches produced by them fail on Write. The
+	// batched wrapper's Flush calls batch.Write(), which surfaces the error.
+	idx.table.Topic = &errOnBatchWriteStore{Store: memorydb.New(), writeErr: errors.New("boom-topic")}
+	idx.table.Logrec = &errOnBatchWriteStore{Store: memorydb.New(), writeErr: errors.New("boom-logrec")}
+
+	unwrap := idx.WrapTablesAsBatched()
+
+	// Push a record so both batches are non-empty (Flush short-circuits on
+	// empty batches in some implementations, but here always calls Write).
+	require.NoError(t, idx.Push(&types.Log{
+		BlockNumber: 1,
+		Address:     randAddress(),
+		Topics:      []common.Hash{{}},
+	}))
+
+	unwrap()
+
+	out := buf.String()
+	require.Contains(t, out, "Failed to flush topic batch")
+	require.Contains(t, out, "boom-topic")
+	require.Contains(t, out, "Failed to flush logrec batch")
+	require.Contains(t, out, "boom-logrec")
+}

--- a/utils/cser/read_writer.go
+++ b/utils/cser/read_writer.go
@@ -30,8 +30,6 @@ var (
 	ErrTooLargeAlloc        = errors.New("too large allocation")
 )
 
-const MaxAlloc = 100 * 1024
-
 type Writer struct {
 	BitsW  *bits.Writer
 	BytesW *fast.Writer

--- a/utils/dbutil/autocompact/store.go
+++ b/utils/dbutil/autocompact/store.go
@@ -104,8 +104,12 @@ func (s *Store) mayCompact(force bool) {
 
 	if force || s.cont.Size() > s.limit {
 		for _, r := range s.cont.Ranges() {
-			log.Debug("Autocompact", "name", s.name, "from", hexutils.BytesToHex(r.minKey), "to", hexutils.BytesToHex(r.maxKey))
-			_ = s.Compact(r.minKey, r.maxKey)
+			log.Debug("Autocompact", "name", s.name, "from",
+				hexutils.BytesToHex(r.minKey), "to", hexutils.BytesToHex(r.maxKey))
+			if err := s.Compact(r.minKey, r.maxKey); err != nil {
+				log.Error("Autocompact range failed", "name", s.name,
+					"from", hexutils.BytesToHex(r.minKey), "to", hexutils.BytesToHex(r.maxKey), "err", err)
+			}
 		}
 		s.cont.Reset()
 	}

--- a/utils/dbutil/autocompact/store_test.go
+++ b/utils/dbutil/autocompact/store_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package autocompact
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/kvdb"
+	"github.com/Fantom-foundation/lachesis-base/kvdb/memorydb"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+// errStore wraps a kvdb.Store so that Compact always returns a fixed error.
+type errStore struct {
+	kvdb.Store
+	compactErr error
+}
+
+func (e *errStore) Compact(start []byte, limit []byte) error { return e.compactErr }
+
+func TestMayCompact_LogsCompactError(t *testing.T) {
+	buf := &bytes.Buffer{}
+	orig := log.Root()
+	log.SetDefault(log.NewLogger(log.NewTerminalHandler(buf, false)))
+	t.Cleanup(func() { log.SetDefault(orig) })
+
+	inner := &errStore{Store: memorydb.New(), compactErr: errors.New("boom-compact")}
+	// limit=0 → any write triggers compaction immediately.
+	s := Wrap(inner, 0, NewBackwardsCont, "test-db")
+
+	require.NoError(t, s.Put([]byte("key"), []byte("value")))
+
+	out := buf.String()
+	require.Contains(t, out, "Autocompact range failed")
+	require.Contains(t, out, "test-db")
+	require.Contains(t, out, "boom-compact")
+}


### PR DESCRIPTION
This PR applies the cleanup findings of the AI audit.
Three quality of life changes are applied:
- Removal of unused `MaxAlloc` constant
- Add an empty check to the `getLoggerName` function
- Add logs in case of failures