### PR TITLE
Adjust memory diff in the vmTrace option for trace RPC methods

### DIFF
--- a/api/ethapi/tx_trace.go
+++ b/api/ethapi/tx_trace.go
@@ -365,7 +365,11 @@ func (s *PublicTxTraceAPI) traceCallExec(
 		callResult.StateDiff = tracedEVM.stateDiffLogger.GetResult()
 	}
 	if traceOptions.VmTrace {
-		callResult.VmTrace = tracedEVM.vmTraceLogger.GetResult()
+		vmTrace, err := tracedEVM.vmTraceLogger.GetResult()
+		if err != nil {
+			return nil, err
+		}
+		callResult.VmTrace = vmTrace
 	}
 
 	return callResult, nil

--- a/tests/rpcs/trace_call_vm_trace_test.go
+++ b/tests/rpcs/trace_call_vm_trace_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package rpcs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/require"
+)
+
+// vmTraceCallResult captures the vmTrace part of a trace_call response.
+type vmTraceCallResult struct {
+	VmTrace json.RawMessage `json:"vmTrace"`
+}
+
+// vmTraceOps mirrors the minimal vmTrace structure needed for assertions.
+type vmTraceOps struct {
+	Ops []struct {
+		Op string          `json:"op"`
+		Ex json.RawMessage `json:"ex"`
+	} `json:"ops"`
+}
+
+// TestVmTrace_TraceCall_HugeMemoryOperandsDoNotExhaustMemory verifies that a
+// trace_call with the vmTrace option survives bytecode whose memory operands
+// are far beyond any allocatable size. The traced code is executed as init
+// code of a contract creation:
+//
+//	PUSH1 0x00; PUSH1 0x00; PUSH9 0xff..ff; CALLDATACOPY
+//	  — zero-length copy to an offset near 2^72: executes successfully
+//	    without expanding memory, so the tracer sees a huge (truncated)
+//	    offset but must not report or allocate any region for it.
+//	PUSH1 0x01; PUSH9 0xff..ff; MSTORE
+//	  — memory expansion to ~2^72 overflows the gas calculation and the
+//	    opcode faults with out-of-gas; the tracer must not allocate the
+//	    32-byte region at that offset either.
+//
+// The call itself fails with out-of-gas, but the RPC must return a bounded
+// vmTrace (no error, no node crash, no multi-gigabyte allocation).
+func TestVmTrace_TraceCall_HugeMemoryOperandsDoNotExhaustMemory(t *testing.T) {
+	net := tests.StartIntegrationTestNet(t)
+
+	sender := tests.NewAccount()
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	code := []byte{
+		0x60, 0x00, // PUSH1 0x00 (size)
+		0x60, 0x00, // PUSH1 0x00 (source offset)
+		0x68, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // PUSH9 dest offset ~2^72
+		0x37,       // CALLDATACOPY (zero-size, succeeds)
+		0x60, 0x01, // PUSH1 0x01 (value)
+		0x68, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // PUSH9 offset ~2^72
+		0x52, // MSTORE (faults with out-of-gas)
+	}
+
+	txArgs := map[string]any{
+		"from": sender.Address(),
+		"gas":  hexutil.Uint64(500_000),
+		"data": hexutil.Bytes(code),
+	}
+
+	var result vmTraceCallResult
+	err = client.Client().Call(&result, "trace_call", txArgs, []string{"vmTrace"}, "latest")
+	require.NoError(t, err, "trace_call must not fail on huge memory operands")
+	require.NotEmpty(t, result.VmTrace, "vmTrace must be present in the response")
+
+	// The response must stay bounded: no memory region may have been dumped
+	// for the huge operands. The full trace of this short program is tiny.
+	require.Less(t, len(result.VmTrace), 1<<20,
+		"vmTrace response unexpectedly large — a huge memory region may have been recorded")
+
+	var trace vmTraceOps
+	require.NoError(t, json.Unmarshal(result.VmTrace, &trace))
+	require.NotEmpty(t, trace.Ops, "vmTrace must record the executed opcodes")
+
+	// The faulting MSTORE is the last recorded op and must have no execution
+	// result (Ex == null) — in particular no memory region.
+	last := trace.Ops[len(trace.Ops)-1]
+	require.Equal(t, "MSTORE", last.Op)
+	require.Equal(t, "null", string(last.Ex), "faulting MSTORE must have null ex")
+
+	// The node must still be responsive after serving the hostile trace.
+	var blockNumber hexutil.Uint64
+	require.NoError(t, client.Client().Call(&blockNumber, "eth_blockNumber"),
+		"node must remain responsive after the trace")
+}

--- a/txtrace/vm_trace.go
+++ b/txtrace/vm_trace.go
@@ -17,7 +17,6 @@
 package txtrace
 
 import (
-	"bytes"
 	"errors"
 	"math/big"
 
@@ -52,7 +51,8 @@ type VmExecutedOperation struct {
 	Store *StorageDiff  `json:"store"`
 }
 
-// MemoryDiff records the full VM memory snapshot at opcode execution time.
+// MemoryDiff records the memory region written (or, for MLOAD, read) by an
+// opcode, matching the Parity/OpenEthereum vmTrace "mem" semantics.
 type MemoryDiff struct {
 	Off  uint64        `json:"off"`
 	Data hexutil.Bytes `json:"data"`
@@ -66,11 +66,26 @@ type StorageDiff struct {
 
 // vmTraceFrame is the call frame state maintained by VmTraceLogger.
 type vmTraceFrame struct {
-	trace       *VmTrace
-	lastOpIdx   int       // index of the most recently appended op, -1 if none
-	lastOp      vm.OpCode // opcode at lastOpIdx
-	memSnapshot []byte    // memory snapshot taken at OnOpcode time for the last op
+	trace     *VmTrace
+	lastOpIdx int       // index of the most recently appended op, -1 if none
+	lastOp    vm.OpCode // opcode at lastOpIdx
+	showMem   bool      // lastOp touches a memory region to be reported
+	memOff    uint64    // offset of the memory region touched by lastOp
+	memLen    uint64    // length of the memory region touched by lastOp
 }
+
+// vmTraceSizeLimit caps the cumulative size of data retained in a single
+// vmTrace (memory regions, code, per-op overhead). Tracing aborts with an
+// error once the limit is exceeded, protecting the node from OOM on
+// pathological traces.
+const vmTraceSizeLimit = 256 << 20 // 256 MB
+
+// vmTraceOpOverhead approximates the fixed per-operation memory footprint
+// counted against vmTraceSizeLimit.
+const vmTraceOpOverhead = 64
+
+// errVmTraceTooLarge is returned by GetResult when the trace exceeded vmTraceSizeLimit.
+var errVmTraceTooLarge = errors.New("vmTrace result exceeds size limit")
 
 // VmTraceLogger implements VM tracing hooks to build vmTrace.
 type VmTraceLogger struct {
@@ -78,6 +93,8 @@ type VmTraceLogger struct {
 	result       *VmTrace
 	stateDB      tracing.StateDB
 	pendingStore *StorageDiff // latest storage write, attributed to the current op
+	traceSize    uint64       // approximate retained bytes, checked against vmTraceSizeLimit
+	err          error        // set when the trace was aborted (size limit exceeded)
 }
 
 // NewVmTraceLogger creates a new VmTraceLogger.
@@ -97,14 +114,34 @@ func (l *VmTraceLogger) Hooks() *tracing.Hooks {
 	}
 }
 
-// GetResult returns the completed vmTrace after execution.
-func (l *VmTraceLogger) GetResult() *VmTrace {
-	return l.result
+// GetResult returns the completed vmTrace after execution, or an error when
+// the trace was aborted because it exceeded the size limit.
+func (l *VmTraceLogger) GetResult() (*VmTrace, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+	return l.result, nil
+}
+
+// addSize accounts n bytes against the trace size limit. When the limit is
+// exceeded, the trace is aborted: the error is recorded and all accumulated
+// data is released so it can be garbage collected.
+func (l *VmTraceLogger) addSize(n uint64) {
+	l.traceSize += n
+	if l.traceSize > vmTraceSizeLimit {
+		l.err = errVmTraceTooLarge
+		l.traceStack = nil
+		l.result = nil
+		l.pendingStore = nil
+	}
 }
 
 // OnStorageChange records a storage write so it can be attributed to the
 // currently executing opcode.
 func (l *VmTraceLogger) OnStorageChange(_ common.Address, slot common.Hash, _ common.Hash, newVal common.Hash) {
+	if l.err != nil {
+		return
+	}
 	l.pendingStore = &StorageDiff{Key: slot, Val: newVal}
 }
 
@@ -115,6 +152,9 @@ func (l *VmTraceLogger) onTxStart(vmCtx *tracing.VMContext, _ *types.Transaction
 
 // onEnter creates a new VmTrace frame for each call or create.
 func (l *VmTraceLogger) onEnter(depth int, typ byte, _ common.Address, to common.Address, input []byte, gas uint64, _ *big.Int) {
+	if l.err != nil {
+		return
+	}
 	var (
 		code    []byte
 		noTrace = false
@@ -143,6 +183,11 @@ func (l *VmTraceLogger) onEnter(depth int, typ byte, _ common.Address, to common
 		lastOpIdx: -1,
 	}
 
+	l.addSize(uint64(len(code)))
+	if l.err != nil {
+		return
+	}
+
 	// Link this trace to the parent frame's last operation as a sub-trace.
 	if depth > 0 && len(l.traceStack) > 0 {
 		parent := l.traceStack[len(l.traceStack)-1]
@@ -156,7 +201,7 @@ func (l *VmTraceLogger) onEnter(depth int, typ byte, _ common.Address, to common
 
 // onExit finalizes the exiting frame's last operation and pops the frame.
 func (l *VmTraceLogger) onExit(depth int, _ []byte, _ uint64, _ error, _ bool) {
-	if len(l.traceStack) == 0 {
+	if l.err != nil || len(l.traceStack) == 0 {
 		return
 	}
 	frame := l.traceStack[len(l.traceStack)-1]
@@ -185,7 +230,7 @@ func (l *VmTraceLogger) onExit(depth int, _ []byte, _ uint64, _ error, _ bool) {
 // It finalizes the previous op's Ex using the current post execution
 // state, then records a new operation entry for the current opcode.
 func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, _ []byte, _ int, _ error) {
-	if len(l.traceStack) == 0 {
+	if l.err != nil || len(l.traceStack) == 0 {
 		return
 	}
 	frame := l.traceStack[len(l.traceStack)-1]
@@ -197,13 +242,17 @@ func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tra
 		if prevOp.Ex != nil {
 			prevOp.Ex.Push = computePushed(frame.lastOp, scope.StackData())
 			// scope.MemoryData() here is post-execution of the previous op.
-			// Compare against the pre-execution snapshot; only record a Mem diff
-			// when the opcode actually wrote to memory.
-			curMem := scope.MemoryData()
-			if !bytes.Equal(curMem, frame.memSnapshot) {
-				postMem := make([]byte, len(curMem))
-				copy(postMem, curMem)
-				prevOp.Ex.Mem = &MemoryDiff{Off: 0, Data: hexutil.Bytes(postMem)}
+			// Record only the memory region the previous op touched, matching
+			// the Parity/OpenEthereum "mem" semantics. For CALL-family ops this
+			// fires when the frame resumes after the sub-call, so the region
+			// holds the return data written to the caller's memory.
+			if frame.showMem && frame.memLen > 0 {
+				data := memoryRegion(scope.MemoryData(), frame.memOff, frame.memLen)
+				prevOp.Ex.Mem = &MemoryDiff{Off: frame.memOff, Data: data}
+				l.addSize(uint64(len(data)))
+				if l.err != nil {
+					return
+				}
 			}
 			if l.pendingStore != nil {
 				prevOp.Ex.Store = l.pendingStore
@@ -224,12 +273,60 @@ func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tra
 	frame.lastOpIdx = len(frame.trace.Ops) - 1
 	frame.lastOp = vm.OpCode(op)
 
-	// Memory snapshot is taken here. For dynamic gas opcodes this is BEFORE memory
-	// expansion (the interpreter expands memory after firing OnOpcode), so the snapshot
-	// reflects the pre execution memory state of this opcode.
-	curMem := scope.MemoryData()
-	frame.memSnapshot = make([]byte, len(curMem))
-	copy(frame.memSnapshot, curMem)
+	// Determine the memory region this opcode will touch. The stack is
+	// pre-execution here, so operand offsets/lengths can be read from it.
+	frame.showMem, frame.memOff, frame.memLen = memTouchedRegion(vm.OpCode(op), scope.StackData())
+	l.addSize(vmTraceOpOverhead)
+}
+
+// stackBack returns the n-th element from the top of the stack (0 = top).
+func stackBack(st []uint256.Int, n int) *uint256.Int {
+	return &st[len(st)-1-n]
+}
+
+// memTouchedRegion returns the memory region reported for an opcode in the
+// Parity/OpenEthereum vmTrace format: the region written by the op (MLOAD is
+// the historical exception — Parity reports the region it reads). Offsets and
+// lengths come from the pre-execution stack. CREATE/CREATE2/SELFDESTRUCT
+// report no region, matching OpenEthereum.
+func memTouchedRegion(op vm.OpCode, st []uint256.Int) (show bool, off, size uint64) {
+	switch op {
+	case vm.MSTORE, vm.MLOAD:
+		if len(st) > 0 {
+			return true, stackBack(st, 0).Uint64(), 32
+		}
+	case vm.MSTORE8:
+		if len(st) > 0 {
+			return true, stackBack(st, 0).Uint64(), 1
+		}
+	case vm.RETURNDATACOPY, vm.CALLDATACOPY, vm.CODECOPY, vm.MCOPY:
+		if len(st) > 2 {
+			return true, stackBack(st, 0).Uint64(), stackBack(st, 2).Uint64()
+		}
+	case vm.EXTCODECOPY:
+		if len(st) > 3 {
+			return true, stackBack(st, 1).Uint64(), stackBack(st, 3).Uint64()
+		}
+	case vm.STATICCALL, vm.DELEGATECALL:
+		if len(st) > 5 {
+			return true, stackBack(st, 4).Uint64(), stackBack(st, 5).Uint64()
+		}
+	case vm.CALL, vm.CALLCODE:
+		if len(st) > 6 {
+			return true, stackBack(st, 5).Uint64(), stackBack(st, 6).Uint64()
+		}
+	}
+	return false, 0, 0
+}
+
+// memoryRegion copies [off, off+size) from mem, zero-padding any part that
+// lies beyond the current memory size.
+func memoryRegion(mem []byte, off, size uint64) hexutil.Bytes {
+	data := make([]byte, size)
+	if off < uint64(len(mem)) {
+		copy(data, mem[off:])
+	}
+	return data
 }
 
 // onFault is called when an opcode causes a fault.
@@ -240,7 +337,7 @@ func (l *VmTraceLogger) onFault(_ uint64, _ byte, _, _ uint64, _ tracing.OpConte
 		// REVERT is a valid opcode execution; its Ex remains intact.
 		return
 	}
-	if len(l.traceStack) == 0 {
+	if l.err != nil || len(l.traceStack) == 0 {
 		return
 	}
 	frame := l.traceStack[len(l.traceStack)-1]

--- a/txtrace/vm_trace.go
+++ b/txtrace/vm_trace.go
@@ -230,7 +230,7 @@ func (l *VmTraceLogger) onExit(depth int, _ []byte, _ uint64, _ error, _ bool) {
 // onOpcode is called before each opcode executes.
 // It finalizes the previous op's Ex using the current post execution
 // state, then records a new operation entry for the current opcode.
-func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, _ []byte, _ int, _ error) {
+func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, _ []byte, _ int, opErr error) {
 	if l.err != nil || len(l.traceStack) == 0 {
 		return
 	}
@@ -266,11 +266,20 @@ func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tra
 
 	// Create a new operation entry. Ex.Used = gas before this opcode (gasCopy from
 	// interpreter, captured before any gas deduction for this op).
+	//
+	// The interpreter reports pre-execution failures (stack validation, memory
+	// size overflow, out-of-gas on dynamic gas) through OnOpcode with a non-nil
+	// error instead of OnFault. Such an opcode never executes, so it gets no
+	// execution result — matching the onFault treatment.
+	var ex *VmExecutedOperation
+	if opErr == nil || errors.Is(opErr, vm.ErrExecutionReverted) {
+		ex = &VmExecutedOperation{Used: gas, Push: []hexutil.Big{}}
+	}
 	newOp := VmOperation{
 		Op:   vm.OpCode(op).String(),
 		PC:   pc,
 		Cost: cost,
-		Ex:   &VmExecutedOperation{Used: gas, Push: []hexutil.Big{}},
+		Ex:   ex,
 	}
 	frame.trace.Ops = append(frame.trace.Ops, newOp)
 	frame.lastOpIdx = len(frame.trace.Ops) - 1

--- a/txtrace/vm_trace.go
+++ b/txtrace/vm_trace.go
@@ -247,12 +247,14 @@ func (l *VmTraceLogger) onOpcode(pc uint64, op byte, gas, cost uint64, scope tra
 			// fires when the frame resumes after the sub-call, so the region
 			// holds the return data written to the caller's memory.
 			if frame.showMem && frame.memLen > 0 {
-				data := memoryRegion(scope.MemoryData(), frame.memOff, frame.memLen)
-				prevOp.Ex.Mem = &MemoryDiff{Off: frame.memOff, Data: data}
-				l.addSize(uint64(len(data)))
+				// Account the region size before allocating it so the limit
+				// check cannot be preceded by an oversized allocation.
+				l.addSize(frame.memLen)
 				if l.err != nil {
 					return
 				}
+				data := memoryRegion(scope.MemoryData(), frame.memOff, frame.memLen)
+				prevOp.Ex.Mem = &MemoryDiff{Off: frame.memOff, Data: data}
 			}
 			if l.pendingStore != nil {
 				prevOp.Ex.Store = l.pendingStore

--- a/txtrace/vm_trace.go
+++ b/txtrace/vm_trace.go
@@ -127,13 +127,14 @@ func (l *VmTraceLogger) GetResult() (*VmTrace, error) {
 // exceeded, the trace is aborted: the error is recorded and all accumulated
 // data is released so it can be garbage collected.
 func (l *VmTraceLogger) addSize(n uint64) {
-	l.traceSize += n
-	if l.traceSize > vmTraceSizeLimit {
+	if n > vmTraceSizeLimit-l.traceSize {
 		l.err = errVmTraceTooLarge
 		l.traceStack = nil
 		l.result = nil
 		l.pendingStore = nil
+		return
 	}
+	l.traceSize += n
 }
 
 // OnStorageChange records a storage write so it can be attributed to the

--- a/txtrace/vm_trace_test.go
+++ b/txtrace/vm_trace_test.go
@@ -188,7 +188,9 @@ func TestComputePushed_StackClamp(t *testing.T) {
 
 func TestVmTraceLogger_GetResultBeforeExecution(t *testing.T) {
 	l := NewVmTraceLogger()
-	require.Nil(t, l.GetResult(), "result must be nil before any execution")
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	require.Nil(t, result, "result must be nil before any execution")
 }
 
 func TestVmTraceLogger_EmptyFrame(t *testing.T) {
@@ -199,7 +201,8 @@ func TestVmTraceLogger_EmptyFrame(t *testing.T) {
 	l.onEnter(0, 0x00 /* STOP */, addr(1), addr(2), code, 100, big.NewInt(0))
 	l.onExit(0, nil, 0, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Empty(t, result.Ops)
 }
@@ -215,7 +218,8 @@ func TestVmTraceLogger_OnFaultSetsExToNil(t *testing.T) {
 
 	l.onExit(0, nil, 3, errFoo, true)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Ops, 1)
 	require.Nil(t, result.Ops[0].Ex, "Ex must be nil after a fault")
@@ -238,7 +242,8 @@ func TestVmTraceLogger_StorageChangeAttributed(t *testing.T) {
 
 	l.onExit(0, nil, 20000, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Ops, 2)
 
@@ -260,7 +265,8 @@ func TestVmTraceLogger_GasAccountingUsed(t *testing.T) {
 
 	l.onExit(0, nil, 3, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Ops, 2)
 
@@ -289,7 +295,8 @@ func TestVmTraceLogger_SubTraceLinked(t *testing.T) {
 	l.onOpcode(10, 0x00 /* STOP */, 890, 0, &mockOpContext{}, nil, 0, nil)
 	l.onExit(0, nil, 110, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Ops, 2)
 
@@ -314,7 +321,8 @@ func TestVmTraceLogger_StorageChangeOnLastOp(t *testing.T) {
 	// Frame exits immediately; onExit must consume pendingStore.
 	l.onExit(0, nil, 20000, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Ops, 1)
 
@@ -329,7 +337,9 @@ func TestVmTraceLogger_NoOpsOnEmptyExec(t *testing.T) {
 	l := NewVmTraceLogger()
 	// Guard: multiple OnExit calls without matching OnEnter must not panic
 	l.onExit(0, nil, 0, nil, false)
-	require.Nil(t, l.GetResult())
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	require.Nil(t, result)
 }
 
 func TestVmTraceLogger_RevertHasNonNilEx(t *testing.T) {
@@ -340,7 +350,8 @@ func TestVmTraceLogger_RevertHasNonNilEx(t *testing.T) {
 	l.onFault(0, 0xfd, 1000, 0, &mockOpContext{}, 0, vm.ErrExecutionReverted)
 	l.onExit(0, nil, 0, vm.ErrExecutionReverted, true)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Ops, 1)
 	require.NotNil(t, result.Ops[0].Ex, "REVERT must have non-nil Ex")
@@ -379,18 +390,20 @@ func TestVmTraceLogger_MemNilForNonMemoryOp(t *testing.T) {
 	l.onOpcode(2, byte(vm.STOP), 997, 0, &mockOpContext{}, nil, 0, nil)
 	l.onExit(0, nil, 3, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.Len(t, result.Ops, 2)
 	require.Nil(t, result.Ops[0].Ex.Mem, "PUSH1 must have Mem=nil (no memory write)")
 }
 
 func TestVmTraceLogger_MemSetAfterMSTORE(t *testing.T) {
-	// MSTORE writes 32 bytes; Ex.Mem must carry the post-execution memory with Off=0.
+	// MSTORE writes 32 bytes; Ex.Mem must carry the written region with the
+	// offset taken from the stack (Parity/OpenEthereum semantics).
 	l := NewVmTraceLogger()
 	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
 
-	// Before MSTORE: memory empty.
-	ctxBeforeMstore := &mockOpContext{memory: []byte{}}
+	// MSTORE stack (top last): value=0x42, offset=0.
+	ctxBeforeMstore := &mockOpContext{stack: makeStack(0x42, 0)}
 	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, ctxBeforeMstore, nil, 0, nil)
 
 	// After MSTORE: 32 bytes, last byte = 0x42.
@@ -401,22 +414,24 @@ func TestVmTraceLogger_MemSetAfterMSTORE(t *testing.T) {
 
 	l.onExit(0, nil, 6, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.Len(t, result.Ops, 2)
 
 	mstoreOp := result.Ops[0]
 	require.NotNil(t, mstoreOp.Ex)
 	require.NotNil(t, mstoreOp.Ex.Mem, "MSTORE must have Mem set")
-	require.Equal(t, uint64(0), mstoreOp.Ex.Mem.Off, "Mem.Off must be 0")
-	require.Equal(t, []byte(memAfter), []byte(mstoreOp.Ex.Mem.Data), "Mem.Data must equal post-MSTORE memory")
+	require.Equal(t, uint64(0), mstoreOp.Ex.Mem.Off, "Mem.Off must be the MSTORE offset")
+	require.Equal(t, []byte(memAfter), []byte(mstoreOp.Ex.Mem.Data), "Mem.Data must equal the written 32-byte region")
 }
 
-func TestVmTraceLogger_MemOffAlwaysZero(t *testing.T) {
-	// Off must be 0 regardless of memory size — never len(data).
+func TestVmTraceLogger_MemOffsetFromStack(t *testing.T) {
+	// MSTORE at offset 32 must report Off=32 and only the written 32-byte region.
 	l := NewVmTraceLogger()
 	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
 
-	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{memory: []byte{}}, nil, 0, nil)
+	// MSTORE stack (top last): value=0x02, offset=32.
+	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{stack: makeStack(0x02, 32)}, nil, 0, nil)
 
 	// 64-byte post-execution memory (two MSTORE slots).
 	bigMem := make([]byte, 64)
@@ -425,12 +440,274 @@ func TestVmTraceLogger_MemOffAlwaysZero(t *testing.T) {
 	l.onOpcode(33, byte(vm.STOP), 994, 0, &mockOpContext{memory: bigMem}, nil, 0, nil)
 	l.onExit(0, nil, 6, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.Len(t, result.Ops, 2)
 	mem := result.Ops[0].Ex.Mem
 	require.NotNil(t, mem)
-	require.Equal(t, uint64(0), mem.Off, "Off must be 0, not len(data)")
-	require.NotEqual(t, uint64(len(mem.Data)), mem.Off, "Off must not equal len(Data)")
+	require.Equal(t, uint64(32), mem.Off, "Off must be the MSTORE offset")
+	require.Equal(t, []byte(bigMem[32:64]), []byte(mem.Data), "Data must be the written region only")
+}
+
+func TestVmTraceLogger_MemRegionForCallReturnData(t *testing.T) {
+	// A CALL op must report the return-data region (retOffset, retSize) of the
+	// caller's memory once the frame resumes after the sub-call.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	// CALL stack (top last): retSize=32, retOffset=64, argsLen, argsOff, value, to, gas.
+	callStack := makeStack(32, 64, 0, 0, 0, 2, 800)
+	l.onOpcode(0, byte(vm.CALL), 1000, 100, &mockOpContext{stack: callStack}, nil, 0, nil)
+
+	// Sub-call runs and exits.
+	l.onEnter(1, byte(vm.CALL), addr(2), addr(3), nil, 800, big.NewInt(0))
+	l.onExit(1, nil, 10, nil, false)
+
+	// Back in the root frame: memory now holds return data at [64, 96).
+	mem := make([]byte, 96)
+	mem[64] = 0xAA
+	mem[95] = 0xBB
+	l.onOpcode(10, byte(vm.STOP), 890, 0, &mockOpContext{memory: mem, stack: makeStack(1)}, nil, 0, nil)
+	l.onExit(0, nil, 110, nil, false)
+
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	require.Len(t, result.Ops, 2)
+
+	callOp := result.Ops[0]
+	require.NotNil(t, callOp.Ex.Mem, "CALL must report the return-data region")
+	require.Equal(t, uint64(64), callOp.Ex.Mem.Off)
+	require.Equal(t, []byte(mem[64:96]), []byte(callOp.Ex.Mem.Data))
+}
+
+func TestVmTraceLogger_MemZeroPaddedBeyondMemory(t *testing.T) {
+	// A region extending past the current memory size is zero-padded.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	// MSTORE at offset 16 while post-exec memory is only 24 bytes long
+	// (cannot happen in the real EVM, but the copy must stay safe).
+	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{stack: makeStack(0x01, 16)}, nil, 0, nil)
+	shortMem := make([]byte, 24)
+	shortMem[16] = 0x7F
+	l.onOpcode(33, byte(vm.STOP), 994, 0, &mockOpContext{memory: shortMem}, nil, 0, nil)
+	l.onExit(0, nil, 6, nil, false)
+
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	mem := result.Ops[0].Ex.Mem
+	require.NotNil(t, mem)
+	require.Equal(t, uint64(16), mem.Off)
+	require.Len(t, []byte(mem.Data), 32)
+	require.Equal(t, byte(0x7F), mem.Data[0])
+	require.Equal(t, make([]byte, 24), []byte(mem.Data[8:]), "bytes beyond memory must be zero-padded")
+}
+
+func TestVmTraceLogger_SizeLimitAbortsTrace(t *testing.T) {
+	// Exceeding vmTraceSizeLimit must abort the trace, release the data, and
+	// surface an error from GetResult.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+	l.traceSize = vmTraceSizeLimit // next accounted byte tips over the limit
+
+	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{stack: makeStack(0x01, 0)}, nil, 0, nil)
+	l.onOpcode(33, byte(vm.STOP), 994, 0, &mockOpContext{memory: make([]byte, 32)}, nil, 0, nil)
+	l.onExit(0, nil, 6, nil, false)
+
+	result, err := l.GetResult()
+	require.ErrorIs(t, err, errVmTraceTooLarge)
+	require.Nil(t, result)
+	require.Nil(t, l.traceStack, "accumulated data must be released on abort")
+}
+
+func TestMemTouchedRegion(t *testing.T) {
+	// Stacks are built with makeStack (top of stack = last element).
+	tests := []struct {
+		name     string
+		op       vm.OpCode
+		stack    []uint256.Int
+		wantShow bool
+		wantOff  uint64
+		wantLen  uint64
+	}{
+		// Region-reporting opcodes, offsets/lengths from the pre-execution stack.
+		{"MSTORE", vm.MSTORE, makeStack(0x42, 5), true, 5, 32},
+		{"MLOAD", vm.MLOAD, makeStack(7), true, 7, 32},
+		{"MSTORE8", vm.MSTORE8, makeStack(0x42, 9), true, 9, 1},
+		{"CALLDATACOPY", vm.CALLDATACOPY, makeStack(10, 3, 64), true, 64, 10},
+		{"CODECOPY", vm.CODECOPY, makeStack(10, 3, 64), true, 64, 10},
+		{"RETURNDATACOPY", vm.RETURNDATACOPY, makeStack(10, 3, 64), true, 64, 10},
+		{"MCOPY", vm.MCOPY, makeStack(10, 3, 64), true, 64, 10},
+		{"EXTCODECOPY", vm.EXTCODECOPY, makeStack(10, 3, 64, 0xAA), true, 64, 10},
+		{"CALL", vm.CALL, makeStack(32, 96, 0, 0, 0, 2, 800), true, 96, 32},
+		{"CALLCODE", vm.CALLCODE, makeStack(32, 96, 0, 0, 0, 2, 800), true, 96, 32},
+		{"DELEGATECALL", vm.DELEGATECALL, makeStack(32, 96, 0, 0, 2, 800), true, 96, 32},
+		{"STATICCALL", vm.STATICCALL, makeStack(32, 96, 0, 0, 2, 800), true, 96, 32},
+
+		// Zero-length regions are still reported as touched; the logger skips
+		// emitting a Mem entry for them (memLen > 0 guard).
+		{"CALLDATACOPY zero length", vm.CALLDATACOPY, makeStack(0, 3, 64), true, 64, 0},
+		{"CALL zero retSize", vm.CALL, makeStack(0, 96, 0, 0, 0, 2, 800), true, 96, 0},
+
+		// Stack too shallow for the operands → nothing reported (the op will fault).
+		{"MSTORE empty stack", vm.MSTORE, nil, false, 0, 0},
+		{"MLOAD empty stack", vm.MLOAD, nil, false, 0, 0},
+		{"CALLDATACOPY short stack", vm.CALLDATACOPY, makeStack(1, 2), false, 0, 0},
+		{"EXTCODECOPY short stack", vm.EXTCODECOPY, makeStack(1, 2, 3), false, 0, 0},
+		{"CALL short stack", vm.CALL, makeStack(1, 2, 3, 4, 5, 6), false, 0, 0},
+		{"STATICCALL short stack", vm.STATICCALL, makeStack(1, 2, 3, 4, 5), false, 0, 0},
+
+		// Opcodes that never report a region, matching OpenEthereum. CREATE,
+		// CREATE2 and SELFDESTRUCT are explicitly excluded there.
+		{"ADD", vm.ADD, makeStack(1, 2), false, 0, 0},
+		{"SSTORE", vm.SSTORE, makeStack(1, 2), false, 0, 0},
+		{"KECCAK256 reads only", vm.KECCAK256, makeStack(32, 0), false, 0, 0},
+		{"RETURN", vm.RETURN, makeStack(32, 0), false, 0, 0},
+		{"REVERT", vm.REVERT, makeStack(32, 0), false, 0, 0},
+		{"LOG0 reads only", vm.LOG0, makeStack(32, 0), false, 0, 0},
+		{"CREATE", vm.CREATE, makeStack(32, 0, 0), false, 0, 0},
+		{"CREATE2", vm.CREATE2, makeStack(1, 32, 0, 0), false, 0, 0},
+		{"SELFDESTRUCT", vm.SELFDESTRUCT, makeStack(2), false, 0, 0},
+		{"STOP", vm.STOP, nil, false, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			show, off, size := memTouchedRegion(tt.op, tt.stack)
+			require.Equal(t, tt.wantShow, show)
+			require.Equal(t, tt.wantOff, off)
+			require.Equal(t, tt.wantLen, size)
+		})
+	}
+}
+
+func TestMemTouchedRegion_OffsetBeyondUint64DoesNotPanic(t *testing.T) {
+	// An offset ≥ 2^64 cannot be executed (the op faults on gas), but the
+	// region decoding must not panic on it. Uint64() truncates; the value is
+	// irrelevant because onFault nils the op's Ex before any Mem is emitted.
+	huge := uint256.MustFromBig(new(big.Int).Lsh(big.NewInt(1), 64))
+	stack := []uint256.Int{*uint256.NewInt(0x42), *huge}
+	require.NotPanics(t, func() {
+		show, _, size := memTouchedRegion(vm.MSTORE, stack)
+		require.True(t, show)
+		require.Equal(t, uint64(32), size)
+	})
+}
+
+func TestMemoryRegion(t *testing.T) {
+	mem := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	tests := []struct {
+		name string
+		off  uint64
+		size uint64
+		want []byte
+	}{
+		{"fully inside", 2, 4, []byte{2, 3, 4, 5}},
+		{"exact fit", 0, 10, mem},
+		{"partially beyond end", 8, 4, []byte{8, 9, 0, 0}},
+		{"offset at memory size", 10, 3, []byte{0, 0, 0}},
+		{"offset beyond memory size", 20, 3, []byte{0, 0, 0}},
+		{"zero size", 2, 0, []byte{}},
+		{"empty memory", 0, 3, []byte{0, 0, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := mem
+			if tt.name == "empty memory" {
+				src = nil
+			}
+			got := memoryRegion(src, tt.off, tt.size)
+			require.Equal(t, tt.want, []byte(got))
+		})
+	}
+}
+
+func TestVmTraceLogger_ZeroLengthCopyHasNoMem(t *testing.T) {
+	// CALLDATACOPY with length 0 touches nothing → Mem must stay nil.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	l.onOpcode(0, byte(vm.CALLDATACOPY), 1000, 3, &mockOpContext{stack: makeStack(0, 0, 64)}, nil, 0, nil)
+	l.onOpcode(1, byte(vm.STOP), 997, 0, &mockOpContext{memory: make([]byte, 96)}, nil, 0, nil)
+	l.onExit(0, nil, 3, nil, false)
+
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	require.Len(t, result.Ops, 2)
+	require.Nil(t, result.Ops[0].Ex.Mem, "zero-length copy must not produce a Mem entry")
+}
+
+func TestVmTraceLogger_MLOADReportsReadRegion(t *testing.T) {
+	// Parity quirk: MLOAD reports the 32-byte region it reads.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	mem := make([]byte, 64)
+	mem[32] = 0x11
+	mem[63] = 0x22
+	l.onOpcode(0, byte(vm.MLOAD), 1000, 3, &mockOpContext{stack: makeStack(32), memory: mem}, nil, 0, nil)
+	l.onOpcode(1, byte(vm.STOP), 997, 0, &mockOpContext{memory: mem, stack: makeStack(0x11)}, nil, 0, nil)
+	l.onExit(0, nil, 3, nil, false)
+
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	require.Len(t, result.Ops, 2)
+	mloadOp := result.Ops[0]
+	require.NotNil(t, mloadOp.Ex.Mem, "MLOAD must report the region it reads")
+	require.Equal(t, uint64(32), mloadOp.Ex.Mem.Off)
+	require.Equal(t, []byte(mem[32:64]), []byte(mloadOp.Ex.Mem.Data))
+}
+
+func TestVmTraceLogger_FaultedMemoryOpHasNoMem(t *testing.T) {
+	// A memory op that faults gets Ex=nil; the pending region must not be
+	// emitted and nothing may panic.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+
+	l.onOpcode(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{stack: makeStack(0x42, 0)}, nil, 0, nil)
+	l.onFault(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{}, 0, errFoo)
+	l.onExit(0, nil, 1000, errFoo, true)
+
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	require.Len(t, result.Ops, 1)
+	require.Nil(t, result.Ops[0].Ex, "faulted op must have Ex=nil")
+}
+
+func TestVmTraceLogger_SizeLimitBoundaryIsNotExceeded(t *testing.T) {
+	// Reaching the limit exactly is fine; only exceeding it aborts.
+	l := NewVmTraceLogger()
+	l.onEnter(0, 0x00, addr(1), addr(2), nil, 1000, big.NewInt(0))
+	l.traceSize = vmTraceSizeLimit - vmTraceOpOverhead
+
+	l.onOpcode(0, byte(vm.STOP), 1000, 0, &mockOpContext{}, nil, 0, nil)
+	l.onExit(0, nil, 0, nil, false)
+
+	result, err := l.GetResult()
+	require.NoError(t, err)
+	require.Len(t, result.Ops, 1)
+}
+
+func TestVmTraceLogger_OversizedCodeAbortsAndHooksStayInert(t *testing.T) {
+	// Contract code accounting can trip the limit in onEnter; every later hook
+	// must be a no-op without panicking.
+	l := NewVmTraceLogger()
+	l.traceSize = vmTraceSizeLimit - 10
+
+	l.onEnter(0, byte(vm.CREATE), addr(1), addr(2), make([]byte, 100), 1000, big.NewInt(0))
+
+	require.NotPanics(t, func() {
+		l.onEnter(1, byte(vm.CALL), addr(2), addr(3), nil, 500, big.NewInt(0))
+		l.onOpcode(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{stack: makeStack(0x42, 0)}, nil, 0, nil)
+		l.onFault(0, byte(vm.MSTORE), 1000, 6, &mockOpContext{}, 0, errFoo)
+		l.OnStorageChange(addr(2), common.Hash{0x01}, common.Hash{}, common.Hash{0x02})
+		l.onExit(1, nil, 0, nil, false)
+		l.onExit(0, nil, 0, nil, false)
+	})
+
+	result, err := l.GetResult()
+	require.ErrorIs(t, err, errVmTraceTooLarge)
+	require.Nil(t, result)
+	require.Nil(t, l.traceStack, "accumulated data must be released on abort")
 }
 
 func TestVmTraceLogger_MemLastOpIsNil(t *testing.T) {
@@ -442,7 +719,8 @@ func TestVmTraceLogger_MemLastOpIsNil(t *testing.T) {
 	l.onOpcode(0, byte(vm.STOP), 1000, 0, &mockOpContext{}, nil, 0, nil)
 	l.onExit(0, nil, 0, nil, false)
 
-	result := l.GetResult()
+	result, err := l.GetResult()
+	require.NoError(t, err)
 	require.Len(t, result.Ops, 1)
 	require.Nil(t, result.Ops[0].Ex.Mem, "last op must have Mem=nil")
 }

--- a/txtrace/vm_trace_test.go
+++ b/txtrace/vm_trace_test.go
@@ -18,6 +18,7 @@ package txtrace
 
 import (
 	"errors"
+	"math"
 	"math/big"
 	"testing"
 
@@ -518,6 +519,17 @@ func TestVmTraceLogger_SizeLimitAbortsTrace(t *testing.T) {
 	require.ErrorIs(t, err, errVmTraceTooLarge)
 	require.Nil(t, result)
 	require.Nil(t, l.traceStack, "accumulated data must be released on abort")
+}
+
+func TestVmTraceLogger_AddSizeHugeValueDoesNotOverflow(t *testing.T) {
+	// A size close to the uint64 maximum must abort the trace instead of
+	// wrapping traceSize around and bypassing the limit.
+	l := NewVmTraceLogger()
+	l.addSize(math.MaxUint64)
+
+	result, err := l.GetResult()
+	require.ErrorIs(t, err, errVmTraceTooLarge)
+	require.Nil(t, result)
 }
 
 func TestMemTouchedRegion(t *testing.T) {


### PR DESCRIPTION
This PR fixes output of the memory diff when creating transaction trace with vmTrace option. It was wrongly outputting whole memory content instead of a diff. This has been adjusted and covered with tests. Limit for the trace size was introduced to protect the node.

Before change:
<img width="1273" height="510" alt="memory before change" src="https://github.com/user-attachments/assets/1f6cc114-6b36-421d-b50c-3b8b7c7bf950" />
After fix:
<img width="1274" height="591" alt="memory after fix" src="https://github.com/user-attachments/assets/c2e9338a-2ff9-41e1-82bf-d190a908fdae" />
