### PR TITLE
Bound the wait for pending-transaction notifications

### DIFF
--- a/tests/pending_transactions_subscription_test.go
+++ b/tests/pending_transactions_subscription_test.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/sonic/api/ethapi"
 	"github.com/0xsoniclabs/sonic/opera"
@@ -26,6 +27,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
+
+// pendingTxNotificationTimeout bounds the wait for a newPendingTransactions
+// notification. The notification is emitted when the transaction is accepted
+// into the pool rather than when it is included in a block, so this only has
+// to cover pool acceptance plus delivery over the web socket. It matches the
+// 60s RPC timeout the nodes of the integration test net are started with.
+const pendingTxNotificationTimeout = 60 * time.Second
 
 func TestPendingTransactionSubscription_ReturnsFullTransaction(t *testing.T) {
 
@@ -56,7 +64,15 @@ func TestPendingTransactionSubscription_ReturnsFullTransaction(t *testing.T) {
 	err = client.SendTransaction(t.Context(), tx)
 	require.NoError(t, err, "failed to send transaction ", err)
 
-	got := <-pendingTxs
+	var got *ethapi.RPCTransaction
+	select {
+	case got = <-pendingTxs:
+	case err := <-subs.Err():
+		t.Fatalf("subscription failed before a pending transaction was received: %v", err)
+	case <-time.After(pendingTxNotificationTimeout):
+		t.Fatalf("no pending-transaction notification received within %v", pendingTxNotificationTimeout)
+	}
+
 	want := ethapi.NewRPCPendingTransaction(tx, tx.GasPrice(), session.GetChainId())
 	require.Equal(t, want, got, "transaction from address does not match")
 
@@ -82,6 +98,14 @@ func TestPendingTransactionSubscription_ReturnsHashes(t *testing.T) {
 	err = client.SendTransaction(t.Context(), tx)
 	require.NoError(t, err, "failed to send transaction ", err)
 
-	got := <-pendingTxs
+	var got common.Hash
+	select {
+	case got = <-pendingTxs:
+	case err := <-subs.Err():
+		t.Fatalf("subscription failed before a pending transaction was received: %v", err)
+	case <-time.After(pendingTxNotificationTimeout):
+		t.Fatalf("no pending-transaction notification received within %v", pendingTxNotificationTimeout)
+	}
+
 	require.Equal(t, tx.Hash(), got, "transaction hash does not match")
 }

--- a/tests/pending_transactions_subscription_test.go
+++ b/tests/pending_transactions_subscription_test.go
@@ -31,7 +31,7 @@ import (
 // pendingTxNotificationTimeout bounds the wait for a newPendingTransactions
 // notification. The notification is emitted when the transaction is accepted
 // into the pool rather than when it is included in a block, so this only has
-// to cover pool acceptance plus delivery over the web socket. It matches the
+// to cover pool acceptance plus delivery over the WebSocket. It matches the
 // 60s RPC timeout the nodes of the integration test net are started with.
 const pendingTxNotificationTimeout = 60 * time.Second
 


### PR DESCRIPTION
Fixes https://github.com/0xsoniclabs/sonic-admin/issues/752

## Root cause

Both pending-transaction subscription tests received from the notification channel with a bare, unbounded channel receive:

```go
got := <-pendingTxs
```

No `select`, no case for `subs.Err()`, no timeout. If the subscription fails or a notification is never delivered, the test blocks forever and the deferred `subs.Unsubscribe()` never runs.

Because the suite runs as `go test --timeout 30m -failfast ./...` (`Makefile`), a single stuck test does not fail on its own — it takes down the **entire `tests` package** with a 30-minute panic. That is exactly what the report shows: `TestPendingTransactionSubscription_ReturnsHashes` hung for 27m34s, then `panic: test timed out after 30m0s` with `goroutine 1 [chan receive, 27 minutes]`.

The sibling test `TestPendingTransactionSubscription_ReturnsFullTransaction` had the identical hazard, so both are fixed here.

## The fix

Wrap both receives in a `select` over the notification channel, `subs.Err()`, and a bounded timeout — the pattern already used in `tests/block_in_archive_test.go`, which selects over both its head channel and `subscription.Err()`.

The timeout is 60s, matching the `--rpc.timeout 60s` the test net starts its nodes with (established in #997 and followed by #1043). A `newPendingTransactions` notification is emitted on **pool acceptance**, not block inclusion, so 60s is generous for what it has to cover.

## What this does and does not fix

This bounds the **symptom**. A lost notification now surfaces in seconds with a message that distinguishes a subscription error from a missing notification.

It does **not** explain why the notification went missing in the reported run. That could still be a genuine `newPendingTransactions` delivery bug, and it is worth investigating — note the test runs on the shared long-lived session net, so it competes with every other net in the package for CPU. The point of this change is that the next occurrence will be *diagnosable* in seconds instead of presenting as an unattributable 30-minute suite-wide panic.

## Verification

The failure mode was induced rather than waited for, by suppressing the send so no notification can arrive:

```
pending_transactions_subscription_test.go:105: no pending-transaction notification received within 5s
--- FAIL: TestPendingTransactionSubscription_ReturnsHashes (6.36s)
```

Six seconds with a clear diagnostic, in place of a 30-minute panic that took the package with it. (A short-timeout variant was also tried first and passed — with both select cases ready, Go picks at random — which is why the check was done by removing the notification entirely.)

Happy path, both tests:

```
--- PASS: TestPendingTransactionSubscription_ReturnsFullTransaction (1.27s)
--- PASS: TestPendingTransactionSubscription_ReturnsHashes (0.05s)

go vet ./tests   clean
```

The full `tests` package (~30 min) was not run; the change is confined to two receives in a single file. Happy to run it if a reviewer would like it before merge.

## Scope

Test-only. One file: `tests/pending_transactions_subscription_test.go`. No product code, no shared test helpers.

---
*Prepared with Claude Code. The containment was verified by inducing the failure, not inferred.*
