### PR TITLE
Cache emitter priority queries

### DIFF
--- a/config/make_node.go
+++ b/config/make_node.go
@@ -146,8 +146,9 @@ func MakeNode(sigCtx context.Context, ctx *cli.Context, cfg *Config) (*node.Node
 	}
 	signer := valkeystore.NewSignerAuthority(valKeystore, cfg.Emitter.Validator.PubKey)
 
-	// shared resource between the tx pool and the emitter
+	// shared resources between the tx pool and the emitter
 	bundleEvaluationCache := evmcore.NewBundleEvaluationCache()
+	priorityCache := evmcore.NewPriorityCache(cfg.TxPool)
 
 	// Create and register a gossip network service.
 	newTxPool := func(reader evmcore.StateReader) gossip.TxPool {
@@ -196,6 +197,7 @@ func MakeNode(sigCtx context.Context, ctx *cli.Context, cfg *Config) (*node.Node
 			gdb.AsBaseFeeSource(),
 			errorLock,
 			bundleEvaluationCache,
+			priorityCache,
 		))
 	}
 

--- a/evmcore/priorities_cache.go
+++ b/evmcore/priorities_cache.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package evmcore
+
+import (
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// PriorityCache memoizes the priority classification of transactions.
+//
+// Entries do not expire; they are evicted in least-recently-used order once the
+// cache is full. Stale classifications are acceptable: a transaction that loses
+// its priority keeps it here, which only works in its favor, and one that gains
+// priority later is old by then, so promoting it no longer helps. Emission order
+// is best-effort regardless and does not affect correctness.
+//
+// A nil cache treats everything as non-prioritized.
+type PriorityCache struct {
+	// entries maps a transaction hash to its priorities.Priority. The
+	// underlying cache is safe for concurrent use.
+	entries *lru.Cache[common.Hash, priorities.Priority]
+}
+
+// NewPriorityCache creates a cache holding as many priorities as the given
+// configuration admits transactions to the pool. The configuration is sanitized
+// like the pool sanitizes it, so both derive their capacity from the same values.
+func NewPriorityCache(poolConfig TxPoolConfig) *PriorityCache {
+	config := poolConfig.sanitize()
+	capacity := config.GlobalSlots + config.GlobalQueue
+	entries, _ := lru.New[common.Hash, priorities.Priority](int(capacity)) // sanitizing guarantees a positive capacity
+	return &PriorityCache{entries: entries}
+}
+
+// GetOrClassify returns the cached priority of the given transaction, or
+// classifies and caches it on a miss.
+func (c *PriorityCache) GetOrClassify(
+	tx *types.Transaction,
+	classifier priorities.Classifier,
+) priorities.Priority {
+	if c == nil {
+		return priorities.Priority{}
+	}
+	hash := tx.Hash()
+	if entry, found := c.entries.Get(hash); found {
+		return entry
+	}
+	priority, err := classifier.Priority(tx)
+	if err != nil {
+		priority = priorities.Priority{}
+	}
+	c.entries.Add(hash, priority)
+	return priority
+}

--- a/evmcore/priorities_cache_test.go
+++ b/evmcore/priorities_cache_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package evmcore
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewPriorityCache_HoldsTheSanitizedPoolCapacity(t *testing.T) {
+	tests := map[string]struct {
+		config   TxPoolConfig
+		capacity int
+	}{
+		"configured": {
+			config:   TxPoolConfig{GlobalSlots: 3, GlobalQueue: 2},
+			capacity: 5,
+		},
+		// An unworkable capacity falls back to the same defaults the pool uses.
+		"sanitized": {
+			config:   TxPoolConfig{},
+			capacity: int(DefaultTxPoolConfig.GlobalSlots + DefaultTxPoolConfig.GlobalQueue),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cache := NewPriorityCache(test.config)
+			for i := range test.capacity + 1 {
+				cache.entries.Add(common.Hash{byte(i), byte(i >> 8)}, priorities.Priority{})
+			}
+			require.Equal(t, test.capacity, cache.entries.Len())
+		})
+	}
+}
+
+func TestPriorityCache_GetOrClassify_PrefersTheCacheAndRetainsClassifications(t *testing.T) {
+	tests := map[string]struct {
+		cached      *priorities.Priority
+		classified  priorities.Priority
+		classifyErr error
+		expected    priorities.Priority
+	}{
+		"cached": {
+			cached:   new(priorities.Priority{Level: 1}),
+			expected: priorities.Priority{Level: 1},
+		},
+		"not cached": {
+			classified: priorities.Priority{Level: 1},
+			expected:   priorities.Priority{Level: 1},
+		},
+		"failed classification": {
+			classified:  priorities.Priority{Level: 1},
+			classifyErr: errors.New("injected error"),
+			expected:    priorities.Priority{},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tx := types.NewTx(&types.LegacyTx{})
+			classifier := priorities.NewMockClassifier(gomock.NewController(t))
+			if tc.cached == nil {
+				classifier.EXPECT().Priority(tx).Return(tc.classified, tc.classifyErr)
+			}
+
+			cache := NewPriorityCache(DefaultTxPoolConfig)
+			if tc.cached != nil {
+				cache.entries.Add(tx.Hash(), *tc.cached)
+			}
+
+			require.Equal(t, tc.expected, cache.GetOrClassify(tx, classifier))
+
+			entry, found := cache.entries.Get(tx.Hash())
+			require.True(t, found)
+			require.Equal(t, tc.expected, entry)
+		})
+	}
+}
+
+func TestPriorityCache_NilCache_TreatsTransactionsAsNotPrioritized(t *testing.T) {
+	tx := types.NewTx(&types.LegacyTx{})
+	classifier := priorities.NewMockClassifier(gomock.NewController(t))
+
+	var cache *PriorityCache
+	require.Equal(t, priorities.Priority{}, cache.GetOrClassify(tx, classifier))
+}

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -211,7 +211,8 @@ func newTestEnvWithUpgrades(
 		signer := valkeystore.NewSignerAuthority(keyStore, pubkey)
 		world := env.EmitterWorld(signer)
 		world.External = testEmitterWorldExternal{world.External, env}
-		em := emitter.NewEmitter(cfg, world, store.AsBaseFeeSource(), nil, nil)
+		em := emitter.NewEmitter(cfg, world, store.AsBaseFeeSource(), nil, nil,
+			evmcore.NewPriorityCache(evmcore.DefaultTxPoolConfig))
 		env.RegisterEmitter(em)
 		env.pubkeys = append(env.pubkeys, pubkey)
 		em.Start()

--- a/gossip/emitter/emitter.go
+++ b/gossip/emitter/emitter.go
@@ -156,6 +156,9 @@ type Emitter struct {
 		priorityConfig priorities.Config // rate limits read while the sortedTxs were built
 	}
 
+	// priorityCache memoizes the transaction priorities used for ordering.
+	priorityCache *evmcore.PriorityCache
+
 	emittedEventFile *os.File
 	emittedBvsFile   *os.File
 	emittedEvFile    *os.File
@@ -204,6 +207,7 @@ func NewEmitter(
 	baseFeeSource BaseFeeSource,
 	errorLock *errlock.ErrorLock,
 	bundleCache evmcore.BundleEvaluator,
+	priorityCache *evmcore.PriorityCache,
 ) *Emitter {
 	// Randomize event time to decrease chance of 2 parallel instances emitting event at the same time
 	// It increases the chance of detecting parallel instances
@@ -218,6 +222,7 @@ func NewEmitter(
 		baseFeeSource: baseFeeSource,
 		errorLock:     errorLock,
 		bundleCache:   bundleCache,
+		priorityCache: priorityCache,
 	}
 	res.eventEmissionThrottler = throttler.NewThrottlingState(
 		config.Validator.ID,

--- a/gossip/emitter/emitter_test.go
+++ b/gossip/emitter/emitter_test.go
@@ -84,7 +84,7 @@ func TestEmitter(t *testing.T) {
 		TxPool:            txPool,
 		EventsSigner:      signer,
 		TransactionSigner: txSigner,
-	}, fixedPriceBaseFeeSource{}, nil, nil)
+	}, fixedPriceBaseFeeSource{}, nil, nil, nil)
 
 	t.Run("init", func(t *testing.T) {
 		external.EXPECT().GetRules().
@@ -699,18 +699,37 @@ func TestEmitter_EmitEvent_skippingTxsAlsoSkipsGappedNoncesTxs(t *testing.T) {
 	require.False(t, ok, "expected no more txs after the nonce gap")
 }
 
-func TestEmitter_GetSortedTxs_ClassifiesCandidatesPriorityAgainstHeadStateWhenPrioritiesEnabled(t *testing.T) {
+func TestEmitter_GetSortedTxs_ResolvesCandidatePrioritiesFromTheCacheOrTheHeadState(t *testing.T) {
 	tests := map[string]struct {
-		priorities bool
-		wantConfig priorities.Config
+		prioritiesEnabled bool
+		cached            *priorities.Priority
+		queried           bool
+		expectPriority    priorities.Priority
+		expectConfig      priorities.Config
 	}{
+		// The cache is not consulted at all, so the seeded priority is ignored
+		// and left untouched.
 		"disabled": {
-			false,
-			priorities.Config{},
+			prioritiesEnabled: false,
+			cached:            &priorities.Priority{Level: 1},
+			expectPriority:    priorities.Priority{},
+			expectConfig:      priorities.Config{},
 		},
-		"enabled": {
-			true,
-			priorities.FallbackConfig,
+		// No registry is deployed, so the candidate cannot be prioritized and
+		// the failed classification is memoized.
+		"cache miss": {
+			prioritiesEnabled: true,
+			cached:            nil,
+			queried:           true,
+			// queried always returns the default priority because the contract is not deployed, but it makes sure that the db is called.
+			expectPriority: priorities.Priority{},
+			expectConfig:   priorities.FallbackConfig,
+		},
+		"cache hit": {
+			prioritiesEnabled: true,
+			cached:            &priorities.Priority{Level: 1},
+			expectPriority:    priorities.Priority{Level: 1},
+			expectConfig:      priorities.FallbackConfig,
 		},
 	}
 
@@ -727,13 +746,13 @@ func TestEmitter_GetSortedTxs_ClassifiesCandidatesPriorityAgainstHeadStateWhenPr
 			world := NewMockExternal(ctrl)
 			upgrades := opera.GetSonicUpgrades()
 			upgrades.SingleProposerBlockFormation = true
-			upgrades.TransactionPriorities = test.priorities
+			upgrades.TransactionPriorities = test.prioritiesEnabled
 			world.EXPECT().GetRules().Return(opera.FakeNetRules(upgrades)).Times(2)
 			world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)) // for the cache
 
 			txSigner := NewMockTxSigner(ctrl)
 
-			if test.priorities {
+			if test.prioritiesEnabled {
 				world.EXPECT().GetLatestBlockIndex().Return(idx.Block(1)) // for the chain config
 				world.EXPECT().GetLatestBlock().Return(&inter.Block{})
 				world.EXPECT().Header(any, any).Return(&evmcore.EvmHeader{
@@ -742,18 +761,19 @@ func TestEmitter_GetSortedTxs_ClassifiesCandidatesPriorityAgainstHeadStateWhenPr
 					PrevRandao: common.Hash{1}, // required by the EVM block context
 				})
 				world.EXPECT().GetUpgradeHeights()
-				txSigner.EXPECT().Sender(any).Return(common.Address{2}, nil)
 
-				// The head state is acquired for the duration of the build only.
-				// No registry is deployed, so the config read falls back to the
-				// fallback config and the candidate cannot be classified as
-				// prioritized.
-				// Two registry calls, one for the config and one for the candidate.
+				// It is read once for the config, and once more for the candidate
+				// unless its priority is already cached.
+				registryCalls := 1
+				if test.queried {
+					registryCalls = 2
+					txSigner.EXPECT().Sender(tx).Return(common.Address{1}, nil)
+				}
 				statedb := state.NewMockStateDB(ctrl)
-				statedb.EXPECT().InterTxSnapshot().Times(2)
-				statedb.EXPECT().RevertToInterTxSnapshot(any).Times(2)
-				statedb.EXPECT().Snapshot().Times(2)
-				statedb.EXPECT().Exist(registry.GetAddress()).Return(false).Times(2)
+				statedb.EXPECT().InterTxSnapshot().Times(registryCalls)
+				statedb.EXPECT().RevertToInterTxSnapshot(any).Times(registryCalls)
+				statedb.EXPECT().Snapshot().Times(registryCalls)
+				statedb.EXPECT().Exist(registry.GetAddress()).Return(false).Times(registryCalls)
 				statedb.EXPECT().Release()
 				world.EXPECT().StateDB().Return(statedb)
 			}
@@ -768,15 +788,19 @@ func TestEmitter_GetSortedTxs_ClassifiesCandidatesPriorityAgainstHeadStateWhenPr
 				config: config.Config{MaxTxsPerAddress: 10},
 				world:  World{External: world, TxPool: txPool, TransactionSigner: txSigner},
 			}
+			cacheClassifier := priorities.NewMockClassifier(ctrl)
+			em.priorityCache = evmcore.NewPriorityCache(evmcore.DefaultTxPoolConfig)
+			// If the element should be cached, query it here once so that it is added to the cache.
+			if test.cached != nil {
+				cacheClassifier.EXPECT().Priority(tx).Return(*test.cached, nil)
+				em.priorityCache.GetOrClassify(tx, cacheClassifier)
+			}
 
 			entry, ok := em.getSortedTxs(big.NewInt(0)).Peek()
 			require.True(t, ok)
 			require.Equal(t, tx.Hash(), entry.tx.Hash)
-			require.Equal(t, priorities.Priority{}, entry.priority)
-
-			// The rate limits read along with the context are kept for the event
-			// built from this ordering.
-			require.Equal(t, test.wantConfig, em.cache.priorityConfig)
+			require.Equal(t, test.expectPriority, entry.priority)
+			require.Equal(t, test.expectConfig, em.cache.priorityConfig)
 		})
 	}
 }
@@ -862,7 +886,10 @@ func TestEmitter_GetSortedTxs_ReusesTheCachedOrderingAndItsPriorityConfig(t *tes
 	em.cache.sortedTxs = newTransactionsByPriorityAndPriceAndNonce(
 		map[common.Address][]*txpool.LazyTransaction{sender: {tx}},
 		nil,
-		&priorityContext{classifier: classifier},
+		&priorityContext{
+			cache:      evmcore.NewPriorityCache(evmcore.DefaultTxPoolConfig),
+			classifier: classifier,
+		},
 		alwaysMyTurn,
 	)
 	em.cache.poolBlock = idx.Block(1)

--- a/gossip/emitter/ordering_test.go
+++ b/gossip/emitter/ordering_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -281,7 +282,11 @@ func TestTransactionsByPriorityAndPriceAndNonce_OrdersByStagePriorityTipAndTime(
 		},
 	).AnyTimes()
 
-	txset := newTransactionsByPriorityAndPriceAndNonce(txBySender, nil, &priorityContext{classifier: classifier},
+	context := &priorityContext{
+		cache:      evmcore.NewPriorityCache(evmcore.DefaultTxPoolConfig),
+		classifier: classifier,
+	}
+	txset := newTransactionsByPriorityAndPriceAndNonce(txBySender, nil, context,
 		func(tx *txpool.LazyTransaction) bool { return turnByHash[tx.Hash] })
 
 	got := make([]string, 0, len(expected))

--- a/gossip/emitter/parents_test.go
+++ b/gossip/emitter/parents_test.go
@@ -38,6 +38,7 @@ func TestChooseParents_NoParentsForGenesisEvent(t *testing.T) {
 		fixedPriceBaseFeeSource{},
 		nil,
 		nil,
+		nil,
 	)
 
 	epoch := idx.Epoch(1)
@@ -64,6 +65,7 @@ func TestChooseParents_NonGenesisEventMustHaveOneSelfParent(t *testing.T) {
 		config.DefaultConfig(),
 		World{External: external},
 		fixedPriceBaseFeeSource{},
+		nil,
 		nil,
 		nil,
 	)

--- a/gossip/emitter/priorities.go
+++ b/gossip/emitter/priorities.go
@@ -27,8 +27,10 @@ import (
 // priorityContext holds the state required to classify and rate-limit
 // prioritized transactions against the current head block. It is owned by the
 // emitter for the duration of one ordering build, which is the only user of the
-// acquired state db.
+// acquired state db. The cache it classifies into outlives the context, see
+// PriorityCache.
 type priorityContext struct {
+	cache      *evmcore.PriorityCache
 	classifier priorities.Classifier
 	config     priorities.Config
 	releaseDB  func()
@@ -69,6 +71,7 @@ func (em *Emitter) newPriorityContext() *priorityContext {
 	config := priorities.GetConfigOrFallback(rules.Upgrades, evm, priorityConfigFailures)
 	statedb.RevertToInterTxSnapshot(snapshot)
 	return &priorityContext{
+		cache:      em.priorityCache,
 		classifier: priorities.NewEvmClassifier(rules.Upgrades, evm, em.world.TransactionSigner, statedb, priorityTxFailures),
 		config:     config,
 		releaseDB:  statedb.Release,
@@ -89,11 +92,7 @@ func (c *priorityContext) priorityOf(tx *types.Transaction) priorities.Priority 
 	if c == nil {
 		return priorities.Priority{}
 	}
-	priority, err := c.classifier.Priority(tx)
-	if err != nil {
-		return priorities.Priority{}
-	}
-	return priority
+	return c.cache.GetOrClassify(tx, c.classifier)
 }
 
 // getConfig returns the rate limits read along with the context, or the

--- a/gossip/emitter/priorities_test.go
+++ b/gossip/emitter/priorities_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
@@ -113,8 +114,7 @@ func TestPriorityContext_Release_CallsReleaseDBFunctionIfContextNotNil(t *testin
 }
 
 func TestPriorityContext_PriorityOf_TakesTheClassificationUnlessItFails(t *testing.T) {
-	key, _ := newSenderKey(t)
-	tx := makeLazyTx(t, key, 0, 1, baseTime).Tx
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
 
 	tests := map[string]struct {
 		priority priorities.Priority
@@ -141,17 +141,18 @@ func TestPriorityContext_PriorityOf_TakesTheClassificationUnlessItFails(t *testi
 		t.Run(name, func(t *testing.T) {
 			classifier := priorities.NewMockClassifier(gomock.NewController(t))
 			classifier.EXPECT().Priority(tx).Return(test.priority, test.err)
-			context := &priorityContext{classifier: classifier}
+			context := &priorityContext{
+				cache:      evmcore.NewPriorityCache(evmcore.DefaultTxPoolConfig),
+				classifier: classifier,
+			}
 			require.Equal(t, test.expected, context.priorityOf(tx))
 		})
 	}
 }
 
 func TestPriorityContext_PriorityOf_ReturnsNotPrioritizedWhenContextIsNil(t *testing.T) {
-	key, _ := newSenderKey(t)
-
 	var context *priorityContext
-	require.Equal(t, priorities.Priority{}, context.priorityOf(makeLazyTx(t, key, 0, 1, baseTime).Tx))
+	require.Equal(t, priorities.Priority{}, context.priorityOf(types.NewTx(&types.LegacyTx{Nonce: 1})))
 }
 
 func TestPriorityContext_GetConfig_ReturnsConfigIfContextIsNotNil(t *testing.T) {

--- a/gossip/emitter/txs_test.go
+++ b/gossip/emitter/txs_test.go
@@ -580,5 +580,9 @@ func (f *addTxsFixture) makeSorted(t *testing.T, priorityOf map[common.Hash]prio
 		},
 	).AnyTimes()
 
-	return newTransactionsByPriorityAndPriceAndNonce(bySender, nil, &priorityContext{classifier: classifier}, policy)
+	context := &priorityContext{
+		cache:      evmcore.NewPriorityCache(evmcore.DefaultTxPoolConfig),
+		classifier: classifier,
+	}
+	return newTransactionsByPriorityAndPriceAndNonce(bySender, nil, context, policy)
 }


### PR DESCRIPTION
This PR adds a cache for the priorities queried by the emitter. This cache is needed, because otherwise every time `getSortedTxs` is called (and the state of the pool changed), the priorities of all transactions in the pool would be queried again. Every query is an EVM call and with the default pool size this would mean ~1500 EVM calls.
The cache resolves this issue since there will only be a single query for each transaction, no matter how often `getSortedTxs` gets called.