### PR TITLE
Deploy priority registry in fake genesis and report as system contract

### DIFF
--- a/api/ethapi/config.go
+++ b/api/ethapi/config.go
@@ -23,7 +23,8 @@ import (
 	"hash/crc32"
 	"math/big"
 
-	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -85,7 +86,10 @@ func activeSystemContracts(upgrade opera.Upgrades) contractRegistry {
 		sysContracts["HISTORY_STORAGE_ADDRESS"] = params.HistoryStorageAddress
 	}
 	if upgrade.GasSubsidies {
-		sysContracts["GAS_SUBSIDY_REGISTRY_ADDRESS"] = registry.GetAddress()
+		sysContracts["GAS_SUBSIDY_REGISTRY_ADDRESS"] = subsidiesregistry.GetAddress()
+	}
+	if upgrade.TransactionPriorities {
+		sysContracts["TRANSACTION_PRIORITY_REGISTRY_ADDRESS"] = priorityregistry.GetAddress()
 	}
 	return sysContracts
 }

--- a/api/ethapi/config.go
+++ b/api/ethapi/config.go
@@ -23,8 +23,8 @@ import (
 	"hash/crc32"
 	"math/big"
 
-	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
-	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	priorityRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	subsidiesRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -86,10 +86,10 @@ func activeSystemContracts(upgrade opera.Upgrades) contractRegistry {
 		sysContracts["HISTORY_STORAGE_ADDRESS"] = params.HistoryStorageAddress
 	}
 	if upgrade.GasSubsidies {
-		sysContracts["GAS_SUBSIDY_REGISTRY_ADDRESS"] = subsidiesregistry.GetAddress()
+		sysContracts["GAS_SUBSIDY_REGISTRY_ADDRESS"] = subsidiesRegistry.GetAddress()
 	}
 	if upgrade.TransactionPriorities {
-		sysContracts["TRANSACTION_PRIORITY_REGISTRY_ADDRESS"] = priorityregistry.GetAddress()
+		sysContracts["TRANSACTION_PRIORITY_REGISTRY_ADDRESS"] = priorityRegistry.GetAddress()
 	}
 	return sysContracts
 }

--- a/api/ethapi/config_test.go
+++ b/api/ethapi/config_test.go
@@ -26,7 +26,8 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
-	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -93,6 +94,10 @@ func TestForkId_UpgradesProduceDifferentIds(t *testing.T) {
 		"with bundles":    true,
 		"without bundles": false,
 	}
+	priorities := map[string]bool{
+		"with priorities":    true,
+		"without priorities": false,
+	}
 
 	genesisHash := common.Hash{0x42}
 
@@ -101,22 +106,25 @@ func TestForkId_UpgradesProduceDifferentIds(t *testing.T) {
 		for proposerName, singleProposer := range proposer {
 			for subsidiesName, withSubsidies := range subsidies {
 				for bundlesName, withBundles := range bundles {
-					for _, height := range []idx.Block{1, 5, 10} {
-						upgrades := upgrades
-						upgrades.SingleProposerBlockFormation = singleProposer
-						upgrades.GasSubsidies = withSubsidies
-						upgrades.TransactionBundles = withBundles
+					for prioritiesName, withPriorities := range priorities {
+						for _, height := range []idx.Block{1, 5, 10} {
+							upgrades := upgrades
+							upgrades.SingleProposerBlockFormation = singleProposer
+							upgrades.GasSubsidies = withSubsidies
+							upgrades.TransactionBundles = withBundles
+							upgrades.TransactionPriorities = withPriorities
 
-						upgradeHeight := opera.MakeUpgradeHeight(upgrades, height)
-						testName := fmt.Sprintf("%s-%s-%s-%s-%d", hardfork, proposerName, subsidiesName, bundlesName, height)
+							upgradeHeight := opera.MakeUpgradeHeight(upgrades, height)
+							testName := fmt.Sprintf("%s-%s-%s-%s-%s-%d", hardfork, proposerName, subsidiesName, bundlesName, prioritiesName, height)
 
-						t.Run(testName, func(t *testing.T) {
-							got, err := MakeForkId(upgradeHeight, genesisHash)
-							require.NoError(t, err, "makeForkHash failed")
-							_, exists := generated[got]
-							require.False(t, exists, "duplicate fork ID generated for different upgrades")
-							generated[got] = struct{}{}
-						})
+							t.Run(testName, func(t *testing.T) {
+								got, err := MakeForkId(upgradeHeight, genesisHash)
+								require.NoError(t, err, "makeForkHash failed")
+								_, exists := generated[got]
+								require.False(t, exists, "duplicate fork ID generated for different upgrades")
+								generated[got] = struct{}{}
+							})
+						}
 					}
 				}
 			}
@@ -156,6 +164,7 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 	sonicHeight := idx.Block(1)
 	allegroHeight := idx.Block(5)
 	gasSubsidiesHeight := idx.Block(10)
+	prioritiesHeight := idx.Block(15)
 
 	tests := map[string]struct {
 		upgradeHeight    opera.UpgradeHeight
@@ -182,7 +191,7 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 				}(),
 				Height: gasSubsidiesHeight,
 			},
-			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": registry.GetAddress()},
+			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesregistry.GetAddress()},
 		},
 		"Sonic+GasSubsidies": {
 			upgradeHeight: opera.UpgradeHeight{
@@ -193,7 +202,7 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 				}(),
 				Height: gasSubsidiesHeight,
 			},
-			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": registry.GetAddress()},
+			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesregistry.GetAddress()},
 		},
 		"Allegro+GasSubsidies": {
 			upgradeHeight: opera.UpgradeHeight{
@@ -206,7 +215,30 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 			},
 			wantSysContracts: contractRegistry{
 				"HISTORY_STORAGE_ADDRESS":      params.HistoryStorageAddress,
-				"GAS_SUBSIDY_REGISTRY_ADDRESS": registry.GetAddress(),
+				"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesregistry.GetAddress(),
+			},
+		},
+		"TransactionPriorities": {
+			upgradeHeight: opera.UpgradeHeight{
+				Upgrades: opera.Upgrades{TransactionPriorities: true},
+				Height:   prioritiesHeight,
+			},
+			wantSysContracts: contractRegistry{"TRANSACTION_PRIORITY_REGISTRY_ADDRESS": priorityregistry.GetAddress()},
+		},
+		"Allegro+GasSubsidies+TransactionPriorities": {
+			upgradeHeight: opera.UpgradeHeight{
+				Upgrades: func() opera.Upgrades {
+					upgrades := opera.GetAllegroUpgrades()
+					upgrades.GasSubsidies = true
+					upgrades.TransactionPriorities = true
+					return upgrades
+				}(),
+				Height: prioritiesHeight,
+			},
+			wantSysContracts: contractRegistry{
+				"HISTORY_STORAGE_ADDRESS":               params.HistoryStorageAddress,
+				"GAS_SUBSIDY_REGISTRY_ADDRESS":          subsidiesregistry.GetAddress(),
+				"TRANSACTION_PRIORITY_REGISTRY_ADDRESS": priorityregistry.GetAddress(),
 			},
 		},
 	}

--- a/api/ethapi/config_test.go
+++ b/api/ethapi/config_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
-	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
-	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	priorityRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	subsidiesRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -191,7 +191,7 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 				}(),
 				Height: gasSubsidiesHeight,
 			},
-			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesregistry.GetAddress()},
+			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesRegistry.GetAddress()},
 		},
 		"Sonic+GasSubsidies": {
 			upgradeHeight: opera.UpgradeHeight{
@@ -202,7 +202,7 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 				}(),
 				Height: gasSubsidiesHeight,
 			},
-			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesregistry.GetAddress()},
+			wantSysContracts: contractRegistry{"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesRegistry.GetAddress()},
 		},
 		"Allegro+GasSubsidies": {
 			upgradeHeight: opera.UpgradeHeight{
@@ -215,7 +215,7 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 			},
 			wantSysContracts: contractRegistry{
 				"HISTORY_STORAGE_ADDRESS":      params.HistoryStorageAddress,
-				"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesregistry.GetAddress(),
+				"GAS_SUBSIDY_REGISTRY_ADDRESS": subsidiesRegistry.GetAddress(),
 			},
 		},
 		"TransactionPriorities": {
@@ -223,7 +223,7 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 				Upgrades: opera.Upgrades{TransactionPriorities: true},
 				Height:   prioritiesHeight,
 			},
-			wantSysContracts: contractRegistry{"TRANSACTION_PRIORITY_REGISTRY_ADDRESS": priorityregistry.GetAddress()},
+			wantSysContracts: contractRegistry{"TRANSACTION_PRIORITY_REGISTRY_ADDRESS": priorityRegistry.GetAddress()},
 		},
 		"Allegro+GasSubsidies+TransactionPriorities": {
 			upgradeHeight: opera.UpgradeHeight{
@@ -237,8 +237,8 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 			},
 			wantSysContracts: contractRegistry{
 				"HISTORY_STORAGE_ADDRESS":               params.HistoryStorageAddress,
-				"GAS_SUBSIDY_REGISTRY_ADDRESS":          subsidiesregistry.GetAddress(),
-				"TRANSACTION_PRIORITY_REGISTRY_ADDRESS": priorityregistry.GetAddress(),
+				"GAS_SUBSIDY_REGISTRY_ADDRESS":          subsidiesRegistry.GetAddress(),
+				"TRANSACTION_PRIORITY_REGISTRY_ADDRESS": priorityRegistry.GetAddress(),
 			},
 		},
 	}

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -25,8 +25,9 @@ import (
 	"os"
 	"time"
 
+	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/proxy"
-	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/integration/makegenesis"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/drivertype"
@@ -156,7 +157,7 @@ func GenerateFakeJsonGenesis(
 		copy(addressAsStorageValue[12:], implementationAddress[:])
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
 			Name:    "GasSubsidiesRegistryProxy",
-			Address: registry.GetAddress(),
+			Address: subsidiesregistry.GetAddress(),
 			Code:    proxy.GetCode(),
 			Nonce:   1,
 			Storage: map[common.Hash]common.Hash{
@@ -168,7 +169,31 @@ func GenerateFakeJsonGenesis(
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
 			Name:    "GasSubsidiesRegistryImplementation",
 			Address: implementationAddress,
-			Code:    registry.GetCode(),
+			Code:    subsidiesregistry.GetCode(),
+			Nonce:   1,
+		})
+	}
+
+	// Deploy the transaction priority registry contract if enabled.
+	if upgrades.TransactionPriorities {
+		implementationAddress := common.Address{1, 2, 3, 4, 5, 6, 8}
+		addressAsStorageValue := common.Hash{}
+		copy(addressAsStorageValue[12:], implementationAddress[:])
+		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
+			Name:    "PriorityRegistryProxy",
+			Address: priorityregistry.GetAddress(),
+			Code:    proxy.GetCode(),
+			Nonce:   1,
+			Storage: map[common.Hash]common.Hash{
+				// Set the implementation address in the proxy contract.
+				proxy.GetSlotForImplementation(): addressAsStorageValue,
+			},
+		})
+
+		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
+			Name:    "PriorityRegistryImplementation",
+			Address: implementationAddress,
+			Code:    priorityregistry.GetCode(),
 			Nonce:   1,
 		})
 	}

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -25,9 +25,9 @@ import (
 	"os"
 	"time"
 
-	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	priorityRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/proxy"
-	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	subsidiesRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/integration/makegenesis"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/drivertype"
@@ -157,7 +157,7 @@ func GenerateFakeJsonGenesis(
 		copy(addressAsStorageValue[12:], implementationAddress[:])
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
 			Name:    "GasSubsidiesRegistryProxy",
-			Address: subsidiesregistry.GetAddress(),
+			Address: subsidiesRegistry.GetAddress(),
 			Code:    proxy.GetCode(),
 			Nonce:   1,
 			Storage: map[common.Hash]common.Hash{
@@ -169,7 +169,7 @@ func GenerateFakeJsonGenesis(
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
 			Name:    "GasSubsidiesRegistryImplementation",
 			Address: implementationAddress,
-			Code:    subsidiesregistry.GetCode(),
+			Code:    subsidiesRegistry.GetCode(),
 			Nonce:   1,
 		})
 	}
@@ -181,7 +181,7 @@ func GenerateFakeJsonGenesis(
 		copy(addressAsStorageValue[12:], implementationAddress[:])
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
 			Name:    "PriorityRegistryProxy",
-			Address: priorityregistry.GetAddress(),
+			Address: priorityRegistry.GetAddress(),
 			Code:    proxy.GetCode(),
 			Nonce:   1,
 			Storage: map[common.Hash]common.Hash{
@@ -193,7 +193,7 @@ func GenerateFakeJsonGenesis(
 		jsonGenesis.Accounts = append(jsonGenesis.Accounts, Account{
 			Name:    "PriorityRegistryImplementation",
 			Address: implementationAddress,
-			Code:    priorityregistry.GetCode(),
+			Code:    priorityRegistry.GetCode(),
 			Nonce:   1,
 		})
 	}

--- a/integration/makefakegenesis/json_test.go
+++ b/integration/makefakegenesis/json_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
-	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	priorityRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/proxy"
-	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
+	subsidiesRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -48,13 +48,13 @@ func TestJsonGenesis_DeploysRegistryContracts(t *testing.T) {
 	}{
 		"gas subsidies registry": {
 			enable:  func(u *opera.Upgrades) { u.GasSubsidies = true },
-			address: subsidiesregistry.GetAddress(),
-			code:    subsidiesregistry.GetCode(),
+			address: subsidiesRegistry.GetAddress(),
+			code:    subsidiesRegistry.GetCode(),
 		},
 		"transaction priority registry": {
 			enable:  func(u *opera.Upgrades) { u.TransactionPriorities = true },
-			address: priorityregistry.GetAddress(),
-			code:    priorityregistry.GetCode(),
+			address: priorityRegistry.GetAddress(),
+			code:    priorityRegistry.GetCode(),
 		},
 	}
 

--- a/integration/makefakegenesis/json_test.go
+++ b/integration/makefakegenesis/json_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 	"time"
 
+	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/proxy"
+	subsidiesregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -35,6 +38,59 @@ func TestJsonGenesis_AcceptsGenesisWithoutCommittee(t *testing.T) {
 	genesis := GenerateFakeJsonGenesis(opera.GetSonicUpgrades(), CreateEqualValidatorStake(1))
 	_, err := ApplyGenesisJson(genesis)
 	require.NoError(t, err)
+}
+
+func TestJsonGenesis_DeploysRegistryContracts(t *testing.T) {
+	tests := map[string]struct {
+		enable  func(*opera.Upgrades)
+		address common.Address
+		code    []byte
+	}{
+		"gas subsidies registry": {
+			enable:  func(u *opera.Upgrades) { u.GasSubsidies = true },
+			address: subsidiesregistry.GetAddress(),
+			code:    subsidiesregistry.GetCode(),
+		},
+		"transaction priority registry": {
+			enable:  func(u *opera.Upgrades) { u.TransactionPriorities = true },
+			address: priorityregistry.GetAddress(),
+			code:    priorityregistry.GetCode(),
+		},
+	}
+
+	findAccount := func(genesis *GenesisJson, address common.Address) *Account {
+		for i := range genesis.Accounts {
+			if genesis.Accounts[i].Address == address {
+				return &genesis.Accounts[i]
+			}
+		}
+		return nil
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			upgrades := opera.GetSonicUpgrades()
+
+			// The registry is not deployed while the feature is disabled.
+			genesis := GenerateFakeJsonGenesis(upgrades, CreateEqualValidatorStake(1))
+			require.Nil(t, findAccount(genesis, test.address))
+
+			// Enabling the feature deploys a proxy pointing at an
+			// implementation holding the registry code.
+			test.enable(&upgrades)
+			genesis = GenerateFakeJsonGenesis(upgrades, CreateEqualValidatorStake(1))
+
+			proxyAccount := findAccount(genesis, test.address)
+			require.NotNil(t, proxyAccount)
+			require.Equal(t, proxy.GetCode(), []byte(proxyAccount.Code))
+
+			implAddress := common.BytesToAddress(
+				proxyAccount.Storage[proxy.GetSlotForImplementation()].Bytes())
+			implAccount := findAccount(genesis, implAddress)
+			require.NotNil(t, implAccount)
+			require.Equal(t, test.code, []byte(implAccount.Code))
+		})
+	}
 }
 
 func TestJsonGenesis_Network_RulesValidated_WithAllegroAndLater(t *testing.T) {


### PR DESCRIPTION
This PR deploys the priority registry in the fake genesis when the priorities feature is enables and report as it as a system contract.