### PR TITLE
Use FrontierHeap for emitter

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -369,7 +369,7 @@ func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
 		}
 	}
 
-	sortedTxs := newTransactionsByPriceAndNonce(em.world.TransactionSigner, txs, baseFee)
+	sortedTxs := newTransactionsByPriceAndNonce(txs, baseFee)
 	em.cache.sortedTxs = sortedTxs
 	em.cache.poolCount = poolCount
 	em.cache.poolBlock = em.world.GetLatestBlockIndex()

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -681,13 +681,13 @@ func TestEmitter_EmitEvent_skippingTxsAlsoSkipsGappedNoncesTxs(t *testing.T) {
 	// Only the valid tx at nonce=0 should survive.
 	// The malformed tx at nonce=1 was skipped, which breaks the loop
 	// and also drops the valid tx at nonce=2 due to the nonce gap.
-	tx, _ := sorted.Peek()
-	require.NotNil(t, tx, "expected the valid tx at nonce=0 to be present")
-	require.Equal(t, validTx0.Hash(), tx.Hash)
+	entry, ok := sorted.Peek()
+	require.True(t, ok, "expected the valid tx at nonce=0 to be present")
+	require.Equal(t, validTx0.Hash(), entry.tx.Hash)
 
 	sorted.Shift()
-	tx, _ = sorted.Peek()
-	require.Nil(t, tx, "expected no more txs after the nonce gap")
+	_, ok = sorted.Peek()
+	require.False(t, ok, "expected no more txs after the nonce gap")
 }
 
 func TestEmitter_ThrottlerWorldAdapter_ReturnsNilIfNoEventIsFound(t *testing.T) {

--- a/gossip/emitter/ordering.go
+++ b/gossip/emitter/ordering.go
@@ -17,12 +17,10 @@
 package emitter
 
 import (
-	"container/heap"
-	"maps"
 	"math/big"
-	"slices"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/utils/frontierheap"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -59,123 +57,47 @@ func newTxWithMinerFee(tx *txpool.LazyTransaction, from common.Address, baseFee 
 	}, nil
 }
 
-// txByPriceAndTime implements both the sort and the heap interface, making it useful
-// for all at once sorting as well as individually adding and removing elements.
-type txByPriceAndTime []*txWithMinerFee
-
-func (s txByPriceAndTime) Len() int { return len(s) }
-func (s txByPriceAndTime) Less(i, j int) bool {
-	// If the prices are equal, use the time the transaction was first seen for
-	// deterministic sorting
-	cmp := s[i].fees.Cmp(s[j].fees)
-	if cmp == 0 {
-		return s[i].tx.Time.Before(s[j].tx.Time)
+// compareTxByPriceAndTime orders transactions by (effective miner tip desc,
+// first-seen time asc), returning >0 when a precedes b.
+func compareTxByPriceAndTime(a, b *txWithMinerFee) int {
+	if c := a.fees.Cmp(b.fees); c != 0 {
+		return c
 	}
-	return cmp > 0
-}
-func (s txByPriceAndTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-
-func (s *txByPriceAndTime) Push(x interface{}) {
-	*s = append(*s, x.(*txWithMinerFee))
+	return b.tx.Time.Compare(a.tx.Time)
 }
 
-func (s *txByPriceAndTime) Pop() interface{} {
-	old := *s
-	n := len(old)
-	x := old[n-1]
-	old[n-1] = nil
-	*s = old[0 : n-1]
-	return x
-}
+// transactionsByPriceAndNonce is the heap of transaction sequences used to
+// order the candidates of an event, see newTransactionsByPriceAndNonce.
+type transactionsByPriceAndNonce = frontierheap.FrontierHeap[*txWithMinerFee]
 
-// transactionsByPriceAndNonce represents a set of transactions that can return
-// transactions in a profit-maximizing sorted order, while supporting removing
-// entire batches of transactions for non-executable accounts.
-type transactionsByPriceAndNonce struct {
-	txs     map[common.Address][]*txpool.LazyTransaction // Per account nonce-sorted list of transactions
-	heads   txByPriceAndTime                             // Next transaction for each unique account (price heap)
-	signer  types.Signer                                 // Signer for the set of transactions
-	baseFee *uint256.Int                                 // Current base fee
-}
-
-// newTransactionsByPriceAndNonce creates a transaction set that can retrieve
-// price sorted transactions in a nonce-honouring way.
+// newTransactionsByPriceAndNonce creates a heap over the senders' transaction
+// sequences that returns transactions in a profit-maximizing order (effective
+// tip desc, time asc) while honouring per-sender nonce sequencing.
 //
-// Note, the input map is reowned so the caller should not interact any more with
-// if after providing it to the constructor.
-func newTransactionsByPriceAndNonce(signer types.Signer, txs map[common.Address][]*txpool.LazyTransaction, baseFee *big.Int) *transactionsByPriceAndNonce {
+// Every transaction is wrapped up front. A transaction whose effective tip
+// cannot be computed is dropped together with the sender's later nonces, which
+// depend on it.
+func newTransactionsByPriceAndNonce(
+	txs map[common.Address][]*txpool.LazyTransaction,
+	baseFee *big.Int,
+) *transactionsByPriceAndNonce {
 	// Convert the basefee from header format to uint256 format
 	var baseFeeUint *uint256.Int
 	if baseFee != nil {
 		baseFeeUint = uint256.MustFromBig(baseFee)
 	}
-	// Initialize a price and received time based heap with the head transactions
-	heads := make(txByPriceAndTime, 0, len(txs))
-	for from, accTxs := range txs {
-		wrapped, err := newTxWithMinerFee(accTxs[0], from, baseFeeUint)
-		if err != nil {
-			delete(txs, from)
-			continue
+
+	heap := frontierheap.NewFrontierHeap(compareTxByPriceAndTime)
+	for sender, senderTxs := range txs {
+		sequence := make([]*txWithMinerFee, 0, len(senderTxs))
+		for _, tx := range senderTxs {
+			wrapped, err := newTxWithMinerFee(tx, sender, baseFeeUint)
+			if err != nil {
+				break // the sender's later nonces depend on the dropped transaction
+			}
+			sequence = append(sequence, wrapped)
 		}
-		heads = append(heads, wrapped)
-		txs[from] = accTxs[1:]
+		heap.AddSequence(sequence)
 	}
-	heap.Init(&heads)
-
-	// Assemble and return the transaction set
-	return &transactionsByPriceAndNonce{
-		txs:     txs,
-		heads:   heads,
-		signer:  signer,
-		baseFee: baseFeeUint,
-	}
-}
-
-// Peek returns the next transaction by price.
-func (t *transactionsByPriceAndNonce) Peek() (*txpool.LazyTransaction, *uint256.Int) {
-	if len(t.heads) == 0 {
-		return nil, nil
-	}
-	return t.heads[0].tx, t.heads[0].fees
-}
-
-// Shift replaces the current best head with the next one from the same account.
-func (t *transactionsByPriceAndNonce) Shift() {
-	acc := t.heads[0].from
-	if txs, ok := t.txs[acc]; ok && len(txs) > 0 {
-		if wrapped, err := newTxWithMinerFee(txs[0], acc, t.baseFee); err == nil {
-			t.heads[0], t.txs[acc] = wrapped, txs[1:]
-			heap.Fix(&t.heads, 0)
-			return
-		}
-	}
-	heap.Pop(&t.heads)
-}
-
-// Pop removes the best transaction, *not* replacing it with the next one from
-// the same account. This should be used when a transaction cannot be executed
-// and hence all subsequent ones should be discarded from the same account.
-func (t *transactionsByPriceAndNonce) Pop() {
-	heap.Pop(&t.heads)
-}
-
-// Empty returns if the price heap is empty. It can be used to check it simpler
-// than calling peek and checking for nil return.
-func (t *transactionsByPriceAndNonce) Empty() bool {
-	return len(t.heads) == 0
-}
-
-// Clear removes the entire content of the heap.
-func (t *transactionsByPriceAndNonce) Clear() {
-	t.heads, t.txs = nil, nil
-}
-
-func (t *transactionsByPriceAndNonce) Copy() *transactionsByPriceAndNonce {
-	txsCopy := maps.Clone(t.txs)
-	return &transactionsByPriceAndNonce{
-		txs:     txsCopy,
-		heads:   slices.Clone(t.heads),
-		signer:  t.signer,
-		baseFee: t.baseFee, // not writable, no need to copy
-	}
+	return heap
 }

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -17,6 +17,7 @@
 package emitter
 
 import (
+	"cmp"
 	"crypto/ecdsa"
 	"math/big"
 	"math/rand/v2"
@@ -105,11 +106,11 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 		expectedCount += count
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(signer, groups, baseFee)
+	txset := newTransactionsByPriceAndNonce(groups, baseFee)
 
 	txs := types.Transactions{}
-	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {
-		txs = append(txs, tx.Tx)
+	for entry, ok := txset.Peek(); ok; entry, ok = txset.Peek() {
+		txs = append(txs, entry.tx.Tx)
 		txset.Shift()
 	}
 	if len(txs) != expectedCount {
@@ -171,11 +172,11 @@ func TestTransactionTimeSort(t *testing.T) {
 		})
 	}
 	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(signer, groups, nil)
+	txset := newTransactionsByPriceAndNonce(groups, nil)
 
 	txs := types.Transactions{}
-	for tx, _ := txset.Peek(); tx != nil; tx, _ = txset.Peek() {
-		txs = append(txs, tx.Tx)
+	for entry, ok := txset.Peek(); ok; entry, ok = txset.Peek() {
+		txs = append(txs, entry.tx.Tx)
 		txset.Shift()
 	}
 	if len(txs) != len(keys) {
@@ -281,4 +282,138 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 			}
 		})
 	}
+}
+
+func TestCompareTxByPriceAndTime_OrdersByFeeThenByTime(t *testing.T) {
+	entry := func(fees uint64, at time.Time) *txWithMinerFee {
+		return &txWithMinerFee{
+			tx:   &txpool.LazyTransaction{Time: at},
+			fees: uint256.NewInt(fees),
+		}
+	}
+	later := baseTime.Add(time.Second)
+
+	tests := map[string]struct {
+		a, b     *txWithMinerFee
+		expected int
+	}{
+		"higher fee precedes": {
+			a:        entry(2, baseTime),
+			b:        entry(1, baseTime),
+			expected: 1,
+		},
+		"lower fee follows": {
+			a:        entry(1, baseTime),
+			b:        entry(2, baseTime),
+			expected: -1,
+		},
+		"equal fee, earlier time precedes": {
+			a:        entry(1, baseTime),
+			b:        entry(1, later),
+			expected: 1,
+		},
+		"equal fee, later time follows": {
+			a:        entry(1, later),
+			b:        entry(1, baseTime),
+			expected: -1,
+		},
+		"equal fee and time are equivalent": {
+			a:        entry(1, baseTime),
+			b:        entry(1, baseTime),
+			expected: 0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := compareTxByPriceAndTime(test.a, test.b)
+			require.Equal(t, test.expected, cmp.Compare(got, 0))
+		})
+	}
+}
+
+func TestTxOrdering_OrdersByFeeAndTimeWithinNonceConstraints(t *testing.T) {
+	keyA, addrA := newSenderKey(t)
+	keyB, addrB := newSenderKey(t)
+	keyC, addrC := newSenderKey(t)
+	keyD, addrD := newSenderKey(t)
+
+	a0 := makeLazyTx(t, keyA, 0, 9, baseTime.Add(2*time.Second))
+	a1 := makeLazyTx(t, keyA, 1, 3, baseTime.Add(2*time.Second))
+	b0 := makeLazyTx(t, keyB, 0, 8, baseTime)
+	b1 := makeLazyTx(t, keyB, 1, 7, baseTime)
+	c0 := makeLazyTx(t, keyC, 0, 2, baseTime)
+	c1 := makeLazyTx(t, keyC, 1, 10, baseTime)
+	d0 := makeLazyTx(t, keyD, 0, 3, baseTime.Add(time.Second))
+
+	txset := newTransactionsByPriceAndNonce(
+		map[common.Address][]*txpool.LazyTransaction{
+			addrA: {a0, a1}, addrB: {b0, b1}, addrC: {c0, c1}, addrD: {d0},
+		},
+		nil,
+	)
+
+	names := map[common.Hash]string{
+		a0.Hash: "a0", a1.Hash: "a1",
+		b0.Hash: "b0", b1.Hash: "b1",
+		c0.Hash: "c0", c1.Hash: "c1",
+		d0.Hash: "d0",
+	}
+	out := drain(txset)
+	got := make([]string, 0, len(out))
+	for _, e := range out {
+		got = append(got, names[e.tx.Hash])
+	}
+
+	require.Equal(t, []string{"a0", "b0", "b1", "d0", "a1", "c0", "c1"}, got)
+}
+
+var (
+	orderingSigner = types.LatestSignerForChainID(common.Big1)
+	baseTime       = time.Unix(1_000, 0)
+)
+
+// newSenderKey returns a fresh private key and its derived sender address.
+func newSenderKey(t *testing.T) (*ecdsa.PrivateKey, common.Address) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	return key, crypto.PubkeyToAddress(key.PublicKey)
+}
+
+// makeLazyTx builds a signed dynamic-fee LazyTransaction. With a nil base fee
+// (as used by these tests) the effective miner tip equals tip, so tip is the
+// "price" used for ordering. at is the transaction's first-seen time, used as
+// the final ordering tie-break.
+func makeLazyTx(t *testing.T, key *ecdsa.PrivateKey, nonce uint64, tip int64, at time.Time) *txpool.LazyTransaction {
+	t.Helper()
+	raw, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+		ChainID:   common.Big1,
+		Nonce:     nonce,
+		To:        &common.Address{0x2},
+		Value:     big.NewInt(0),
+		Gas:       21000,
+		GasFeeCap: big.NewInt(tip),
+		GasTipCap: big.NewInt(tip),
+	}), orderingSigner, key)
+	require.NoError(t, err)
+	raw.SetTime(at)
+	return &txpool.LazyTransaction{
+		Hash:      raw.Hash(),
+		Tx:        raw,
+		Time:      raw.Time(),
+		GasFeeCap: uint256.MustFromBig(raw.GasFeeCap()),
+		GasTipCap: uint256.MustFromBig(raw.GasTipCap()),
+		Gas:       raw.Gas(),
+	}
+}
+
+// drain consumes the whole set in its ordering.
+func drain(txset *transactionsByPriceAndNonce) []*txWithMinerFee {
+	var out []*txWithMinerFee
+	for e, ok := txset.Peek(); ok; e, ok = txset.Peek() {
+		out = append(out, e)
+		txset.Shift()
+	}
+	return out
 }

--- a/gossip/emitter/proposals.go
+++ b/gossip/emitter/proposals.go
@@ -30,7 +30,6 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
-	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -316,18 +315,18 @@ type counterMetric interface {
 	Inc(int64)
 }
 
-// transactionPriorityAdapter is an adapter between the transactionsByPriceAndNonce
+// transactionPriorityAdapter is an adapter between the transaction ordering heap
 // and the scheduler's PrioritizedTransactions interface.
 type transactionPriorityAdapter struct {
 	sorted transactionIndex
 }
 
 func (a *transactionPriorityAdapter) Current() *types.Transaction {
-	tx, _ := a.sorted.Peek()
-	if tx == nil {
+	entry, ok := a.sorted.Peek()
+	if !ok {
 		return nil
 	}
-	return tx.Resolve()
+	return entry.tx.Resolve()
 }
 
 func (a *transactionPriorityAdapter) Accept() {
@@ -335,11 +334,11 @@ func (a *transactionPriorityAdapter) Accept() {
 }
 
 func (a *transactionPriorityAdapter) Skip() {
-	a.sorted.Pop()
+	a.sorted.PopSequence()
 }
 
 type transactionIndex interface {
-	Peek() (*txpool.LazyTransaction, *uint256.Int)
-	Shift()
-	Pop()
+	Peek() (*txWithMinerFee, bool)
+	Shift() (*txWithMinerFee, bool)
+	PopSequence() ([]*txWithMinerFee, bool)
 }

--- a/gossip/emitter/proposals_mock.go
+++ b/gossip/emitter/proposals_mock.go
@@ -19,9 +19,7 @@ import (
 	opera "github.com/0xsoniclabs/sonic/opera"
 	hash "github.com/Fantom-foundation/lachesis-base/hash"
 	idx "github.com/Fantom-foundation/lachesis-base/inter/idx"
-	txpool "github.com/ethereum/go-ethereum/core/txpool"
 	types "github.com/ethereum/go-ethereum/core/types"
-	uint256 "github.com/holiman/uint256"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -264,11 +262,11 @@ func (m *MocktransactionIndex) EXPECT() *MocktransactionIndexMockRecorder {
 }
 
 // Peek mocks base method.
-func (m *MocktransactionIndex) Peek() (*txpool.LazyTransaction, *uint256.Int) {
+func (m *MocktransactionIndex) Peek() (*txWithMinerFee, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Peek")
-	ret0, _ := ret[0].(*txpool.LazyTransaction)
-	ret1, _ := ret[1].(*uint256.Int)
+	ret0, _ := ret[0].(*txWithMinerFee)
+	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
@@ -278,22 +276,28 @@ func (mr *MocktransactionIndexMockRecorder) Peek() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peek", reflect.TypeOf((*MocktransactionIndex)(nil).Peek))
 }
 
-// Pop mocks base method.
-func (m *MocktransactionIndex) Pop() {
+// PopSequence mocks base method.
+func (m *MocktransactionIndex) PopSequence() ([]*txWithMinerFee, bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Pop")
+	ret := m.ctrl.Call(m, "PopSequence")
+	ret0, _ := ret[0].([]*txWithMinerFee)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
-// Pop indicates an expected call of Pop.
-func (mr *MocktransactionIndexMockRecorder) Pop() *gomock.Call {
+// PopSequence indicates an expected call of PopSequence.
+func (mr *MocktransactionIndexMockRecorder) PopSequence() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pop", reflect.TypeOf((*MocktransactionIndex)(nil).Pop))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopSequence", reflect.TypeOf((*MocktransactionIndex)(nil).PopSequence))
 }
 
 // Shift mocks base method.
-func (m *MocktransactionIndex) Shift() {
+func (m *MocktransactionIndex) Shift() (*txWithMinerFee, bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Shift")
+	ret := m.ctrl.Call(m, "Shift")
+	ret0, _ := ret[0].(*txWithMinerFee)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 // Shift indicates an expected call of Shift.

--- a/gossip/emitter/proposals_test.go
+++ b/gossip/emitter/proposals_test.go
@@ -498,7 +498,7 @@ func TestTransactionPriorityAdapter_ForwardsCallToWrappedType(t *testing.T) {
 		index := NewMocktransactionIndex(ctrl)
 
 		tx := types.NewTx(&types.LegacyTx{Nonce: 1})
-		index.EXPECT().Peek().Return(&txpool.LazyTransaction{Tx: tx}, nil)
+		index.EXPECT().Peek().Return(&txWithMinerFee{tx: &txpool.LazyTransaction{Tx: tx}}, true)
 
 		adapter := transactionPriorityAdapter{index}
 		got := adapter.Current()
@@ -508,7 +508,7 @@ func TestTransactionPriorityAdapter_ForwardsCallToWrappedType(t *testing.T) {
 	t.Run("Current_Empty", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		index := NewMocktransactionIndex(ctrl)
-		index.EXPECT().Peek().Return(nil, nil)
+		index.EXPECT().Peek().Return(nil, false)
 		adapter := transactionPriorityAdapter{index}
 		got := adapter.Current()
 		require.Nil(t, got)
@@ -525,7 +525,7 @@ func TestTransactionPriorityAdapter_ForwardsCallToWrappedType(t *testing.T) {
 	t.Run("Skip", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		index := NewMocktransactionIndex(ctrl)
-		index.EXPECT().Pop()
+		index.EXPECT().PopSequence()
 		adapter := transactionPriorityAdapter{index}
 		adapter.Skip()
 	})

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -180,14 +180,15 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 
 	// sort transactions by price and nonce
 	rules := em.world.GetRules()
-	for tx, _ := sorted.Peek(); tx != nil; tx, _ = sorted.Peek() {
+	for entry, ok := sorted.Peek(); ok; entry, ok = sorted.Peek() {
+		tx := entry.tx
 		resolvedTx := tx.Resolve()
 
 		// check transaction size limits
 		txSize := resolvedTx.Size()
 		if totalTxSizeInBytes+txSize > maxTotalTransactionsSizeInEventInBytes {
 			txsSkippedSizeLimit.Inc(1)
-			sorted.Pop()
+			sorted.PopSequence()
 			continue
 		}
 
@@ -195,7 +196,7 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 		// check transaction epoch rules (tx type, gas price)
 		if epochcheck.CheckTxs(types.Transactions{resolvedTx}, rules) != nil {
 			txsSkippedEpochRules.Inc(1)
-			sorted.Pop()
+			sorted.PopSequence()
 			continue
 		}
 		// check there's enough gas power to originate the transaction
@@ -205,30 +206,30 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 				// stop if cannot originate even an empty transaction
 				break
 			}
-			sorted.Pop()
+			sorted.PopSequence()
 			continue
 		}
 		// check not conflicted with already originated txs (in any connected event)
 		if em.originatedTxs.TotalOf(sender) != 0 {
 			txsSkippedConflictingSender.Inc(1)
-			sorted.Pop()
+			sorted.PopSequence()
 			continue
 		}
 		// my turn, i.e. try to not include the same tx simultaneously by different validators
 		if !em.isMyTxTurn(tx.Hash, sender, resolvedTx.Nonce(), time.Now(), em.validators.Load(), e.Creator(), idx.Epoch(em.epoch.Load())) {
 			txsSkippedNotMyTurn.Inc(1)
-			sorted.Pop()
+			sorted.PopSequence()
 			continue
 		}
 		// check transaction is not outdated
 		if !em.world.TxPool.Has(tx.Hash) {
 			txsSkippedOutdated.Inc(1)
-			sorted.Pop()
+			sorted.PopSequence()
 			continue
 		}
 		// check validity of bundled transactions
 		if em.world.GetRules().Upgrades.Brio && bundle.IsEnvelope(resolvedTx) && !em.isValidBundleTx(resolvedTx) {
-			sorted.Pop()
+			sorted.PopSequence()
 			continue
 		}
 

--- a/utils/frontierheap/frontier_heap.go
+++ b/utils/frontierheap/frontier_heap.go
@@ -18,6 +18,7 @@ package frontierheap
 
 import (
 	"container/heap"
+	"slices"
 )
 
 // FrontierHeap is a max-heap over the frontier of a set of sequences (sequence
@@ -63,8 +64,6 @@ func (q *FrontierHeap[T]) Shift() (T, bool) {
 	}
 	head := q.heap.sequences[0][0]
 	if len(q.heap.sequences[0]) > 1 {
-		var zero T
-		q.heap.sequences[0][0] = zero
 		q.heap.sequences[0] = q.heap.sequences[0][1:]
 		heap.Fix(&q.heap, 0)
 	} else {
@@ -82,6 +81,17 @@ func (q *FrontierHeap[T]) PopSequence() ([]T, bool) {
 		return nil, false
 	}
 	return heap.Pop(&q.heap).([]T), true
+}
+
+// Copy returns a heap that can be consumed independently of this one. The
+// sequence elements themselves are shared, not copied.
+func (q *FrontierHeap[T]) Copy() *FrontierHeap[T] {
+	// The sequences are only resliced, never mutated, so a deep copy of each
+	// sequence is not necessary.
+	return &FrontierHeap[T]{heap: sequenceHeap[T]{
+		sequences: slices.Clone(q.heap.sequences),
+		order:     q.heap.order,
+	}}
 }
 
 // -- Heap Implementation --

--- a/utils/frontierheap/frontier_heap_test.go
+++ b/utils/frontierheap/frontier_heap_test.go
@@ -110,6 +110,16 @@ func TestFrontierHeap_PopSequence_EmptyHeapReturnsFalse(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestFrontierHeap_Copy_IsConsumedIndependentlyOfTheOriginal(t *testing.T) {
+	h := NewFrontierHeap(cmp.Compare[int])
+	h.AddSequence([]int{5, 4})
+	h.AddSequence([]int{3})
+
+	copy := h.Copy()
+	require.Equal(t, []int{5, 4, 3}, drain(h))
+	require.Equal(t, []int{5, 4, 3}, drain(copy))
+}
+
 func drain[T any](h *FrontierHeap[T]) []T {
 	var out []T
 	for v, ok := h.Shift(); ok; v, ok = h.Shift() {


### PR DESCRIPTION
This PR uses the `FrontierHeap` for the emitter, replacing the previously used custom implementation. This makes the `transactionsByPriceAndNonce` type superfluous, which is removed and replaced with an alias for the frontier heap. As a consequence of using the frontier heap, the signatures change slightly. Also, the consumer now not only has access to the transaction itself, but also to the metadata stored alongside it, which will be needed in the next PR anyway.