### PR TITLE
Fix flaky throttler test by excluding epoch-change transient

### DIFF
--- a/tests/validator_stakes/low_stake_validator_does_not_emit_test.go
+++ b/tests/validator_stakes/low_stake_validator_does_not_emit_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -56,16 +57,19 @@ func TestEventThrottler_NonDominantValidatorsProduceLessEvents_WhenEventThrottle
 
 			net.AdvanceEpoch(t, 1)
 
-			// Poll until enough events are collected for statistical stability
+			// Poll until enough events are collected for statistical stability.
+			// Only events created once every validator has resumed emitting in
+			// the new epoch are considered, see eventsAfterAllValidatorsResumed.
 			const minEvents = 120
-			var eventsInEpoch eventMap
+			var eventsInWindow eventMap
 			require.Eventually(t, func() bool {
-				eventsInEpoch = getEventsInEpoch(t, net)
-				return len(eventsInEpoch) >= minEvents
+				eventsInWindow = eventsAfterAllValidatorsResumed(
+					getEventsInEpoch(t, net), len(initialStake))
+				return len(eventsInWindow) >= minEvents
 			}, 100*time.Second, 50*time.Millisecond,
-				"timed out waiting for at least %d events", minEvents)
+				"timed out waiting for at least %d events created while all validators were emitting", minEvents)
 
-			percentages := calculateValidatorEmissionPercentages(eventsInEpoch)
+			percentages := calculateValidatorEmissionPercentages(eventsInWindow)
 
 			if throttlerEnabled {
 				require.GreaterOrEqual(t, percentages[1], 0.9,
@@ -74,7 +78,7 @@ func TestEventThrottler_NonDominantValidatorsProduceLessEvents_WhenEventThrottle
 					"Low stake validator should create very few events")
 			} else {
 				// Without emitter throttling, both validators should create the same amount of events
-				require.InDelta(t, percentages[1], percentages[2], 0.2,
+				require.InDelta(t, percentages[1], percentages[2], 0.1,
 					"Both validators should create equal amount of events")
 			}
 		})
@@ -84,10 +88,50 @@ func TestEventThrottler_NonDominantValidatorsProduceLessEvents_WhenEventThrottle
 type eventMap map[hash.Event]testEvent
 
 type testEvent struct {
-	Epoch   idx.Block
-	Id      hash.Event
-	Creator idx.ValidatorID
-	Parents []hash.Event
+	Epoch        idx.Block
+	Id           hash.Event
+	Creator      idx.ValidatorID
+	CreationTime inter.Timestamp
+	Parents      []hash.Event
+}
+
+// eventsAfterAllValidatorsResumed reduces the given events to those created
+// after the last of the numValidators validators has created its first event
+// of the epoch.
+//
+// After an epoch change validators do not resume emitting at the same instant;
+// one of them can be several hundred milliseconds ahead of the others. Since
+// the integration test network is configured with an emitter interval of one
+// millisecond, such a delay accounts for hundreds of events and would dominate
+// any measurement of the relative emission rates. The events created before all
+// validators are back are therefore not representative and get discarded.
+//
+// An empty map is returned while some validator has not emitted any event yet.
+func eventsAfterAllValidatorsResumed(events eventMap, numValidators int) eventMap {
+	firstEventTime := map[idx.ValidatorID]inter.Timestamp{}
+	for _, event := range events {
+		cur, found := firstEventTime[event.Creator]
+		if !found || event.CreationTime < cur {
+			firstEventTime[event.Creator] = event.CreationTime
+		}
+	}
+	if len(firstEventTime) < numValidators {
+		return eventMap{}
+	}
+
+	// The window starts when the last validator created its first event.
+	var windowStart inter.Timestamp
+	for _, first := range firstEventTime {
+		windowStart = max(windowStart, first)
+	}
+
+	inWindow := eventMap{}
+	for id, event := range events {
+		if event.CreationTime >= windowStart {
+			inWindow[id] = event
+		}
+	}
+	return inWindow
 }
 
 // getEventsInEpoch returns the events created in the current epoch up to the latest event heads.
@@ -148,6 +192,7 @@ func fetchEvent(t *testing.T, client *tests.PooledEhtClient, eventID hash.Event)
 
 	event.Epoch = idx.Block(toUint64(result["epoch"].(string)))
 	event.Creator = idx.ValidatorID(toUint64(result["creator"].(string)))
+	event.CreationTime = inter.Timestamp(toUint64(result["creationTime"].(string)))
 	event.Id = hash.Event(common.HexToHash(result["id"].(string)))
 	event.Parents = make([]hash.Event, 0)
 	for _, parent := range result["parents"].([]any) {


### PR DESCRIPTION
The test sampled the first 120 events after an epoch change. With the integration test net emitter interval of 1ms that window spans only ~0.6s, during which validators have not all resumed emitting yet, so the measurement reflected which node switched epoch first rather than the relative emission rates.

Only count events created after the last validator emitted its first event of the epoch. This drops the observed difference from 0.35 to 0.02, so the tolerance is tightened back to 0.1.