### PR TITLE
Stop filter event loop before closing the store

### DIFF
--- a/gossip/filters/api.go
+++ b/gossip/filters/api.go
@@ -105,6 +105,11 @@ func NewPublicFilterAPI(backend Backend, cfg Config) *PublicFilterAPI {
 	return api
 }
 
+// Stop shuts down the API's event system and blocks until it has stopped.
+func (api *PublicFilterAPI) Stop() {
+	api.events.Stop()
+}
+
 // timeoutLoop runs at the interval set by 'timeout' and deletes filters
 // that have not been recently used. It is started when the API is created.
 func timeoutLoop(

--- a/gossip/filters/filter_system.go
+++ b/gossip/filters/filter_system.go
@@ -98,6 +98,11 @@ type EventSystem struct {
 	txsCh     chan evmcore.NewTxsNotify    // Channel to receive new transactions notify
 	logsCh    chan []*types.Log            // Channel to receive new log notify
 	blocksCh  chan evmcore.ChainHeadNotify // Channel to receive new chain notify
+
+	// Lifecycle
+	quit     chan struct{} // closed by Stop to signal the loop to exit
+	stopOnce sync.Once     // makes Stop idempotent
+	done     chan struct{} // closed once the loop has exited
 }
 
 // NewEventSystem creates a new manager that listens for event on the given chans,
@@ -113,6 +118,8 @@ func NewEventSystem(backend Backend) *EventSystem {
 		blocksCh:  make(chan evmcore.ChainHeadNotify, blocksChanSize),
 		txsCh:     make(chan evmcore.NewTxsNotify, txChanSize),
 		logsCh:    make(chan []*types.Log, logsChanSize),
+		quit:      make(chan struct{}),
+		done:      make(chan struct{}),
 	}
 
 	// Subscribe events
@@ -127,6 +134,16 @@ func NewEventSystem(backend Backend) *EventSystem {
 
 	go m.eventLoop()
 	return m
+}
+
+// Stop terminates the event loop and blocks until it has exited, including any
+// broadcast in progress. After Stop returns the backend is no longer read, so
+// it is safe to close. Stop is idempotent.
+func (es *EventSystem) Stop() {
+	es.stopOnce.Do(func() {
+		close(es.quit)
+	})
+	<-es.done
 }
 
 // Subscription is created when the client registers itself for a particular event.
@@ -329,6 +346,7 @@ func (es *EventSystem) broadcast(filters filterIndex, ev interface{}) {
 
 // eventLoop (un)installs filters and processes mux events.
 func (es *EventSystem) eventLoop() {
+	defer close(es.done)
 	// Ensure all subscriptions get cleaned up
 	defer func() {
 		es.blocksSub.Unsubscribe()
@@ -342,7 +360,17 @@ func (es *EventSystem) eventLoop() {
 	}
 
 	for {
+		// Prioritize quit so no buffered event is broadcast after Stop.
 		select {
+		case <-es.quit:
+			return
+		default:
+		}
+
+		select {
+		case <-es.quit:
+			return
+
 		// Handle subscribed events
 		case ev := <-es.txsCh:
 			es.broadcast(index, ev)

--- a/gossip/filters/filter_system_test.go
+++ b/gossip/filters/filter_system_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"math/big"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -155,6 +157,131 @@ func (b *testBackend) CalcBlockExtApi() bool {
 
 func (b *testBackend) ChainID() *big.Int {
 	return params.TestChainConfig.ChainID
+}
+
+// instrumentedBackend observes and, optionally, blocks the GetReceiptsByNumber
+// calls the event loop makes while broadcasting blocks.
+type instrumentedBackend struct {
+	*testBackend
+	receiptCalls atomic.Int32
+	entered      chan struct{} // if non-nil, signaled on each call
+	release      chan struct{} // if non-nil, each call blocks until it is closed
+}
+
+func (b *instrumentedBackend) GetReceiptsByNumber(ctx context.Context, number rpc.BlockNumber) (types.Receipts, error) {
+	b.receiptCalls.Add(1)
+	if b.entered != nil {
+		b.entered <- struct{}{}
+	}
+	if b.release != nil {
+		<-b.release
+	}
+	return b.testBackend.GetReceiptsByNumber(ctx, number)
+}
+
+func sendBlock(backend *instrumentedBackend, number int64) {
+	backend.blocksFeed.Send(evmcore.ChainHeadNotify{
+		Block: &evmcore.EvmBlock{
+			EvmHeader: evmcore.EvmHeader{Number: big.NewInt(number)},
+		},
+	})
+}
+
+// Stop must not return while a broadcast is reading from the backend, since the
+// store may be closed right after.
+func TestEventSystem_Stop_WaitsForInFlightBroadcast(t *testing.T) {
+	backend := &instrumentedBackend{
+		testBackend: newTestBackend(),
+		entered:     make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	es := NewEventSystem(backend)
+
+	sendBlock(backend, 1)
+
+	// Wait until the broadcast is blocked inside the backend read.
+	select {
+	case <-backend.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("broadcast did not reach the backend")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		es.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned while a broadcast was still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(backend.release)
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return after the broadcast completed")
+	}
+}
+
+// After Stop returns the loop is gone and no longer reads from the backend.
+func TestEventSystem_Stop_NoBroadcastAfterStop(t *testing.T) {
+	backend := &instrumentedBackend{testBackend: newTestBackend()}
+	es := NewEventSystem(backend)
+
+	es.Stop()
+
+	sendBlock(backend, 1)
+	time.Sleep(100 * time.Millisecond) // allow any erroneous processing to run
+
+	if got := backend.receiptCalls.Load(); got != 0 {
+		t.Fatalf("expected no receipt reads after Stop, got %d", got)
+	}
+}
+
+func TestEventSystem_Stop_Idempotent(t *testing.T) {
+	es := NewEventSystem(newTestBackend())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			es.Stop()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Stop calls did not all return")
+	}
+
+	es.Stop()
+}
+
+func TestPublicFilterAPI_Stop(t *testing.T) {
+	api := NewPublicFilterAPI(newTestBackend(), testConfig())
+
+	done := make(chan struct{})
+	go func() {
+		api.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PublicFilterAPI.Stop did not return")
+	}
 }
 
 func TestPendingTxFilter(t *testing.T) {

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -256,6 +256,9 @@ type Service struct {
 	EthAPI        *EthAPIBackend
 	netRPCService *ethapi.PublicNetAPI
 
+	// filterAPI must be stopped during shutdown before the store is closed.
+	filterAPI *filters.PublicFilterAPI
+
 	procLogger *proclogger.Logger
 
 	stopped   bool
@@ -526,6 +529,9 @@ func (s *Service) Protocols() ([]p2p.Protocol, CleanupFunc) {
 func (s *Service) APIs() []rpc.API {
 	apis := api.GetAPIs(s.EthAPI)
 
+	// Retained so its event loop can be stopped before the store is closed.
+	s.filterAPI = filters.NewPublicFilterAPI(s.EthAPI, s.config.FilterAPI)
+
 	apis = append(apis, []rpc.API{
 		{
 			Namespace: "eth",
@@ -535,7 +541,7 @@ func (s *Service) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.EthAPI, s.config.FilterAPI),
+			Service:   s.filterAPI,
 			Public:    true,
 		}, {
 			Namespace: "net",
@@ -625,6 +631,10 @@ func (s *Service) Stop() error {
 	s.operaDialCandidates.Close()
 
 	s.handler.Stop()
+	// Must stop before the store is closed to avoid reading from a closed store.
+	if s.filterAPI != nil {
+		s.filterAPI.Stop()
+	}
 	s.feed.Stop()
 	s.gpo.Stop()
 	// it's safe to stop tflusher only before locking engineMu


### PR DESCRIPTION
This PR cleans up the shutdown process of the client. The filter system loop is now guaranteed to stop before the database caches (that are read from) are set to nil.