### PR TITLE
Wait for a readiness marker before interrupting the password read

### DIFF
--- a/cmd/sonicd/app/unlocking_test.go
+++ b/cmd/sonicd/app/unlocking_test.go
@@ -244,9 +244,30 @@ func TestUnlockFlagPasswordFifoInterruptedBySignal(t *testing.T) {
 		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a",
 		"--ipcdisable")
 
-	// Give the node a moment to start and block reading the empty password
-	// FIFO before sending the shutdown signal.
-	time.Sleep(500 * time.Millisecond)
+	// Wait until the node is actually blocked reading the empty password FIFO
+	// before sending the shutdown signal.
+	//
+	// A fixed sleep is not a sufficient barrier here: before reaching the
+	// blocking read the node has to install its signal handler, open the live
+	// and archive databases and start the whole gossip service. On a loaded
+	// machine, and in particular under the race detector, that can take well
+	// over half a second. An interrupt delivered before the signal handler is
+	// installed takes the default disposition and kills the node silently,
+	// which is exactly the empty-stderr failure reported in the issue.
+	//
+	// The log line below is emitted immediately before the blocking open of
+	// the FIFO, so its appearance is a reliable readiness marker.
+	const readyMarker = "Reading keystore password from file"
+	const readyTimeout = 60 * time.Second
+	deadline := time.Now().Add(readyTimeout)
+	for !strings.Contains(cli.StderrText(), readyMarker) {
+		if time.Now().After(deadline) {
+			cli.Kill()
+			t.Fatalf("node did not reach the password reading stage within %v, stderr:\n%s",
+				readyTimeout, cli.StderrText())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	cli.Interrupt()
 
 	exited := make(chan struct{})


### PR DESCRIPTION
Fixes https://github.com/0xsoniclabs/sonic-admin/issues/860

## Root cause

`TestUnlockFlagPasswordFifoInterruptedBySignal` used a fixed 500ms sleep as its only barrier before sending SIGINT:

```go
// Give the node a moment to start and block reading the empty password
// FIFO before sending the shutdown signal.
time.Sleep(500 * time.Millisecond)
cli.Interrupt()
```

Before it reaches the blocking read on the FIFO, the child has to re-exec the (race-instrumented) test binary, parse flags, install its signal handler via `signal.NotifyContext`, run `config.MakeNode` — which opens the live *and* archive databases and loads the fakenet genesis — and complete `stack.Start()`, bringing up the whole gossip service and emitter. Only then does `unlockAccounts` reach `readFileWithContext`, where the blocking `os.Open` on the FIFO and the `<-ctx.Done()` path actually live.

On a loaded CI machine, and especially under `-race`, that does not fit in 500ms. When the interrupt arrives first, the child takes the **default** SIGINT disposition and dies without printing anything — which is why the reported failure's `got:` was empty rather than containing some other error.

## The fix

Wait for the `"Reading keystore password from file"` log line, which `config.MakePasswordList` emits immediately before the blocking open of the FIFO. Its appearance is a genuine readiness marker: it proves both that the signal handler is installed and that the process is blocked exactly where the test intends.

`cmdtest.TestCmd.StderrText()` takes `tt.stderr.mu` before reading the buffer, so polling it while the child runs is safe under the race detector.

The 60s bound is a failure ceiling, not an expected wait — locally the marker appears in about 8s under `-race`. If it is ever hit, the test now reports the captured stderr, which is far more actionable than an empty-string mismatch.

## Verification

The original failure was reproduced **deterministically** by shortening the wait to 1ms:

```
unlocking_test.go:280: stderr text does not contain expected shutdown error, got:
--- FAIL: TestUnlockFlagPasswordFifoInterruptedBySignal (7.03s)
```

Note the empty `got:` — this is the reported signature, which confirms the mechanism is the interrupt racing the signal-handler installation rather than anything about the FIFO or the shutdown path itself.

With the marker wait in place:

```
go test ./cmd/sonicd/app -run TestUnlockFlagPasswordFifoInterruptedBySignal -count=5 -race
  ok   github.com/0xsoniclabs/sonic/cmd/sonicd/app   42.287s

go test ./cmd/sonicd/app -run TestUnlockFlagPasswordFifoInterruptedBySignal -count=3 -race
  ok   github.com/0xsoniclabs/sonic/cmd/sonicd/app   27.074s
```

## Note

This is not masking a product defect. The node does handle the signal correctly once `NotifyContext` is live; the unguarded window is the process startup that precedes it, which is inherent to any process and is the test's job to wait out.

The test was added three days before the issue was filed, in #1092, and nothing in `cmd/sonicd/app` has changed since — so this is a new test that was flaky from the start rather than a regression.

## Scope

Test-only. One file: `cmd/sonicd/app/unlocking_test.go`. No product code, no shared test helpers.

---
*Prepared with Claude Code. The root cause was verified by deterministic reproduction, not inferred.*
