### PR TITLE
Modify wait for initialize to reduce flakiness

### DIFF
--- a/cmd/sonicd/app/unlocking_test.go
+++ b/cmd/sonicd/app/unlocking_test.go
@@ -226,6 +226,21 @@ Testing your passphrase against all of them...
 	}
 }
 
+// waitForStderr blocks until the child process has written want to stderr, or
+// fails the test if that has not happened within timeout.
+func waitForStderr(t *testing.T, cli *testcli, want string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(cli.StderrText(), want) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cli.Kill()
+	t.Fatalf("stderr text does not contain %q after %v, got:\n%s", want, timeout, cli.StderrText())
+}
+
 // TestUnlockFlagPasswordFifoInterruptedBySignal verifies that a shutdown
 // signal interrupts --unlock while it is blocked reading an empty --password
 // FIFO, instead of hanging forever waiting for data that never arrives.
@@ -244,9 +259,12 @@ func TestUnlockFlagPasswordFifoInterruptedBySignal(t *testing.T) {
 		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a",
 		"--ipcdisable")
 
-	// Give the node a moment to start and block reading the empty password
-	// FIFO before sending the shutdown signal.
-	time.Sleep(500 * time.Millisecond)
+	// The node only installs its signal handler part way through startup; a
+	// signal delivered before that point terminates the process with the
+	// default disposition and no output at all. Wait for the log line that is
+	// emitted right before the blocking FIFO read instead of guessing how long
+	// startup takes.
+	waitForStderr(t, cli, "Reading keystore password from file", 60*time.Second)
 	cli.Interrupt()
 
 	exited := make(chan struct{})


### PR DESCRIPTION
The changes presented wait for the code to reach the correct initialization instead of assuming a time duration. 