### PR TITLE
Support adding multiple transactions to pool atomically in tests

### DIFF
--- a/api/testapi/api.go
+++ b/api/testapi/api.go
@@ -48,13 +48,45 @@ func (a *TestApi) ProposeTransactions(
 	if !a.backend.IsTestOnlyApiEnabled() {
 		return fmt.Errorf("test-only API is not enabled")
 	}
+	txs, err := decodeTransactions(transactions)
+	if err != nil {
+		return err
+	}
+	return a.backend.ProposeTransactions(txs)
+}
+
+// AddTransactions decodes and adds a batch of transactions to the node's
+// transaction pool in a single call, so they all become available for event
+// emission at the same time. Unlike ProposeTransactions it does not bypass the
+// pool: normal validation and priority-based ordering still apply.
+//
+// This method is intended to be used in integration tests that need a whole
+// batch to reach the pool atomically, avoiding the race where the emitter
+// builds an event before every transaction submitted via separate RPCs has
+// arrived.
+func (a *TestApi) AddTransactions(
+	_ context.Context,
+	transactions [][]byte,
+) error {
+	if !a.backend.IsTestOnlyApiEnabled() {
+		return fmt.Errorf("test-only API is not enabled")
+	}
+	txs, err := decodeTransactions(transactions)
+	if err != nil {
+		return err
+	}
+	return a.backend.AddTransactions(txs)
+}
+
+// decodeTransactions RLP-decodes a batch of transactions.
+func decodeTransactions(transactions [][]byte) (types.Transactions, error) {
 	txs := make(types.Transactions, len(transactions))
 	for i, cur := range transactions {
 		var tx types.Transaction
 		if err := rlp.DecodeBytes(cur, &tx); err != nil {
-			return err
+			return nil, err
 		}
 		txs[i] = &tx
 	}
-	return a.backend.ProposeTransactions(txs)
+	return txs, nil
 }

--- a/api/testapi/api_test.go
+++ b/api/testapi/api_test.go
@@ -17,6 +17,7 @@
 package testapi
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -26,64 +27,92 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestTestApi_ProposeTransactions_FailsIfNotEnabled(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	backend := NewMockBackend(ctrl)
-	backend.EXPECT().IsTestOnlyApiEnabled().Return(false)
-
-	api := &TestApi{backend: backend}
-
-	err := api.ProposeTransactions(t.Context(), nil)
-	require.ErrorContains(t, err, "test-only API is not enabled")
+var methods = map[string]struct {
+	call   func(*TestApi, context.Context, [][]byte) error
+	expect func(*MockBackend) *gomock.Call
+}{
+	"ProposeTransactions": {
+		call:   (*TestApi).ProposeTransactions,
+		expect: func(b *MockBackend) *gomock.Call { return b.EXPECT().ProposeTransactions(gomock.Any()) },
+	},
+	"AddTransactions": {
+		call:   (*TestApi).AddTransactions,
+		expect: func(b *MockBackend) *gomock.Call { return b.EXPECT().AddTransactions(gomock.Any()) },
+	},
 }
 
-func TestTestApi_ProposeTransactions_FailsOnDecodingError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	backend := NewMockBackend(ctrl)
-	backend.EXPECT().IsTestOnlyApiEnabled().Return(true)
+func TestTestApi_FailsIfNotEnabled(t *testing.T) {
+	for name, m := range methods {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			backend := NewMockBackend(ctrl)
+			backend.EXPECT().IsTestOnlyApiEnabled().Return(false)
 
-	data := [][]byte{[]byte("not a valid RLP encoding")}
-
-	api := &TestApi{backend: backend}
-	err := api.ProposeTransactions(t.Context(), data)
-	require.ErrorContains(t, err, "typed transaction too short")
+			api := &TestApi{backend: backend}
+			err := m.call(api, t.Context(), nil)
+			require.ErrorContains(t, err, "test-only API is not enabled")
+		})
+	}
 }
 
-func TestTestApi_ProposeTransactions_ForwardsTransactionsToBackend(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	backend := NewMockBackend(ctrl)
-	backend.EXPECT().IsTestOnlyApiEnabled().Return(true)
+func TestTestApi_FailsOnDecodingError(t *testing.T) {
+	for name, m := range methods {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			backend := NewMockBackend(ctrl)
+			backend.EXPECT().IsTestOnlyApiEnabled().Return(true)
 
-	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
-	txData, err := rlp.EncodeToBytes(tx)
-	require.NoError(t, err)
+			data := [][]byte{[]byte("not a valid RLP encoding")}
 
-	want := []*types.Transaction{tx}
-	data := [][]byte{txData}
-
-	backend.EXPECT().ProposeTransactions(gomock.Any()).DoAndReturn(
-		func(got []*types.Transaction) error {
-			require.Equal(t, len(want), len(got))
-			for i := range want {
-				require.Equal(t, want[i].Hash(), got[i].Hash())
-			}
-			return nil
-		},
-	)
-
-	api := &TestApi{backend: backend}
-	require.NoError(t, api.ProposeTransactions(t.Context(), data))
+			api := &TestApi{backend: backend}
+			err := m.call(api, t.Context(), data)
+			require.ErrorContains(t, err, "typed transaction too short")
+		})
+	}
 }
 
-func TestTestApi_ProposeTransactions_ReturnsEncounteredIssueDuringProposing(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	backend := NewMockBackend(ctrl)
-	backend.EXPECT().IsTestOnlyApiEnabled().Return(true)
+func TestTestApi_ForwardsTransactionsToBackend(t *testing.T) {
+	for name, m := range methods {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			backend := NewMockBackend(ctrl)
+			backend.EXPECT().IsTestOnlyApiEnabled().Return(true)
 
-	issue := fmt.Errorf("introduced test-issue")
+			tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+			txData, err := rlp.EncodeToBytes(tx)
+			require.NoError(t, err)
 
-	backend.EXPECT().ProposeTransactions(gomock.Any()).Return(issue)
+			want := []*types.Transaction{tx}
+			data := [][]byte{txData}
 
-	api := &TestApi{backend: backend}
-	require.ErrorIs(t, api.ProposeTransactions(t.Context(), nil), issue)
+			m.expect(backend).DoAndReturn(
+				func(got []*types.Transaction) error {
+					require.Equal(t, len(want), len(got))
+					for i := range want {
+						require.Equal(t, want[i].Hash(), got[i].Hash())
+					}
+					return nil
+				},
+			)
+
+			api := &TestApi{backend: backend}
+			require.NoError(t, m.call(api, t.Context(), data))
+		})
+	}
+}
+
+func TestTestApi_ReturnsEncounteredIssueFromBackend(t *testing.T) {
+	for name, m := range methods {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			backend := NewMockBackend(ctrl)
+			backend.EXPECT().IsTestOnlyApiEnabled().Return(true)
+
+			issue := fmt.Errorf("introduced test-issue")
+			m.expect(backend).Return(issue)
+
+			api := &TestApi{backend: backend}
+			require.ErrorIs(t, m.call(api, t.Context(), nil), issue)
+		})
+	}
 }

--- a/api/testapi/backend.go
+++ b/api/testapi/backend.go
@@ -33,4 +33,10 @@ type Backend interface {
 	// This method is intended to be used in integration tests to simulate the
 	// malicious behavior of a validator proposing invalid transactions.
 	ProposeTransactions(txs types.Transactions) error
+
+	// AddTransactions adds a batch of transactions to the node's transaction
+	// pool in a single call, so they all become available for event emission at
+	// the same time. In contrast to ProposeTransactions the transactions are
+	// not proposed directly but validated and ordered by the emitter as usual.
+	AddTransactions(txs types.Transactions) error
 }

--- a/api/testapi/backend_mock.go
+++ b/api/testapi/backend_mock.go
@@ -40,6 +40,20 @@ func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 	return m.recorder
 }
 
+// AddTransactions mocks base method.
+func (m *MockBackend) AddTransactions(txs types.Transactions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTransactions", txs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddTransactions indicates an expected call of AddTransactions.
+func (mr *MockBackendMockRecorder) AddTransactions(txs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTransactions", reflect.TypeOf((*MockBackend)(nil).AddTransactions), txs)
+}
+
 // IsTestOnlyApiEnabled mocks base method.
 func (m *MockBackend) IsTestOnlyApiEnabled() bool {
 	m.ctrl.T.Helper()

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -18,6 +18,7 @@ package gossip
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -657,6 +658,18 @@ func (b *EthAPIBackend) ProposeTransactions(
 		return fmt.Errorf("no emitters available to propose transactions")
 	}
 	return b.proposeTransactionsInternal(txs, b.svc.emitters[0])
+}
+
+func (b *EthAPIBackend) AddTransactions(
+	txs types.Transactions,
+) error {
+	if !b.IsTestOnlyApiEnabled() {
+		return fmt.Errorf("this feature is disabled")
+	}
+	if b.svc.txpool == nil {
+		return fmt.Errorf("no transaction pool available to add transactions")
+	}
+	return stderrors.Join(b.svc.txpool.AddLocals(txs)...)
 }
 
 func (b *EthAPIBackend) proposeTransactionsInternal(

--- a/gossip/ethapi_backend_test.go
+++ b/gossip/ethapi_backend_test.go
@@ -185,6 +185,67 @@ func TestEthApiBackend_proposeTransactionsInternal_ReturnsEmissionIssue(t *testi
 	require.ErrorIs(t, backend.proposeTransactionsInternal(nil, emitter), issue)
 }
 
+func TestEthApiBackend_AddTransactions_ReturnsErrorWhenTestOnlyApiDisabled(t *testing.T) {
+	backend := &EthAPIBackend{
+		svc: &Service{
+			config: Config{EnableTestOnlyApi: false},
+		},
+	}
+
+	err := backend.AddTransactions(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "disabled")
+}
+
+func TestEthApiBackend_AddTransactions_ReturnsErrorWhenTxPoolMissing(t *testing.T) {
+	backend := &EthAPIBackend{
+		svc: &Service{
+			config: Config{EnableTestOnlyApi: true},
+		},
+	}
+
+	err := backend.AddTransactions(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no transaction pool")
+}
+
+func TestEthApiBackend_AddTransactions_ForwardsTransactionsToPool(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	pool := NewMockTxPool(ctrl)
+
+	backend := &EthAPIBackend{
+		svc: &Service{
+			config: Config{EnableTestOnlyApi: true},
+			txpool: pool,
+		},
+	}
+
+	txs := []*types.Transaction{
+		types.NewTx(&types.LegacyTx{Nonce: 1}),
+		types.NewTx(&types.LegacyTx{Nonce: 2}),
+	}
+
+	pool.EXPECT().AddLocals(types.Transactions(txs)).Return([]error{nil, nil})
+	require.NoError(t, backend.AddTransactions(txs))
+}
+
+func TestEthApiBackend_AddTransactions_ReturnsPoolRejections(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	pool := NewMockTxPool(ctrl)
+
+	backend := &EthAPIBackend{
+		svc: &Service{
+			config: Config{EnableTestOnlyApi: true},
+			txpool: pool,
+		},
+	}
+
+	issue := fmt.Errorf("injected test issue")
+
+	pool.EXPECT().AddLocals(gomock.Any()).Return([]error{nil, issue})
+	require.ErrorIs(t, backend.AddTransactions(nil), issue)
+}
+
 func TestEthApiBackend_epochWithDefault_RejectsEpochsAboveUint32Max(t *testing.T) {
 	const currentEpoch = idx.Epoch(1000)
 

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -1201,6 +1201,16 @@ func (s *Session) TrySendAll(tx []*types.Transaction) ([]common.Hash, map[common
 	return accepted, rejected, err
 }
 
+// SendAllToPool adds the given transactions to the node's transaction pool in a
+// single batch RPC, so they all become available for event emission at the same
+// time. Unlike SendAll, which submits each transaction via a separate parallel
+// RPC, this avoids the race where the emitter builds an event before the whole
+// batch has reached the pool. The transactions are ordered by the emitter as
+// usual. It returns the transaction hashes in input order.
+func (s *Session) SendAllToPool(ctx context.Context, txs []*types.Transaction) ([]common.Hash, error) {
+	return s.callWithEncodedTxs(ctx, "test_addTransactions", txs)
+}
+
 func (s *Session) ForceEmit(
 	ctx context.Context,
 	tx *types.Transaction,
@@ -1213,6 +1223,10 @@ func (s *Session) ForceEmit(
 }
 
 func (s *Session) ForceEmitAll(ctx context.Context, txs []*types.Transaction) ([]common.Hash, error) {
+	return s.callWithEncodedTxs(ctx, "test_proposeTransactions", txs)
+}
+
+func (s *Session) callWithEncodedTxs(ctx context.Context, method string, txs []*types.Transaction) ([]common.Hash, error) {
 	client, err := s.GetClient()
 	if err != nil {
 		return nil, err
@@ -1228,8 +1242,7 @@ func (s *Session) ForceEmitAll(ctx context.Context, txs []*types.Transaction) ([
 		data[i] = encoded
 	}
 
-	err = client.Client().CallContext(ctx, nil, "test_proposeTransactions", data)
-	if err != nil {
+	if err := client.Client().CallContext(ctx, nil, method, data); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR allows tests so add a bunch of transactions at once to the txpool. This is useful so that test can assume that once they get processed (emitter stage), all transactions are guaranteed to be in the pool, and there is no race between the first transactions being emitted, and the last ones getting into the pool.