### PR TITLE
Fix flaky TestTransactionAllowedTxSize

### DIFF
--- a/evmcore/tx_pool_test.go
+++ b/evmcore/tx_pool_test.go
@@ -2130,8 +2130,13 @@ func TestTransactionAllowedTxSize(t *testing.T) {
 	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentMaxGas, big.NewInt(1), key, txMaxSize)); err == nil {
 		t.Fatalf("expected rejection on slightly oversize transaction")
 	}
-	// Try adding a transaction of random not allowed size
-	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentMaxGas, big.NewInt(1), key, dataSize+1+uint64(rand.IntN(10*txMaxSize)))); err == nil {
+	// Try adding a transaction of random not allowed size.
+	//
+	// The size is derived from txMaxSize rather than from dataSize: dataSize is
+	// a lower bound on the maximum allowed data size, so dataSize+1 is not
+	// guaranteed to exceed the limit. Letting the data alone exceed txMaxSize
+	// makes the rejection independent of the actual non-data overhead.
+	if err := pool.addRemoteSync(pricedDataTransaction(2, pool.currentMaxGas, big.NewInt(1), key, txMaxSize+1+uint64(rand.IntN(9*txMaxSize)))); err == nil {
 		t.Fatalf("expected rejection on oversize transaction")
 	}
 	// Run some sanity checks on the pool internals


### PR DESCRIPTION
Fixes https://github.com/0xsoniclabs/sonic-admin/issues/712

## Root cause — arithmetic, not timing

The reported failure ran in 0.01s, which already rules out a timing race.

`TestTransactionAllowedTxSize` computes

```go
baseSize := uint64(213)          // an upper estimate of the non-data fields
dataSize := txMaxSize - baseSize
```

`dataSize` is therefore a deliberately conservative **lower** bound on the maximum allowed data size, and it is used correctly as such where the test adds a transaction of maximal *allowed* size.

The "random not allowed size" case then reused it as if it were an **upper** bound:

```go
pricedDataTransaction(2, ..., dataSize+1+uint64(rand.IntN(10*txMaxSize)))
```

That assumes `dataSize+1` must be over the limit. It is not. The real RLP overhead of the transaction built here is about 103 bytes, not 213, so `tx.Size() ≈ d + 103`. With `d = dataSize+1+r = 130860 + r` and `txMaxSize = 131072`, rejection only holds once `r > 109`. For `r ∈ [0, 109]` the "oversize" transaction was legitimately **under** the limit, was correctly accepted by the pool, and the test failed.

`rand` here is an unseeded `math/rand/v2`, drawing fresh each run over `[0, 10*txMaxSize)`, so the failure probability is roughly `110/1310720 ≈ 8.4e-5` — about one run in twelve thousand, which matches the observed rate of a single sighting in two years.

## The fix

Derive the size from `txMaxSize` rather than from `dataSize`, so the data alone exceeds the cap and the expected rejection no longer depends on the non-data overhead at all:

```go
pricedDataTransaction(2, ..., txMaxSize+1+uint64(rand.IntN(9*txMaxSize)))
```

This is not a tolerance bump — it removes the dependence on an estimate that was being used in the wrong direction. The random range is kept at a comparable magnitude.

## Verification

The flake was reproduced **deterministically** rather than waited out, by pinning the draw to its worst case (`r = 0`):

```
tx_pool_test.go:2135: expected rejection on oversize transaction
--- FAIL: TestTransactionAllowedTxSize (0.01s)
```

That is the same assertion, message and duration as the report. With the fix applied and the *same* pinned input, the transaction is correctly rejected.

Statistical confirmation on top of that:

```
go test ./evmcore -run TestTransactionAllowedTxSize -count=20000 -race
  ok   github.com/0xsoniclabs/sonic/evmcore   1159.700s

go test ./evmcore -count=1
  ok   github.com/0xsoniclabs/sonic/evmcore   14.433s

go build ./...   OK
```

20,000 clean iterations is roughly 1.7× the expected failure interval at the old rate.

## Scope

Test-only. One expression plus an explanatory comment in `evmcore/tx_pool_test.go`. No product code, no shared test helpers.

---
*Prepared with Claude Code. The root-cause arithmetic was verified by deterministic reproduction, not inferred.*
