### PR TITLE
Fix data race in TxPool.Stop from duplicate shutdown calls

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -330,6 +330,7 @@ type TxPool struct {
 	reorgDoneCh     chan chan struct{}
 	reorgShutdownCh chan struct{}  // requests shutdown of scheduleReorgLoop
 	wg              sync.WaitGroup // tracks loop, scheduleReorgLoop
+	stopOnce        sync.Once      // ensures Stop is only executed once, even if invoked concurrently
 
 	waitForIdleReorgLoopRequestCh  chan struct{} // requests to wait for reorg completion
 	waitForIdleReorgLoopResponseCh chan struct{} // responses to waitForReorgDoneRequestCh
@@ -506,21 +507,25 @@ func (pool *TxPool) loop() {
 	}
 }
 
-// Stop terminates the transaction pool.
+// Stop terminates the transaction pool. It is called both by the gossip
+// service's own shutdown and by config.MakeNode's cleanup chain, so it must
+// tolerate being invoked more than once, including concurrently.
 func (pool *TxPool) Stop() {
-	// Unsubscribe all subscriptions registered from txpool
-	pool.scope.Close()
+	pool.stopOnce.Do(func() {
+		// Unsubscribe all subscriptions registered from txpool
+		pool.scope.Close()
 
-	// Unsubscribe subscriptions registered from blockchain
-	pool.chainHeadSub.Unsubscribe()
-	pool.wg.Wait()
+		// Unsubscribe subscriptions registered from blockchain
+		pool.chainHeadSub.Unsubscribe()
+		pool.wg.Wait()
 
-	if pool.journal != nil {
-		if err := pool.journal.close(); err != nil {
-			log.Warn("Failed to close transaction journal:", err)
+		if pool.journal != nil {
+			if err := pool.journal.close(); err != nil {
+				log.Warn("Failed to close transaction journal:", err)
+			}
 		}
-	}
-	log.Info("Transaction pool stopped")
+		log.Info("Transaction pool stopped")
+	})
 }
 
 // SubscribeNewTxsNotify registers a subscription of NewTxsNotify and

--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -521,7 +521,7 @@ func (pool *TxPool) Stop() {
 
 		if pool.journal != nil {
 			if err := pool.journal.close(); err != nil {
-				log.Warn("Failed to close transaction journal:", err)
+				log.Warn("Failed to close transaction journal:", "err", err)
 			}
 		}
 		log.Info("Transaction pool stopped")


### PR DESCRIPTION
## Summary
- `TestUnlockFlagPasswordFifoInterruptedBySignal` occasionally fails under `-race`: `TxPool.Stop()` gets called twice concurrently during shutdown (once via `gossip.Service`'s node lifecycle stop, once via `config.MakeNode`'s cleanup chain), and both calls race on the unguarded `journal.writer` field.
- Guard `TxPool.Stop()` with `sync.Once` so repeated/concurrent calls are safe.

## Test plan
- [x] `go test -race -run TestUnlockFlagPasswordFifoInterruptedBySignal ./cmd/sonicd/app/...` passes, race and double-close warning are gone.