### PR TITLE
Remove error print in sonictool during shutdown

### DIFF
--- a/topicsdb/index.go
+++ b/topicsdb/index.go
@@ -17,6 +17,8 @@
 package topicsdb
 
 import (
+	"errors"
+
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/batched"
 	"github.com/Fantom-foundation/lachesis-base/kvdb/table"
@@ -109,10 +111,13 @@ func (tt *index) Push(recs ...*types.Log) error {
 }
 
 func (tt *index) Close() {
-	if err := tt.table.Topic.Close(); err != nil {
+	// The tables are usually prefixed views over a store owned by the caller of
+	// newIndex, and those do not support being closed. Not being able to close
+	// such a view is expected and not an error.
+	if err := tt.table.Topic.Close(); err != nil && !errors.Is(err, kvdb.ErrUnsupportedOp) {
 		log.Error("Failed to close topic table", "err", err)
 	}
-	if err := tt.table.Logrec.Close(); err != nil {
+	if err := tt.table.Logrec.Close(); err != nil && !errors.Is(err, kvdb.ErrUnsupportedOp) {
 		log.Error("Failed to close logrec table", "err", err)
 	}
 }

--- a/topicsdb/index_test.go
+++ b/topicsdb/index_test.go
@@ -19,6 +19,7 @@ package topicsdb
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/Fantom-foundation/lachesis-base/kvdb"
@@ -61,6 +62,36 @@ func TestIndex_Close_LogsTopicAndLogrecErrors(t *testing.T) {
 	require.Contains(t, out, "boom-topic")
 	require.Contains(t, out, "Failed to close logrec table")
 	require.Contains(t, out, "boom-logrec")
+}
+
+func TestIndex_Close_DoesNotLogUnsupportedCloseOfTableViews(t *testing.T) {
+	buf := captureLog(t)
+
+	// newIndex builds its tables as prefixed views over the given store, and
+	// those do not support Close. This is the production setup.
+	idx := newIndex(memorydb.New())
+
+	idx.Close()
+
+	require.Empty(t, buf.String())
+}
+
+func TestIndex_Close_DoesNotLogWrappedUnsupportedError(t *testing.T) {
+	buf := captureLog(t)
+
+	idx := newIndex(memorydb.New())
+	idx.table.Topic = &errOnCloseStore{
+		Store:    memorydb.New(),
+		closeErr: fmt.Errorf("closing topic table: %w", kvdb.ErrUnsupportedOp),
+	}
+	idx.table.Logrec = &errOnCloseStore{
+		Store:    memorydb.New(),
+		closeErr: fmt.Errorf("closing logrec table: %w", kvdb.ErrUnsupportedOp),
+	}
+
+	idx.Close()
+
+	require.Empty(t, buf.String())
 }
 
 // errOnBatchWriteStore wraps a kvdb.Store whose batches always fail on Write.


### PR DESCRIPTION
Sonic tool would log errors about Lachesis store non-implemented methods. This is not a bug, just stubs that return errors instead of being a noop. 
<img width="1253" height="210" alt="image" src="https://github.com/user-attachments/assets/11257908-ec06-465f-a814-ad297985333f" />


The code is patched to avoid concerning users with false errors. 