### PR TITLE
Use newer version of lru cache which supports generics

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/metrics"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 var (
@@ -484,7 +484,7 @@ type BundleEvaluator interface {
 }
 
 type bundleEvaluationCache struct {
-	cache *lru.Cache
+	cache *lru.Cache[string, BundleState]
 }
 
 // NewBundleEvaluationCache creates a new instance of bundleEvaluationCache,
@@ -510,7 +510,7 @@ func NewBundleEvaluationCache() *bundleEvaluationCache {
 	// 32  + 8 + ( 1+1 + 24, aligned to 32) = 72 bytes per entry, so ~7.2MiB for 100k entries.
 	// Notice that the reasons in the bundle state point to static strings,
 	// so they do not contribute to the memory consumption of each entry.
-	cache, _ := lru.New(100_000)
+	cache, _ := lru.New[string, BundleState](100_000)
 	return &bundleEvaluationCache{cache: cache}
 }
 
@@ -548,7 +548,7 @@ func (c *bundleEvaluationCache) GetBundleState(
 		planHash.Bytes()...,
 	))
 	if state, ok := c.cache.Get(key); ok {
-		return state.(BundleState)
+		return state
 	}
 
 	state := GetBundleState(chain, stateDb, envelope)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/deckarep/golang-set v1.8.0
 	github.com/ethereum/go-ethereum v1.17.1
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08
-	github.com/hashicorp/golang-lru v1.0.2
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/holiman/uint256 v1.3.2
 	github.com/klauspost/pgzip v1.2.6
 	github.com/mattn/go-colorable v0.1.14
@@ -94,7 +94,7 @@ require (
 	github.com/grafana/pyroscope-go v1.2.8 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/hashicorp/go-bexpr v0.1.16 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/holiman/billy v0.0.0-20250707135307-f2f9b9aae7db // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect

--- a/gossip/emitter/originatedtxs/txs_ring_buffer.go
+++ b/gossip/emitter/originatedtxs/txs_ring_buffer.go
@@ -18,16 +18,16 @@ package originatedtxs
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
 type Buffer struct {
-	senderCount *simplelru.LRU // sender address -> number of transactions
+	senderCount *simplelru.LRU[common.Address, int] // sender address -> number of transactions
 }
 
 func New(maxAddresses int) *Buffer {
 	ring := &Buffer{}
-	ring.senderCount, _ = simplelru.NewLRU(maxAddresses, nil)
+	ring.senderCount, _ = simplelru.NewLRU[common.Address, int](maxAddresses, nil)
 	return ring
 }
 
@@ -35,9 +35,9 @@ func New(maxAddresses int) *Buffer {
 func (ring *Buffer) Inc(sender common.Address) {
 	cur, ok := ring.senderCount.Peek(sender)
 	if ok {
-		ring.senderCount.Add(sender, cur.(int)+1)
+		ring.senderCount.Add(sender, cur+1)
 	} else {
-		ring.senderCount.Add(sender, int(1))
+		ring.senderCount.Add(sender, 1)
 	}
 }
 
@@ -47,10 +47,10 @@ func (ring *Buffer) Dec(sender common.Address) {
 	if !ok {
 		return
 	}
-	if cur.(int) <= 1 {
+	if cur <= 1 {
 		ring.senderCount.Remove(sender)
 	} else {
-		ring.senderCount.Add(sender, cur.(int)-1)
+		ring.senderCount.Add(sender, cur-1)
 	}
 }
 
@@ -65,7 +65,7 @@ func (ring *Buffer) TotalOf(sender common.Address) int {
 	if !ok {
 		return 0
 	}
-	return cur.(int)
+	return cur
 }
 
 // Empty is not safe for concurrent use

--- a/gossip/gasprice/gasprice.go
+++ b/gossip/gasprice/gasprice.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 var (
@@ -83,7 +83,7 @@ type Oracle struct {
 
 	cfg Config
 
-	tCache *lru.Cache
+	tCache *lru.Cache[uint64, tipCache]
 
 	wg   sync.WaitGroup
 	quit chan struct{}
@@ -111,7 +111,7 @@ func NewOracle(params Config, backend Reader) *Oracle {
 	params.MaxGasPrice = sanitizeBigInt(params.MaxGasPrice, nil, nil, DefaultMaxGasPrice(), "MaxGasPrice")
 	params.MinGasPrice = sanitizeBigInt(params.MinGasPrice, nil, nil, new(big.Int), "MinGasPrice")
 	params.DefaultCertainty = sanitizeBigInt(new(big.Int).SetUint64(params.DefaultCertainty), big.NewInt(0), DecimalUnitBn, big.NewInt(DecimalUnit/2), "DefaultCertainty").Uint64()
-	tCache, _ := lru.New(100)
+	tCache, _ := lru.New[uint64, tipCache](100)
 	return &Oracle{
 		cfg:     params,
 		tCache:  tCache,
@@ -174,8 +174,7 @@ func (gpo *Oracle) SuggestTip(certainty uint64) *big.Int {
 
 	const cacheSlack = DecimalUnit * 0.05
 	roundedCertainty := certainty / cacheSlack
-	if cached, ok := gpo.tCache.Get(roundedCertainty); ok {
-		cache := cached.(tipCache)
+	if cache, ok := gpo.tCache.Get(roundedCertainty); ok {
 		if time.Since(cache.upd) < statUpdatePeriod {
 			return new(big.Int).Set(cache.tip)
 		} else {

--- a/utils/checker_cache.go
+++ b/utils/checker_cache.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 type TransactionCheckFunc func(*types.Transaction) bool
@@ -45,7 +45,7 @@ type TransactionCheckFunc func(*types.Transaction) bool
 // This approach balances performance (by avoiding repeated expensive checks) and correctness
 // (by ensuring results are eventually refreshed), adapting dynamically to transaction access patterns.
 type TransactionCheckCache struct {
-	cache *lru.Cache
+	cache *lru.Cache[common.Hash, checkerEntry]
 }
 
 // NewCheckerCache creates a new CheckerCache with the given size in bytes.
@@ -57,13 +57,13 @@ func NewCheckerCache(size int) *TransactionCheckCache {
 
 	entrySize := reflect.TypeOf(checkerEntry{}).Size()
 	capacity := max(size/(int(entrySize)), 1)
-	cache, _ := lru.New(capacity) // only fails if capacity <= 0
+	cache, _ := lru.New[common.Hash, checkerEntry](capacity) // only fails if capacity <= 0
 	return &TransactionCheckCache{cache: cache}
 }
 
 func (c *TransactionCheckCache) get(txHash common.Hash) (checkerEntry, bool) {
 	if entry, ok := c.cache.Get(txHash); ok {
-		return entry.(checkerEntry), true
+		return entry, true
 	}
 	return checkerEntry{}, false
 }

--- a/utils/checker_cache_test.go
+++ b/utils/checker_cache_test.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"math/big"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -47,7 +48,7 @@ func TestNewCachedChecker_CapacityIsEnforced(t *testing.T) {
 			// To check the full size, we add entries until one is evicted.
 			i := 0
 			for ; ; i++ {
-				if cache.cache.Add(i, struct{}{}) {
+				if cache.cache.Add(common.BigToHash(big.NewInt(int64(i))), checkerEntry{}) {
 					break
 				}
 			}


### PR DESCRIPTION
This PR uses the `v2` version of the `golang-lru` package. Unlike the previous version is supports generics. This has two advantages:
- type safety - no more casting which can fail at runtime
- no interface boxing - fewer allocations

We already depended on the new version transitively, now it is a direct dependency. The old version is now only an indirect dependency.