### PR TITLE
Add TransactionPriorities upgrade flag

### DIFF
--- a/opera/legacy_serialization.go
+++ b/opera/legacy_serialization.go
@@ -127,6 +127,9 @@ func (u Upgrades) EncodeRLP(w io.Writer) error {
 	if u.TransactionBundles {
 		bitmap.V |= transactionBundlesBit
 	}
+	if u.TransactionPriorities {
+		bitmap.V |= transactionPrioritiesBit
+	}
 	return rlp.Encode(w, &bitmap)
 }
 
@@ -149,6 +152,7 @@ func (u *Upgrades) DecodeRLP(s *rlp.Stream) error {
 	u.SingleProposerBlockFormation = (bitmap.V & singleProposerBlockFormationBit) != 0
 	u.GasSubsidies = (bitmap.V & gasSubsidiesBit) != 0
 	u.TransactionBundles = (bitmap.V & transactionBundlesBit) != 0
+	u.TransactionPriorities = (bitmap.V & transactionPrioritiesBit) != 0
 	return nil
 }
 

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -147,6 +147,7 @@ func TestUpgradesRLP_CanBeEncodedAndDecoded(t *testing.T) {
 		func(u *Upgrades) { u.Brio = true },
 		func(u *Upgrades) { u.GasSubsidies = true },
 		func(u *Upgrades) { u.TransactionBundles = true },
+		func(u *Upgrades) { u.TransactionPriorities = true },
 	}
 
 	for mask := range 1 << len(setUpgrade) {

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -49,6 +49,7 @@ const (
 	singleProposerBlockFormationBit = 1 << 63
 	gasSubsidiesBit                 = 1 << 62
 	transactionBundlesBit           = 1 << 61
+	transactionPrioritiesBit        = 1 << 60
 
 	MinimumMaxBlockGas          = 5_000_000_000 // < must be large enough to allow internal transactions to seal blocks
 	MaximumMaxBlockGas          = math.MaxInt64 // < should fit into 64-bit signed integers to avoid parsing errors in third-party libraries
@@ -264,6 +265,22 @@ type Upgrades struct {
 	// It can be enabled or disabled at any time. Changes in the feature state
 	// become effective at the start of the next epoch.
 	TransactionBundles bool
+
+	// TransactionPriorities enables the transaction priorities feature, allowing
+	// an on-chain registry contract to designate a subset of transactions to be
+	// scheduled ahead of others within a block.
+	// This feature is introduced by V2.3 of the Sonic client. It thus
+	//
+	//    MUST ONLY BE ENABLED WHEN ALL NODES ARE RUNNING V2.3 OR LATER
+	//
+	// Any node not running V2.3 or later will ignore this flag, will not apply
+	// the priority ordering, and eventually drop off the network due to the
+	// inability to reproduce the resulting blocks.
+	//
+	// Given the conditions stated above, the feature is considered optional.
+	// It can be enabled or disabled at any time. Changes in the feature state
+	// become effective at the start of the next epoch.
+	TransactionPriorities bool
 }
 
 // UpgradeHeight contains the information about the block height at which

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -205,6 +205,11 @@ func TestRules_Copy_CopiesAreDisjoint(t *testing.T) {
 				rule.Upgrades.TransactionBundles = !rule.Upgrades.TransactionBundles
 			},
 		},
+		"upgrade Upgrades.TransactionPriorities": {
+			update: func(rule *Rules) {
+				rule.Upgrades.TransactionPriorities = !rule.Upgrades.TransactionPriorities
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -289,5 +289,7 @@ func validateUpgrades(old, new Upgrades) error {
 
 	// The GasSubsidies feature can be freely modified.
 
+	// The TransactionPriorities feature can be freely modified.
+
 	return errors.Join(issues...)
 }


### PR DESCRIPTION
This PR introduce the TransactionPriorities feature flag gating the upcoming transaction-priorities ordering (GBS). It is wired through the Upgrades struct, RLP bitmap serialization, and rule validation (freely toggleable at epoch boundaries, like GasSubsidies). No behavior change while off.