### PR TITLE
Add priority ordering core

### DIFF
--- a/gossip/blockproc/priorities/contract_calls_test.go
+++ b/gossip/blockproc/priorities/contract_calls_test.go
@@ -99,7 +99,7 @@ func TestGetPriority_InvalidResult_ReportsIssue(t *testing.T) {
 
 func TestGetPriority_DecodesResult(t *testing.T) {
 	tx, signer := makeTx(t)
-	id := [16]byte{0xde, 0xad}
+	id := PriorityID{0xde, 0xad}
 	result := make([]byte, 96)
 	binary.BigEndian.PutUint64(result[24:32], 3)
 	binary.BigEndian.PutUint64(result[56:64], 5)

--- a/gossip/blockproc/priorities/ordering.go
+++ b/gossip/blockproc/priorities/ordering.go
@@ -40,16 +40,17 @@ type NonceReader interface {
 	GetNonce(common.Address) uint64
 }
 
-// txWithPrio pairs a transaction with its classified priority.
-type txWithPrio struct {
+// transactionWithPriority pairs a transaction with its classified priority.
+type transactionWithPriority struct {
 	tx       *types.Transaction
 	priority Priority
 }
 
-// cmpLevelWeightHash orders two txWithPrio for the prioritized prefix, returning
-// >0 when x precedes y, i.e. by (level desc, weight desc, hash asc). Note this is
-// the opposite sign convention to the ascending cmpNonceHash.
-func (x txWithPrio) cmpLevelWeightHash(y txWithPrio) int {
+// cmpLevelWeightHash orders two transactionWithPriority for the prioritized
+// prefix, returning >0 when x precedes y, i.e. by (level desc, weight desc,
+// hash asc). Note this is the opposite sign convention to the ascending
+// cmpNonceHash.
+func (x transactionWithPriority) cmpLevelWeightHash(y transactionWithPriority) int {
 	if c := cmp.Compare(x.priority.Level, y.priority.Level); c != 0 {
 		return c
 	}
@@ -59,8 +60,8 @@ func (x txWithPrio) cmpLevelWeightHash(y txWithPrio) int {
 	return bytes.Compare(y.tx.Hash().Bytes(), x.tx.Hash().Bytes())
 }
 
-// cmpNonceHash orders two txWithPrio by (nonce asc, hash asc).
-func (x txWithPrio) cmpNonceHash(y txWithPrio) int {
+// cmpNonceHash orders two transactionWithPriority by (nonce asc, hash asc).
+func (x transactionWithPriority) cmpNonceHash(y transactionWithPriority) int {
 	if c := cmp.Compare(x.tx.Nonce(), y.tx.Nonce()); c != 0 {
 		return c
 	}
@@ -72,7 +73,7 @@ func (x txWithPrio) cmpNonceHash(y txWithPrio) int {
 // subject to two coupled constraints:
 //
 //   - Per-sender nonce ordering: a transaction keeps its priority only while it
-//     extends its sender's contiguous run of prioritized nonces from the
+//     extends its sender's contiguous sequence of prioritized nonces from the
 //     block-start account nonce. This keeps each sender in nonce order: a later
 //     nonce hoisted ahead of a lower-nonce predecessor left behind would be
 //     nonce-too-high and skipped.
@@ -81,7 +82,7 @@ func (x txWithPrio) cmpNonceHash(y txWithPrio) int {
 //
 // Transactions that are not selected — non-prioritized, nonce-blocked, or over
 // budget — are pushed back by the hoisted prioritized prefix but keep their
-// relative base order among themselves.
+// original relative order among themselves.
 //
 // The base order must already be the mode-specific order (scrambler output in
 // legacy mode, proposal order in single-proposer mode) and must already be
@@ -105,11 +106,11 @@ func Prioritize(
 	txsWithPrio := classify(base, classifier)
 
 	// Collect the prioritized transactions per sender ordered by nonce which
-	// form a continuous run starting at the start-of-block sender nonce.
-	prioSenderRuns := prioritizedSenderRuns(txsWithPrio, signer, state)
+	// form a continuous sequence starting at the start-of-block sender nonce.
+	prioSenderSequences := prioritizedSenderSequences(txsWithPrio, signer, state)
 
 	// Collect the transaction indices which should form the block txs prefix.
-	prioPrefixIndices := prioritizedTxsPrefix(txsWithPrio, prioSenderRuns, cfg.MaxGasPerEntityPerBlock)
+	prioPrefixIndices := computePrioritizedTxsPrefix(txsWithPrio, prioSenderSequences, cfg.MaxGasPerEntityPerBlock)
 
 	return combinePrioPrefixWithRemainder(txsWithPrio, prioPrefixIndices)
 }
@@ -117,27 +118,28 @@ func Prioritize(
 // classify pairs each transaction with its priority, preserving order. A
 // classifier error is treated as "not prioritized" (zero Priority), which
 // keeps Prioritize a total function of its inputs.
-func classify(base types.Transactions, classifier Classifier) []txWithPrio {
-	txsWithPrio := make([]txWithPrio, len(base))
+func classify(base types.Transactions, classifier Classifier) []transactionWithPriority {
+	txsWithPrio := make([]transactionWithPriority, len(base))
 	for i, tx := range base {
 		p, err := classifier.Priority(tx)
 		if err != nil {
 			p = Priority{} // deterministic failure rule: errors => not prioritized
 		}
-		txsWithPrio[i] = txWithPrio{tx: tx, priority: p}
+		txsWithPrio[i] = transactionWithPriority{tx: tx, priority: p}
 	}
 	return txsWithPrio
 }
 
-// prioritizedSenderRuns groups the prioritized entries by sender and reduces
-// each sender to its run: its prioritized transactions in nonce order forming a
-// contiguous run from the block-start account nonce. Stale nonces (below the
-// account nonce) are skipped and the first gap ends the run, as later nonces are
-// unreachable. A transaction whose sender cannot be recovered is left
-// non-prioritized. It returns, per sender, the entry indices of the run in
-// nonce order; senders left with an empty run are omitted.
-func prioritizedSenderRuns(
-	txsWithPrio []txWithPrio,
+// prioritizedSenderSequences groups the prioritized entries by sender and
+// reduces each sender to its sequence: its prioritized transactions in nonce
+// order forming a contiguous sequence from the block-start account nonce. Stale
+// nonces (below the account nonce) are skipped and the first gap ends the
+// sequence, as later nonces are unreachable. A transaction whose sender cannot
+// be recovered is left non-prioritized. It returns, per sender, the entry
+// indices of the sequence in nonce order; senders left with an empty sequence
+// are omitted.
+func prioritizedSenderSequences(
+	txsWithPrio []transactionWithPriority,
 	signer types.Signer,
 	state NonceReader,
 ) map[common.Address][]int {
@@ -154,43 +156,47 @@ func prioritizedSenderRuns(
 		bySender[sender] = append(bySender[sender], i)
 	}
 
-	// Reduce each sender's transactions to its run.
+	// Reduce each sender's transactions to its sequence.
 	for sender, idxs := range bySender {
 		slices.SortFunc(idxs, func(a, b int) int {
+			// Sort by nonce to ensure transactions can execute and use hash as
+			// tie breaker.
 			return txsWithPrio[a].cmpNonceHash(txsWithPrio[b])
 		})
 		expected := state.GetNonce(sender)
-		var run []int
+		var sequence []int
 		for _, idx := range idxs {
 			n := txsWithPrio[idx].tx.Nonce()
 			if n < expected {
 				continue // stale nonce: do not prioritize this transaction
 			}
 			if n > expected {
-				break // nonce gap: do not prioritize this or any later transaction from this sender
+				// nonce gap: do not prioritize this or any later transaction
+				// from this sender
+				break
 			}
-			run = append(run, idx)
+			sequence = append(sequence, idx)
 			expected++
 		}
-		if len(run) == 0 {
+		if len(sequence) == 0 {
 			delete(bySender, sender)
 		} else {
-			bySender[sender] = run
+			bySender[sender] = sequence
 		}
 	}
 	return bySender
 }
 
-// prioritizedTxsPrefix walks the per-sender runs greedily, returning the
-// entry indices in prioritized-prefix order. Each step takes the highest-priority
-// eligible frontier transaction (a sender's lowest un-selected nonce) and
-// advances that sender. A frontier that does not fit its entity budget removes
-// the sender's remaining transactions (its later nonces depend on it),
-// so a budget is only ever spent on transactions that can actually execute in
-// the prioritized prefix. It consumes bySender, mutating it as senders are
-// advanced and exhausted.
-func prioritizedTxsPrefix(
-	txsWithPrio []txWithPrio,
+// computePrioritizedTxsPrefix walks the per-sender sequences greedily,
+// returning the entry indices in prioritized-prefix order. Each step takes the
+// highest-priority eligible frontier transaction (a sender's lowest un-selected
+// nonce) and advances that sender. A frontier that does not fit its entity
+// budget removes the sender's remaining transactions (its later nonces depend
+// on it), so a budget is only ever spent on transactions that can actually
+// execute in the prioritized prefix. It consumes bySender, mutating it as
+// senders are advanced and exhausted.
+func computePrioritizedTxsPrefix(
+	txsWithPrio []transactionWithPriority,
 	bySender map[common.Address][]int,
 	perEntityBudget uint64,
 ) []int {
@@ -205,8 +211,8 @@ func prioritizedTxsPrefix(
 	for len(bySender) > 0 {
 		best := -1
 		var bestSender common.Address
-		for sender, run := range bySender {
-			idx := run[0]
+		for sender, sequence := range bySender {
+			idx := sequence[0]
 			if txsWithPrio[idx].tx.Gas() > budgetOf(txsWithPrio[idx].priority.ID) {
 				delete(bySender, sender) // frontier does not fit the budget: sender blocked
 				continue
@@ -232,7 +238,7 @@ func prioritizedTxsPrefix(
 // combinePrioPrefixWithRemainder builds the final transaction order: the
 // prioritized entries in prefix order, followed by the remaining entries
 // (demoted + non-prioritized) in their original base order.
-func combinePrioPrefixWithRemainder(entries []txWithPrio, prioPrefixIndices []int) types.Transactions {
+func combinePrioPrefixWithRemainder(entries []transactionWithPriority, prioPrefixIndices []int) types.Transactions {
 	isPrioritized := make([]bool, len(entries))
 	result := make(types.Transactions, 0, len(entries))
 	for _, i := range prioPrefixIndices {

--- a/gossip/blockproc/priorities/ordering.go
+++ b/gossip/blockproc/priorities/ordering.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package priorities
+
+import (
+	"bytes"
+	"cmp"
+	"slices"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Classifier determines the Priority of a transaction. Implementations may
+// query the registry per transaction or apply criteria fetched once per block
+// in native code.
+type Classifier interface {
+	// Priority returns the priority of the transaction. A non-nil error must be
+	// treated by the caller as "not prioritized".
+	Priority(tx *types.Transaction) (Priority, error)
+}
+
+// NonceReader reads block-start account nonces; it is the subset of
+// state.StateDB that Prioritize needs to enforce per-sender nonce ordering.
+type NonceReader interface {
+	GetNonce(common.Address) uint64
+}
+
+// txWithPrio pairs a transaction with its classified priority.
+type txWithPrio struct {
+	tx       *types.Transaction
+	priority Priority
+}
+
+// cmpLevelWeightHash orders two txWithPrio for the prioritized prefix, returning
+// >0 when x precedes y, i.e. by (level desc, weight desc, hash asc). Note this is
+// the opposite sign convention to the ascending cmpNonceHash.
+func (x txWithPrio) cmpLevelWeightHash(y txWithPrio) int {
+	if c := cmp.Compare(x.priority.Level, y.priority.Level); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(x.priority.Weight, y.priority.Weight); c != 0 {
+		return c
+	}
+	return bytes.Compare(y.tx.Hash().Bytes(), x.tx.Hash().Bytes())
+}
+
+// cmpNonceHash orders two txWithPrio by (nonce asc, hash asc).
+func (x txWithPrio) cmpNonceHash(y txWithPrio) int {
+	if c := cmp.Compare(x.tx.Nonce(), y.tx.Nonce()); c != 0 {
+		return c
+	}
+	return bytes.Compare(x.tx.Hash().Bytes(), y.tx.Hash().Bytes())
+}
+
+// Prioritize reorders the given base-ordered transactions so that prioritized
+// transactions appear first, in (level desc, weight desc, hash asc) order,
+// subject to two coupled constraints:
+//
+//   - Per-sender nonce ordering: a transaction keeps its priority only while it
+//     extends its sender's contiguous run of prioritized nonces from the
+//     block-start account nonce. This keeps each sender in nonce order: a later
+//     nonce hoisted ahead of a lower-nonce predecessor left behind would be
+//     nonce-too-high and skipped.
+//   - Per-entity gas budget: an entity may spend at most
+//     cfg.MaxGasPerEntityPerBlock gas (gas limit) on prioritized transactions.
+//
+// Transactions that are not selected — non-prioritized, nonce-blocked, or over
+// budget — are pushed back by the hoisted prioritized prefix but keep their
+// relative base order among themselves.
+//
+// The base order must already be the mode-specific order (scrambler output in
+// legacy mode, proposal order in single-proposer mode) and must already be
+// filtered to permissible transactions. The result is a permutation of base.
+//
+// Prioritize is a pure, deterministic, total function of (base, classifier,
+// signer, state, cfg): any classifier error is treated as "not prioritized",
+// no pass depends on Go map iteration order.
+func Prioritize(
+	base types.Transactions,
+	classifier Classifier,
+	signer types.Signer,
+	state NonceReader,
+	cfg Config,
+) types.Transactions {
+	if len(base) == 0 {
+		return base
+	}
+
+	// Determine the priority of every transaction.
+	txsWithPrio := classify(base, classifier)
+
+	// Collect the prioritized transactions per sender ordered by nonce which
+	// form a continuous run starting at the start-of-block sender nonce.
+	prioSenderRuns := prioritizedSenderRuns(txsWithPrio, signer, state)
+
+	// Collect the transaction indices which should form the block txs prefix.
+	prioPrefixIndices := prioritizedTxsPrefix(txsWithPrio, prioSenderRuns, cfg.MaxGasPerEntityPerBlock)
+
+	return combinePrioPrefixWithRemainder(txsWithPrio, prioPrefixIndices)
+}
+
+// classify pairs each transaction with its priority, preserving order. A
+// classifier error is treated as "not prioritized" (zero Priority), which
+// keeps Prioritize a total function of its inputs.
+func classify(base types.Transactions, classifier Classifier) []txWithPrio {
+	txsWithPrio := make([]txWithPrio, len(base))
+	for i, tx := range base {
+		p, err := classifier.Priority(tx)
+		if err != nil {
+			p = Priority{} // deterministic failure rule: errors => not prioritized
+		}
+		txsWithPrio[i] = txWithPrio{tx: tx, priority: p}
+	}
+	return txsWithPrio
+}
+
+// prioritizedSenderRuns groups the prioritized entries by sender and reduces
+// each sender to its run: its prioritized transactions in nonce order forming a
+// contiguous run from the block-start account nonce. Stale nonces (below the
+// account nonce) are skipped and the first gap ends the run, as later nonces are
+// unreachable. A transaction whose sender cannot be recovered is left
+// non-prioritized. It returns, per sender, the entry indices of the run in
+// nonce order; senders left with an empty run are omitted.
+func prioritizedSenderRuns(
+	txsWithPrio []txWithPrio,
+	signer types.Signer,
+	state NonceReader,
+) map[common.Address][]int {
+	// Group prioritized transactions by sender.
+	bySender := make(map[common.Address][]int)
+	for i := range txsWithPrio {
+		if !txsWithPrio[i].priority.IsPrioritized() {
+			continue
+		}
+		sender, err := types.Sender(signer, txsWithPrio[i].tx)
+		if err != nil {
+			continue // sender unknown: cannot nonce-check, leave non-prioritized
+		}
+		bySender[sender] = append(bySender[sender], i)
+	}
+
+	// Reduce each sender's transactions to its run.
+	for sender, idxs := range bySender {
+		slices.SortFunc(idxs, func(a, b int) int {
+			return txsWithPrio[a].cmpNonceHash(txsWithPrio[b])
+		})
+		expected := state.GetNonce(sender)
+		var run []int
+		for _, idx := range idxs {
+			n := txsWithPrio[idx].tx.Nonce()
+			if n < expected {
+				continue // stale nonce: do not prioritize this transaction
+			}
+			if n > expected {
+				break // nonce gap: do not prioritize this or any later transaction from this sender
+			}
+			run = append(run, idx)
+			expected++
+		}
+		if len(run) == 0 {
+			delete(bySender, sender)
+		} else {
+			bySender[sender] = run
+		}
+	}
+	return bySender
+}
+
+// prioritizedTxsPrefix walks the per-sender runs greedily, returning the
+// entry indices in prioritized-prefix order. Each step takes the highest-priority
+// eligible frontier transaction (a sender's lowest un-selected nonce) and
+// advances that sender. A frontier that does not fit its entity budget removes
+// the sender's remaining transactions (its later nonces depend on it),
+// so a budget is only ever spent on transactions that can actually execute in
+// the prioritized prefix. It consumes bySender, mutating it as senders are
+// advanced and exhausted.
+func prioritizedTxsPrefix(
+	txsWithPrio []txWithPrio,
+	bySender map[common.Address][]int,
+	perEntityBudget uint64,
+) []int {
+	selected := make([]int, 0, len(txsWithPrio))
+	remaining := make(map[[16]byte]uint64)
+	budgetOf := func(id [16]byte) uint64 {
+		if r, ok := remaining[id]; ok {
+			return r
+		}
+		return perEntityBudget
+	}
+	for len(bySender) > 0 {
+		best := -1
+		var bestSender common.Address
+		for sender, run := range bySender {
+			idx := run[0]
+			if txsWithPrio[idx].tx.Gas() > budgetOf(txsWithPrio[idx].priority.ID) {
+				delete(bySender, sender) // frontier does not fit the budget: sender blocked
+				continue
+			}
+			if best == -1 || txsWithPrio[idx].cmpLevelWeightHash(txsWithPrio[best]) > 0 {
+				best, bestSender = idx, sender
+			}
+		}
+		if best == -1 {
+			break
+		}
+		id := txsWithPrio[best].priority.ID
+		remaining[id] = budgetOf(id) - txsWithPrio[best].tx.Gas()
+		selected = append(selected, best)
+		bySender[bestSender] = bySender[bestSender][1:]
+		if len(bySender[bestSender]) == 0 {
+			delete(bySender, bestSender)
+		}
+	}
+	return selected
+}
+
+// combinePrioPrefixWithRemainder builds the final transaction order: the
+// prioritized entries in prefix order, followed by the remaining entries
+// (demoted + non-prioritized) in their original base order.
+func combinePrioPrefixWithRemainder(entries []txWithPrio, prioPrefixIndices []int) types.Transactions {
+	isPrioritized := make([]bool, len(entries))
+	result := make(types.Transactions, 0, len(entries))
+	for _, i := range prioPrefixIndices {
+		isPrioritized[i] = true
+		result = append(result, entries[i].tx)
+	}
+	// Append the remainder in original base order (demoted + non-prioritized).
+	for i := range entries {
+		if !isPrioritized[i] {
+			result = append(result, entries[i].tx)
+		}
+	}
+	return result
+}

--- a/gossip/blockproc/priorities/ordering.go
+++ b/gossip/blockproc/priorities/ordering.go
@@ -110,9 +110,9 @@ func Prioritize(
 	prioSenderSequences := prioritizedSenderSequences(txsWithPrio, signer, state)
 
 	// Collect the transaction indices which should form the block txs prefix.
-	prioPrefixIndices := computePrioritizedTxsPrefix(txsWithPrio, prioSenderSequences, cfg.MaxGasPerEntityPerBlock)
+	prioritizedPrefixIndices := computePrioritizedTxsPrefix(txsWithPrio, prioSenderSequences, cfg.MaxGasPerEntityPerBlock)
 
-	return combinePrioPrefixWithRemainder(txsWithPrio, prioPrefixIndices)
+	return combinePrioritizedPrefixWithRemainder(txsWithPrio, prioritizedPrefixIndices)
 }
 
 // classify pairs each transaction with its priority, preserving order. A
@@ -235,13 +235,13 @@ func computePrioritizedTxsPrefix(
 	return selected
 }
 
-// combinePrioPrefixWithRemainder builds the final transaction order: the
-// prioritized entries in prefix order, followed by the remaining entries
+// combinePrioritizedPrefixWithRemainder builds the final transaction order:
+// the prioritized entries in prefix order, followed by the remaining entries
 // (demoted + non-prioritized) in their original base order.
-func combinePrioPrefixWithRemainder(entries []transactionWithPriority, prioPrefixIndices []int) types.Transactions {
+func combinePrioritizedPrefixWithRemainder(entries []transactionWithPriority, prioritizedPrefixIndices []int) types.Transactions {
 	isPrioritized := make([]bool, len(entries))
 	result := make(types.Transactions, 0, len(entries))
-	for _, i := range prioPrefixIndices {
+	for _, i := range prioritizedPrefixIndices {
 		isPrioritized[i] = true
 		result = append(result, entries[i].tx)
 	}

--- a/gossip/blockproc/priorities/ordering.go
+++ b/gossip/blockproc/priorities/ordering.go
@@ -201,8 +201,8 @@ func computePrioritizedTxsPrefix(
 	perEntityBudget uint64,
 ) []int {
 	selected := make([]int, 0, len(txsWithPrio))
-	remaining := make(map[[16]byte]uint64)
-	budgetOf := func(id [16]byte) uint64 {
+	remaining := make(map[PriorityID]uint64)
+	budgetOf := func(id PriorityID) uint64 {
 		if r, ok := remaining[id]; ok {
 			return r
 		}

--- a/gossip/blockproc/priorities/ordering_test.go
+++ b/gossip/blockproc/priorities/ordering_test.go
@@ -1,0 +1,478 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package priorities
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxWithPrio_Cmp_ComparesByLevelDescWeightDescHashAsc(t *testing.T) {
+	lowHash, highHash := makeTxN(0), makeTxN(1)
+	if bytes.Compare(lowHash.Hash().Bytes(), highHash.Hash().Bytes()) > 0 {
+		lowHash, highHash = highHash, lowHash
+	}
+	tx := makeTxN(0)
+
+	cases := map[string]struct {
+		a         txWithPrio
+		b         txWithPrio
+		expectCmp int
+	}{
+		"higher level wins": {
+			txWithPrio{tx, Prio(2, 10, 100)},
+			txWithPrio{tx, Prio(1, 10, 100)},
+			1,
+		},
+		"lower level loses": {
+			txWithPrio{tx, Prio(1, 10, 100)},
+			txWithPrio{tx, Prio(2, 10, 100)},
+			-1,
+		},
+		"same level higher weight wins": {
+			txWithPrio{tx, Prio(1, 20, 100)},
+			txWithPrio{tx, Prio(1, 10, 100)},
+			1,
+		},
+		"same level lower weight loses": {
+			txWithPrio{tx, Prio(1, 10, 100)},
+			txWithPrio{tx, Prio(1, 20, 100)},
+			-1,
+		},
+		"same level and weight lower hash wins": {
+			txWithPrio{lowHash, Prio(1, 10, 100)},
+			txWithPrio{highHash, Prio(1, 10, 100)},
+			1,
+		},
+		"same level and weight higher hash loses": {
+			txWithPrio{highHash, Prio(1, 10, 100)},
+			txWithPrio{lowHash, Prio(1, 10, 100)},
+			-1,
+		},
+		"same level and weight and hash is equal": {
+			txWithPrio{tx, Prio(1, 10, 100)},
+			txWithPrio{tx, Prio(1, 10, 200)}, // entity does not matter
+			0,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expectCmp, tc.a.cmpLevelWeightHash(tc.b))
+		})
+	}
+}
+
+func TestTxWithPrio_CmpNonceHash_ComparesByNonceAscHashAsc(t *testing.T) {
+	// Same nonce, different hash
+	lowHash, highHash := makeTxG(0, 21000), makeTxG(0, 22000)
+	if bytes.Compare(lowHash.Hash().Bytes(), highHash.Hash().Bytes()) > 0 {
+		lowHash, highHash = highHash, lowHash
+	}
+	prio := Prio(1, 10, 100)
+
+	cases := map[string]struct {
+		a         txWithPrio
+		b         txWithPrio
+		expectCmp int
+	}{
+		"lower nonce wins": {
+			txWithPrio{makeTxN(0), prio},
+			txWithPrio{makeTxN(1), prio},
+			-1,
+		},
+		"higher nonce loses": {
+			txWithPrio{makeTxN(1), prio},
+			txWithPrio{makeTxN(0), prio},
+			1,
+		},
+		"same nonce lower hash wins": {
+			txWithPrio{lowHash, prio},
+			txWithPrio{highHash, prio},
+			-1,
+		},
+		"same nonce higher hash loses": {
+			txWithPrio{highHash, prio},
+			txWithPrio{lowHash, prio},
+			1,
+		},
+		"same nonce and hash is equal": {
+			txWithPrio{lowHash, prio},
+			txWithPrio{lowHash, Prio(2, 20, 200)}, // prio does not matter
+			0,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expectCmp, tc.a.cmpNonceHash(tc.b))
+		})
+	}
+}
+
+func TestPrioritize_NoPriorities_IsIdentity(t *testing.T) {
+	base := types.Transactions{makeTxN(0), makeTxN(1), makeTxN(2)}
+	// No transaction is prioritized, so the signer and nonce reader are unused.
+	got := Prioritize(base, fakeClassifier{}, fakeSigner{}, fakeNonceReader{}, Config{MaxGasPerEntityPerBlock: 1_000_000})
+	require.Equal(t, hashes(base), hashes(got))
+}
+
+// TestPrioritize_EndToEnd exercises the four helpers together: classification,
+// per-sender nonce runs, the budgeted prefix, and the remainder recombination.
+// Each entity has its own budget of two 21k-gas txs (42000):
+//   - A (entity 100): a0, a1 prioritized and contiguous -> both in prefix.
+//   - B (entity 101): b0 is level 2 -> first in prefix.
+//   - C (entity 102): c is prioritized but nonce-gapped -> demoted.
+//   - D (entity 103): d0, d1, d2 prioritized; the budget demotes d2.
+//   - x: not prioritized.
+func TestPrioritize_EndToEnd(t *testing.T) {
+	a0, a1 := makeTxN(0), makeTxN(1)
+	b0 := makeTxN(5)
+	c := makeTxN(7)
+	d0, d1, d2 := makeTxN(2), makeTxN(3), makeTxN(4)
+	x := makeTxN(8)
+	base := types.Transactions{a0, a1, b0, c, d0, d1, d2, x}
+	cls := fakeClassifier{prio: map[common.Hash]Priority{
+		a0.Hash(): Prio(1, 10, 100), a1.Hash(): Prio(1, 50, 100),
+		b0.Hash(): Prio(2, 20, 101),
+		c.Hash():  Prio(1, 90, 102),
+		d0.Hash(): Prio(1, 40, 103), d1.Hash(): Prio(1, 30, 103), d2.Hash(): Prio(1, 20, 103),
+	}}
+	A, B, C, D, X := common.Address{0xa}, common.Address{0xb}, common.Address{0xc}, common.Address{0xd}, common.Address{0x9}
+	signer := fakeSigner{sender: map[common.Hash]common.Address{
+		a0.Hash(): A, a1.Hash(): A,
+		b0.Hash(): B,
+		c.Hash():  C,
+		d0.Hash(): D, d1.Hash(): D, d2.Hash(): D,
+		x.Hash(): X,
+	}}
+	nonceReader := fakeNonceReader{A: 0, B: 5, C: 6, D: 2, X: 8}
+	got := Prioritize(base, cls, signer, nonceReader, Config{MaxGasPerEntityPerBlock: 2 * 21000})
+	// prefix: b0 (level 2), then d0, d1 (entity 4 budget), then a0, a1;
+	// remainder in base order: c (nonce-gapped), d2 (over budget), x (not prioritized).
+	require.Equal(t, hashes(types.Transactions{b0, d0, d1, a0, a1, c, d2, x}), hashes(got))
+}
+
+func TestClassify_PairsTransactionsWithPriorityTreatingErrorsAsNotPrioritized(t *testing.T) {
+	a, b, c := makeTxN(0), makeTxN(1), makeTxN(2)
+	cls := fakeClassifier{
+		prio: map[common.Hash]Priority{
+			a.Hash(): Prio(1, 10, 100),
+			b.Hash(): Prio(2, 20, 101),
+		},
+		errOn: map[common.Hash]bool{
+			b.Hash(): true, // error overrides the priority
+		},
+	}
+	got := classify(types.Transactions{a, b, c}, cls)
+	require.Equal(t, []txWithPrio{
+		{a, Prio(1, 10, 100)},
+		{b, Priority{}}, // error => not prioritized
+		{c, Priority{}}, // unclassified => not prioritized
+	}, got)
+}
+
+func TestPrioritizedSenderRuns_ReducesToContiguousNonceRunOfPrioTxsFromAccountNonce(t *testing.T) {
+	type tx struct {
+		nonce  uint64
+		level  uint64 // 0 = not prioritized
+		sender byte
+	}
+	tests := map[string]struct {
+		txs          []tx
+		startNonces  map[byte]uint64 // per-sender block-start nonce
+		expectedRuns map[byte][]int  // per-sender surviving entry indices, nonce order
+	}{
+		"non-prioritized skipped": {
+			txs:          []tx{{nonce: 0, level: 0, sender: 0xa}},
+			startNonces:  map[byte]uint64{0xa: 0},
+			expectedRuns: map[byte][]int{},
+		},
+		"stale nonce demoted": {
+			txs:          []tx{{nonce: 3, level: 1, sender: 0xa}},
+			startNonces:  map[byte]uint64{0xa: 5},
+			expectedRuns: map[byte][]int{},
+		},
+		"nonce gap demoted": {
+			txs:          []tx{{nonce: 2, level: 1, sender: 0xa}},
+			startNonces:  map[byte]uint64{0xa: 0},
+			expectedRuns: map[byte][]int{},
+		},
+		"stale lower nonce keeps the next": {
+			txs:          []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}},
+			startNonces:  map[byte]uint64{0xa: 1},
+			expectedRuns: map[byte][]int{0xa: {1}},
+		},
+		"gap after run demotes the tail": {
+			// nonce 1 not prioritized breaks the run before nonce 2.
+			txs:          []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 0, sender: 0xa}, {nonce: 2, level: 1, sender: 0xa}},
+			startNonces:  map[byte]uint64{0xa: 0},
+			expectedRuns: map[byte][]int{0xa: {0}},
+		},
+		"contiguous run kept": {
+			txs:          []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}, {nonce: 2, level: 1, sender: 0xa}},
+			startNonces:  map[byte]uint64{0xa: 0},
+			expectedRuns: map[byte][]int{0xa: {0, 1, 2}},
+		},
+		"run ordered by nonce not input order": {
+			txs:          []tx{{nonce: 1, level: 1, sender: 0xa}, {nonce: 0, level: 1, sender: 0xa}},
+			startNonces:  map[byte]uint64{0xa: 0},
+			expectedRuns: map[byte][]int{0xa: {1, 0}},
+		},
+		"per sender independent": {
+			txs:          []tx{{nonce: 1, level: 1, sender: 0xa}, {nonce: 2, level: 1, sender: 0xb}},
+			startNonces:  map[byte]uint64{0xa: 0, 0xb: 2},
+			expectedRuns: map[byte][]int{0xb: {1}},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			entries := make([]txWithPrio, len(tc.txs))
+			signer := fakeSigner{sender: map[common.Hash]common.Address{}}
+			nonceReader := fakeNonceReader{}
+			for i, spec := range tc.txs {
+				txn := makeTxN(spec.nonce)
+				entries[i] = txWithPrio{txn, Prio(spec.level, 10, 100)}
+				addr := common.Address{spec.sender}
+				signer.sender[txn.Hash()] = addr
+				nonceReader[addr] = tc.startNonces[spec.sender]
+			}
+			want := map[common.Address][]int{}
+			for s, idxs := range tc.expectedRuns {
+				want[common.Address{s}] = idxs
+			}
+			require.Equal(t, want, prioritizedSenderRuns(entries, signer, nonceReader))
+		})
+	}
+}
+
+func TestPrioritizedSenderRuns_SameNonceDemotesAllButLowestHash(t *testing.T) {
+	txs := []*types.Transaction{makeTxG(0, 21000), makeTxG(0, 22000), makeTxG(0, 23000)}
+	slices.SortFunc(txs, func(a, b *types.Transaction) int {
+		return bytes.Compare(a.Hash().Bytes(), b.Hash().Bytes())
+	})
+	// the lowest hash (txs[0]) is at index 1
+	entries := []txWithPrio{{txs[2], Prio(1, 10, 100)}, {txs[0], Prio(1, 10, 100)}, {txs[1], Prio(1, 10, 100)}}
+	signer := fakeSigner{sender: map[common.Hash]common.Address{
+		txs[0].Hash(): {0xa}, txs[1].Hash(): {0xa}, txs[2].Hash(): {0xa},
+	}}
+	nonceReader := fakeNonceReader{{0xa}: 0}
+	require.Equal(t, map[common.Address][]int{{0xa}: {1}}, prioritizedSenderRuns(entries, signer, nonceReader))
+}
+
+func TestPrioritizedSenderRuns_SenderExtractionFailureDemotesTransaction(t *testing.T) {
+	bad, good := makeTxN(0), makeTxN(1)
+	entries := []txWithPrio{{bad, Prio(1, 10, 100)}, {good, Prio(1, 10, 100)}}
+	signer := fakeSigner{
+		sender: map[common.Hash]common.Address{good.Hash(): {0xa}},
+		errOn:  map[common.Hash]bool{bad.Hash(): true},
+	}
+	nonceReader := fakeNonceReader{{0xa}: 1}
+	require.Equal(t, map[common.Address][]int{{0xa}: {1}}, prioritizedSenderRuns(entries, signer, nonceReader))
+}
+
+func TestPrioritizedTxsPrefix_SelectsByPriorityRespectingNonceOrderUnderPerEntityBudget(t *testing.T) {
+	tests := map[string]struct {
+		entries  []txWithPrio
+		bySender map[common.Address][]int
+		budget   uint64
+		want     []int
+	}{
+		"orders by level then weight": {
+			// three transactions from different entities (100, 101, 102) with different priorities
+			entries: []txWithPrio{
+				{makeTxN(0), Prio(1, 20, 100)},
+				{makeTxN(1), Prio(2, 10, 101)},
+				{makeTxN(2), Prio(1, 30, 102)},
+			},
+			bySender: map[common.Address][]int{{0xa}: {0}, {0xb}: {1}, {0xc}: {2}},
+			budget:   1_000_000,
+			want:     []int{1, 2, 0},
+		},
+		"per-entity budget demotes excess": {
+			// three transactions from the same entity (100) but different senders; the budget fits two
+			entries: []txWithPrio{
+				{makeTxN(0), Prio(1, 10, 100)},
+				{makeTxN(1), Prio(1, 30, 100)},
+				{makeTxN(2), Prio(1, 20, 100)},
+			},
+			bySender: map[common.Address][]int{{0xa}: {0}, {0xb}: {1}, {0xc}: {2}},
+			budget:   2 * 21000,
+			want:     []int{1, 2},
+		},
+		"over-budget frontier blocks sender chain not the entity": {
+			// one entity, two senders: A's 100k frontier busts the 50k budget,
+			// demoting its whole chain (even the cheap index 1); B still fits.
+			entries: []txWithPrio{
+				{makeTxG(0, 100_000), Prio(1, 20, 100)},
+				{makeTxG(1, 10_000), Prio(1, 10, 100)},
+				{makeTxG(0, 10_000), Prio(1, 5, 100)},
+			},
+			bySender: map[common.Address][]int{{0xa}: {0, 1}, {0xb}: {2}},
+			budget:   50_000,
+			want:     []int{2},
+		},
+		"frontier follows nonce order within a sender": {
+			// 4 transactions from 2 entities and senders
+			// the next tx is only picked from the lowest nonce frontier
+			// pick 1: choose between index 0 and 2 -> pick 2
+			// pick 2: choose between index 0 and 3 -> pick 0
+			// pick 3: choose between index 1 and 3 -> pick 1
+			// pick 4: only index 3 remaining       -> pick 3
+			entries: []txWithPrio{
+				{makeTxN(0), Prio(1, 20, 100)},
+				{makeTxN(1), Prio(1, 40, 100)},
+				{makeTxN(0), Prio(1, 30, 101)},
+				{makeTxN(1), Prio(1, 10, 101)},
+			},
+			bySender: map[common.Address][]int{{0xa}: {0, 1}, {0xb}: {2, 3}},
+			budget:   1_000_000,
+			want:     []int{2, 0, 1, 3},
+		},
+		"zero budget selects nothing": {
+			entries:  []txWithPrio{{makeTxN(0), Prio(5, 99, 100)}},
+			bySender: map[common.Address][]int{{0xa}: {0}},
+			budget:   0,
+			want:     []int{},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.want, prioritizedTxsPrefix(tc.entries, tc.bySender, tc.budget))
+		})
+	}
+}
+
+func TestPrioritizedTxsPrefix_BreaksLevelWeightTiesByHashAscending(t *testing.T) {
+	lowHash, highHash := makeTxN(0), makeTxN(1)
+	if bytes.Compare(lowHash.Hash().Bytes(), highHash.Hash().Bytes()) > 0 {
+		lowHash, highHash = highHash, lowHash
+	}
+
+	entries := []txWithPrio{{highHash, Prio(1, 10, 100)}, {lowHash, Prio(1, 10, 101)}}
+	bySender := map[common.Address][]int{{0xa}: {0}, {0xb}: {1}}
+	require.Equal(t, []int{1, 0}, prioritizedTxsPrefix(entries, bySender, 1_000_000))
+}
+
+func TestPrioritizedTxsPrefix_PacksManyCheapOrFewExpensivePerEntity(t *testing.T) {
+	// entity 1: three 50k-gas txs -> all fit (150k). entity 2: three 80k-gas txs
+	// -> only two fit (160k); the third exceeds 200k and is demoted.
+	entries := []txWithPrio{
+		{makeTxG(0, 50_000), Prio(1, 30, 100)},
+		{makeTxG(1, 50_000), Prio(1, 20, 100)},
+		{makeTxG(2, 50_000), Prio(1, 10, 100)},
+		{makeTxG(3, 80_000), Prio(1, 30, 101)},
+		{makeTxG(4, 80_000), Prio(1, 20, 101)},
+		{makeTxG(5, 80_000), Prio(1, 10, 101)},
+	}
+	bySender := map[common.Address][]int{{0x1}: {0, 1, 2}, {0x2}: {3, 4, 5}}
+	got := prioritizedTxsPrefix(entries, bySender, 200_000)
+	require.ElementsMatch(t, []int{0, 1, 2, 3, 4}, got) // index 5 (third expensive) demoted
+}
+
+func TestCombinePrioPrefixWithRemainder_PrefixThenRemainderInBaseOrder(t *testing.T) {
+	t0, t1, t2, t3 := makeTxN(0), makeTxN(1), makeTxN(2), makeTxN(3)
+	entries := []txWithPrio{{t0, Priority{}}, {t1, Priority{}}, {t2, Priority{}}, {t3, Priority{}}}
+	tests := map[string]struct {
+		prefix []int
+		want   types.Transactions
+	}{
+		"empty prefix is identity": {
+			nil,
+			types.Transactions{t0, t1, t2, t3},
+		},
+		"prefix in order then remainder": {
+			[]int{2, 0},
+			types.Transactions{t2, t0, t1, t3},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, hashes(tc.want), hashes(combinePrioPrefixWithRemainder(entries, tc.prefix)))
+		})
+	}
+}
+
+// fakeClassifier maps transactions (by hash) to priorities, with optional errors.
+type fakeClassifier struct {
+	prio  map[common.Hash]Priority
+	errOn map[common.Hash]bool
+}
+
+func (c fakeClassifier) Priority(tx *types.Transaction) (Priority, error) {
+	if c.errOn[tx.Hash()] {
+		return Priority{}, fmt.Errorf("boom")
+	}
+	if p, ok := c.prio[tx.Hash()]; ok {
+		return p, nil
+	}
+	return Priority{}, nil
+}
+
+// fakeSigner recovers a per-transaction sender from a hash map, standing in for
+// a real signer over unsigned test transactions. Hashes in errOn, and hashes
+// absent from the map, fail recovery.
+type fakeSigner struct {
+	types.Signer
+	sender map[common.Hash]common.Address
+	errOn  map[common.Hash]bool
+}
+
+func (s fakeSigner) Sender(tx *types.Transaction) (common.Address, error) {
+	if s.errOn[tx.Hash()] {
+		return common.Address{}, fmt.Errorf("cannot recover sender")
+	}
+	addr, ok := s.sender[tx.Hash()]
+	if !ok {
+		return common.Address{}, fmt.Errorf("unknown sender for tx %s", tx.Hash())
+	}
+	return addr, nil
+}
+
+func (fakeSigner) Equal(types.Signer) bool { return false }
+
+// fakeNonceReader is a NonceReader backed by per-address block-start account nonces.
+type fakeNonceReader map[common.Address]uint64
+
+func (f fakeNonceReader) GetNonce(sender common.Address) uint64 { return f[sender] }
+
+// makeTxN creates a transaction with the given nonce and 21k gas.
+func makeTxN(nonce uint64) *types.Transaction {
+	return makeTxG(nonce, 21000)
+}
+
+// makeTxG creates a transaction with the given nonce and gas.
+func makeTxG(nonce, gas uint64) *types.Transaction {
+	to := common.Address{0xbb}
+	return types.NewTransaction(nonce, to, big.NewInt(0), gas, big.NewInt(1), nil)
+}
+
+// hashes collects the hashes of the transactions.
+func hashes(txs types.Transactions) []common.Hash {
+	out := make([]common.Hash, len(txs))
+	for i, tx := range txs {
+		out[i] = tx.Hash()
+	}
+	return out
+}

--- a/gossip/blockproc/priorities/ordering_test.go
+++ b/gossip/blockproc/priorities/ordering_test.go
@@ -28,51 +28,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTxWithPrio_Cmp_ComparesByLevelDescWeightDescHashAsc(t *testing.T) {
-	lowHash, highHash := makeTxN(0), makeTxN(1)
+func TestTransactionWithPriority_Cmp_ComparesByLevelDescWeightDescHashAsc(t *testing.T) {
+	lowHash, highHash := makeTxWithNonce(0), makeTxWithNonce(1)
 	if bytes.Compare(lowHash.Hash().Bytes(), highHash.Hash().Bytes()) > 0 {
 		lowHash, highHash = highHash, lowHash
 	}
-	tx := makeTxN(0)
+	tx := makeTxWithNonce(0)
 
 	cases := map[string]struct {
-		a         txWithPrio
-		b         txWithPrio
+		a         transactionWithPriority
+		b         transactionWithPriority
 		expectCmp int
 	}{
 		"higher level wins": {
-			txWithPrio{tx, Prio(2, 10, 100)},
-			txWithPrio{tx, Prio(1, 10, 100)},
+			transactionWithPriority{tx, Prio(2, 10, 100)},
+			transactionWithPriority{tx, Prio(1, 10, 100)},
 			1,
 		},
 		"lower level loses": {
-			txWithPrio{tx, Prio(1, 10, 100)},
-			txWithPrio{tx, Prio(2, 10, 100)},
+			transactionWithPriority{tx, Prio(1, 10, 100)},
+			transactionWithPriority{tx, Prio(2, 10, 100)},
 			-1,
 		},
 		"same level higher weight wins": {
-			txWithPrio{tx, Prio(1, 20, 100)},
-			txWithPrio{tx, Prio(1, 10, 100)},
+			transactionWithPriority{tx, Prio(1, 20, 100)},
+			transactionWithPriority{tx, Prio(1, 10, 100)},
 			1,
 		},
 		"same level lower weight loses": {
-			txWithPrio{tx, Prio(1, 10, 100)},
-			txWithPrio{tx, Prio(1, 20, 100)},
+			transactionWithPriority{tx, Prio(1, 10, 100)},
+			transactionWithPriority{tx, Prio(1, 20, 100)},
 			-1,
 		},
 		"same level and weight lower hash wins": {
-			txWithPrio{lowHash, Prio(1, 10, 100)},
-			txWithPrio{highHash, Prio(1, 10, 100)},
+			transactionWithPriority{lowHash, Prio(1, 10, 100)},
+			transactionWithPriority{highHash, Prio(1, 10, 100)},
 			1,
 		},
 		"same level and weight higher hash loses": {
-			txWithPrio{highHash, Prio(1, 10, 100)},
-			txWithPrio{lowHash, Prio(1, 10, 100)},
+			transactionWithPriority{highHash, Prio(1, 10, 100)},
+			transactionWithPriority{lowHash, Prio(1, 10, 100)},
 			-1,
 		},
 		"same level and weight and hash is equal": {
-			txWithPrio{tx, Prio(1, 10, 100)},
-			txWithPrio{tx, Prio(1, 10, 200)}, // entity does not matter
+			transactionWithPriority{tx, Prio(1, 10, 100)},
+			transactionWithPriority{tx, Prio(1, 10, 200)}, // entity does not matter
 			0,
 		},
 	}
@@ -84,42 +84,42 @@ func TestTxWithPrio_Cmp_ComparesByLevelDescWeightDescHashAsc(t *testing.T) {
 	}
 }
 
-func TestTxWithPrio_CmpNonceHash_ComparesByNonceAscHashAsc(t *testing.T) {
+func TestTransactionWithPriority_CmpNonceHash_ComparesByNonceAscHashAsc(t *testing.T) {
 	// Same nonce, different hash
-	lowHash, highHash := makeTxG(0, 21000), makeTxG(0, 22000)
+	lowHash, highHash := makeTxWithNonceAndGas(0, 21000), makeTxWithNonceAndGas(0, 22000)
 	if bytes.Compare(lowHash.Hash().Bytes(), highHash.Hash().Bytes()) > 0 {
 		lowHash, highHash = highHash, lowHash
 	}
 	prio := Prio(1, 10, 100)
 
 	cases := map[string]struct {
-		a         txWithPrio
-		b         txWithPrio
+		a         transactionWithPriority
+		b         transactionWithPriority
 		expectCmp int
 	}{
 		"lower nonce wins": {
-			txWithPrio{makeTxN(0), prio},
-			txWithPrio{makeTxN(1), prio},
+			transactionWithPriority{makeTxWithNonce(0), prio},
+			transactionWithPriority{makeTxWithNonce(1), prio},
 			-1,
 		},
 		"higher nonce loses": {
-			txWithPrio{makeTxN(1), prio},
-			txWithPrio{makeTxN(0), prio},
+			transactionWithPriority{makeTxWithNonce(1), prio},
+			transactionWithPriority{makeTxWithNonce(0), prio},
 			1,
 		},
 		"same nonce lower hash wins": {
-			txWithPrio{lowHash, prio},
-			txWithPrio{highHash, prio},
+			transactionWithPriority{lowHash, prio},
+			transactionWithPriority{highHash, prio},
 			-1,
 		},
 		"same nonce higher hash loses": {
-			txWithPrio{highHash, prio},
-			txWithPrio{lowHash, prio},
+			transactionWithPriority{highHash, prio},
+			transactionWithPriority{lowHash, prio},
 			1,
 		},
 		"same nonce and hash is equal": {
-			txWithPrio{lowHash, prio},
-			txWithPrio{lowHash, Prio(2, 20, 200)}, // prio does not matter
+			transactionWithPriority{lowHash, prio},
+			transactionWithPriority{lowHash, Prio(2, 20, 200)}, // prio does not matter
 			0,
 		},
 	}
@@ -132,14 +132,15 @@ func TestTxWithPrio_CmpNonceHash_ComparesByNonceAscHashAsc(t *testing.T) {
 }
 
 func TestPrioritize_NoPriorities_IsIdentity(t *testing.T) {
-	base := types.Transactions{makeTxN(0), makeTxN(1), makeTxN(2)}
+	base := types.Transactions{makeTxWithNonce(0), makeTxWithNonce(1), makeTxWithNonce(2)}
 	// No transaction is prioritized, so the signer and nonce reader are unused.
 	got := Prioritize(base, fakeClassifier{}, fakeSigner{}, fakeNonceReader{}, Config{MaxGasPerEntityPerBlock: 1_000_000})
 	require.Equal(t, hashes(base), hashes(got))
 }
 
 // TestPrioritize_EndToEnd exercises the four helpers together: classification,
-// per-sender nonce runs, the budgeted prefix, and the remainder recombination.
+// per-sender nonce sequences, the budgeted prefix, and the remainder
+// recombination.
 // Each entity has its own budget of two 21k-gas txs (42000):
 //   - A (entity 100): a0, a1 prioritized and contiguous -> both in prefix.
 //   - B (entity 101): b0 is level 2 -> first in prefix.
@@ -147,11 +148,11 @@ func TestPrioritize_NoPriorities_IsIdentity(t *testing.T) {
 //   - D (entity 103): d0, d1, d2 prioritized; the budget demotes d2.
 //   - x: not prioritized.
 func TestPrioritize_EndToEnd(t *testing.T) {
-	a0, a1 := makeTxN(0), makeTxN(1)
-	b0 := makeTxN(5)
-	c := makeTxN(7)
-	d0, d1, d2 := makeTxN(2), makeTxN(3), makeTxN(4)
-	x := makeTxN(8)
+	a0, a1 := makeTxWithNonce(0), makeTxWithNonce(1)
+	b0 := makeTxWithNonce(5)
+	c := makeTxWithNonce(7)
+	d0, d1, d2 := makeTxWithNonce(2), makeTxWithNonce(3), makeTxWithNonce(4)
+	x := makeTxWithNonce(8)
 	base := types.Transactions{a0, a1, b0, c, d0, d1, d2, x}
 	cls := fakeClassifier{prio: map[common.Hash]Priority{
 		a0.Hash(): Prio(1, 10, 100), a1.Hash(): Prio(1, 50, 100),
@@ -170,12 +171,13 @@ func TestPrioritize_EndToEnd(t *testing.T) {
 	nonceReader := fakeNonceReader{A: 0, B: 5, C: 6, D: 2, X: 8}
 	got := Prioritize(base, cls, signer, nonceReader, Config{MaxGasPerEntityPerBlock: 2 * 21000})
 	// prefix: b0 (level 2), then d0, d1 (entity 4 budget), then a0, a1;
-	// remainder in base order: c (nonce-gapped), d2 (over budget), x (not prioritized).
+	// remainder in base order: c (nonce-gapped), d2 (over budget), x (not
+	// prioritized).
 	require.Equal(t, hashes(types.Transactions{b0, d0, d1, a0, a1, c, d2, x}), hashes(got))
 }
 
 func TestClassify_PairsTransactionsWithPriorityTreatingErrorsAsNotPrioritized(t *testing.T) {
-	a, b, c := makeTxN(0), makeTxN(1), makeTxN(2)
+	a, b, c := makeTxWithNonce(0), makeTxWithNonce(1), makeTxWithNonce(2)
 	cls := fakeClassifier{
 		prio: map[common.Hash]Priority{
 			a.Hash(): Prio(1, 10, 100),
@@ -186,136 +188,151 @@ func TestClassify_PairsTransactionsWithPriorityTreatingErrorsAsNotPrioritized(t 
 		},
 	}
 	got := classify(types.Transactions{a, b, c}, cls)
-	require.Equal(t, []txWithPrio{
+	require.Equal(t, []transactionWithPriority{
 		{a, Prio(1, 10, 100)},
 		{b, Priority{}}, // error => not prioritized
 		{c, Priority{}}, // unclassified => not prioritized
 	}, got)
 }
 
-func TestPrioritizedSenderRuns_ReducesToContiguousNonceRunOfPrioTxsFromAccountNonce(t *testing.T) {
+func TestPrioritizedSenderSequences_ReducesToContiguousNonceSequenceOfPrioTxsFromAccountNonce(t *testing.T) {
 	type tx struct {
 		nonce  uint64
 		level  uint64 // 0 = not prioritized
 		sender byte
 	}
 	tests := map[string]struct {
-		txs          []tx
-		startNonces  map[byte]uint64 // per-sender block-start nonce
-		expectedRuns map[byte][]int  // per-sender surviving entry indices, nonce order
+		txs         []tx
+		startNonces map[byte]uint64 // per-sender block-start nonce
+		// per-sender surviving entry indices, in nonce order
+		expectedSequences map[byte][]int
 	}{
 		"non-prioritized skipped": {
-			txs:          []tx{{nonce: 0, level: 0, sender: 0xa}},
-			startNonces:  map[byte]uint64{0xa: 0},
-			expectedRuns: map[byte][]int{},
+			txs:               []tx{{nonce: 0, level: 0, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 0},
+			expectedSequences: map[byte][]int{},
 		},
 		"stale nonce demoted": {
-			txs:          []tx{{nonce: 3, level: 1, sender: 0xa}},
-			startNonces:  map[byte]uint64{0xa: 5},
-			expectedRuns: map[byte][]int{},
+			txs:               []tx{{nonce: 3, level: 1, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 5},
+			expectedSequences: map[byte][]int{},
 		},
 		"nonce gap demoted": {
-			txs:          []tx{{nonce: 2, level: 1, sender: 0xa}},
-			startNonces:  map[byte]uint64{0xa: 0},
-			expectedRuns: map[byte][]int{},
+			txs:               []tx{{nonce: 2, level: 1, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 0},
+			expectedSequences: map[byte][]int{},
 		},
 		"stale lower nonce keeps the next": {
-			txs:          []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}},
-			startNonces:  map[byte]uint64{0xa: 1},
-			expectedRuns: map[byte][]int{0xa: {1}},
+			txs:               []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 1},
+			expectedSequences: map[byte][]int{0xa: {1}},
 		},
-		"gap after run demotes the tail": {
-			// nonce 1 not prioritized breaks the run before nonce 2.
-			txs:          []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 0, sender: 0xa}, {nonce: 2, level: 1, sender: 0xa}},
-			startNonces:  map[byte]uint64{0xa: 0},
-			expectedRuns: map[byte][]int{0xa: {0}},
+		"gap after sequence demotes the tail": {
+			// nonce 1 not prioritized breaks the sequence before nonce 2.
+			txs:               []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 0, sender: 0xa}, {nonce: 2, level: 1, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 0},
+			expectedSequences: map[byte][]int{0xa: {0}},
 		},
-		"contiguous run kept": {
-			txs:          []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}, {nonce: 2, level: 1, sender: 0xa}},
-			startNonces:  map[byte]uint64{0xa: 0},
-			expectedRuns: map[byte][]int{0xa: {0, 1, 2}},
+		"contiguous sequence kept": {
+			txs:               []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}, {nonce: 2, level: 1, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 0},
+			expectedSequences: map[byte][]int{0xa: {0, 1, 2}},
 		},
-		"run ordered by nonce not input order": {
-			txs:          []tx{{nonce: 1, level: 1, sender: 0xa}, {nonce: 0, level: 1, sender: 0xa}},
-			startNonces:  map[byte]uint64{0xa: 0},
-			expectedRuns: map[byte][]int{0xa: {1, 0}},
+		"sequence ordered by nonce not input order": {
+			txs:               []tx{{nonce: 1, level: 1, sender: 0xa}, {nonce: 0, level: 1, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 0},
+			expectedSequences: map[byte][]int{0xa: {1, 0}},
 		},
 		"per sender independent": {
-			txs:          []tx{{nonce: 1, level: 1, sender: 0xa}, {nonce: 2, level: 1, sender: 0xb}},
-			startNonces:  map[byte]uint64{0xa: 0, 0xb: 2},
-			expectedRuns: map[byte][]int{0xb: {1}},
+			txs:               []tx{{nonce: 1, level: 1, sender: 0xa}, {nonce: 2, level: 1, sender: 0xb}},
+			startNonces:       map[byte]uint64{0xa: 0, 0xb: 2},
+			expectedSequences: map[byte][]int{0xb: {1}},
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			entries := make([]txWithPrio, len(tc.txs))
+			entries := make([]transactionWithPriority, len(tc.txs))
 			signer := fakeSigner{sender: map[common.Hash]common.Address{}}
 			nonceReader := fakeNonceReader{}
 			for i, spec := range tc.txs {
-				txn := makeTxN(spec.nonce)
-				entries[i] = txWithPrio{txn, Prio(spec.level, 10, 100)}
+				txn := makeTxWithNonce(spec.nonce)
+				entries[i] = transactionWithPriority{txn, Prio(spec.level, 10, 100)}
 				addr := common.Address{spec.sender}
 				signer.sender[txn.Hash()] = addr
 				nonceReader[addr] = tc.startNonces[spec.sender]
 			}
 			want := map[common.Address][]int{}
-			for s, idxs := range tc.expectedRuns {
+			for s, idxs := range tc.expectedSequences {
 				want[common.Address{s}] = idxs
 			}
-			require.Equal(t, want, prioritizedSenderRuns(entries, signer, nonceReader))
+			require.Equal(t, want, prioritizedSenderSequences(entries, signer, nonceReader))
 		})
 	}
 }
 
-func TestPrioritizedSenderRuns_SameNonceDemotesAllButLowestHash(t *testing.T) {
-	txs := []*types.Transaction{makeTxG(0, 21000), makeTxG(0, 22000), makeTxG(0, 23000)}
+func TestPrioritizedSenderSequences_SameNonceDemotesAllButLowestHash(t *testing.T) {
+	txs := []*types.Transaction{makeTxWithNonceAndGas(0, 21000), makeTxWithNonceAndGas(0, 22000), makeTxWithNonceAndGas(0, 23000)}
 	slices.SortFunc(txs, func(a, b *types.Transaction) int {
 		return bytes.Compare(a.Hash().Bytes(), b.Hash().Bytes())
 	})
 	// the lowest hash (txs[0]) is at index 1
-	entries := []txWithPrio{{txs[2], Prio(1, 10, 100)}, {txs[0], Prio(1, 10, 100)}, {txs[1], Prio(1, 10, 100)}}
+	entries := []transactionWithPriority{{txs[2], Prio(1, 10, 100)}, {txs[0], Prio(1, 10, 100)}, {txs[1], Prio(1, 10, 100)}}
 	signer := fakeSigner{sender: map[common.Hash]common.Address{
 		txs[0].Hash(): {0xa}, txs[1].Hash(): {0xa}, txs[2].Hash(): {0xa},
 	}}
 	nonceReader := fakeNonceReader{{0xa}: 0}
-	require.Equal(t, map[common.Address][]int{{0xa}: {1}}, prioritizedSenderRuns(entries, signer, nonceReader))
+	require.Equal(t, map[common.Address][]int{{0xa}: {1}}, prioritizedSenderSequences(entries, signer, nonceReader))
 }
 
-func TestPrioritizedSenderRuns_SenderExtractionFailureDemotesTransaction(t *testing.T) {
-	bad, good := makeTxN(0), makeTxN(1)
-	entries := []txWithPrio{{bad, Prio(1, 10, 100)}, {good, Prio(1, 10, 100)}}
+func TestPrioritizedSenderSequences_SenderExtractionFailureDemotesTransaction(t *testing.T) {
+	bad, good := makeTxWithNonce(0), makeTxWithNonce(1)
+	entries := []transactionWithPriority{{bad, Prio(1, 10, 100)}, {good, Prio(1, 10, 100)}}
 	signer := fakeSigner{
 		sender: map[common.Hash]common.Address{good.Hash(): {0xa}},
 		errOn:  map[common.Hash]bool{bad.Hash(): true},
 	}
 	nonceReader := fakeNonceReader{{0xa}: 1}
-	require.Equal(t, map[common.Address][]int{{0xa}: {1}}, prioritizedSenderRuns(entries, signer, nonceReader))
+	require.Equal(t, map[common.Address][]int{{0xa}: {1}}, prioritizedSenderSequences(entries, signer, nonceReader))
 }
 
-func TestPrioritizedTxsPrefix_SelectsByPriorityRespectingNonceOrderUnderPerEntityBudget(t *testing.T) {
+func TestComputePrioritizedTxsPrefix_SelectsByPriorityRespectingNonceOrderUnderPerEntityBudget(t *testing.T) {
 	tests := map[string]struct {
-		entries  []txWithPrio
+		entries  []transactionWithPriority
 		bySender map[common.Address][]int
 		budget   uint64
 		want     []int
 	}{
+		"single sender kept in nonce order despite ascending priorities": {
+			// 3 transactions from same sender with ascending nonces and priorities.
+			// nonce order is respected and higher-priority transactions do not jump ahead.
+			entries: []transactionWithPriority{
+				{makeTxWithNonce(0), Prio(1, 10, 100)},
+				{makeTxWithNonce(1), Prio(2, 20, 100)},
+				{makeTxWithNonce(2), Prio(3, 30, 100)},
+			},
+			bySender: map[common.Address][]int{{0xa}: {0, 1, 2}},
+			budget:   1_000_000,
+			want:     []int{0, 1, 2},
+		},
 		"orders by level then weight": {
-			// three transactions from different entities (100, 101, 102) with different priorities
-			entries: []txWithPrio{
-				{makeTxN(0), Prio(1, 20, 100)},
-				{makeTxN(1), Prio(2, 10, 101)},
-				{makeTxN(2), Prio(1, 30, 102)},
+			// three transactions from different entities (100, 101, 102) with
+			// different priorities
+			entries: []transactionWithPriority{
+				{makeTxWithNonce(0), Prio(1, 20, 100)},
+				{makeTxWithNonce(1), Prio(2, 10, 101)},
+				{makeTxWithNonce(2), Prio(1, 30, 102)},
 			},
 			bySender: map[common.Address][]int{{0xa}: {0}, {0xb}: {1}, {0xc}: {2}},
 			budget:   1_000_000,
 			want:     []int{1, 2, 0},
 		},
 		"per-entity budget demotes excess": {
-			// three transactions from the same entity (100) but different senders; the budget fits two
-			entries: []txWithPrio{
-				{makeTxN(0), Prio(1, 10, 100)},
-				{makeTxN(1), Prio(1, 30, 100)},
-				{makeTxN(2), Prio(1, 20, 100)},
+			// three transactions from the same entity (100) but different
+			// senders; the budget fits two
+			entries: []transactionWithPriority{
+				{makeTxWithNonce(0), Prio(1, 10, 100)},
+				{makeTxWithNonce(1), Prio(1, 30, 100)},
+				{makeTxWithNonce(2), Prio(1, 20, 100)},
 			},
 			bySender: map[common.Address][]int{{0xa}: {0}, {0xb}: {1}, {0xc}: {2}},
 			budget:   2 * 21000,
@@ -324,10 +341,10 @@ func TestPrioritizedTxsPrefix_SelectsByPriorityRespectingNonceOrderUnderPerEntit
 		"over-budget frontier blocks sender chain not the entity": {
 			// one entity, two senders: A's 100k frontier busts the 50k budget,
 			// demoting its whole chain (even the cheap index 1); B still fits.
-			entries: []txWithPrio{
-				{makeTxG(0, 100_000), Prio(1, 20, 100)},
-				{makeTxG(1, 10_000), Prio(1, 10, 100)},
-				{makeTxG(0, 10_000), Prio(1, 5, 100)},
+			entries: []transactionWithPriority{
+				{makeTxWithNonceAndGas(0, 100_000), Prio(1, 20, 100)},
+				{makeTxWithNonceAndGas(1, 10_000), Prio(1, 10, 100)},
+				{makeTxWithNonceAndGas(0, 10_000), Prio(1, 5, 100)},
 			},
 			bySender: map[common.Address][]int{{0xa}: {0, 1}, {0xb}: {2}},
 			budget:   50_000,
@@ -340,18 +357,18 @@ func TestPrioritizedTxsPrefix_SelectsByPriorityRespectingNonceOrderUnderPerEntit
 			// pick 2: choose between index 0 and 3 -> pick 0
 			// pick 3: choose between index 1 and 3 -> pick 1
 			// pick 4: only index 3 remaining       -> pick 3
-			entries: []txWithPrio{
-				{makeTxN(0), Prio(1, 20, 100)},
-				{makeTxN(1), Prio(1, 40, 100)},
-				{makeTxN(0), Prio(1, 30, 101)},
-				{makeTxN(1), Prio(1, 10, 101)},
+			entries: []transactionWithPriority{
+				{makeTxWithNonce(0), Prio(1, 20, 100)},
+				{makeTxWithNonce(1), Prio(1, 40, 100)},
+				{makeTxWithNonce(0), Prio(1, 30, 101)},
+				{makeTxWithNonce(1), Prio(1, 10, 101)},
 			},
 			bySender: map[common.Address][]int{{0xa}: {0, 1}, {0xb}: {2, 3}},
 			budget:   1_000_000,
 			want:     []int{2, 0, 1, 3},
 		},
 		"zero budget selects nothing": {
-			entries:  []txWithPrio{{makeTxN(0), Prio(5, 99, 100)}},
+			entries:  []transactionWithPriority{{makeTxWithNonce(0), Prio(5, 99, 100)}},
 			bySender: map[common.Address][]int{{0xa}: {0}},
 			budget:   0,
 			want:     []int{},
@@ -359,41 +376,42 @@ func TestPrioritizedTxsPrefix_SelectsByPriorityRespectingNonceOrderUnderPerEntit
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, tc.want, prioritizedTxsPrefix(tc.entries, tc.bySender, tc.budget))
+			require.Equal(t, tc.want, computePrioritizedTxsPrefix(tc.entries, tc.bySender, tc.budget))
 		})
 	}
 }
 
-func TestPrioritizedTxsPrefix_BreaksLevelWeightTiesByHashAscending(t *testing.T) {
-	lowHash, highHash := makeTxN(0), makeTxN(1)
+func TestComputePrioritizedTxsPrefix_BreaksLevelWeightTiesByHashAscending(t *testing.T) {
+	lowHash, highHash := makeTxWithNonce(0), makeTxWithNonce(1)
 	if bytes.Compare(lowHash.Hash().Bytes(), highHash.Hash().Bytes()) > 0 {
 		lowHash, highHash = highHash, lowHash
 	}
 
-	entries := []txWithPrio{{highHash, Prio(1, 10, 100)}, {lowHash, Prio(1, 10, 101)}}
+	entries := []transactionWithPriority{{highHash, Prio(1, 10, 100)}, {lowHash, Prio(1, 10, 101)}}
 	bySender := map[common.Address][]int{{0xa}: {0}, {0xb}: {1}}
-	require.Equal(t, []int{1, 0}, prioritizedTxsPrefix(entries, bySender, 1_000_000))
+	require.Equal(t, []int{1, 0}, computePrioritizedTxsPrefix(entries, bySender, 1_000_000))
 }
 
-func TestPrioritizedTxsPrefix_PacksManyCheapOrFewExpensivePerEntity(t *testing.T) {
+func TestComputePrioritizedTxsPrefix_PacksManyCheapOrFewExpensivePerEntity(t *testing.T) {
 	// entity 1: three 50k-gas txs -> all fit (150k). entity 2: three 80k-gas txs
 	// -> only two fit (160k); the third exceeds 200k and is demoted.
-	entries := []txWithPrio{
-		{makeTxG(0, 50_000), Prio(1, 30, 100)},
-		{makeTxG(1, 50_000), Prio(1, 20, 100)},
-		{makeTxG(2, 50_000), Prio(1, 10, 100)},
-		{makeTxG(3, 80_000), Prio(1, 30, 101)},
-		{makeTxG(4, 80_000), Prio(1, 20, 101)},
-		{makeTxG(5, 80_000), Prio(1, 10, 101)},
+	entries := []transactionWithPriority{
+		{makeTxWithNonceAndGas(0, 50_000), Prio(1, 30, 100)},
+		{makeTxWithNonceAndGas(1, 50_000), Prio(1, 20, 100)},
+		{makeTxWithNonceAndGas(2, 50_000), Prio(1, 10, 100)},
+		{makeTxWithNonceAndGas(3, 80_000), Prio(1, 30, 101)},
+		{makeTxWithNonceAndGas(4, 80_000), Prio(1, 20, 101)},
+		{makeTxWithNonceAndGas(5, 80_000), Prio(1, 10, 101)},
 	}
 	bySender := map[common.Address][]int{{0x1}: {0, 1, 2}, {0x2}: {3, 4, 5}}
-	got := prioritizedTxsPrefix(entries, bySender, 200_000)
-	require.ElementsMatch(t, []int{0, 1, 2, 3, 4}, got) // index 5 (third expensive) demoted
+	got := computePrioritizedTxsPrefix(entries, bySender, 200_000)
+	// index 5 (third expensive) demoted
+	require.ElementsMatch(t, []int{0, 1, 2, 3, 4}, got)
 }
 
 func TestCombinePrioPrefixWithRemainder_PrefixThenRemainderInBaseOrder(t *testing.T) {
-	t0, t1, t2, t3 := makeTxN(0), makeTxN(1), makeTxN(2), makeTxN(3)
-	entries := []txWithPrio{{t0, Priority{}}, {t1, Priority{}}, {t2, Priority{}}, {t3, Priority{}}}
+	t0, t1, t2, t3 := makeTxWithNonce(0), makeTxWithNonce(1), makeTxWithNonce(2), makeTxWithNonce(3)
+	entries := []transactionWithPriority{{t0, Priority{}}, {t1, Priority{}}, {t2, Priority{}}, {t3, Priority{}}}
 	tests := map[string]struct {
 		prefix []int
 		want   types.Transactions
@@ -414,7 +432,8 @@ func TestCombinePrioPrefixWithRemainder_PrefixThenRemainderInBaseOrder(t *testin
 	}
 }
 
-// fakeClassifier maps transactions (by hash) to priorities, with optional errors.
+// fakeClassifier maps transactions (by hash) to priorities, with optional
+// errors.
 type fakeClassifier struct {
 	prio  map[common.Hash]Priority
 	errOn map[common.Hash]bool
@@ -452,18 +471,19 @@ func (s fakeSigner) Sender(tx *types.Transaction) (common.Address, error) {
 
 func (fakeSigner) Equal(types.Signer) bool { return false }
 
-// fakeNonceReader is a NonceReader backed by per-address block-start account nonces.
+// fakeNonceReader is a NonceReader backed by per-address block-start account
+// nonces.
 type fakeNonceReader map[common.Address]uint64
 
 func (f fakeNonceReader) GetNonce(sender common.Address) uint64 { return f[sender] }
 
-// makeTxN creates a transaction with the given nonce and 21k gas.
-func makeTxN(nonce uint64) *types.Transaction {
-	return makeTxG(nonce, 21000)
+// makeTxWithNonce creates a transaction with the given nonce and 21k gas.
+func makeTxWithNonce(nonce uint64) *types.Transaction {
+	return makeTxWithNonceAndGas(nonce, 21000)
 }
 
-// makeTxG creates a transaction with the given nonce and gas.
-func makeTxG(nonce, gas uint64) *types.Transaction {
+// makeTxWithNonceAndGas creates a transaction with the given nonce and gas.
+func makeTxWithNonceAndGas(nonce, gas uint64) *types.Transaction {
 	to := common.Address{0xbb}
 	return types.NewTransaction(nonce, to, big.NewInt(0), gas, big.NewInt(1), nil)
 }

--- a/gossip/blockproc/priorities/ordering_test.go
+++ b/gossip/blockproc/priorities/ordering_test.go
@@ -233,6 +233,11 @@ func TestPrioritizedSenderSequences_ReducesToContiguousNonceSequenceOfPrioTxsFro
 			startNonces:       map[byte]uint64{0xa: 0},
 			expectedSequences: map[byte][]int{0xa: {0}},
 		},
+		"duplicate nonce demoted but sequence not skipped": {
+			txs:               []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 0, level: 0, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}},
+			startNonces:       map[byte]uint64{0xa: 0},
+			expectedSequences: map[byte][]int{0xa: {0, 2}},
+		},
 		"contiguous sequence kept": {
 			txs:               []tx{{nonce: 0, level: 1, sender: 0xa}, {nonce: 1, level: 1, sender: 0xa}, {nonce: 2, level: 1, sender: 0xa}},
 			startNonces:       map[byte]uint64{0xa: 0},

--- a/gossip/blockproc/priorities/ordering_test.go
+++ b/gossip/blockproc/priorities/ordering_test.go
@@ -60,6 +60,11 @@ func TestTransactionWithPriority_Cmp_ComparesByLevelDescWeightDescHashAsc(t *tes
 			transactionWithPriority{tx, Prio(1, 20, 100)},
 			-1,
 		},
+		"zero level different weight not equal": {
+			transactionWithPriority{tx, Prio(0, 10, 100)},
+			transactionWithPriority{tx, Prio(0, 20, 100)},
+			-1,
+		},
 		"same level and weight lower hash wins": {
 			transactionWithPriority{lowHash, Prio(1, 10, 100)},
 			transactionWithPriority{highHash, Prio(1, 10, 100)},

--- a/gossip/blockproc/priorities/ordering_test.go
+++ b/gossip/blockproc/priorities/ordering_test.go
@@ -409,7 +409,7 @@ func TestComputePrioritizedTxsPrefix_PacksManyCheapOrFewExpensivePerEntity(t *te
 	require.ElementsMatch(t, []int{0, 1, 2, 3, 4}, got)
 }
 
-func TestCombinePrioPrefixWithRemainder_PrefixThenRemainderInBaseOrder(t *testing.T) {
+func TestCombinePrioritizedPrefixWithRemainder_PrefixThenRemainderInBaseOrder(t *testing.T) {
 	t0, t1, t2, t3 := makeTxWithNonce(0), makeTxWithNonce(1), makeTxWithNonce(2), makeTxWithNonce(3)
 	entries := []transactionWithPriority{{t0, Priority{}}, {t1, Priority{}}, {t2, Priority{}}, {t3, Priority{}}}
 	tests := map[string]struct {
@@ -427,7 +427,7 @@ func TestCombinePrioPrefixWithRemainder_PrefixThenRemainderInBaseOrder(t *testin
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, hashes(tc.want), hashes(combinePrioPrefixWithRemainder(entries, tc.prefix)))
+			require.Equal(t, hashes(tc.want), hashes(combinePrioritizedPrefixWithRemainder(entries, tc.prefix)))
 		})
 	}
 }

--- a/gossip/blockproc/priorities/types.go
+++ b/gossip/blockproc/priorities/types.go
@@ -60,9 +60,9 @@ type Config struct {
 	// MaxGasPerEntityPerBlock bounds the total gas limit of prioritized
 	// transactions of one entity in a single block (authoritative, enforced at
 	// block formation).
-	// Transactions are packed in (level desc, weight desc, hash asc) order
-	// until the next transaction would exceed the budget; the remainder is
-	// demoted.
+	// Transactions are packed in (level desc, weight desc, hash asc) order until
+	// one would exceed the budget; that transaction and the later nonces of its
+	// sender are demoted, while other senders of the same entity keep packing.
 	MaxGasPerEntityPerBlock uint64
 	// MaxPiggybackTxsPerEntityPerEvent bounds how many prioritized transactions
 	// of one entity a validator eagerly includes in a single emitted event

--- a/gossip/blockproc/priorities/types.go
+++ b/gossip/blockproc/priorities/types.go
@@ -60,9 +60,10 @@ type Config struct {
 	// MaxGasPerEntityPerBlock bounds the total gas limit of prioritized
 	// transactions of one entity in a single block (authoritative, enforced at
 	// block formation).
-	// Transactions are packed in (level desc, weight desc, hash asc) order until
-	// one would exceed the budget; that transaction and the later nonces of its
-	// sender are demoted, while other senders of the same entity keep packing.
+	// Prioritized transactions are hoisted ahead of ordinary ones in
+	// (level desc, weight desc, hash asc) order until one would exceed the
+	// budget; that transaction and the later nonces of its sender are demoted,
+	// while other senders of the same entity keep packing.
 	MaxGasPerEntityPerBlock uint64
 	// MaxPiggybackTxsPerEntityPerEvent bounds how many prioritized transactions
 	// of one entity a validator eagerly includes in a single emitted event

--- a/gossip/blockproc/priorities/types.go
+++ b/gossip/blockproc/priorities/types.go
@@ -32,7 +32,7 @@ import "cmp"
 type Priority struct {
 	Level  uint64
 	Weight uint64
-	ID     [16]byte
+	ID     PriorityID
 }
 
 // IsPrioritized reports whether the transaction has a non-zero priority level.
@@ -53,6 +53,8 @@ func (p Priority) Cmp(other Priority) int {
 	}
 	return cmp.Compare(p.Weight, other.Weight)
 }
+
+type PriorityID [16]byte
 
 // Config holds the per-entity rate limits returned by the registry's
 // getPriorityConfig function.

--- a/gossip/blockproc/priorities/types_test.go
+++ b/gossip/blockproc/priorities/types_test.go
@@ -62,5 +62,5 @@ func TestPriority_Cmp(t *testing.T) {
 // Prio builds a Priority for tests. The id is limited to a single byte for
 // simplicity.
 func Prio(level uint64, weight uint64, id byte) Priority {
-	return Priority{Level: level, Weight: weight, ID: [16]byte{15: id}}
+	return Priority{Level: level, Weight: weight, ID: PriorityID{15: id}}
 }


### PR DESCRIPTION
This PR adds the pure ordering core of the transaction-priorities feature.
This is used in a follow-up to order the transactions in the `c_block_callbacks.go` after the scrambler run.

`Prioritize` reorders a base-ordered, pre-filtered transaction list so that registry-prioritized transactions form a prefix in (level desc, weight desc, hash asc) order, subject to two coupled constraints:
- Per-sender nonce ordering — a transaction keeps its priority only while it extends its sender's contiguous run of prioritized nonces from the block-start account nonce; stale nonces are demoted and the first gap demotes the rest of the sender's txs (they would be nonce-too-high in the prefix).
- Per-entity gas budget — each entity may spend at most `Config.MaxGasPerEntityPerBlock` gas (by gas limit) on prioritized transactions. Selection walks the per-sender frontiers greedily; a frontier that doesn't fit its entity's remaining budget blocks that sender's run, so budget is only spent on transactions that can actually execute in the prefix.
Everything not selected (non-prioritized, nonce-blocked, over budget) keeps its relative base order after the prefix. The function is a pure, deterministic total function of its inputs. 

Classification is abstracted behind a Classifier interface (the EVM-backed implementation and the block-formation call site land in a follow-up).

Unit tests cover each helper (classification, nonce-run, budgeted prefix selection, packing) plus an end-to-end scenario exercising all constraints together.
