### PR TITLE
Make emitter candidate ordering priority aware

### DIFF
--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
 	"github.com/0xsoniclabs/sonic/gossip/emitter/config"
 	"github.com/0xsoniclabs/sonic/gossip/emitter/originatedtxs"
 	"github.com/0xsoniclabs/sonic/gossip/emitter/throttler"
@@ -84,6 +85,9 @@ var (
 	txsSkippedConflictingSender = metrics.GetOrRegisterCounter("emitter/skipped/conflictingsender", nil) // tx by given sender in some unconfirmed event
 	txsSkippedNotMyTurn         = metrics.GetOrRegisterCounter("emitter/skipped/notmyturn", nil)         // tx should be handled by other validator
 	txsSkippedOutdated          = metrics.GetOrRegisterCounter("emitter/skipped/outdated", nil)          // tx skipped because it is outdated
+
+	txsSkippedPiggybackLimit    = metrics.GetOrRegisterCounter("emitter/skipped/piggybacklimit", nil)    // eager admission would exceed the per-entity or the gas limit
+	txsSkippedPiggybackRollback = metrics.GetOrRegisterCounter("emitter/skipped/piggybackrollback", nil) // eager admissions rolled back, the event carries none of this validator's own txs
 
 	skippedOfflineValidatorsCounter = metrics.GetOrRegisterCounter("emitter/skipped_offline", nil)
 
@@ -145,10 +149,11 @@ type Emitter struct {
 	maxParents idx.Event
 
 	cache struct {
-		sortedTxs *transactionsByPriceAndNonce
-		poolTime  time.Time
-		poolBlock idx.Block
-		poolCount int
+		sortedTxs      *transactionsByPriorityAndPriceAndNonce
+		poolTime       time.Time
+		poolBlock      idx.Block
+		poolCount      int
+		priorityConfig priorities.Config // rate limits read while the sortedTxs were built
 	}
 
 	emittedEventFile *os.File
@@ -313,13 +318,13 @@ func (em *Emitter) tick() {
 	}
 }
 
-func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
+func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriorityAndPriceAndNonce {
 	// Short circuit if pool wasn't updated since the cache was built
 	poolCount := em.world.TxPool.Count()
 	if em.cache.sortedTxs != nil &&
 		em.cache.poolBlock == em.world.GetLatestBlockIndex() &&
 		em.cache.poolCount == poolCount &&
-		time.Since(em.cache.poolTime) < em.config.TxsCacheInvalidation {
+		time.Since(em.cache.poolTime) < min(em.config.TxsCacheInvalidation, txTurnPeriodLatency) {
 		return em.cache.sortedTxs.Copy()
 	}
 	// Build the cache
@@ -374,7 +379,14 @@ func (em *Emitter) getSortedTxs(baseFee *big.Int) *transactionsByPriceAndNonce {
 		}
 	}
 
-	sortedTxs := newTransactionsByPriceAndNonce(txs, baseFee)
+	// The candidates are classified against the head state while the ordering is
+	// built, so the context — and thereby the acquired head state — is only held
+	// for the duration of the build.
+	context := em.newPriorityContext()
+	defer context.release()
+	sortedTxs := newTransactionsByPriorityAndPriceAndNonce(
+		txs, baseFee, context, em.newTurnPolicy(rules.Upgrades))
+	em.cache.priorityConfig = context.getConfig()
 	em.cache.sortedTxs = sortedTxs
 	em.cache.poolCount = poolCount
 	em.cache.poolBlock = em.world.GetLatestBlockIndex()
@@ -492,7 +504,7 @@ func (em *Emitter) loadPrevEmitTime() time.Time {
 }
 
 // createEvent is not safe for concurrent use.
-func (em *Emitter) createEvent(sortedTxs *transactionsByPriceAndNonce) (*inter.EventPayload, error) {
+func (em *Emitter) createEvent(sortedTxs *transactionsByPriorityAndPriceAndNonce) (*inter.EventPayload, error) {
 	if synced := em.logSyncStatus(em.isSyncedToEmit()); !synced {
 		// I'm reindexing my old events, so don't create events until connect all the existing self-events
 		return nil, nil

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -26,14 +26,19 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
 	"github.com/0xsoniclabs/sonic/gossip/emitter/config"
 	"github.com/0xsoniclabs/sonic/integration/makefakegenesis"
 	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/logger"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils/txtime"
@@ -390,6 +395,8 @@ func TestEmitter_EmitEvent_DoesNotEmit_IfWorldIsBusy(t *testing.T) {
 	world := NewMockExternal(ctrl)
 	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
 	world.EXPECT().IsBusy().Return(true)
+	world.EXPECT().Lock()
+	world.EXPECT().Unlock()
 
 	signer := valkeystore.NewMockSignerAuthority(ctrl)
 
@@ -435,10 +442,10 @@ func TestEmitter_EmitEvent(t *testing.T) {
 	world := NewMockExternal(ctrl)
 	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
 	world.EXPECT().IsBusy().Return(false)
-	world.EXPECT().Lock()
+	world.EXPECT().Lock().Times(2) // once for the ordering build, once for the emission
 	world.EXPECT().Process(any)
 	world.EXPECT().Broadcast(any)
-	world.EXPECT().Unlock()
+	world.EXPECT().Unlock().Times(2)
 
 	signer := valkeystore.NewMockSignerAuthority(ctrl)
 
@@ -555,8 +562,8 @@ func TestEmitter_EmitEvent_logsErrorAndSkipsMalformedTxs(t *testing.T) {
 			world.EXPECT().GetLatestBlock().Return(&inter.Block{}).AnyTimes()
 			world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
 			world.EXPECT().IsBusy().AnyTimes()
-			world.EXPECT().Lock()
-			world.EXPECT().Unlock()
+			world.EXPECT().Lock().Times(2) // once for the ordering build, once for the emission
+			world.EXPECT().Unlock().Times(2)
 			world.EXPECT().Process(any)
 			world.EXPECT().Broadcast(any)
 
@@ -637,6 +644,8 @@ func TestEmitter_EmitEvent_skippingTxsAlsoSkipsGappedNoncesTxs(t *testing.T) {
 	world := NewMockExternal(ctrl)
 	world.EXPECT().GetRules().AnyTimes()
 	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).AnyTimes()
+	world.EXPECT().Lock()
+	world.EXPECT().Unlock()
 
 	log := logger.NewMockLogger(ctrl)
 	// Expect exactly one warning for the malformed tx at nonce=1.
@@ -688,6 +697,219 @@ func TestEmitter_EmitEvent_skippingTxsAlsoSkipsGappedNoncesTxs(t *testing.T) {
 	sorted.Shift()
 	_, ok = sorted.Peek()
 	require.False(t, ok, "expected no more txs after the nonce gap")
+}
+
+func TestEmitter_GetSortedTxs_ClassifiesCandidatesPriorityAgainstHeadStateWhenPrioritiesEnabled(t *testing.T) {
+	tests := map[string]struct {
+		priorities bool
+		wantConfig priorities.Config
+	}{
+		"disabled": {
+			false,
+			priorities.Config{},
+		},
+		"enabled": {
+			true,
+			priorities.FallbackConfig,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx := types.NewTx(&types.LegacyTx{
+				Nonce:    0,
+				GasPrice: big.NewInt(1000),
+				Gas:      21000,
+			})
+
+			any := gomock.Any()
+			ctrl := gomock.NewController(t)
+			world := NewMockExternal(ctrl)
+			upgrades := opera.GetSonicUpgrades()
+			upgrades.SingleProposerBlockFormation = true
+			upgrades.TransactionPriorities = test.priorities
+			world.EXPECT().GetRules().Return(opera.FakeNetRules(upgrades)).Times(2)
+			world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)) // for the cache
+
+			txSigner := NewMockTxSigner(ctrl)
+
+			if test.priorities {
+				world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)) // for the chain config
+				world.EXPECT().GetLatestBlock().Return(&inter.Block{})
+				world.EXPECT().Header(any, any).Return(&evmcore.EvmHeader{
+					Number:     big.NewInt(1),
+					BaseFee:    big.NewInt(0),
+					PrevRandao: common.Hash{1}, // required by the EVM block context
+				})
+				world.EXPECT().GetUpgradeHeights()
+				txSigner.EXPECT().Sender(any).Return(common.Address{2}, nil)
+
+				// The head state is acquired for the duration of the build only.
+				// No registry is deployed, so the config read falls back to the
+				// fallback config and the candidate cannot be classified as
+				// prioritized.
+				// Two registry calls, one for the config and one for the candidate.
+				statedb := state.NewMockStateDB(ctrl)
+				statedb.EXPECT().InterTxSnapshot().Times(2)
+				statedb.EXPECT().RevertToInterTxSnapshot(any).Times(2)
+				statedb.EXPECT().Snapshot().Times(2)
+				statedb.EXPECT().Exist(registry.GetAddress()).Return(false).Times(2)
+				statedb.EXPECT().Release()
+				world.EXPECT().StateDB().Return(statedb)
+			}
+
+			txPool := NewMockTxPool(ctrl)
+			txPool.EXPECT().Count().Return(1)
+			txPool.EXPECT().Pending(true).Return(
+				map[common.Address]types.Transactions{{1}: {tx}}, nil,
+			)
+
+			em := &Emitter{
+				config: config.Config{MaxTxsPerAddress: 10},
+				world:  World{External: world, TxPool: txPool, TransactionSigner: txSigner},
+			}
+
+			entry, ok := em.getSortedTxs(big.NewInt(0)).Peek()
+			require.True(t, ok)
+			require.Equal(t, tx.Hash(), entry.tx.Hash)
+			require.Equal(t, priorities.Priority{}, entry.priority)
+
+			// The rate limits read along with the context are kept for the event
+			// built from this ordering.
+			require.Equal(t, test.wantConfig, em.cache.priorityConfig)
+		})
+	}
+}
+
+func TestEmitter_GetSortedTxs_QueriesTheTurnStatusOfCandidates(t *testing.T) {
+	me, other := idx.ValidatorID(1), idx.ValidatorID(2)
+
+	tests := map[string]struct {
+		singleProposer bool
+		turnOf         idx.ValidatorID
+		wantMyTurn     bool
+	}{
+		"my turn":                  {false, me, true},
+		"another validator's turn": {false, other, false},
+		// The proposer schedules every candidate itself.
+		"single proposer": {true, other, true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			key, sender := newSenderKey(t)
+			first := makeLazyTx(t, key, 0, 1, baseTime).Tx
+			second := makeLazyTx(t, key, 1, 1, baseTime).Tx
+
+			// A sole validator owns the turn of every transaction.
+			builder := pos.NewBuilder()
+			builder.Set(test.turnOf, pos.Weight(1))
+
+			ctrl := gomock.NewController(t)
+			world := NewMockExternal(ctrl)
+			world.EXPECT().GetRules().Return(opera.Rules{Upgrades: opera.Upgrades{
+				SingleProposerBlockFormation: test.singleProposer,
+			}}).Times(2)
+			world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1))
+			if !test.singleProposer {
+				// for newTurnPolicy
+				world.EXPECT().Lock()
+				world.EXPECT().Unlock()
+			}
+
+			txPool := NewMockTxPool(ctrl)
+			txPool.EXPECT().Count().Return(2)
+			txPool.EXPECT().Pending(true).Return(
+				map[common.Address]types.Transactions{sender: {first, second}}, nil,
+			)
+
+			em := &Emitter{
+				config: config.Config{
+					MaxTxsPerAddress: 10,
+					Validator:        config.ValidatorConfig{ID: me},
+				},
+				world: World{External: world, TxPool: txPool, TransactionSigner: orderingSigner},
+			}
+			em.validators.Store(builder.Build())
+			em.epoch.Store(1)
+
+			entry, ok := em.getSortedTxs(big.NewInt(0)).Peek()
+			require.True(t, ok)
+			require.Equal(t, test.wantMyTurn, entry.myTurn)
+		})
+	}
+}
+
+func TestEmitter_GetSortedTxs_ReusesTheCachedOrderingAndItsPriorityConfig(t *testing.T) {
+	key, sender := newSenderKey(t)
+	tx := makeLazyTx(t, key, 0, 1, baseTime)
+
+	ctrl := gomock.NewController(t)
+	// Neither the pending set nor the head state is queried again.
+	world := NewMockExternal(ctrl)
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1))
+	txPool := NewMockTxPool(ctrl)
+	txPool.EXPECT().Count().Return(1)
+
+	classifier := priorities.NewMockClassifier(ctrl)
+	classifier.EXPECT().Priority(tx.Tx).Return(prio(1, 1, 1), nil)
+
+	priorityConfig := priorities.Config{MaxPiggybackTxsPerEntityPerEvent: 4}
+	em := &Emitter{
+		config: config.Config{TxsCacheInvalidation: time.Minute},
+		world:  World{External: world, TxPool: txPool},
+	}
+	em.cache.sortedTxs = newTransactionsByPriorityAndPriceAndNonce(
+		map[common.Address][]*txpool.LazyTransaction{sender: {tx}},
+		nil,
+		&priorityContext{classifier: classifier},
+		alwaysMyTurn,
+	)
+	em.cache.poolBlock = idx.Block(1)
+	em.cache.poolCount = 1
+	em.cache.poolTime = time.Now()
+	em.cache.priorityConfig = priorityConfig
+
+	entry, ok := em.getSortedTxs(big.NewInt(0)).Peek()
+	require.True(t, ok)
+	require.Equal(t, tx.Hash, entry.tx.Hash)
+	require.Equal(t, prio(1, 1, 1), entry.priority)
+	require.Equal(t, priorityConfig, em.cache.priorityConfig)
+}
+
+func TestEmitter_GetSortedTxs_CapsTheCacheReuseAtTheTurnValidity(t *testing.T) {
+	key, sender := newSenderKey(t)
+	cached := makeLazyTx(t, key, 0, 1, baseTime)
+	pending := makeLazyTx(t, key, 1, 1, baseTime).Tx
+
+	// The configured invalidation period outlives the turn verdicts the cached
+	// ordering carries, so the ordering is rebuilt once they expire.
+	ctrl := gomock.NewController(t)
+	world := NewMockExternal(ctrl)
+	world.EXPECT().GetRules().Return(opera.Rules{Upgrades: opera.Upgrades{
+		SingleProposerBlockFormation: true,
+	}}).Times(2)
+	world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)).Times(2)
+
+	txPool := NewMockTxPool(ctrl)
+	txPool.EXPECT().Count().Return(1)
+	txPool.EXPECT().Pending(true).Return(
+		map[common.Address]types.Transactions{sender: {pending}}, nil,
+	)
+
+	em := &Emitter{
+		config: config.Config{MaxTxsPerAddress: 10, TxsCacheInvalidation: time.Minute},
+		world:  World{External: world, TxPool: txPool},
+	}
+	em.cache.sortedTxs = newTransactionsByPriorityAndPriceAndNonce(
+		map[common.Address][]*txpool.LazyTransaction{sender: {cached}}, nil, nil, alwaysMyTurn)
+	em.cache.poolBlock = idx.Block(1)
+	em.cache.poolCount = 1
+	em.cache.poolTime = time.Now().Add(-txTurnPeriodLatency)
+
+	entry, ok := em.getSortedTxs(big.NewInt(0)).Peek()
+	require.True(t, ok)
+	require.Equal(t, pending.Hash(), entry.tx.Hash)
 }
 
 func TestEmitter_ThrottlerWorldAdapter_ReturnsNilIfNoEventIsFound(t *testing.T) {

--- a/gossip/emitter/ordering.go
+++ b/gossip/emitter/ordering.go
@@ -17,8 +17,10 @@
 package emitter
 
 import (
+	"cmp"
 	"math/big"
 
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/utils/frontierheap"
 	"github.com/ethereum/go-ethereum/common"
@@ -27,75 +29,113 @@ import (
 	"github.com/holiman/uint256"
 )
 
-// txWithMinerFee wraps a transaction with its gas price or effective miner gasTipCap
-type txWithMinerFee struct {
-	tx   *txpool.LazyTransaction
-	from common.Address
-	fees *uint256.Int
+// stage is the consumption stage of a transaction.
+type stage uint8
+
+const (
+	stagePrioritizedMyTurn stage = iota
+	stagePrioritizedNotMyTurn
+	stageNotPrioritized
+)
+
+// txWithMetadata wraps a transaction with its effective miner tip, its priority
+// and whether it is this validator's turn to originate it. Non-prioritized
+// entries carry a zero-valued priority.
+type txWithMetadata struct {
+	tx       *txpool.LazyTransaction
+	tip      *uint256.Int
+	priority priorities.Priority
+	myTurn   bool
 }
 
-// newTxWithMinerFee creates a wrapped transaction, calculating the effective
-// miner gasTipCap if a base fee is provided.
-// Returns error in case of a negative effective miner gasTipCap.
-func newTxWithMinerFee(tx *txpool.LazyTransaction, from common.Address, baseFee *uint256.Int) (*txWithMinerFee, error) {
-	tip := new(uint256.Int).Set(tx.GasTipCap)
-	if baseFee != nil {
-		if tx.GasFeeCap.Cmp(baseFee) < 0 {
-			if !subsidies.IsSponsorshipRequest(tx.Tx) {
-				return nil, types.ErrGasFeeCapTooLow
-			}
-		}
-		tip = new(uint256.Int).Sub(tx.GasFeeCap, baseFee)
-		if tip.Gt(tx.GasTipCap) {
-			tip = tx.GasTipCap
-		}
+// stage returns the consumption stage of the transaction.
+func (t *txWithMetadata) stage() stage {
+	switch {
+	case !t.priority.IsPrioritized():
+		return stageNotPrioritized
+	case t.myTurn:
+		return stagePrioritizedMyTurn
+	default:
+		return stagePrioritizedNotMyTurn
 	}
-	return &txWithMinerFee{
-		tx:   tx,
-		from: from,
-		fees: tip,
-	}, nil
 }
 
-// compareTxByPriceAndTime orders transactions by (effective miner tip desc,
+// computeEffectiveTip returns the miner tip the transaction yields at the given
+// base fee. A transaction not covering the base fee has no tip to offer and is
+// rejected unless it requests sponsorship.
+func computeEffectiveTip(tx *txpool.LazyTransaction, baseFee *uint256.Int) (*uint256.Int, error) {
+	if baseFee == nil {
+		return new(uint256.Int).Set(tx.GasTipCap), nil
+	}
+	if tx.GasFeeCap.Cmp(baseFee) < 0 && !subsidies.IsSponsorshipRequest(tx.Tx) {
+		return nil, types.ErrGasFeeCapTooLow
+	}
+	tip := new(uint256.Int).Sub(tx.GasFeeCap, baseFee)
+	if tip.Gt(tx.GasTipCap) {
+		tip = tx.GasTipCap
+	}
+	return tip, nil
+}
+
+// compareTxByStagePriorityPriceTime orders transactions by (stage asc,
+// priority level desc, priority weight desc, effective miner tip desc,
 // first-seen time asc), returning >0 when a precedes b.
-func compareTxByPriceAndTime(a, b *txWithMinerFee) int {
-	if c := a.fees.Cmp(b.fees); c != 0 {
+func compareTxByStagePriorityPriceTime(a, b *txWithMetadata) int {
+	if c := cmp.Compare(b.stage(), a.stage()); c != 0 {
+		return c
+	}
+	if c := a.priority.Cmp(b.priority); c != 0 {
+		return c
+	}
+	if c := a.tip.Cmp(b.tip); c != 0 {
 		return c
 	}
 	return b.tx.Time.Compare(a.tx.Time)
 }
 
-// transactionsByPriceAndNonce is the heap of transaction sequences used to
-// order the candidates of an event, see newTransactionsByPriceAndNonce.
-type transactionsByPriceAndNonce = frontierheap.FrontierHeap[*txWithMinerFee]
+// transactionsByPriorityAndPriceAndNonce is a heap over the senders'
+// transaction sequences that returns transactions in the order
+// (stage asc, priority desc, effective tip desc, time asc) while honouring
+// per-sender nonce sequencing.
+// Because of nonce sequencing, elements are NOT necessarily in monotonic order.
+type transactionsByPriorityAndPriceAndNonce = frontierheap.FrontierHeap[*txWithMetadata]
 
-// newTransactionsByPriceAndNonce creates a heap over the senders' transaction
-// sequences that returns transactions in a profit-maximizing order (effective
-// tip desc, time asc) while honouring per-sender nonce sequencing.
+// newTransactionsByPriorityAndPriceAndNonce collects the senders' transactions
+// into a transactionsByPriorityAndPriceAndNonce, wrapping each with the metadata
+// the ordering compares: its effective tip at baseFee, its priority as
+// classified by context and its turn status as decided by turnPolicy.
 //
-// Every transaction is wrapped up front. A transaction whose effective tip
-// cannot be computed is dropped together with the sender's later nonces, which
-// depend on it.
-func newTransactionsByPriceAndNonce(
+// A transaction whose effective tip cannot be computed is dropped together with
+// the sender's later nonces, which depend on it.
+//
+// A nil context treats every transaction as non-prioritized and thereby disables
+// priority ordering altogether.
+func newTransactionsByPriorityAndPriceAndNonce(
 	txs map[common.Address][]*txpool.LazyTransaction,
 	baseFee *big.Int,
-) *transactionsByPriceAndNonce {
+	context *priorityContext,
+	turnPolicy func(tx *txpool.LazyTransaction) bool,
+) *transactionsByPriorityAndPriceAndNonce {
 	// Convert the basefee from header format to uint256 format
 	var baseFeeUint *uint256.Int
 	if baseFee != nil {
 		baseFeeUint = uint256.MustFromBig(baseFee)
 	}
 
-	heap := frontierheap.NewFrontierHeap(compareTxByPriceAndTime)
-	for sender, senderTxs := range txs {
-		sequence := make([]*txWithMinerFee, 0, len(senderTxs))
+	heap := frontierheap.NewFrontierHeap(compareTxByStagePriorityPriceTime)
+	for _, senderTxs := range txs {
+		sequence := make([]*txWithMetadata, 0, len(senderTxs))
 		for _, tx := range senderTxs {
-			wrapped, err := newTxWithMinerFee(tx, sender, baseFeeUint)
+			tip, err := computeEffectiveTip(tx, baseFeeUint)
 			if err != nil {
 				break // the sender's later nonces depend on the dropped transaction
 			}
-			sequence = append(sequence, wrapped)
+			sequence = append(sequence, &txWithMetadata{
+				tx:       tx,
+				tip:      tip,
+				priority: context.priorityOf(tx.Resolve()),
+				myTurn:   turnPolicy(tx),
+			})
 		}
 		heap.AddSequence(sequence)
 	}

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -17,14 +17,12 @@
 package emitter
 
 import (
-	"cmp"
 	"crypto/ecdsa"
 	"math/big"
-	"math/rand/v2"
 	"testing"
 	"time"
 
-	"github.com/0xsoniclabs/sonic/gossip/gasprice"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -32,174 +30,29 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
-func TestTransactionPriceNonceSortLegacy(t *testing.T) {
-	t.Parallel()
-	testTransactionPriceNonceSort(t, nil)
-}
-
-func TestTransactionPriceNonceSort1559(t *testing.T) {
-	t.Parallel()
-	testTransactionPriceNonceSort(t, big.NewInt(0))
-	testTransactionPriceNonceSort(t, big.NewInt(5))
-	testTransactionPriceNonceSort(t, big.NewInt(50))
-}
-
-// Tests that transactions can be correctly sorted according to their price in
-// decreasing order, but at the same time with increasing nonces when issued by
-// the same account.
-func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
-	// Generate a batch of accounts to start with
-	keys := make([]*ecdsa.PrivateKey, 25)
-	for i := 0; i < len(keys); i++ {
-		keys[i], _ = crypto.GenerateKey()
+func TestTxWithMetadata_StageFollowsPriorityAndTurn(t *testing.T) {
+	tests := map[string]struct {
+		priority priorities.Priority
+		myTurn   bool
+		want     stage
+	}{
+		"prioritized, my turn":     {withPrio, true, stagePrioritizedMyTurn},
+		"prioritized, not my turn": {withPrio, false, stagePrioritizedNotMyTurn},
+		"ordinary, my turn":        {withoutPrio, true, stageNotPrioritized},
+		"ordinary, not my turn":    {withoutPrio, false, stageNotPrioritized},
 	}
-	signer := types.LatestSignerForChainID(common.Big1)
-
-	// Generate a batch of transactions with overlapping values, but shifted nonces
-	groups := map[common.Address][]*txpool.LazyTransaction{}
-	expectedCount := 0
-	for start, key := range keys {
-		addr := crypto.PubkeyToAddress(key.PublicKey)
-		count := 25
-		for i := 0; i < 25; i++ {
-			var tx *types.Transaction
-			gasFeeCap := rand.IntN(50)
-			if baseFee == nil {
-				tx = types.NewTx(&types.LegacyTx{
-					Nonce: uint64(start + i),
-					// no to, cannot be a sponsored tx
-					Value:    big.NewInt(100),
-					Gas:      100,
-					GasPrice: big.NewInt(int64(gasFeeCap)),
-					Data:     nil,
-				})
-			} else {
-				tx = types.NewTx(&types.DynamicFeeTx{
-					Nonce: uint64(start + i),
-					// no to, cannot be a sponsored tx
-					Value:     big.NewInt(100),
-					Gas:       100,
-					GasFeeCap: big.NewInt(int64(gasFeeCap)),
-					GasTipCap: big.NewInt(int64(rand.IntN(gasFeeCap + 1))),
-					Data:      nil,
-				})
-				if count == 25 && int64(gasFeeCap) < baseFee.Int64() {
-					count = i
-				}
-			}
-			tx, err := types.SignTx(tx, signer, key)
-			if err != nil {
-				t.Fatalf("failed to sign tx: %s", err)
-			}
-			groups[addr] = append(groups[addr], &txpool.LazyTransaction{
-				Hash:      tx.Hash(),
-				Tx:        tx,
-				Time:      tx.Time(),
-				GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
-				GasTipCap: uint256.MustFromBig(tx.GasTipCap()),
-				Gas:       tx.Gas(),
-				BlobGas:   tx.BlobGas(),
-			})
-		}
-		expectedCount += count
-	}
-	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(groups, baseFee)
-
-	txs := types.Transactions{}
-	for entry, ok := txset.Peek(); ok; entry, ok = txset.Peek() {
-		txs = append(txs, entry.tx.Tx)
-		txset.Shift()
-	}
-	if len(txs) != expectedCount {
-		t.Errorf("expected %d transactions, found %d", expectedCount, len(txs))
-	}
-	for i, txi := range txs {
-		fromi, _ := types.Sender(signer, txi)
-
-		// Make sure the nonce order is valid
-		for j, txj := range txs[i+1:] {
-			fromj, _ := types.Sender(signer, txj)
-			if fromi == fromj && txi.Nonce() > txj.Nonce() {
-				t.Errorf("invalid nonce ordering: tx #%d (A=%x N=%v) < tx #%d (A=%x N=%v)", i, fromi[:4], txi.Nonce(), i+j, fromj[:4], txj.Nonce())
-			}
-		}
-		// If the next tx has different from account, the price must be lower than the current one
-		if i+1 < len(txs) {
-			next := txs[i+1]
-			fromNext, _ := types.Sender(signer, next)
-			tip, err := gasprice.EffectiveGasTip(txi, baseFee)
-			nextTip, nextErr := gasprice.EffectiveGasTip(next, baseFee)
-			if err != nil || nextErr != nil {
-				t.Errorf("error calculating effective tip: %v, %v", err, nextErr)
-			}
-			if fromi != fromNext && tip.Cmp(nextTip) < 0 {
-				t.Errorf("invalid gasprice ordering: tx #%d (A=%x P=%v) < tx #%d (A=%x P=%v)", i, fromi[:4], txi.GasPrice(), i+1, fromNext[:4], next.GasPrice())
-			}
-		}
-	}
-}
-
-// Tests that if multiple transactions have the same price, the ones seen earlier
-// are prioritized to avoid network spam attacks aiming for a specific ordering.
-func TestTransactionTimeSort(t *testing.T) {
-	t.Parallel()
-	// Generate a batch of accounts to start with
-	keys := make([]*ecdsa.PrivateKey, 5)
-	for i := 0; i < len(keys); i++ {
-		keys[i], _ = crypto.GenerateKey()
-	}
-	signer := types.HomesteadSigner{}
-
-	// Generate a batch of transactions with overlapping prices, but different creation times
-	groups := map[common.Address][]*txpool.LazyTransaction{}
-	for start, key := range keys {
-		addr := crypto.PubkeyToAddress(key.PublicKey)
-
-		tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(100), 100, big.NewInt(1), nil), signer, key)
-		tx.SetTime(time.Unix(0, int64(len(keys)-start)))
-
-		groups[addr] = append(groups[addr], &txpool.LazyTransaction{
-			Hash:      tx.Hash(),
-			Tx:        tx,
-			Time:      tx.Time(),
-			GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
-			GasTipCap: uint256.MustFromBig(tx.GasTipCap()),
-			Gas:       tx.Gas(),
-			BlobGas:   tx.BlobGas(),
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			entry := txWithMetadata{priority: test.priority, myTurn: test.myTurn}
+			require.Equal(t, test.want, entry.stage())
 		})
 	}
-	// Sort the transactions and cross check the nonce ordering
-	txset := newTransactionsByPriceAndNonce(groups, nil)
-
-	txs := types.Transactions{}
-	for entry, ok := txset.Peek(); ok; entry, ok = txset.Peek() {
-		txs = append(txs, entry.tx.Tx)
-		txset.Shift()
-	}
-	if len(txs) != len(keys) {
-		t.Errorf("expected %d transactions, found %d", len(keys), len(txs))
-	}
-	for i, txi := range txs {
-		fromi, _ := types.Sender(signer, txi)
-		if i+1 < len(txs) {
-			next := txs[i+1]
-			fromNext, _ := types.Sender(signer, next)
-
-			if txi.GasPrice().Cmp(next.GasPrice()) < 0 {
-				t.Errorf("invalid gasprice ordering: tx #%d (A=%x P=%v) < tx #%d (A=%x P=%v)", i, fromi[:4], txi.GasPrice(), i+1, fromNext[:4], next.GasPrice())
-			}
-			// Make sure time order is ascending if the txs have the same gas price
-			if txi.GasPrice().Cmp(next.GasPrice()) == 0 && txi.Time().After(next.Time()) {
-				t.Errorf("invalid received time ordering: tx #%d (A=%x T=%v) > tx #%d (A=%x T=%v)", i, fromi[:4], txi.Time(), i+1, fromNext[:4], next.Time())
-			}
-		}
-	}
 }
 
-func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testing.T) {
+func TestComputeEffectiveTip_TipCanBeComputedForAllTransactionKinds(t *testing.T) {
 
 	baseFee := uint256.NewInt(50)
 
@@ -207,9 +60,9 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 	// when calculating the miner fee for sorting purposes.
 
 	tests := map[string]struct {
-		tx               *types.Transaction
-		expectedError    error
-		expectedMinerFee uint64
+		tx            *types.Transaction
+		expectedError error
+		expectedTip   uint64
 	}{
 		"sponsored transaction": {
 			tx: types.NewTx(&types.DynamicFeeTx{
@@ -219,7 +72,7 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 				GasTipCap: big.NewInt(0),
 				V:         big.NewInt(27), // non-internal, since internal transaction cannot be sponsored
 			}),
-			expectedMinerFee: 0,
+			expectedTip: 0,
 		},
 		"non sponsored transaction": {
 			tx: types.NewTx(&types.DynamicFeeTx{
@@ -238,7 +91,7 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 				GasFeeCap: big.NewInt(100),
 				GasTipCap: big.NewInt(0),
 			}),
-			expectedMinerFee: 0,
+			expectedTip: 0,
 		},
 		"non sponsored transaction with enough fee cap and tip": {
 			tx: types.NewTx(&types.DynamicFeeTx{
@@ -247,7 +100,7 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 				GasFeeCap: big.NewInt(100),
 				GasTipCap: big.NewInt(10),
 			}),
-			expectedMinerFee: 10,
+			expectedTip: 10,
 		},
 		"non sponsored legacy transaction": {
 			// legacy transactions have a default tip equal to the gas price
@@ -258,7 +111,7 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 				Gas:      100,
 				GasPrice: big.NewInt(100),
 			}),
-			expectedMinerFee: 50, // gas price - base fee
+			expectedTip: 50, // gas price - base fee
 		},
 	}
 
@@ -273,104 +126,203 @@ func TestTransactionsOrdering_MinerFeesCanBeComputedWithAllTransactions(t *testi
 				Gas:       test.tx.Gas(),
 				BlobGas:   test.tx.BlobGas(),
 			}
-			from := common.Address{1}
-
-			withFee, err := newTxWithMinerFee(lazy, from, baseFee)
+			tip, err := computeEffectiveTip(lazy, baseFee)
 			require.ErrorIs(t, err, test.expectedError)
 			if test.expectedError == nil {
-				require.EqualValues(t, withFee.fees.Uint64(), test.expectedMinerFee)
+				require.EqualValues(t, test.expectedTip, tip.Uint64())
 			}
 		})
 	}
 }
 
-func TestCompareTxByPriceAndTime_OrdersByFeeThenByTime(t *testing.T) {
-	entry := func(fees uint64, at time.Time) *txWithMinerFee {
-		return &txWithMinerFee{
-			tx:   &txpool.LazyTransaction{Time: at},
-			fees: uint256.NewInt(fees),
+func TestCompareTxByStagePriorityPriceTime_OrdersByStageThenPriorityThenTipThenTime(t *testing.T) {
+	later := baseTime.Add(time.Second)
+	entry := func(priority priorities.Priority, myTurn bool, tip uint64, at time.Time) *txWithMetadata {
+		return &txWithMetadata{
+			tx:       &txpool.LazyTransaction{Time: at},
+			tip:      uint256.NewInt(tip),
+			priority: priority,
+			myTurn:   myTurn,
 		}
 	}
-	later := baseTime.Add(time.Second)
 
 	tests := map[string]struct {
-		a, b     *txWithMinerFee
+		a, b     *txWithMetadata
 		expected int
 	}{
-		"higher fee precedes": {
-			a:        entry(2, baseTime),
-			b:        entry(1, baseTime),
+		"my turn with priority precedes not my turn, whatever its priority and tip and time": {
+			a:        entry(withPrio, true, 1, later),
+			b:        entry(withPrio, false, 100, baseTime),
 			expected: 1,
 		},
-		"lower fee follows": {
-			a:        entry(1, baseTime),
-			b:        entry(2, baseTime),
-			expected: -1,
-		},
-		"equal fee, earlier time precedes": {
-			a:        entry(1, baseTime),
-			b:        entry(1, later),
+		"my turn with priority precedes without priority, whatever its turn and tip and time": {
+			a:        entry(withPrio, true, 1, later),
+			b:        entry(withoutPrio, true, 100, baseTime),
 			expected: 1,
 		},
-		"equal fee, later time follows": {
-			a:        entry(1, later),
-			b:        entry(1, baseTime),
-			expected: -1,
+		"not my turn with priority precedes without priority, whatever its turn and tip and time": {
+			a:        entry(withPrio, false, 1, later),
+			b:        entry(withoutPrio, true, 100, baseTime),
+			expected: 1,
 		},
-		"equal fee and time are equivalent": {
-			a:        entry(1, baseTime),
-			b:        entry(1, baseTime),
+		"without priority, the turn is ignored": {
+			a:        entry(withoutPrio, true, 1, baseTime),
+			b:        entry(withoutPrio, false, 1, baseTime),
+			expected: 0,
+		},
+		"higher level precedes, whatever its weight and tip and time": {
+			a:        entry(prio(2, 1, 0), true, 1, later),
+			b:        entry(prio(1, 9, 0), true, 100, baseTime),
+			expected: 1,
+		},
+		"higher weight precedes, whatever its tip and time": {
+			a:        entry(prio(1, 2, 0), true, 1, later),
+			b:        entry(prio(1, 1, 0), true, 100, baseTime),
+			expected: 1,
+		},
+		"without priority, the weight is ignored": {
+			a:        entry(prio(0, 1, 0), true, 1, baseTime),
+			b:        entry(prio(0, 9, 0), true, 1, baseTime),
+			expected: 0,
+		},
+		"higher tip precedes, whatever its time": {
+			a:        entry(withoutPrio, true, 2, later),
+			b:        entry(withoutPrio, true, 1, baseTime),
+			expected: 1,
+		},
+		"earlier time precedes": {
+			a:        entry(withoutPrio, true, 1, baseTime),
+			b:        entry(withoutPrio, true, 1, later),
+			expected: 1,
+		},
+		"entries differing only in priority ID are equivalent": {
+			a:        entry(prio(1, 1, 1), true, 1, baseTime),
+			b:        entry(prio(1, 1, 2), true, 1, baseTime),
 			expected: 0,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := compareTxByPriceAndTime(test.a, test.b)
-			require.Equal(t, test.expected, cmp.Compare(got, 0))
+			got := compareTxByStagePriorityPriceTime(test.a, test.b)
+			require.Equal(t, test.expected, got)
+			reversed := compareTxByStagePriorityPriceTime(test.b, test.a)
+			require.Equal(t, -test.expected, reversed)
 		})
 	}
 }
 
-func TestTxOrdering_OrdersByFeeAndTimeWithinNonceConstraints(t *testing.T) {
-	keyA, addrA := newSenderKey(t)
-	keyB, addrB := newSenderKey(t)
-	keyC, addrC := newSenderKey(t)
-	keyD, addrD := newSenderKey(t)
+// TestTransactionsByPriorityAndPriceAndNonce_OrdersByStagePriorityTipAndTime
+// cross-checks the composite order on a whole set: that the metadata the set
+// attaches to each transaction feeds the comparison as intended, that only a
+// sender's lowest nonce takes part in that comparison, and that a promoted
+// nonce is staged on its own metadata rather than its predecessor's - which
+// makes the resulting order non-monotonic.
+func TestTransactionsByPriorityAndPriceAndNonce_OrdersByStagePriorityTipAndTime(t *testing.T) {
+	specs := []struct {
+		name     string
+		sender   string
+		priority priorities.Priority
+		myTurn   bool
+		tip      int64
+		delay    time.Duration
+	}{
+		{name: "level2", sender: "a", priority: prio(2, 1, 1), myTurn: true, tip: 1},
+		{name: "level1/weight2", sender: "b", priority: prio(1, 2, 2), myTurn: true, tip: 1},
+		{name: "level1/weight1", sender: "c", priority: prio(1, 1, 3), myTurn: true, tip: 1},
+		{name: "prioNotMyTurn", sender: "d", priority: prio(9, 9, 4), tip: 1},
+		{name: "tip50", sender: "e", tip: 50},
+		{name: "tip5/early", sender: "f", tip: 5},
+		{name: "tip5/late", sender: "g", tip: 5, delay: time.Second},
+		{name: "blocking", sender: "h", tip: 10},
+		{name: "blocked", sender: "h", priority: prio(3, 1, 5), myTurn: true, tip: 100},
+	}
 
-	a0 := makeLazyTx(t, keyA, 0, 9, baseTime.Add(2*time.Second))
-	a1 := makeLazyTx(t, keyA, 1, 3, baseTime.Add(2*time.Second))
-	b0 := makeLazyTx(t, keyB, 0, 8, baseTime)
-	b1 := makeLazyTx(t, keyB, 1, 7, baseTime)
-	c0 := makeLazyTx(t, keyC, 0, 2, baseTime)
-	c1 := makeLazyTx(t, keyC, 1, 10, baseTime)
-	d0 := makeLazyTx(t, keyD, 0, 3, baseTime.Add(time.Second))
+	expected := []string{
+		// prioritized and my turn, by level, then weight
+		"level2", "level1/weight2", "level1/weight1",
+		// prioritized but not my turn, whatever its level and weight
+		"prioNotMyTurn",
+		// not prioritized, by tip - the blocked nonce takes no part in the
+		// comparison until its predecessor has been consumed
+		"tip50", "blocking",
+		// promoted and staged on its own priority, ahead of what is left
+		"blocked",
+		// not prioritized, equal tips broken by the first-seen time
+		"tip5/early", "tip5/late",
+	}
 
-	txset := newTransactionsByPriceAndNonce(
-		map[common.Address][]*txpool.LazyTransaction{
-			addrA: {a0, a1}, addrB: {b0, b1}, addrC: {c0, c1}, addrD: {d0},
+	type sender struct {
+		key  *ecdsa.PrivateKey
+		addr common.Address
+	}
+	senders := map[string]sender{}
+	txBySender := map[common.Address][]*txpool.LazyTransaction{}
+	prioByHash := map[common.Hash]priorities.Priority{}
+	nameByHash := map[common.Hash]string{}
+	turnByHash := map[common.Hash]bool{}
+	for _, spec := range specs {
+		if _, ok := senders[spec.sender]; !ok {
+			key, addr := newSenderKey(t)
+			senders[spec.sender] = sender{key, addr}
+		}
+		s := senders[spec.sender]
+		tx := makeLazyTx(t, s.key, uint64(len(txBySender[s.addr])), spec.tip, baseTime.Add(spec.delay))
+		txBySender[s.addr] = append(txBySender[s.addr], tx)
+		nameByHash[tx.Hash] = spec.name
+		prioByHash[tx.Hash] = spec.priority
+		turnByHash[tx.Hash] = spec.myTurn
+	}
+
+	classifier := priorities.NewMockClassifier(gomock.NewController(t))
+	classifier.EXPECT().Priority(gomock.Any()).DoAndReturn(
+		func(tx *types.Transaction) (priorities.Priority, error) {
+			return prioByHash[tx.Hash()], nil
 		},
-		nil,
-	)
+	).AnyTimes()
 
-	names := map[common.Hash]string{
-		a0.Hash: "a0", a1.Hash: "a1",
-		b0.Hash: "b0", b1.Hash: "b1",
-		c0.Hash: "c0", c1.Hash: "c1",
-		d0.Hash: "d0",
-	}
-	out := drain(txset)
-	got := make([]string, 0, len(out))
-	for _, e := range out {
-		got = append(got, names[e.tx.Hash])
-	}
+	txset := newTransactionsByPriorityAndPriceAndNonce(txBySender, nil, &priorityContext{classifier: classifier},
+		func(tx *txpool.LazyTransaction) bool { return turnByHash[tx.Hash] })
 
-	require.Equal(t, []string{"a0", "b0", "b1", "d0", "a1", "c0", "c1"}, got)
+	got := make([]string, 0, len(expected))
+	for _, e := range drain(txset) {
+		got = append(got, nameByHash[e.tx.Hash])
+	}
+	require.Equal(t, expected, got)
+}
+
+func TestNewTransactionsByPriorityAndPriceAndNonce_DropsSenderTailWithoutComputableTip(t *testing.T) {
+	baseFee := big.NewInt(50)
+
+	tests := map[string]struct {
+		tips []int64
+		want int
+	}{
+		"every nonce covers the base fee": {[]int64{100, 100, 100}, 3},
+		"a later nonce falls short":       {[]int64{100, 10, 100}, 1},
+		"the first nonce falls short":     {[]int64{10, 100}, 0},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			key, addr := newSenderKey(t)
+			txs := make([]*txpool.LazyTransaction, len(test.tips))
+			for i, tip := range test.tips {
+				txs[i] = makeLazyTx(t, key, uint64(i), tip, baseTime)
+			}
+			txset := newTransactionsByPriorityAndPriceAndNonce(
+				map[common.Address][]*txpool.LazyTransaction{addr: txs}, baseFee, nil, alwaysMyTurn)
+
+			require.Len(t, drain(txset), test.want)
+		})
+	}
 }
 
 var (
 	orderingSigner = types.LatestSignerForChainID(common.Big1)
 	baseTime       = time.Unix(1_000, 0)
+
+	withPrio    = prio(1, 1, 1)
+	withoutPrio = prio(0, 0, 0)
 )
 
 // newSenderKey returns a fresh private key and its derived sender address.
@@ -408,9 +360,21 @@ func makeLazyTx(t *testing.T, key *ecdsa.PrivateKey, nonce uint64, tip int64, at
 	}
 }
 
+func alwaysMyTurn(*txpool.LazyTransaction) bool { return true }
+
+// myTurnFor returns a turn policy putting only the given transactions at this
+// validator's turn.
+func myTurnFor(txs ...*types.Transaction) func(tx *txpool.LazyTransaction) bool {
+	mine := make(map[common.Hash]bool, len(txs))
+	for _, tx := range txs {
+		mine[tx.Hash()] = true
+	}
+	return func(tx *txpool.LazyTransaction) bool { return mine[tx.Hash] }
+}
+
 // drain consumes the whole set in its ordering.
-func drain(txset *transactionsByPriceAndNonce) []*txWithMinerFee {
-	var out []*txWithMinerFee
+func drain(txset *transactionsByPriorityAndPriceAndNonce) []*txWithMetadata {
+	var out []*txWithMetadata
 	for e, ok := txset.Peek(); ok; e, ok = txset.Peek() {
 		out = append(out, e)
 		txset.Shift()

--- a/gossip/emitter/proposals.go
+++ b/gossip/emitter/proposals.go
@@ -54,7 +54,7 @@ import (
 // proposer for the current turn can be determined.
 func (em *Emitter) createPayload(
 	event inter.EventI,
-	sorted *transactionsByPriceAndNonce,
+	sorted *transactionsByPriorityAndPriceAndNonce,
 ) (inter.Payload, error) {
 	adapter := worldAdapter{External: em.world}
 	randaoMixer := randao.NewRandaoMixerAdapter(em.world.EventsSigner)
@@ -87,7 +87,7 @@ func createPayload(
 	validators *pos.Validators,
 	event inter.EventI,
 	proposalTracker proposalTracker,
-	sorted *transactionsByPriceAndNonce,
+	sorted *transactionsByPriorityAndPriceAndNonce,
 	transactionScheduler txScheduler,
 	randaoMixer randao.RandaoMixer,
 	durationMetric timerMetric,
@@ -338,7 +338,7 @@ func (a *transactionPriorityAdapter) Skip() {
 }
 
 type transactionIndex interface {
-	Peek() (*txWithMinerFee, bool)
-	Shift() (*txWithMinerFee, bool)
-	PopSequence() ([]*txWithMinerFee, bool)
+	Peek() (*txWithMetadata, bool)
+	Shift() (*txWithMetadata, bool)
+	PopSequence() ([]*txWithMetadata, bool)
 }

--- a/gossip/emitter/proposals_mock.go
+++ b/gossip/emitter/proposals_mock.go
@@ -262,10 +262,10 @@ func (m *MocktransactionIndex) EXPECT() *MocktransactionIndexMockRecorder {
 }
 
 // Peek mocks base method.
-func (m *MocktransactionIndex) Peek() (*txWithMinerFee, bool) {
+func (m *MocktransactionIndex) Peek() (*txWithMetadata, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Peek")
-	ret0, _ := ret[0].(*txWithMinerFee)
+	ret0, _ := ret[0].(*txWithMetadata)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -277,10 +277,10 @@ func (mr *MocktransactionIndexMockRecorder) Peek() *gomock.Call {
 }
 
 // PopSequence mocks base method.
-func (m *MocktransactionIndex) PopSequence() ([]*txWithMinerFee, bool) {
+func (m *MocktransactionIndex) PopSequence() ([]*txWithMetadata, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PopSequence")
-	ret0, _ := ret[0].([]*txWithMinerFee)
+	ret0, _ := ret[0].([]*txWithMetadata)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -292,10 +292,10 @@ func (mr *MocktransactionIndexMockRecorder) PopSequence() *gomock.Call {
 }
 
 // Shift mocks base method.
-func (m *MocktransactionIndex) Shift() (*txWithMinerFee, bool) {
+func (m *MocktransactionIndex) Shift() (*txWithMetadata, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Shift")
-	ret0, _ := ret[0].(*txWithMinerFee)
+	ret0, _ := ret[0].(*txWithMetadata)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }

--- a/gossip/emitter/proposals_test.go
+++ b/gossip/emitter/proposals_test.go
@@ -498,7 +498,7 @@ func TestTransactionPriorityAdapter_ForwardsCallToWrappedType(t *testing.T) {
 		index := NewMocktransactionIndex(ctrl)
 
 		tx := types.NewTx(&types.LegacyTx{Nonce: 1})
-		index.EXPECT().Peek().Return(&txWithMinerFee{tx: &txpool.LazyTransaction{Tx: tx}}, true)
+		index.EXPECT().Peek().Return(&txWithMetadata{tx: &txpool.LazyTransaction{Tx: tx}}, true)
 
 		adapter := transactionPriorityAdapter{index}
 		got := adapter.Current()

--- a/gossip/emitter/txs.go
+++ b/gossip/emitter/txs.go
@@ -17,6 +17,7 @@
 package emitter
 
 import (
+	"maps"
 	"time"
 
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
@@ -24,6 +25,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,6 +34,7 @@ import (
 	"github.com/0xsoniclabs/sonic/eventcheck/gaspowercheck"
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
@@ -140,7 +143,7 @@ func getTxRoundIndex(now, txTime time.Time, validatorsNum idx.Validator) int {
 }
 
 // safe for concurrent use
-func (em *Emitter) isMyTxTurn(txHash common.Hash, sender common.Address, accountNonce uint64, now time.Time, validators *pos.Validators, me idx.ValidatorID, epoch idx.Epoch) bool {
+func (em *Emitter) isMyTxTurn(txHash common.Hash, sender common.Address, accountNonce uint64, now time.Time, validators *pos.Validators, offlineValidators map[idx.ValidatorID]bool, me idx.ValidatorID, epoch idx.Epoch) bool {
 	txTime := txtime.Of(txHash)
 
 	roundIndex := getTxRoundIndex(now, txTime, validators.Len())
@@ -161,7 +164,7 @@ func (em *Emitter) isMyTxTurn(txHash common.Hash, sender common.Address, account
 		if chosenValidator == me {
 			return true // current validator is the chosen - emit
 		}
-		if !em.offlineValidators[chosenValidator] {
+		if !offlineValidators[chosenValidator] {
 			return false // chosen validator is online - don't emit
 		}
 		// otherwise try next validator in the sequence
@@ -170,17 +173,81 @@ func (em *Emitter) isMyTxTurn(txHash common.Hash, sender common.Address, account
 	return false
 }
 
-func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPriceAndNonce) {
+// newTurnPolicy returns the per-transaction turn check of this validator, used
+// to stage the transactions of the ordering set.
+//
+// The set of offline validators the check consults is guarded by the world lock,
+// so it is snapshotted here. The returned policy reads only that snapshot and can
+// therefore be evaluated without holding the lock.
+func (em *Emitter) newTurnPolicy(upgrades opera.Upgrades) func(tx *txpool.LazyTransaction) bool {
+	if upgrades.SingleProposerBlockFormation {
+		return func(*txpool.LazyTransaction) bool { return true }
+	}
+	em.world.Lock()
+	offlineValidators := maps.Clone(em.offlineValidators)
+	em.world.Unlock()
+
+	return func(tx *txpool.LazyTransaction) bool {
+		resolvedTx := tx.Resolve()
+		sender, _ := types.Sender(em.world.TransactionSigner, resolvedTx)
+		return em.isMyTxTurn(tx.Hash, sender, resolvedTx.Nonce(), time.Now(), em.validators.Load(), offlineValidators, em.config.Validator.ID, idx.Epoch(em.epoch.Load()))
+	}
+}
+
+// addTxs appends transactions from sorted to the event e within its gas-power
+// and size budgets.
+//
+// A transaction is admitted on this validator's turn, or eagerly while it is
+// another validator's turn so that prioritized transactions reach a block
+// quickly; anything else is dropped. An eager admission requires a priority and
+// counts against MaxPiggybackTxsPerEntityPerEvent per Priority.ID and half of the
+// gas budget, since prioritized candidates are staged first and a few large ones
+// would otherwise starve this validator's own. Eager admissions are rolled back
+// if the event carries nothing of this validator's own, and never affect
+// consensus: the authoritative priority ordering is re-derived during block
+// formation.
+func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPriorityAndPriceAndNonce) {
 	maxGasUsed := em.maxGasPowerToUse(e)
 	if maxGasUsed <= e.GasPowerUsed() {
 		return
 	}
 
 	totalTxSizeInBytes := uint64(0)
-
-	// sort transactions by price and nonce
 	rules := em.world.GetRules()
+
+	// Eager admissions per entity, and the share of the gas budget they may
+	// consume, leaving the rest for this validator's own transactions.
+	maxPiggybackTxs := em.cache.priorityConfig.MaxPiggybackTxsPerEntityPerEvent
+	piggybackTxs := map[priorities.PriorityID]uint64{}
+	maxPiggybackGas := (maxGasUsed - e.GasPowerUsed()) / 2
+	piggybackGas := uint64(0)
+
+	// State to restore if the event ends up carrying foreign-priority
+	// transactions only.
+	txPrefixOnEntry := e.Transactions()
+	gasPowerUsedOnEntry := e.GasPowerUsed()
+	gasPowerLeftOnEntry := e.GasPowerLeft()
+	ownTxs := false
+	eagerTxs := int64(0)
+
 	for entry, ok := sorted.Peek(); ok; entry, ok = sorted.Peek() {
+		// Another validator's turn: admit eagerly only if the transaction is
+		// prioritized and the eager limits are not yet exhausted.
+		if !entry.myTurn {
+			priority := entry.priority
+			if !priority.IsPrioritized() {
+				txsSkippedNotMyTurn.Inc(1)
+				sorted.PopSequence()
+				continue
+			}
+			if piggybackTxs[priority.ID] >= maxPiggybackTxs ||
+				piggybackGas+entry.tx.Gas > maxPiggybackGas {
+				txsSkippedPiggybackLimit.Inc(1)
+				sorted.PopSequence()
+				continue
+			}
+		}
+
 		tx := entry.tx
 		resolvedTx := tx.Resolve()
 
@@ -215,12 +282,6 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 			sorted.PopSequence()
 			continue
 		}
-		// my turn, i.e. try to not include the same tx simultaneously by different validators
-		if !em.isMyTxTurn(tx.Hash, sender, resolvedTx.Nonce(), time.Now(), em.validators.Load(), e.Creator(), idx.Epoch(em.epoch.Load())) {
-			txsSkippedNotMyTurn.Inc(1)
-			sorted.PopSequence()
-			continue
-		}
 		// check transaction is not outdated
 		if !em.world.TxPool.Has(tx.Hash) {
 			txsSkippedOutdated.Inc(1)
@@ -238,7 +299,23 @@ func (em *Emitter) addTxs(e *inter.MutableEventPayload, sorted *transactionsByPr
 		e.SetGasPowerLeft(e.GasPowerLeft().Sub(tx.Gas))
 		e.SetTxs(append(e.Transactions(), resolvedTx))
 		totalTxSizeInBytes += txSize
+		if entry.myTurn {
+			ownTxs = true
+		} else {
+			piggybackGas += tx.Gas
+			piggybackTxs[entry.priority.ID]++
+			eagerTxs++
+		}
 		sorted.Shift()
+	}
+
+	// If this validator contributed none of its own transactions, roll the
+	// eagerly included ones back.
+	if !ownTxs && eagerTxs > 0 {
+		e.SetTxs(txPrefixOnEntry)
+		e.SetGasPowerUsed(gasPowerUsedOnEntry)
+		e.SetGasPowerLeft(gasPowerLeftOnEntry)
+		txsSkippedPiggybackRollback.Inc(eagerTxs)
 	}
 }
 

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -23,14 +23,21 @@ import (
 
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
 	"github.com/0xsoniclabs/sonic/gossip/emitter/config"
+	"github.com/0xsoniclabs/sonic/gossip/emitter/originatedtxs"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -44,6 +51,147 @@ func Test_DefaultMaxTxsPerAddress_Equals_txTurnNonces(t *testing.T) {
 
 	defaultConfig := config.DefaultConfig()
 	require.EqualValues(t, txTurnNonces, defaultConfig.MaxTxsPerAddress, "Default MaxTxsPerAddress should equal txTurnNonces")
+}
+
+func TestEmitter_addTxs_PerEntityCapEnforcedForPrioritizedNotMyTurnTransactions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	f := newAddTxsFixture(t, ctrl)
+
+	// 3 prioritized txs & 1 ordinary tx whose turn it is, so eager admissions are not rolled back.
+	prio1 := f.makeTx(t)
+	prio2 := f.makeTx(t)
+	prio3 := f.makeTx(t)
+	ordinary := f.makeTx(t)
+
+	tests := map[string]struct {
+		entityCap  uint64
+		entities   [3]byte
+		turn       func(tx *txpool.LazyTransaction) bool
+		wantTxs    []*types.Transaction
+		wantCapped int64
+	}{
+		"my-turn prio bypasses cap":       {0, [3]byte{7, 7, 7}, alwaysMyTurn, []*types.Transaction{prio1, prio2, prio3, ordinary}, 0},
+		"not-my-turn prio subject to cap": {2, [3]byte{7, 7, 7}, myTurnFor(ordinary), []*types.Transaction{prio1, prio2, ordinary}, 1},
+		"cap applies per entity":          {1, [3]byte{7, 7, 8}, myTurnFor(ordinary), []*types.Transaction{prio1, prio3, ordinary}, 1},
+		"zero cap admits nothing eagerly": {0, [3]byte{7, 7, 7}, myTurnFor(ordinary), []*types.Transaction{ordinary}, 3},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			f.em.cache.priorityConfig.MaxPiggybackTxsPerEntityPerEvent = test.entityCap
+			lookup := map[common.Hash]priorities.Priority{
+				prio1.Hash(): prio(1, 1, test.entities[0]),
+				prio2.Hash(): prio(1, 1, test.entities[1]),
+				prio3.Hash(): prio(1, 1, test.entities[2]),
+			}
+
+			capped := counterDelta(txsSkippedPiggybackLimit)
+
+			event := f.makeEvent()
+			f.em.addTxs(event, f.makeSorted(t, lookup, test.turn, prio1, prio2, prio3, ordinary))
+
+			require.Equal(t, hashes(test.wantTxs), hashes(event.Transactions()))
+			require.Equal(t, test.wantCapped, capped())
+		})
+	}
+}
+
+// TestEmitter_addTxs_EagerAdmissionsAreBoundedByGasShare verifies that the eager
+// path cannot consume more than half of the event's gas budget, so large
+// prioritized transactions of other validators' turns leave room for this
+// validator's own ones.
+func TestEmitter_addTxs_EagerAdmissionsAreBoundedByGasShare(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	f := newAddTxsFixture(t, ctrl) // MaxEventGas is 100_000_000
+	f.em.cache.priorityConfig.MaxPiggybackTxsPerEntityPerEvent = 5
+
+	// Two prioritized txs of another validator's turn, each fitting into the
+	// gas share on its own but not together, and one ordinary tx of this
+	// validator's turn that only fits if the second one is dropped.
+	foreign1 := f.makeTxs(t, 40_000_000, 0)[0]
+	foreign2 := f.makeTxs(t, 40_000_000, 0)[0]
+	mine := f.makeTxs(t, 30_000_000, 0)[0]
+
+	lookup := map[common.Hash]priorities.Priority{
+		foreign1.Hash(): prio(1, 1, 7),
+		foreign2.Hash(): prio(1, 1, 7),
+	}
+
+	event := f.makeEvent()
+	f.em.addTxs(event, f.makeSorted(t, lookup, myTurnFor(mine), foreign1, foreign2, mine))
+
+	require.Equal(t,
+		[]common.Hash{foreign1.Hash(), mine.Hash()},
+		hashes(event.Transactions()),
+	)
+}
+
+func TestEmitter_addTxs_EagerAdmissionsNeedAnOwnContributionOtherwiseRollback(t *testing.T) {
+	type candidate struct {
+		prio   bool
+		myTurn bool
+	}
+
+	tests := map[string]struct {
+		txs          []candidate
+		expectIdx    []uint
+		wantRollback int64
+	}{
+		"no own contribution rolls the event back": {
+			[]candidate{{true, false}, {true, false}},
+			[]uint{},
+			2,
+		},
+		"promoted my-turn nonce keeps the event": {
+			[]candidate{{true, false}, {true, true}},
+			[]uint{0, 1},
+			0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			f := newAddTxsFixture(t, ctrl)
+			f.em.cache.priorityConfig.MaxPiggybackTxsPerEntityPerEvent = 5
+
+			// Consecutive nonces of one sender, so that a candidate only surfaces
+			// once its predecessor has been admitted.
+			nonces := make([]uint64, len(test.txs))
+			for i := range nonces {
+				nonces[i] = uint64(i)
+			}
+			txs := f.makeTxs(t, params.TxGas, nonces...)
+
+			lookup := map[common.Hash]priorities.Priority{}
+			var myTurn []*types.Transaction
+			for i, candidate := range test.txs {
+				if candidate.prio {
+					lookup[txs[i].Hash()] = prio(1, 1, 3)
+				}
+				if candidate.myTurn {
+					myTurn = append(myTurn, txs[i])
+				}
+			}
+
+			expected := make(types.Transactions, len(test.expectIdx))
+			for i, index := range test.expectIdx {
+				expected[i] = txs[index]
+			}
+
+			event := f.makeEvent()
+			gasPowerLeft := event.GasPowerLeft()
+			rolledBack := counterDelta(txsSkippedPiggybackRollback)
+			f.em.addTxs(event, f.makeSorted(t, lookup, myTurnFor(myTurn...), txs...))
+
+			// only the expected transactions are included, and the gasUsed and gasPowerLeft only reflects the included ones
+			gasUsed := uint64(len(expected)) * params.TxGas
+			require.Equal(t, hashes(expected), hashes(event.Transactions()))
+			require.Equal(t, gasUsed, event.GasPowerUsed())
+			require.Equal(t, gasPowerLeft.Sub(gasUsed), event.GasPowerLeft())
+			require.Equal(t, test.wantRollback, rolledBack())
+		})
+	}
 }
 
 func Test_Emitter_isValidBundleTx_AcceptsValidBundleIfBundlesAreEnabled(t *testing.T) {
@@ -320,4 +468,117 @@ func Test_Emitter_evaluateBundleTx_ReturnsGasEfficiencyFromEvaluator(t *testing.
 			require.Equal(t, tc.executable, valid)
 		})
 	}
+}
+
+// counterDelta captures a counter and returns how much it advanced since the
+// capture.
+func counterDelta(counter *metrics.Counter) func() int64 {
+	before := counter.Snapshot().Count()
+	return func() int64 { return counter.Snapshot().Count() - before }
+}
+
+func hashes(txs types.Transactions) []common.Hash {
+	hashes := make([]common.Hash, len(txs))
+	for i, tx := range txs {
+		hashes[i] = tx.Hash()
+	}
+	return hashes
+}
+
+// addTxsFixture builds a minimal Emitter ready to exercise addTxs. Its
+// cache.priorityConfig carries the rate limits an ordering build would have read
+// from the registry, zero by default, which admits nothing eagerly.
+type addTxsFixture struct {
+	em     *Emitter
+	signer types.Signer
+}
+
+func newAddTxsFixture(t *testing.T, ctrl *gomock.Controller) *addTxsFixture {
+	t.Helper()
+
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+
+	rules := opera.Rules{
+		NetworkID: 1,
+		Economy: opera.EconomyRules{
+			Gas: opera.GasRules{MaxEventGas: 100_000_000},
+		},
+		Blocks: opera.BlocksRules{MaxBlockGas: 100_000_000},
+	}
+
+	external := NewMockExternal(ctrl)
+	external.EXPECT().GetRules().Return(rules).AnyTimes()
+
+	txPool := NewMockTxPool(ctrl)
+	txPool.EXPECT().Has(gomock.Any()).Return(true).AnyTimes()
+
+	em := &Emitter{
+		world: World{
+			External:          external,
+			TxPool:            txPool,
+			TransactionSigner: signer,
+		},
+		originatedTxs: originatedtxs.New(SenderCountBufferSize),
+	}
+
+	return &addTxsFixture{em: em, signer: signer}
+}
+
+// makeTx returns a signed legacy transaction from a fresh, unique sender, so
+// each tx forms its own account queue in makeSorted.
+func (f *addTxsFixture) makeTx(t *testing.T) *types.Transaction {
+	t.Helper()
+	return f.makeTxs(t, params.TxGas, 0)[0]
+}
+
+// makeTxs returns one signed legacy transaction per given nonce, all from a
+// single fresh sender and with the given gas limit, so they form one
+// nonce-ordered account queue in makeSorted. Pass the nonces in ascending order.
+func (f *addTxsFixture) makeTxs(t *testing.T, gas uint64, nonces ...uint64) []*types.Transaction {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	txs := make([]*types.Transaction, len(nonces))
+	for i, nonce := range nonces {
+		tx, err := types.SignTx(
+			types.NewTransaction(nonce, common.Address{0xaa}, big.NewInt(0), gas, big.NewInt(1), nil),
+			f.signer, key,
+		)
+		require.NoError(t, err)
+		txs[i] = tx
+	}
+	return txs
+}
+
+// makeEvent returns a mutable event payload with plenty of gas power.
+func (f *addTxsFixture) makeEvent() *inter.MutableEventPayload {
+	e := &inter.MutableEventPayload{}
+	e.SetGasPowerLeft(inter.GasPowerLeft{Gas: [2]uint64{100_000_000, 100_000_000}})
+	return e
+}
+
+// makeSorted wraps the given txs as a transactionsByPriorityAndPriceAndNonce
+// set, grouping them by recovered sender. The priorities and the turn policy
+// stage every transaction of the set.
+func (f *addTxsFixture) makeSorted(t *testing.T, priorityOf map[common.Hash]priorities.Priority, policy func(tx *txpool.LazyTransaction) bool, txs ...*types.Transaction) *transactionsByPriorityAndPriceAndNonce {
+	bySender := map[common.Address][]*txpool.LazyTransaction{}
+	for _, tx := range txs {
+		sender, _ := types.Sender(f.signer, tx)
+		bySender[sender] = append(bySender[sender], &txpool.LazyTransaction{
+			Hash:      tx.Hash(),
+			Tx:        tx,
+			Time:      tx.Time(),
+			GasFeeCap: uint256.MustFromBig(tx.GasFeeCap()),
+			GasTipCap: uint256.MustFromBig(tx.GasTipCap()),
+			Gas:       tx.Gas(),
+		})
+	}
+	classifier := priorities.NewMockClassifier(gomock.NewController(t))
+	classifier.EXPECT().Priority(gomock.Any()).DoAndReturn(
+		func(tx *types.Transaction) (priorities.Priority, error) {
+			return priorityOf[tx.Hash()], nil
+		},
+	).AnyTimes()
+
+	return newTransactionsByPriorityAndPriceAndNonce(bySender, nil, &priorityContext{classifier: classifier}, policy)
 }


### PR DESCRIPTION
This PR makes the emitter's candidate ordering priority-aware and lets a validator eagerly include prioritized transactions that are not its own turn, so that prioritized transactions reach a block without waiting for their turn-owner to emit.

`transactionsByPriceAndNonce` becomes `transactionsByPriorityAndPriceAndNonce` and orders candidates by

    (stage asc, priority level desc, priority weight desc, effective tip desc, first-seen time asc)

where `stage` partitions candidates into prioritized-my-turn, prioritized-not-my-turn and not-prioritized. Per-sender nonce sequencing is still honored by the underlying `FrontierHeap`, so the emitted order is not monotonic: a promoted nonce is staged on its own metadata, not its predecessor's.