### PR TITLE
Handle sigterm during node start/password reading

### DIFF
--- a/cmd/sonicd/app/accounts.go
+++ b/cmd/sonicd/app/accounts.go
@@ -47,7 +47,7 @@ func unlockAccounts(sigCtx context.Context, ctx *cli.Context, stack *node.Node) 
 		return fmt.Errorf("account unlock with HTTP access is forbidden")
 	}
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-	passwords, err := config.MakePasswordList(ctx)
+	passwords, err := config.MakePasswordList(sigCtx, ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/sonicd/app/accounts.go
+++ b/cmd/sonicd/app/accounts.go
@@ -17,17 +17,19 @@
 package app
 
 import (
+	"context"
 	"fmt"
+	"strings"
+
 	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/config/flags"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/node"
 	"gopkg.in/urfave/cli.v1"
-	"strings"
 )
 
 // unlockAccounts unlocks any account specifically requested.
-func unlockAccounts(ctx *cli.Context, stack *node.Node) error {
+func unlockAccounts(sigCtx context.Context, ctx *cli.Context, stack *node.Node) error {
 	var unlocks []string
 	inputs := strings.Split(ctx.GlobalString(flags.UnlockedAccountFlag.Name), ",")
 	for _, input := range inputs {
@@ -50,7 +52,7 @@ func unlockAccounts(ctx *cli.Context, stack *node.Node) error {
 		return err
 	}
 	for i, account := range unlocks {
-		if _, _, err := config.UnlockAccount(ks, account, i, passwords); err != nil {
+		if _, _, err := config.UnlockAccount(sigCtx, ks, account, i, passwords); err != nil {
 			return err
 		}
 	}

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -353,7 +353,7 @@ func startNode(sigCtx context.Context, ctx *cli.Context, stack *node.Node) error
 	}()
 
 	// Unlock any account specifically requested
-	err := unlockAccounts(ctx, stack)
+	err := unlockAccounts(sigCtx, ctx, stack)
 	if err != nil {
 		return fmt.Errorf("failed to unlock accounts: %w", err)
 	}

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -349,7 +349,6 @@ func startNode(sigCtx context.Context, ctx *cli.Context, stack *node.Node) error
 		if err := stack.Close(); err != nil {
 			log.Warn("Error during shutdown", "err", err)
 		}
-		log.Info("Shutdown complete.")
 	}()
 
 	// Unlock any account specifically requested

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -291,7 +292,10 @@ func lachesisMainInternal(
 		cfg.OperaStore.EVM.StateDb.ArchiveCache = archiveCache
 	}
 
-	node, _, nodeClose, err := config.MakeNode(ctx, cfg)
+	sigCtx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	node, _, nodeClose, err := config.MakeNode(sigCtx, ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to initialize the node: %w", err)
 	}
@@ -304,8 +308,7 @@ func lachesisMainInternal(
 		return config.SaveAllConfigs(outputConfigFile, cfg)
 	}
 
-	stop := make(chan bool, 1)
-	if err := startNode(ctx, node, stop); err != nil {
+	if err := startNode(sigCtx, ctx, node); err != nil {
 		return fmt.Errorf("failed to start the node: %w", err)
 	}
 
@@ -322,10 +325,7 @@ func lachesisMainInternal(
 			go func() {
 				<-control.Shutdown
 				log.Info("Got shutdown signal, shutting down...")
-				close(stop)
-				if err := node.Close(); err != nil {
-					log.Warn("Error during shutdown", "err", err)
-				}
+				cancel()
 			}()
 		}
 	}
@@ -336,45 +336,26 @@ func lachesisMainInternal(
 
 // startNode boots up the system node and all registered protocols, after which
 // it unlocks any requested accounts, and starts the RPC/IPC interfaces.
-func startNode(ctx *cli.Context, stack *node.Node, stop <-chan bool) error {
+func startNode(sigCtx context.Context, ctx *cli.Context, stack *node.Node) error {
 	// Start up the node itself
 	if err := stack.Start(); err != nil {
 		return fmt.Errorf("error starting protocol stack: %w", err)
 	}
 	go func() {
 		stopNodeSig := make(chan os.Signal, 1)
-		signal.Notify(stopNodeSig, syscall.SIGINT, syscall.SIGTERM)
-		defer signal.Stop(stopNodeSig)
-
 		startFreeDiskSpaceMonitor(ctx, stopNodeSig, stack.InstanceDir())
 
 		select {
 		case <-stopNodeSig:
-			log.Info("Node got interrupt, shutting down...")
-		case <-stop:
+			log.Info("Node got interrupt by disk space monitoring, shutting down...")
+		case <-sigCtx.Done():
 			log.Info("Node received stop signal, shutting down...")
 		}
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			if err := stack.Close(); err != nil {
-				log.Warn("Error during shutdown", "err", err)
-			}
-		}()
-		for i := 10; i > 0; i-- {
-			select {
-			case <-stopNodeSig:
-				if i > 1 {
-					log.Warn("Already shutting down, interrupt more to panic.", "times", i-1)
-				}
-			case <-done:
-				log.Info("Shutdown complete.")
-				return
-			}
+
+		if err := stack.Close(); err != nil {
+			log.Warn("Error during shutdown", "err", err)
 		}
-		// received 10 interrupts - kill the node forcefully
-		debug.Exit(ctx) // ensure trace and CPU profile data is flushed.
-		debug.LoudPanic("boom")
+		log.Info("Shutdown complete.")
 	}()
 
 	// Unlock any account specifically requested
@@ -425,7 +406,7 @@ func startNode(ctx *cli.Context, stack *node.Node, stop <-chan bool) error {
 						log.Warn("Failed to close wallet", "url", event.Wallet.URL(), "err", err)
 					}
 				}
-			case <-stop:
+			case <-sigCtx.Done():
 				return
 			}
 		}

--- a/cmd/sonicd/app/launcher.go
+++ b/cmd/sonicd/app/launcher.go
@@ -19,7 +19,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/signal"
 	"sort"
 	"strings"
@@ -308,6 +307,8 @@ func lachesisMainInternal(
 		return config.SaveAllConfigs(outputConfigFile, cfg)
 	}
 
+	startFreeDiskSpaceMonitor(sigCtx, ctx, cancel, node.InstanceDir())
+
 	if err := startNode(sigCtx, ctx, node); err != nil {
 		return fmt.Errorf("failed to start the node: %w", err)
 	}
@@ -342,16 +343,9 @@ func startNode(sigCtx context.Context, ctx *cli.Context, stack *node.Node) error
 		return fmt.Errorf("error starting protocol stack: %w", err)
 	}
 	go func() {
-		stopNodeSig := make(chan os.Signal, 1)
-		startFreeDiskSpaceMonitor(ctx, stopNodeSig, stack.InstanceDir())
-
-		select {
-		case <-stopNodeSig:
-			log.Info("Node got interrupt by disk space monitoring, shutting down...")
-		case <-sigCtx.Done():
-			log.Info("Node received stop signal, shutting down...")
-		}
-
+		// stop the node when the context is canceled
+		<-sigCtx.Done()
+		log.Info("Shutting down...")
 		if err := stack.Close(); err != nil {
 			log.Warn("Error during shutdown", "err", err)
 		}
@@ -415,7 +409,7 @@ func startNode(sigCtx context.Context, ctx *cli.Context, stack *node.Node) error
 	return nil
 }
 
-func startFreeDiskSpaceMonitor(ctx *cli.Context, stopNodeSig chan os.Signal, path string) {
+func startFreeDiskSpaceMonitor(sigCtx context.Context, ctx *cli.Context, stopNode context.CancelFunc, path string) {
 	var minFreeDiskSpace int
 	if ctx.GlobalIsSet(flags.MinFreeDiskSpaceFlag.Name) {
 		minFreeDiskSpace = ctx.GlobalInt(flags.MinFreeDiskSpaceFlag.Name)
@@ -423,6 +417,6 @@ func startFreeDiskSpaceMonitor(ctx *cli.Context, stopNodeSig chan os.Signal, pat
 		minFreeDiskSpace = 8192
 	}
 	if minFreeDiskSpace > 0 {
-		go diskusage.MonitorFreeDiskSpace(stopNodeSig, path, uint64(minFreeDiskSpace)*1024*1024)
+		go diskusage.MonitorFreeDiskSpace(sigCtx, stopNode, path, uint64(minFreeDiskSpace)*1024*1024)
 	}
 }

--- a/cmd/sonicd/app/unlocking_test.go
+++ b/cmd/sonicd/app/unlocking_test.go
@@ -19,7 +19,9 @@ package app
 import (
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/cespare/cp"
 )
@@ -221,5 +223,49 @@ Testing your passphrase against all of them...
 	cli.ExpectExit()
 	if !strings.Contains(cli.StderrText(), "none of the listed files could be unlocked") {
 		t.Errorf("stderr text does not contain expected error")
+	}
+}
+
+// TestUnlockFlagPasswordFifoInterruptedBySignal verifies that a shutdown
+// signal interrupts --unlock while it is blocked reading an empty --password
+// FIFO, instead of hanging forever waiting for data that never arrives.
+func TestUnlockFlagPasswordFifoInterruptedBySignal(t *testing.T) {
+	datadir := tmpDatadirWithKeystore(t)
+	initFakenetDatadir(datadir, 1)
+
+	fifoPath := filepath.Join(tmpdir(t), "password.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := exec(t,
+		"--fakenet", "0/1", "--datadir", datadir, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",
+		"--password", fifoPath,
+		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a",
+		"--ipcdisable")
+
+	// Give the node a moment to start and block reading the empty password
+	// FIFO before sending the shutdown signal.
+	time.Sleep(500 * time.Millisecond)
+	cli.Interrupt()
+
+	exited := make(chan struct{})
+	go func() {
+		cli.WaitExit()
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+		if cli.Cleanup != nil {
+			cli.Cleanup()
+		}
+	case <-time.After(5 * time.Second):
+		cli.Kill()
+		t.Fatal("node did not shut down after the interrupt signal while blocked reading the password FIFO")
+	}
+
+	if !strings.Contains(cli.StderrText(), "context canceled") {
+		t.Errorf("stderr text does not contain expected shutdown error, got:\n%s", cli.StderrText())
 	}
 }

--- a/cmd/sonicd/diskusage/monitor.go
+++ b/cmd/sonicd/diskusage/monitor.go
@@ -17,15 +17,14 @@
 package diskusage
 
 import (
-	"os"
-	"syscall"
+	"context"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
 
-func MonitorFreeDiskSpace(stopNodeSig chan os.Signal, path string, freeDiskSpaceCritical uint64) {
+func MonitorFreeDiskSpace(ctx context.Context, stopNode context.CancelFunc, path string, freeDiskSpaceCritical uint64) {
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -36,11 +35,15 @@ func MonitorFreeDiskSpace(stopNodeSig chan os.Signal, path string, freeDiskSpace
 		}
 		if freeSpace < freeDiskSpaceCritical {
 			log.Error("Low disk space. Gracefully shutting down Sonic to prevent database corruption.", "available", common.StorageSize(freeSpace))
-			stopNodeSig <- syscall.SIGTERM
+			stopNode()
 			break
 		} else if freeSpace < 2*freeDiskSpaceCritical {
 			log.Warn("Disk space is running low. Sonic will shutdown if disk space runs below critical level.", "available", common.StorageSize(freeSpace), "critical_level", common.StorageSize(freeDiskSpaceCritical))
 		}
-		<-ticker.C
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
 	}
 }

--- a/cmd/sonictool/app/account.go
+++ b/cmd/sonictool/app/account.go
@@ -70,7 +70,7 @@ func accountCreate(ctx *cli.Context) error {
 		scryptP = keystore.LightScryptP
 	}
 
-	passwordList, err := config.MakePasswordList(ctx)
+	passwordList, err := config.MakePasswordList(context.Background(), ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get password list: %w", err)
 	}
@@ -148,7 +148,7 @@ func accountImport(ctx *cli.Context) (err error) {
 	}
 	defer caution.CloseAndReportError(&err, stack, "failed to close network stack")
 
-	passwordList, err := config.MakePasswordList(ctx)
+	passwordList, err := config.MakePasswordList(context.Background(), ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get password list: %w", err)
 	}

--- a/cmd/sonictool/app/account.go
+++ b/cmd/sonictool/app/account.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/0xsoniclabs/sonic/config"
@@ -73,7 +74,7 @@ func accountCreate(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get password list: %w", err)
 	}
-	password, err := config.GetPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, passwordList)
+	password, err := config.GetPassPhrase(context.Background(), "Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, passwordList)
 	if err != nil {
 		return fmt.Errorf("failed to get passphrase: %w", err)
 	}
@@ -112,11 +113,11 @@ func accountUpdate(ctx *cli.Context) (err error) {
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 
 	for _, addr := range ctx.Args() {
-		account, oldPassword, err := config.UnlockAccount(ks, addr, 0, nil)
+		account, oldPassword, err := config.UnlockAccount(context.Background(), ks, addr, 0, nil)
 		if err != nil {
 			return err
 		}
-		newPassword, err := config.GetPassPhrase("Please give a new password. Do not forget this password.", true, 0, nil)
+		newPassword, err := config.GetPassPhrase(context.Background(), "Please give a new password. Do not forget this password.", true, 0, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get passphrase: %w", err)
 		}
@@ -151,7 +152,7 @@ func accountImport(ctx *cli.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to get password list: %w", err)
 	}
-	passphrase, err := config.GetPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, passwordList)
+	passphrase, err := config.GetPassPhrase(context.Background(), "Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, passwordList)
 	if err != nil {
 		return fmt.Errorf("failed to get passphrase: %w", err)
 	}

--- a/cmd/sonictool/app/validator.go
+++ b/cmd/sonictool/app/validator.go
@@ -47,7 +47,7 @@ func validatorKeyCreate(ctx *cli.Context) error {
 		return err
 	}
 
-	passwordList, err := config.MakePasswordList(ctx)
+	passwordList, err := config.MakePasswordList(context.Background(), ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get password list: %w", err)
 	}

--- a/cmd/sonictool/app/validator.go
+++ b/cmd/sonictool/app/validator.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"errors"
@@ -50,7 +51,7 @@ func validatorKeyCreate(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get password list: %w", err)
 	}
-	password, err := config.GetPassPhrase("Your new validator key is locked with a password. Please give a password. Do not forget this password.", true, 0, passwordList)
+	password, err := config.GetPassPhrase(context.Background(), "Your new validator key is locked with a password. Please give a password. Do not forget this password.", true, 0, passwordList)
 	if err != nil {
 		return fmt.Errorf("failed to get passphrase: %w", err)
 	}

--- a/cmd/sonictool/chain/import_events.go
+++ b/cmd/sonictool/chain/import_events.go
@@ -19,6 +19,7 @@ package chain
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -65,7 +66,10 @@ func EventsImport(ctx *cli.Context, files ...string) error {
 	cfg.Node.P2P.StaticNodes = nil
 	cfg.Node.P2P.TrustedNodes = nil
 
-	node, svc, nodeClose, err := config.MakeNode(ctx, cfg)
+	sigCtx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	node, svc, nodeClose, err := config.MakeNode(sigCtx, ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -77,7 +81,7 @@ func EventsImport(ctx *cli.Context, files ...string) error {
 
 	for _, fn := range files {
 		log.Info("Importing events from file", "file", fn)
-		if err := importEventsFile(svc, fn); err != nil {
+		if err := importEventsFile(sigCtx, svc, fn); err != nil {
 			log.Error("Import error", "file", fn, "err", err)
 			return err
 		}
@@ -102,13 +106,7 @@ func checkEventsFileHeader(reader io.Reader) error {
 	return nil
 }
 
-func importEventsFile(srv *gossip.Service, filename string) (err error) {
-	// Watch for Ctrl-C while the import is running.
-	// If a signal is received, the import will stop.
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(interrupt)
-
+func importEventsFile(sigCtx context.Context, srv *gossip.Service, filename string) (err error) {
 	// Open the file handle and potentially unwrap the gzip stream
 	fileHandle, err := os.Open(filename)
 	if err != nil {
@@ -161,7 +159,7 @@ func importEventsFile(srv *gossip.Service, filename string) (err error) {
 
 	for {
 		select {
-		case <-interrupt:
+		case <-sigCtx.Done():
 			return fmt.Errorf("interrupted")
 		default:
 		}

--- a/config/account.go
+++ b/config/account.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/0xsoniclabs/sonic/utils/prompt"
@@ -27,7 +28,7 @@ import (
 )
 
 // UnlockAccount tries unlocking the specified account a few times.
-func UnlockAccount(ks *keystore.KeyStore, address string, i int, passwords []string) (accounts.Account, string, error) {
+func UnlockAccount(ctx context.Context, ks *keystore.KeyStore, address string, i int, passwords []string) (accounts.Account, string, error) {
 	if !common.IsHexAddress(address) {
 		return accounts.Account{}, "", fmt.Errorf("could not unlock account - '%s' is not an address", address)
 	}
@@ -35,7 +36,7 @@ func UnlockAccount(ks *keystore.KeyStore, address string, i int, passwords []str
 	var err error
 	for trials := 0; trials < 3; trials++ {
 		prompt := fmt.Sprintf("Unlocking account %s | Attempt %d/%d", address, trials+1, 3)
-		password, errPass := GetPassPhrase(prompt, false, i, passwords)
+		password, errPass := GetPassPhrase(ctx, prompt, false, i, passwords)
 		if errPass != nil {
 			return accounts.Account{}, "", errPass
 		}
@@ -89,7 +90,7 @@ func ambiguousAddrRecovery(ks *keystore.KeyStore, err *keystore.AmbiguousAddrErr
 
 // GetPassPhrase retrieves the password associated with an account, either fetched
 // from a list of preloaded passphrases, or requested interactively from the user.
-func GetPassPhrase(msg string, confirmation bool, i int, passwords []string) (string, error) {
+func GetPassPhrase(ctx context.Context, msg string, confirmation bool, i int, passwords []string) (string, error) {
 	// If a list of passwords was supplied, retrieve from them
 	if len(passwords) > 0 {
 		if i < len(passwords) {
@@ -97,22 +98,39 @@ func GetPassPhrase(msg string, confirmation bool, i int, passwords []string) (st
 		}
 		return passwords[len(passwords)-1], nil
 	}
-	// Otherwise prompt the user for the password
-	if msg != "" {
-		fmt.Println(msg)
+	// Otherwise prompt the user for the password - in a go-rutine to allow interrupting by context
+	type result struct {
+		password string
+		err      error
 	}
-	password, err := prompt.UserPrompt.PromptPassword("Passphrase: ")
-	if err != nil {
-		return "", fmt.Errorf("failed to read passphrase: %v", err)
-	}
-	if confirmation {
-		confirm, err := prompt.UserPrompt.PromptPassword("Repeat passphrase: ")
+	resultChan := make(chan result, 1)
+	go func() {
+		if msg != "" {
+			fmt.Println(msg)
+		}
+		password, err := prompt.UserPrompt.PromptPassword("Passphrase: ")
 		if err != nil {
-			return "", fmt.Errorf("failed to read passphrase confirmation: %v", err)
+			resultChan <- result{"", fmt.Errorf("failed to read passphrase: %v", err)}
+			return
 		}
-		if password != confirm {
-			return "", fmt.Errorf("passphrases do not match")
+		if confirmation {
+			confirm, err := prompt.UserPrompt.PromptPassword("Repeat passphrase: ")
+			if err != nil {
+				resultChan <- result{"", fmt.Errorf("failed to read passphrase confirmation: %v", err)}
+				return
+			}
+			if password != confirm {
+				resultChan <- result{"", fmt.Errorf("passphrases do not match")}
+				return
+			}
 		}
+		resultChan <- result{password, nil}
+	}()
+
+	select {
+	case res := <-resultChan:
+		return res.password, res.err
+	case <-ctx.Done():
+		return "", ctx.Err()
 	}
-	return password, nil
 }

--- a/config/make_node.go
+++ b/config/make_node.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strconv"
@@ -46,7 +47,7 @@ var (
 	chainInfoGauge = metrics.GetOrRegisterGaugeInfo("chain/info", nil)
 )
 
-func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(), error) {
+func MakeNode(sigCtx context.Context, ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(), error) {
 	var success bool
 	var cleanup []func()
 	defer func() { // if the function fails, clean-up in defer, otherwise return cleaning function
@@ -138,7 +139,7 @@ func MakeNode(ctx *cli.Context, cfg *Config) (*node.Node, *gossip.Service, func(
 
 	// unlock validator key
 	if !valPubkey.Empty() {
-		err := unlockValidatorKey(ctx, valPubkey, valKeystore)
+		err := unlockValidatorKey(sigCtx, ctx, valPubkey, valKeystore)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to unlock validator key: %w", err)
 		}

--- a/config/node_config.go
+++ b/config/node_config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"os"
@@ -74,12 +75,13 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) error {
 }
 
 // MakePasswordList reads password lines from the file specified by the global --password flag.
-func MakePasswordList(ctx *cli.Context) ([]string, error) {
+// sigCtx allows interrupting the read if the file is a pipe that never receives data.
+func MakePasswordList(sigCtx context.Context, ctx *cli.Context) ([]string, error) {
 	path := ctx.String(flags.PasswordFileFlag.Name)
 	if path == "" {
 		return nil, nil
 	}
-	text, err := os.ReadFile(path)
+	text, err := readFileWithContext(sigCtx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read password file: %w", err)
 	}

--- a/config/node_config.go
+++ b/config/node_config.go
@@ -81,6 +81,7 @@ func MakePasswordList(sigCtx context.Context, ctx *cli.Context) ([]string, error
 	if path == "" {
 		return nil, nil
 	}
+	log.Info("Reading keystore password from file...", "path", path)
 	text, err := readFileWithContext(sigCtx, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read password file: %w", err)

--- a/config/valkeystore.go
+++ b/config/valkeystore.go
@@ -76,7 +76,7 @@ func unlockValidatorKey(sigCtx context.Context, cliCtx *cli.Context, pubKey vali
 		if err != nil {
 			return err
 		}
-		password, err := GetPassPhrase(prompt, false, 0, passwordList)
+		password, err := GetPassPhrase(sigCtx, prompt, false, 0, passwordList)
 		if err != nil {
 			return err
 		}

--- a/config/valkeystore.go
+++ b/config/valkeystore.go
@@ -48,6 +48,7 @@ func addFakeValidatorKey(ctx *cli.Context, key *ecdsa.PrivateKey, pubkey validat
 // makeValidatorPasswordList reads password lines from the file specified by the global --validator.password flag.
 func makeValidatorPasswordList(sigCtx context.Context, cliCtx *cli.Context) ([]string, error) {
 	if path := cliCtx.GlobalString(flags.ValidatorPasswordFlag.Name); path != "" {
+		log.Info("Reading validator password from file...", "path", path)
 		text, err := readFileWithContext(sigCtx, path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read validator password file: %w", err)

--- a/config/valkeystore.go
+++ b/config/valkeystore.go
@@ -17,11 +17,14 @@
 package config
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/0xsoniclabs/sonic/config/flags"
+	"io"
 	"os"
 	"strings"
+
+	"github.com/0xsoniclabs/sonic/config/flags"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -43,9 +46,9 @@ func addFakeValidatorKey(ctx *cli.Context, key *ecdsa.PrivateKey, pubkey validat
 }
 
 // makeValidatorPasswordList reads password lines from the file specified by the global --validator.password flag.
-func makeValidatorPasswordList(ctx *cli.Context) ([]string, error) {
-	if path := ctx.GlobalString(flags.ValidatorPasswordFlag.Name); path != "" {
-		text, err := os.ReadFile(path)
+func makeValidatorPasswordList(sigCtx context.Context, cliCtx *cli.Context) ([]string, error) {
+	if path := cliCtx.GlobalString(flags.ValidatorPasswordFlag.Name); path != "" {
+		text, err := readFileWithContext(sigCtx, path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read validator password file: %w", err)
 		}
@@ -56,20 +59,20 @@ func makeValidatorPasswordList(ctx *cli.Context) ([]string, error) {
 		}
 		return lines, nil
 	}
-	if ctx.GlobalIsSet(FakeNetFlag.Name) {
+	if cliCtx.GlobalIsSet(FakeNetFlag.Name) {
 		return []string{validatorpk.FakePassword}, nil
 	}
 	return nil, nil
 }
 
-func unlockValidatorKey(ctx *cli.Context, pubKey validatorpk.PubKey, valKeystore valkeystore.KeystoreI) error {
+func unlockValidatorKey(sigCtx context.Context, cliCtx *cli.Context, pubKey validatorpk.PubKey, valKeystore valkeystore.KeystoreI) error {
 	if !valKeystore.Has(pubKey) {
 		return valkeystore.ErrNotFound
 	}
 	var err error
 	for trials := 0; trials < 3; trials++ {
 		prompt := fmt.Sprintf("Unlocking validator key %s | Attempt %d/%d", pubKey.String(), trials+1, 3)
-		passwordList, err := makeValidatorPasswordList(ctx)
+		passwordList, err := makeValidatorPasswordList(sigCtx, cliCtx)
 		if err != nil {
 			return err
 		}
@@ -88,4 +91,30 @@ func unlockValidatorKey(ctx *cli.Context, pubKey validatorpk.PubKey, valKeystore
 	}
 	// All trials expended to unlock account, bail out
 	return err
+}
+
+func readFileWithContext(ctx context.Context, path string) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	resultChan := make(chan result, 1)
+	go func() {
+		f, err := os.Open(path) // blocks on a pipe
+		if err != nil {
+			resultChan <- result{nil, err}
+			return
+		}
+		defer func() { _ = f.Close() }()
+
+		data, err := io.ReadAll(f) // blocks on a pipe
+		resultChan <- result{data, err}
+	}()
+
+	select {
+	case res := <-resultChan:
+		return res.data, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }

--- a/config/valkeystore_test.go
+++ b/config/valkeystore_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
+	"github.com/stretchr/testify/require"
+	cli "gopkg.in/urfave/cli.v1"
+
+	"github.com/0xsoniclabs/sonic/config/flags"
+	"github.com/0xsoniclabs/sonic/inter/validatorpk"
+	"github.com/0xsoniclabs/sonic/valkeystore"
+)
+
+func newTestValidatorKey(t *testing.T) (valkeystore.KeystoreI, validatorpk.PubKey) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	valKeystore := valkeystore.NewLightFileKeystore(path.Join(tmpDir, "validator"))
+	key := makefakegenesis.FakeKey(1)
+	pubkey := makefakegenesis.GetFakeValidators(1)[0].PubKey
+	require.NoError(t, addFakeValidatorKey(nil, key, pubkey, valKeystore))
+	return valKeystore, pubkey
+}
+
+func newCliContextWithPasswordFile(t *testing.T, path string) *cli.Context {
+	t.Helper()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String(flags.ValidatorPasswordFlag.Name, path, "")
+	return cli.NewContext(nil, fs, nil)
+}
+
+func TestUnlockValidatorKey_Successful(t *testing.T) {
+	valKeystore, pubkey := newTestValidatorKey(t)
+
+	tmpDir := t.TempDir()
+	passwordPath := path.Join(tmpDir, "password.txt")
+	require.NoError(t, os.WriteFile(passwordPath, []byte(validatorpk.FakePassword+"\n"), 0600))
+	cliCtx := newCliContextWithPasswordFile(t, passwordPath)
+
+	require.NoError(t, unlockValidatorKey(context.Background(), cliCtx, pubkey, valKeystore))
+	require.True(t, valKeystore.Unlocked(pubkey))
+}
+
+func TestUnlockValidatorKey_PasswordPipe(t *testing.T) {
+	valKeystore, pubkey := newTestValidatorKey(t)
+
+	tmpDir := t.TempDir()
+	fifoPath := path.Join(tmpDir, "password.fifo")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0600))
+	cliCtx := newCliContextWithPasswordFile(t, fifoPath)
+
+	go func() { // write password into the pipe
+		w, err := os.OpenFile(fifoPath, os.O_WRONLY, 0)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer func() { _ = w.Close() }()
+		if _, err := w.Write([]byte(validatorpk.FakePassword)); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	require.NoError(t, unlockValidatorKey(t.Context(), cliCtx, pubkey, valKeystore))
+	require.True(t, valKeystore.Unlocked(pubkey))
+}
+
+func TestUnlockValidatorKey_PasswordPipeTimeout(t *testing.T) {
+	valKeystore, pubkey := newTestValidatorKey(t)
+
+	tmpDir := t.TempDir()
+	fifoPath := path.Join(tmpDir, "password.fifo")
+	require.NoError(t, syscall.Mkfifo(fifoPath, 0600))
+	cliCtx := newCliContextWithPasswordFile(t, fifoPath)
+
+	// nothing written into the pipe - expected to timeout
+	sigCtx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	err := unlockValidatorKey(sigCtx, cliCtx, pubkey, valKeystore)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.False(t, valKeystore.Unlocked(pubkey))
+}


### PR DESCRIPTION
It is possible to use a unix pipe as a source of the validator keystore password.
The issue is, if the node receives SIGTERM while the node is waiting for the password from the pipe, the node terminates improperly and breaks the database. The same applies even without the pipe - when the SIGTERM is received during the startup phase of the node.

**This PR introduce SIGTERM handling by context for the whole duration for which the node keeps the database open.**

As a side effect, this removes the forced-termination by repeated Ctrl+C - we are not going to support termination without proper closing of the database.

Note: startFreeDiskSpaceMonitor moved from startNode() into lachesisMainInternal() - it makes canceling the context from it more straightforward and there is no logical reason for it to be part of the startNode() method.

Edit: The same fix was applied for reading a password from the console (GetPassPhrase).