### PR TITLE
Add FrontierHeap and use it for priority ordering

### DIFF
--- a/gossip/blockproc/priorities/ordering.go
+++ b/gossip/blockproc/priorities/ordering.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/utils/frontierheap"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -246,13 +247,19 @@ func prioritizedSenderSequences(
 // nonce) and advances that sender. A frontier that does not fit its entity
 // budget removes the sender's remaining transactions (its later nonces depend
 // on it), so a budget is only ever spent on transactions that can actually
-// execute in the prioritized prefix. It consumes bySender, mutating it as
-// senders are advanced and exhausted.
+// execute in the prioritized prefix.
 func computePrioritizedTxsPrefix(
 	txsWithPrio []transactionWithPriority,
 	bySender map[common.Address][]int,
 	perEntityBudget uint64,
 ) []int {
+	frontier := frontierheap.NewFrontierHeap(func(a, b int) int {
+		return txsWithPrio[a].cmpLevelWeightHash(txsWithPrio[b])
+	})
+	for _, sequence := range bySender {
+		frontier.AddSequence(sequence)
+	}
+
 	selected := make([]int, 0, len(txsWithPrio))
 	remaining := make(map[PriorityID]uint64)
 	budgetOf := func(id PriorityID) uint64 {
@@ -261,29 +268,21 @@ func computePrioritizedTxsPrefix(
 		}
 		return perEntityBudget
 	}
-	for len(bySender) > 0 {
-		best := -1
-		var bestSender common.Address
-		for sender, sequence := range bySender {
-			idx := sequence[0]
-			if txsWithPrio[idx].tx.Gas() > budgetOf(txsWithPrio[idx].priority.ID) {
-				delete(bySender, sender) // frontier does not fit the budget: sender blocked
-				continue
-			}
-			if best == -1 || txsWithPrio[idx].cmpLevelWeightHash(txsWithPrio[best]) > 0 {
-				best, bestSender = idx, sender
-			}
-		}
-		if best == -1 {
+	for {
+		idx, ok := frontier.Peek()
+		if !ok {
 			break
 		}
-		id := txsWithPrio[best].priority.ID
-		remaining[id] = budgetOf(id) - txsWithPrio[best].tx.Gas()
-		selected = append(selected, best)
-		bySender[bestSender] = bySender[bestSender][1:]
-		if len(bySender[bestSender]) == 0 {
-			delete(bySender, bestSender)
+		gas := txsWithPrio[idx].tx.Gas()
+		id := txsWithPrio[idx].priority.ID
+		budget := budgetOf(id)
+		if gas > budget {
+			frontier.PopSequence() // tx does not fit the budget: sender blocked
+			continue
 		}
+		remaining[id] = budget - gas
+		selected = append(selected, idx)
+		frontier.Shift()
 	}
 	return selected
 }

--- a/utils/frontierheap/frontier_heap.go
+++ b/utils/frontierheap/frontier_heap.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package frontierheap
+
+import (
+	"container/heap"
+)
+
+// FrontierHeap is a max-heap over the frontier of a set of sequences (sequence
+// heads / first elements). Each sequence's remaining elements become reachable
+// one by one as the sequence is advanced via Shift.
+type FrontierHeap[T any] struct {
+	heap sequenceHeap[T]
+}
+
+// NewFrontierHeap creates a new max-heap with the given comparison function.
+func NewFrontierHeap[T any](order func(a, b T) int) *FrontierHeap[T] {
+	return &FrontierHeap[T]{heap: sequenceHeap[T]{order: order}}
+}
+
+// AddSequence inserts a sequence into the heap.
+// Complexity: O(log s), where s is the number of sequences in the heap.
+func (q *FrontierHeap[T]) AddSequence(sequence []T) {
+	if len(sequence) == 0 {
+		return
+	}
+	heap.Push(&q.heap, sequence)
+}
+
+// Peek returns the greatest frontier head, or a zero value and false if the
+// heap is empty.
+// Complexity: O(1).
+func (q *FrontierHeap[T]) Peek() (T, bool) {
+	if q.heap.Len() == 0 {
+		var zero T
+		return zero, false
+	}
+	return q.heap.sequences[0][0], true
+}
+
+// Shift removes and returns the greatest frontier head and advances its
+// sequence: the next element of the same sequence, if any, joins the frontier.
+// Returns a zero value and false if the heap is empty.
+// Complexity: O(log s), where s is the number of sequences in the heap.
+func (q *FrontierHeap[T]) Shift() (T, bool) {
+	if q.heap.Len() == 0 {
+		var zero T
+		return zero, false
+	}
+	head := q.heap.sequences[0][0]
+	if len(q.heap.sequences[0]) > 1 {
+		var zero T
+		q.heap.sequences[0][0] = zero
+		q.heap.sequences[0] = q.heap.sequences[0][1:]
+		heap.Fix(&q.heap, 0)
+	} else {
+		heap.Pop(&q.heap)
+	}
+	return head, true
+}
+
+// PopSequence removes the sequence whose head is the greatest frontier head and
+// returns its remaining elements, the first of which is that head. Returns nil
+// and false if the heap is empty.
+// Complexity: O(log s), where s is the number of sequences in the heap.
+func (q *FrontierHeap[T]) PopSequence() ([]T, bool) {
+	if q.heap.Len() == 0 {
+		return nil, false
+	}
+	return heap.Pop(&q.heap).([]T), true
+}
+
+// -- Heap Implementation --
+
+// sequenceHeap is a heap of non-empty sequences ordered by their order function
+// applied to their heads. It implements heap.Interface to be used with
+// container/heap and provides only the plain heap operations, without the
+// advancing of sequences performed by Shift. It is kept separate from
+// FrontierHeap because the interface's Pop would collide with the public one,
+// and its methods are building blocks that must not be called directly by
+// users of the heap.
+type sequenceHeap[T any] struct {
+	sequences [][]T
+	order     func(a, b T) int
+}
+
+func (h *sequenceHeap[T]) Len() int {
+	return len(h.sequences)
+}
+
+func (h *sequenceHeap[T]) Less(i, j int) bool {
+	return h.order(h.sequences[i][0], h.sequences[j][0]) > 0
+}
+
+func (h *sequenceHeap[T]) Swap(i, j int) {
+	h.sequences[i], h.sequences[j] = h.sequences[j], h.sequences[i]
+}
+
+func (h *sequenceHeap[T]) Push(x any) {
+	h.sequences = append(h.sequences, x.([]T))
+}
+
+func (h *sequenceHeap[T]) Pop() any {
+	last := len(h.sequences) - 1
+	sequence := h.sequences[last]
+	h.sequences[last] = nil
+	h.sequences = h.sequences[:last]
+	return sequence
+}

--- a/utils/frontierheap/frontier_heap_test.go
+++ b/utils/frontierheap/frontier_heap_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package frontierheap
+
+import (
+	"cmp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrontierHeap_AddSequence_EmptySequenceIsNoOp(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	h.AddSequence(nil)
+	require.Empty(t, h.heap.sequences)
+}
+
+func TestFrontierHeap_AddSequence_GreatestHeadIsAtTheRoot(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	for _, head := range []int{2, 4, 5, 3} {
+		h.AddSequence([]int{head})
+	}
+	require.Len(t, h.heap.sequences, 4)
+	require.Equal(t, 5, h.heap.sequences[0][0])
+}
+
+func TestFrontierHeap_Peek_ReturnsGreatestFrontierHeadWithoutConsumingIt(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+
+	h.AddSequence([]int{1, 5})
+	got, ok := h.Peek()
+	require.True(t, ok)
+	require.Equal(t, 1, got)
+
+	h.AddSequence([]int{3})
+	got, ok = h.Peek()
+	require.True(t, ok)
+	require.Equal(t, 3, got)
+}
+
+func TestFrontierHeap_Peek_EmptyHeapReturnsFalse(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	_, ok := h.Peek()
+	require.False(t, ok)
+}
+
+func TestFrontierHeap_Shift_DrainsFrontiersInDescendingOrder(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	h.AddSequence([]int{9, 2, 8})
+	h.AddSequence([]int{7, 3})
+	h.AddSequence([]int{6})
+	require.Equal(t, []int{9, 7, 6, 3, 2, 8}, drain(h))
+}
+
+func TestFrontierHeap_Shift_RemovesHeadOfFirstSequence(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	h.AddSequence([]int{9, 2, 8})
+
+	require.Equal(t, [][]int{{9, 2, 8}}, h.heap.sequences)
+	h.Shift()
+	require.Equal(t, [][]int{{2, 8}}, h.heap.sequences)
+	h.Shift()
+	require.Equal(t, [][]int{{8}}, h.heap.sequences)
+}
+
+func TestFrontierHeap_Shift_EmptyHeapReturnsFalse(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	_, ok := h.Shift()
+	require.False(t, ok)
+}
+
+func TestFrontierHeap_PopSequence_RemovesSequenceOfGreatestHead(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	h.AddSequence([]int{5, 4, 3})
+	h.AddSequence([]int{2})
+	got, ok := h.PopSequence()
+	require.True(t, ok)
+	require.Equal(t, []int{5, 4, 3}, got)
+	require.Equal(t, [][]int{{2}}, h.heap.sequences)
+}
+
+func TestFrontierHeap_PopSequence_ReturnsFullFirstSequence(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	h.heap.sequences = [][]int{{4, 3}, {2, 5}}
+	got, ok := h.PopSequence()
+	require.True(t, ok)
+	require.Equal(t, []int{4, 3}, got)
+	got, ok = h.PopSequence()
+	require.True(t, ok)
+	require.Equal(t, []int{2, 5}, got)
+}
+
+func TestFrontierHeap_PopSequence_EmptyHeapReturnsFalse(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	_, ok := h.PopSequence()
+	require.False(t, ok)
+}
+
+func drain[T any](h *FrontierHeap[T]) []T {
+	var out []T
+	for v, ok := h.Shift(); ok; v, ok = h.Shift() {
+		out = append(out, v)
+	}
+	return out
+}


### PR DESCRIPTION
This PR introduces `utils/frontier_heap`, a generic max-heap over the frontier (heads) of a set of sequences. Each sequence's next element joins the frontier only once the sequence is advanced.

API:
- `AddSequence` — insert a sequence, O(log s)
- `Peek` — greatest frontier head, O(1)
- `Shift` — take the greatest head and advance its sequence, O(log s)
- `PopSequence` — drop the whole sequence owning the greatest head, O(log s)

The priority ordering (`computePrioritizedTxsPrefix`) now uses this heap. This reduces the time complexity from O(n*s) to O(n log s) where n is the total number of transactions and s the number of distinct senders. For the worst case where all senders are distinct (s = n) this means going from O(n²) to O(n log n).

The selection order is unchanged.