### PR TITLE
Add basic types for transaction priorities

### DIFF
--- a/gossip/blockproc/priorities/types.go
+++ b/gossip/blockproc/priorities/types.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+// Package priorities implements the transaction-priorities feature: querying an
+// on-chain registry contract to determine, per transaction, a priority level, a
+// weight, and an entity id, and using those to eagerly emit prioritized
+// transactions and to order them first during block formation.
+package priorities
+
+import "github.com/holiman/uint256"
+
+// Priority is the result of a getPriority query for a single transaction.
+//
+// Level zero means the transaction is not prioritized. A higher level forms an
+// earlier partition (scheduled before lower levels). Weight breaks ties within a
+// level (higher first). Id identifies the entity the transaction belongs to and
+// is used for per-entity rate limiting. The semantics of Id are opaque to this
+// code and only interpreted by the registry.
+type Priority struct {
+	Level  uint256.Int
+	Weight uint256.Int
+	ID     [32]byte
+}
+
+// IsPrioritized reports whether the transaction has a non-zero priority level.
+func (p Priority) IsPrioritized() bool {
+	return !p.Level.IsZero()
+}
+
+// Cmp compares two priorities by (level, weight), returning -1, 0, or +1.
+// A higher level takes precedence; weight breaks ties within the same non-zero
+// level. Non-prioritized entries (level zero) always compare equal regardless
+// of weight.
+func (p Priority) Cmp(other Priority) int {
+	if c := p.Level.Cmp(&other.Level); c != 0 {
+		return c
+	}
+	if p.Level.IsZero() {
+		return 0
+	}
+	return p.Weight.Cmp(&other.Weight)
+}
+
+// Config holds the per-entity rate limits returned by the registry's
+// getPriorityConfig function.
+type Config struct {
+	// MaxGasPerEntityPerBlock bounds the total gas limit of prioritized
+	// transactions of one entity in a single block (authoritative, enforced at
+	// block formation).
+	// Transactions are packed in (level desc, weight desc, hash asc) order
+	// until the next transaction would exceed the budget; the remainder is
+	// demoted.
+	MaxGasPerEntityPerBlock uint64
+	// MaxPiggybackTxsPerEntityPerEvent bounds how many prioritized transactions
+	// of one entity a validator eagerly includes in a single emitted event
+	// (best-effort hint). It applies only to prioritized transactions admitted
+	// while it is not this validator's turn; transactions admitted on the
+	// validator's own turn are not bounded by this limit.
+	MaxPiggybackTxsPerEntityPerEvent uint64
+}

--- a/gossip/blockproc/priorities/types.go
+++ b/gossip/blockproc/priorities/types.go
@@ -20,24 +20,24 @@
 // transactions and to order them first during block formation.
 package priorities
 
-import "github.com/holiman/uint256"
+import "cmp"
 
 // Priority is the result of a getPriority query for a single transaction.
 //
 // Level zero means the transaction is not prioritized. A higher level forms an
 // earlier partition (scheduled before lower levels). Weight breaks ties within a
-// level (higher first). Id identifies the entity the transaction belongs to and
-// is used for per-entity rate limiting. The semantics of Id are opaque to this
+// level (higher first). ID identifies the entity the transaction belongs to and
+// is used for per-entity rate limiting. The semantics of ID are opaque to this
 // code and only interpreted by the registry.
 type Priority struct {
-	Level  uint256.Int
-	Weight uint256.Int
-	ID     [32]byte
+	Level  uint64
+	Weight uint64
+	ID     [16]byte
 }
 
 // IsPrioritized reports whether the transaction has a non-zero priority level.
 func (p Priority) IsPrioritized() bool {
-	return !p.Level.IsZero()
+	return p.Level != 0
 }
 
 // Cmp compares two priorities by (level, weight), returning -1, 0, or +1.
@@ -45,13 +45,13 @@ func (p Priority) IsPrioritized() bool {
 // level. Non-prioritized entries (level zero) always compare equal regardless
 // of weight.
 func (p Priority) Cmp(other Priority) int {
-	if c := p.Level.Cmp(&other.Level); c != 0 {
+	if c := cmp.Compare(p.Level, other.Level); c != 0 {
 		return c
 	}
-	if p.Level.IsZero() {
+	if p.Level == 0 {
 		return 0
 	}
-	return p.Weight.Cmp(&other.Weight)
+	return cmp.Compare(p.Weight, other.Weight)
 }
 
 // Config holds the per-entity rate limits returned by the registry's

--- a/gossip/blockproc/priorities/types.go
+++ b/gossip/blockproc/priorities/types.go
@@ -42,8 +42,8 @@ func (p Priority) IsPrioritized() bool {
 
 // Cmp compares two priorities by (level, weight), returning -1, 0, or +1.
 // A higher level takes precedence; weight breaks ties within the same non-zero
-// level. Non-prioritized entries (level zero) always compare equal regardless
-// of weight.
+// level. Two non-prioritized entries (level zero) always compare equal
+// regardless of weight.
 func (p Priority) Cmp(other Priority) int {
 	if c := cmp.Compare(p.Level, other.Level); c != 0 {
 		return c

--- a/gossip/blockproc/priorities/types_test.go
+++ b/gossip/blockproc/priorities/types_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package priorities
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriority_IsPrioritized_ChecksIfLevelIsGreater0(t *testing.T) {
+	var with9ByteLevel Priority
+	with9ByteLevel.Level.SetUint64(math.MaxUint64)
+	with9ByteLevel.Level.AddUint64(&with9ByteLevel.Level, 1)
+
+	tests := map[string]struct {
+		prio Priority
+		want bool
+	}{
+		"zero level":         {Prio(0, 0, 0), false},
+		"zero level, weight": {Prio(0, 5, 0), false},
+		"non-zero level":     {Prio(1, 0, 0), true},
+		"non-zero 9 byte":    {with9ByteLevel, true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.prio.IsPrioritized())
+		})
+	}
+}
+
+func TestPriority_Cmp(t *testing.T) {
+	tests := map[string]struct {
+		a, b Priority
+		want int
+	}{
+		"higher level wins":                        {Prio(2, 0, 0), Prio(1, 1, 0), 1},
+		"lower level loses":                        {Prio(1, 1, 0), Prio(2, 0, 0), -1},
+		"equal non-zero level, higher weight wins": {Prio(1, 2, 0), Prio(1, 1, 0), 1},
+		"equal non-zero level, lower weight loses": {Prio(1, 1, 0), Prio(1, 2, 0), -1},
+		"equal non-zero level and weight":          {Prio(1, 1, 0), Prio(1, 1, 0), 0},
+		"zero level ignores weight":                {Prio(0, 1, 0), Prio(0, 2, 0), 0},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.a.Cmp(tc.b))
+		})
+	}
+}
+
+// Prio builds a Priority for tests. Level and weight are limited to uint64 and
+// id to a single byte for simplicity.
+func Prio(level uint64, weight uint64, id byte) Priority {
+	p := Priority{}
+	p.Level.SetUint64(level)
+	p.Weight.SetUint64(weight)
+	p.ID[31] = id
+	return p
+}

--- a/gossip/blockproc/priorities/types_test.go
+++ b/gossip/blockproc/priorities/types_test.go
@@ -24,10 +24,6 @@ import (
 )
 
 func TestPriority_IsPrioritized_ChecksIfLevelIsGreater0(t *testing.T) {
-	var with9ByteLevel Priority
-	with9ByteLevel.Level.SetUint64(math.MaxUint64)
-	with9ByteLevel.Level.AddUint64(&with9ByteLevel.Level, 1)
-
 	tests := map[string]struct {
 		prio Priority
 		want bool
@@ -35,7 +31,7 @@ func TestPriority_IsPrioritized_ChecksIfLevelIsGreater0(t *testing.T) {
 		"zero level":         {Prio(0, 0, 0), false},
 		"zero level, weight": {Prio(0, 5, 0), false},
 		"non-zero level":     {Prio(1, 0, 0), true},
-		"non-zero 9 byte":    {with9ByteLevel, true},
+		"max level":          {Prio(math.MaxUint64, 0, 0), true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -63,12 +59,8 @@ func TestPriority_Cmp(t *testing.T) {
 	}
 }
 
-// Prio builds a Priority for tests. Level and weight are limited to uint64 and
-// id to a single byte for simplicity.
+// Prio builds a Priority for tests. The id is limited to a single byte for
+// simplicity.
 func Prio(level uint64, weight uint64, id byte) Priority {
-	p := Priority{}
-	p.Level.SetUint64(level)
-	p.Weight.SetUint64(weight)
-	p.ID[31] = id
-	return p
+	return Priority{Level: level, Weight: weight, ID: [16]byte{15: id}}
 }

--- a/gossip/blockproc/priorities/types_test.go
+++ b/gossip/blockproc/priorities/types_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPriority_IsPrioritized_ChecksIfLevelIsGreater0(t *testing.T) {
+func TestPriority_IsPrioritized_ChecksIfLevelIsNonZero(t *testing.T) {
 	tests := map[string]struct {
 		prio Priority
 		want bool


### PR DESCRIPTION
This PR adds the `Priority` and `Config` types and related methods. These two types are the return types of the `getPriority` and `getPriorityConfig` contract calls which will be added in the next PR. The `Priority` defines which priority should be applied to a given transaction and the entity under which the priority is registered. The `Config` contains the limits that are applied during event emission and block formation.