### PR TITLE
Add counters for registry query failure

### DIFF
--- a/gossip/blockproc/priorities/contract_calls.go
+++ b/gossip/blockproc/priorities/contract_calls.go
@@ -17,7 +17,7 @@
 // Package priorities implements the transaction-priorities feature: querying an
 // on-chain registry contract to determine, per transaction, a priority level, a
 // weight, and an entity id, and using those to order transactions during block
-// formation. See transaction_priorities.md for the design.
+// formation.
 package priorities
 
 import (
@@ -125,10 +125,12 @@ var FallbackConfig = Config{
 }
 
 // GetConfigOrFallback queries the registry configuration via GetConfig and, on
-// error, returns the deterministic FallbackConfig.
-func GetConfigOrFallback(upgrades opera.Upgrades, vm VirtualMachine) Config {
+// error, reports the failure to the failures meter and returns the deterministic
+// FallbackConfig.
+func GetConfigOrFallback(upgrades opera.Upgrades, vm VirtualMachine, failures Meter) Config {
 	cfg, err := GetConfig(upgrades, vm)
 	if err != nil {
+		failures.Mark(1)
 		return FallbackConfig
 	}
 	return cfg

--- a/gossip/blockproc/priorities/contract_calls_test.go
+++ b/gossip/blockproc/priorities/contract_calls_test.go
@@ -210,17 +210,26 @@ func TestGetConfig_EncodesExpectedCalldata(t *testing.T) {
 	require.Equal(t, uint32(registry.GetPriorityConfigFunctionSelector), binary.BigEndian.Uint32(in[0:4]))
 }
 
-func TestGetConfigOrFallback_ReturnsConfigOnSuccess(t *testing.T) {
+func TestGetConfigOrFallback_ValidResult_ReturnsConfig(t *testing.T) {
 	data := make([]byte, 64)
 	binary.BigEndian.PutUint64(data[24:32], 3)
 	binary.BigEndian.PutUint64(data[56:64], 5)
-	cfg := GetConfigOrFallback(enabledUpgrades(), &fakeVM{result: data})
+	var failures countingMeter
+	cfg := GetConfigOrFallback(enabledUpgrades(), &fakeVM{result: data}, &failures)
 	require.Equal(t, Config{MaxGasPerEntityPerBlock: 3, MaxPiggybackTxsPerEntityPerEvent: 5}, cfg)
+	require.Zero(t, failures)
 }
 
-func TestGetConfigOrFallback_ReturnsFallbackOnError(t *testing.T) {
-	cfg := GetConfigOrFallback(enabledUpgrades(), &fakeVM{err: fmt.Errorf("call failed")})
-	require.Equal(t, FallbackConfig, cfg)
+func TestGetConfigOrFallback_CallError_ReturnsFallbackAndCountsEachFailure(t *testing.T) {
+	var failures countingMeter
+	vm := &fakeVM{err: fmt.Errorf("call failed")}
+
+	calls := 2
+	for range calls {
+		cfg := GetConfigOrFallback(enabledUpgrades(), vm, &failures)
+		require.Equal(t, FallbackConfig, cfg)
+	}
+	require.Equal(t, countingMeter(calls), failures)
 }
 
 // TestGetPriorityAndGetConfig_AgainstRealBytecode validates the hand-rolled ABI

--- a/gossip/blockproc/priorities/ordering.go
+++ b/gossip/blockproc/priorities/ordering.go
@@ -58,22 +58,26 @@ type EvmClassifier struct {
 	vm       VirtualMachine
 	signer   types.Signer
 	state    Snapshotter
+	failures Meter
 }
 
 // NewEvmClassifier creates a Classifier that queries the registry per
 // transaction. The provided state must be the same one backing vm so that
-// snapshots isolate the query.
+// snapshots isolate the query. Failed classifications, which silently degrade
+// the transaction to "not prioritized", are reported to the failures meter.
 func NewEvmClassifier(
 	upgrades opera.Upgrades,
 	vm VirtualMachine,
 	signer types.Signer,
 	state Snapshotter,
+	failures Meter,
 ) *EvmClassifier {
 	return &EvmClassifier{
 		upgrades: upgrades,
 		vm:       vm,
 		signer:   signer,
 		state:    state,
+		failures: failures,
 	}
 }
 
@@ -83,6 +87,9 @@ func (c *EvmClassifier) Priority(tx *types.Transaction) (Priority, error) {
 	defer c.state.RevertToInterTxSnapshot(snapshot)
 
 	priority, err := GetPriority(c.upgrades, c.vm, c.signer, tx)
+	if err != nil {
+		c.failures.Mark(1)
+	}
 	return priority, err
 }
 

--- a/gossip/blockproc/priorities/ordering_test.go
+++ b/gossip/blockproc/priorities/ordering_test.go
@@ -33,8 +33,9 @@ import (
 func TestEvmClassifier_Priority_IsolatesEachQueryWithSnapshot(t *testing.T) {
 	tx, signer := makeTx(t)
 	snap := &countingSnapshotter{}
+	var failures countingMeter
 	vm := &fakeVM{result: make([]byte, 96)}
-	cls := NewEvmClassifier(enabledUpgrades(), vm, signer, snap)
+	cls := NewEvmClassifier(enabledUpgrades(), vm, signer, snap, &failures)
 
 	calls := 3
 	for range calls {
@@ -43,13 +44,15 @@ func TestEvmClassifier_Priority_IsolatesEachQueryWithSnapshot(t *testing.T) {
 	}
 	require.Equal(t, calls, snap.snapshots)
 	require.Equal(t, calls, snap.reverts)
+	require.Zero(t, failures)
 }
 
-func TestEvmClassifier_Priority_RevertsSnapshot(t *testing.T) {
+func TestEvmClassifier_Priority_QueryError_RevertsSnapshotAndCountsEachFailure(t *testing.T) {
 	tx, signer := makeTx(t)
 	snap := &countingSnapshotter{}
+	var failures countingMeter
 	vm := &fakeVM{err: fmt.Errorf("boom")}
-	cls := NewEvmClassifier(enabledUpgrades(), vm, signer, snap)
+	cls := NewEvmClassifier(enabledUpgrades(), vm, signer, snap, &failures)
 
 	calls := 2
 	for range calls {
@@ -58,6 +61,7 @@ func TestEvmClassifier_Priority_RevertsSnapshot(t *testing.T) {
 	}
 	require.Equal(t, calls, snap.snapshots)
 	require.Equal(t, calls, snap.reverts)
+	require.Equal(t, countingMeter(calls), failures)
 }
 
 func TestEvmClassifier_Priority_DelegatesToGetPriority(t *testing.T) {
@@ -68,7 +72,7 @@ func TestEvmClassifier_Priority_DelegatesToGetPriority(t *testing.T) {
 	binary.BigEndian.PutUint64(result[56:64], 5)
 	copy(result[80:96], id[:])
 	vm := &fakeVM{result: result}
-	cls := NewEvmClassifier(enabledUpgrades(), vm, signer, &countingSnapshotter{})
+	cls := NewEvmClassifier(enabledUpgrades(), vm, signer, &countingSnapshotter{}, new(countingMeter))
 
 	p, err := cls.Priority(tx)
 	require.NoError(t, err)
@@ -549,6 +553,11 @@ func (c *countingSnapshotter) InterTxSnapshot() int {
 func (c *countingSnapshotter) RevertToInterTxSnapshot(int) {
 	c.reverts++
 }
+
+// countingMeter accumulates the values passed to Mark.
+type countingMeter int64
+
+func (c *countingMeter) Mark(n int64) { *c += countingMeter(n) }
 
 // makeTxWithNonce creates a transaction with the given nonce and 21k gas.
 func makeTxWithNonce(nonce uint64) *types.Transaction {

--- a/gossip/blockproc/priorities/types.go
+++ b/gossip/blockproc/priorities/types.go
@@ -56,6 +56,12 @@ func (p Priority) Cmp(other Priority) int {
 
 type PriorityID [16]byte
 
+// Meter is an abstraction of the metrics.Meter type to facilitate mocking in
+// tests. It is used to report failed registry queries.
+type Meter interface {
+	Mark(int64)
+}
+
 // Config holds the per-entity rate limits returned by the registry's
 // getPriorityConfig function.
 type Config struct {

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -79,6 +79,11 @@ var (
 	skippedTxsMeter   = metrics.GetOrRegisterMeter("chain/txs/skipped", nil)
 	invalidTxsMeter   = metrics.GetOrRegisterMeter("chain/txs/invalid", nil)
 
+	priorityFailures = priorityFailureMeters{
+		config: metrics.GetOrRegisterMeter("chain/priorities/config/failed", nil),
+		txs:    metrics.GetOrRegisterMeter("chain/priorities/txs/failed", nil),
+	}
+
 	confirmedEventsMeter = metrics.GetOrRegisterMeter("chain/events/confirmed", nil) // events received from lachesis
 	spilledEventsMeter   = metrics.GetOrRegisterMeter("chain/events/spilled", nil)   // tx excluded because of MaxBlockGas
 
@@ -95,6 +100,13 @@ var (
 		})),
 	}
 )
+
+// priorityFailureMeters collects the meters reporting silently degraded
+// transaction prioritization.
+type priorityFailureMeters struct {
+	config metricCounter // config query failed, the default limits are used
+	txs    metricCounter // per-transaction query failed, the tx is not prioritized
+}
 
 type ExtendedTxPosition struct {
 	evmstore.TxPosition
@@ -346,6 +358,7 @@ func consensusCallbackBeginBlockFn(
 					blockCtx.Time,
 					randao,
 					lastBlockHeader,
+					priorityFailures,
 				)
 
 				sealer := blockProc.SealerModule.Start(blockCtx, bs, es)
@@ -979,8 +992,10 @@ func isPermissibleInternal(
 // registry query is run against the block-start state through a snapshot that is
 // immediately reverted, so the queries leave no residue in the state used for
 // block execution. The query EVM context is derived exclusively from consensus
-// inputs, so every validator reproduces the same ordering. Any query error is
-// treated as "not prioritized" and never aborts the block formation.
+// inputs, so every validator reproduces the same ordering. Query errors never
+// abort the block formation: a failed config query falls back to
+// priorities.FallbackConfig, a failed transaction query is treated as
+// "not prioritized".
 func applyTransactionPriorities(
 	txs types.Transactions,
 	rules opera.Rules,
@@ -992,6 +1007,7 @@ func applyTransactionPriorities(
 	blockTime inter.Timestamp,
 	randao common.Hash,
 	parent *evmcore.EvmHeader,
+	failures priorityFailureMeters,
 ) types.Transactions {
 	if !rules.Upgrades.TransactionPriorities || len(txs) == 0 {
 		return txs
@@ -1002,10 +1018,10 @@ func applyTransactionPriorities(
 	evm := vm.NewEVM(blockContext, statedb, chainCfg, opera.GetVmConfig(rules))
 
 	snapshot := statedb.InterTxSnapshot()
-	cfg := priorities.GetConfigOrFallback(rules.Upgrades, evm)
+	cfg := priorities.GetConfigOrFallback(rules.Upgrades, evm, failures.config)
 	statedb.RevertToInterTxSnapshot(snapshot)
 
-	classifier := priorities.NewEvmClassifier(rules.Upgrades, evm, signer, statedb)
+	classifier := priorities.NewEvmClassifier(rules.Upgrades, evm, signer, statedb, failures.txs)
 	return priorities.Prioritize(txs, classifier, signer, statedb, cfg)
 }
 

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -80,8 +80,8 @@ var (
 	invalidTxsMeter   = metrics.GetOrRegisterMeter("chain/txs/invalid", nil)
 
 	priorityFailures = priorityFailureMeters{
-		config: metrics.GetOrRegisterMeter("chain/priorities/config/failed", nil),
-		txs:    metrics.GetOrRegisterMeter("chain/priorities/txs/failed", nil),
+		config: metrics.GetOrRegisterMeter("chain/priorities/config/failed", nil), // priority config query failed, the default config is used
+		txs:    metrics.GetOrRegisterMeter("chain/priorities/txs/failed", nil),    // per-transaction query failed, the tx is not prioritized
 	}
 
 	confirmedEventsMeter = metrics.GetOrRegisterMeter("chain/events/confirmed", nil) // events received from lachesis
@@ -104,7 +104,7 @@ var (
 // priorityFailureMeters collects the meters reporting silently degraded
 // transaction prioritization.
 type priorityFailureMeters struct {
-	config metricCounter // config query failed, the default limits are used
+	config metricCounter // config query failed, the default config is used
 	txs    metricCounter // per-transaction query failed, the tx is not prioritized
 }
 

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -2322,6 +2322,7 @@ func TestApplyTransactionPriorities_FeatureDisabled_IsNoOp(t *testing.T) {
 		nil, // reader
 		nil, // signer
 		0, 0, common.Hash{}, nil,
+		priorityFailureMeters{},
 	)
 	require.Equal(t, txs, got)
 }
@@ -2339,6 +2340,7 @@ func TestApplyTransactionPriorities_EmptyInput_IsNoOp(t *testing.T) {
 		nil, // reader
 		nil, // signer
 		0, 0, common.Hash{}, nil,
+		priorityFailureMeters{},
 	)
 	require.Empty(t, got)
 }
@@ -2367,6 +2369,7 @@ func TestApplyTransactionPriorities_EveryQueryIsWrappedInAnInterTxSnapshot(t *te
 	got := applyTransactionPriorities(
 		txs, rules, chainCfg, statedb, nil, signer,
 		1, inter.Timestamp(1234), common.Hash{0x1}, parent,
+		noPriorityFailures(ctrl),
 	)
 
 	require.Equal(t, txs, got) // empty storage => nothing prioritized
@@ -2375,6 +2378,36 @@ func TestApplyTransactionPriorities_EveryQueryIsWrappedInAnInterTxSnapshot(t *te
 	// to the snapshot it took.
 	require.Equal(t, []int{0, 1, 2}, snapshots)
 	require.Equal(t, []int{0, 1, 2}, reverts)
+}
+
+func TestApplyTransactionPriorities_MissingRegistry_CountsConfigAndTxFailuresSeparately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	rules := opera.FakeNetRules(opera.GetBrioUpgrades())
+	rules.Upgrades.TransactionPriorities = true
+	chainCfg := opera.CreateTransientEvmChainConfig(rules.NetworkID, nil, 1)
+	signer := types.LatestSigner(chainCfg)
+
+	// No registry code deployed, so the config query and every per-transaction
+	// query fail.
+	statedb := newRegistryStateDB(ctrl, nil, emptyRegistryStorage)
+	statedb.EXPECT().InterTxSnapshot().Return(0).Times(3) // config plus one per tx
+	statedb.EXPECT().RevertToInterTxSnapshot(gomock.Any()).Times(3)
+
+	configFailures := NewMockmetricCounter(ctrl)
+	configFailures.EXPECT().Mark(int64(1))
+	txFailures := NewMockmetricCounter(ctrl)
+	txFailures.EXPECT().Mark(int64(1)).Times(2)
+
+	txs := types.Transactions{makeSignedTx(t, signer), makeSignedTx(t, signer)}
+	parent := &evmcore.EvmHeader{Hash: common.Hash{0xae}, BaseFee: big.NewInt(1), GasUsed: 10_000}
+
+	got := applyTransactionPriorities(
+		txs, rules, chainCfg, statedb, nil, signer,
+		1, inter.Timestamp(1234), common.Hash{0x1}, parent,
+		priorityFailureMeters{config: configFailures, txs: txFailures},
+	)
+	require.Equal(t, txs, got)
 }
 
 func TestApplyTransactionPriorities_UsesEvmClassifier(t *testing.T) {
@@ -2407,6 +2440,7 @@ func TestApplyTransactionPriorities_UsesEvmClassifier(t *testing.T) {
 	got := applyTransactionPriorities(
 		types.Transactions{plainTx, prioritizedTx}, rules, chainCfg, statedb, nil, signer,
 		1, inter.Timestamp(1234), common.Hash{0x1}, parent,
+		noPriorityFailures(ctrl),
 	)
 	require.Equal(t, types.Transactions{prioritizedTx, plainTx}, got)
 }
@@ -2482,6 +2516,15 @@ func newRegistryStateDB(
 	statedb.EXPECT().SlotInAccessList(any, any).AnyTimes()
 	statedb.EXPECT().AddSlotToAccessList(any, any).AnyTimes()
 	return statedb
+}
+
+// noPriorityFailures returns failure meters that fail the test if a failure is
+// reported to them.
+func noPriorityFailures(ctrl *gomock.Controller) priorityFailureMeters {
+	return priorityFailureMeters{
+		config: NewMockmetricCounter(ctrl),
+		txs:    NewMockmetricCounter(ctrl),
+	}
 }
 
 // emptyRegistryStorage resolves every registry storage slot to zero, under which


### PR DESCRIPTION
This PR adds counters to be able to monitor when queries to the priority registry fail.