### PR TITLE
Clean debug RPC namespace [v2.2]

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2822,7 +2822,7 @@ func NewPrivateDebugAPI(b Backend) *PrivateDebugAPI {
 
 // ChaindbProperty returns leveldb properties of the key-value database.
 func (api *PrivateDebugAPI) ChaindbProperty(property string) (string, error) {
-	return "", errors.New("carmen database does provide db properties")
+	return "", errors.New("carmen database does not provide db properties")
 }
 
 // ChaindbCompact flattens the entire key-value database into a single level,

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2386,16 +2386,6 @@ func (api *PublicDebugAPI) GetBlockRlp(ctx context.Context, number uint64) (stri
 	return fmt.Sprintf("%x", encoded), nil
 }
 
-// TestSignCliqueBlock fetches the given block number, and attempts to sign it as a clique header with the
-// given address, returning the address of the recovered signature
-//
-// This is a temporary method to debug the externalsigner integration,
-func (api *PublicDebugAPI) TestSignCliqueBlock(ctx context.Context, address common.Address, number uint64) (common.Address, error) {
-	// This is a user-facing error, so we want to provide a clear message.
-	//nolint:staticcheck // ST1005: allow capitalized error message and punctuation
-	return common.Address{}, errors.New("Clique isn't supported")
-}
-
 // PrintBlock retrieves a block and returns its pretty printed form.
 func (api *PublicDebugAPI) PrintBlock(ctx context.Context, number uint64) (string, error) {
 	block, err := api.b.BlockByNumber(ctx, rpc.BlockNumber(number))

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2742,12 +2742,12 @@ func (api *PublicDebugAPI) TraceCall(ctx context.Context, args TransactionArgs, 
 	defer statedb.Release()
 
 	blockCtx := GetBlockContext(ctx, api.b, &block.EvmHeader)
-	if config.BlockOverrides != nil {
+	if config != nil && config.BlockOverrides != nil {
 		config.BlockOverrides.apply(&blockCtx)
 	}
 
 	// Apply state overrides
-	if config != nil {
+	if config != nil && config.StateOverrides != nil {
 		if err := config.StateOverrides.Apply(statedb); err != nil {
 			return nil, err
 		}

--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -398,7 +398,7 @@ func TestReplayInternalTransaction(t *testing.T) {
 	require.NoError(t, err, "must be possible to trace internal transaction on index 0 and 1 with zero gas price")
 }
 
-func TestBlockOverrides(t *testing.T) {
+func TestBlockStateOverrides(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -418,6 +418,7 @@ func TestBlockOverrides(t *testing.T) {
 	mockBackend.EXPECT().RPCEVMTimeout().Return(time.Duration(0)).AnyTimes()
 	mockBackend.EXPECT().MaxGasLimit().Return(uint64(10000000)).AnyTimes()
 	mockBackend.EXPECT().HeaderByNumber(any, any).Return(&block.EvmHeader, nil)
+	mockState.EXPECT().SetBalance(common.Address{1}, uint256.NewInt(123)).AnyTimes() // state override
 	setExpectedStateCalls(mockState)
 
 	expectedBlockCtx := &vm.BlockContext{
@@ -436,10 +437,18 @@ func TestBlockOverrides(t *testing.T) {
 		BaseFee: (*hexutil.Big)(big.NewInt(1234)),
 	}
 
+	overwrittenBalance := (*hexutil.U256)(uint256.NewInt(123))
+	stateOverrides := &StateOverride{
+		common.Address{1}: OverrideAccount{
+			Balance: &overwrittenBalance,
+		},
+	}
+
 	// Check block overrides on debug api with debug_traceCall rpc function
 	apiDebug := NewPublicDebugAPI(mockBackend, 10000, 10000)
 	traceConfig := &TraceCallConfig{
 		BlockOverrides: blockOverrides,
+		StateOverrides: stateOverrides,
 	}
 
 	rpcBlkNr := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(blockNr))
@@ -450,10 +459,10 @@ func TestBlockOverrides(t *testing.T) {
 	// Check block overrides on eth api with eth_call and eth_estimateGas rpc function
 	apiEth := NewPublicBlockChainAPI(mockBackend)
 
-	_, err = apiEth.Call(context.Background(), getTxArgs(t), rpcBlkNr, nil, blockOverrides)
+	_, err = apiEth.Call(context.Background(), getTxArgs(t), rpcBlkNr, stateOverrides, blockOverrides)
 	require.NoError(t, err, "debug api must be able to override block number and base fee")
 
-	_, err = apiEth.EstimateGas(context.Background(), getTxArgs(t), &rpcBlkNr, nil, blockOverrides)
+	_, err = apiEth.EstimateGas(context.Background(), getTxArgs(t), &rpcBlkNr, stateOverrides, blockOverrides)
 	require.NoError(t, err, "estimate gas must be able to override block number and base fee")
 }
 


### PR DESCRIPTION
**Merge of #1074 into v2.2**

Few minor cleanings in `debug_*` RPC namespace:
* Fix panic for nil config in `debug_traceCall` (**not security sensitive** - panic catched by handler's recover - only friendly error message)
* Fix error message reporting unsupported `debug_chaindbProperty` (...does **not** provide...)
* Removed `debug_testSignCliqueBlock` RPC method, which was never supported on Sonic and was completely removed on Ethereum 4 years ago