### PR TITLE
Connect two-node test networks from one end only

### DIFF
--- a/tests/connect_p2p_edges_test.go
+++ b/tests/connect_p2p_edges_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRingDialEdges_ConnectsPairsFromExactlyOneEnd(t *testing.T) {
+	// Dialing a pair from both ends can close both connections, see
+	// ringDialEdges. Two nodes are the case at risk: there the ring degenerates
+	// into a single pair.
+	for _, numNodes := range []int{2, 3, 4, 7} {
+		t.Run(fmt.Sprintf("nodes=%d", numNodes), func(t *testing.T) {
+			require := require.New(t)
+
+			seen := map[[2]int]bool{}
+			for _, edge := range ringDialEdges(numNodes) {
+				dialer, target := edge[0], edge[1]
+				require.NotEqual(dialer, target, "node must not dial itself")
+				require.Less(dialer, numNodes)
+				require.Less(target, numNodes)
+
+				pair := [2]int{min(dialer, target), max(dialer, target)}
+				require.False(seen[pair], "pair %v is dialed from both ends", pair)
+				seen[pair] = true
+			}
+		})
+	}
+}
+
+func TestRingDialEdges_FormsConnectedRing(t *testing.T) {
+	for _, numNodes := range []int{2, 3, 4, 7} {
+		t.Run(fmt.Sprintf("nodes=%d", numNodes), func(t *testing.T) {
+			require := require.New(t)
+
+			edges := ringDialEdges(numNodes)
+			// A ring needs one edge per node, except for two nodes, whose two
+			// ring edges collapse into a single connection.
+			want := numNodes
+			if numNodes == 2 {
+				want = 1
+			}
+			require.Len(edges, want)
+
+			// The connections must span all nodes.
+			neighbors := map[int][]int{}
+			for _, edge := range edges {
+				neighbors[edge[0]] = append(neighbors[edge[0]], edge[1])
+				neighbors[edge[1]] = append(neighbors[edge[1]], edge[0])
+			}
+			visited := map[int]bool{0: true}
+			queue := []int{0}
+			for len(queue) > 0 {
+				cur := queue[0]
+				queue = queue[1:]
+				for _, next := range neighbors[cur] {
+					if !visited[next] {
+						visited[next] = true
+						queue = append(queue, next)
+					}
+				}
+			}
+			require.Len(visited, numNodes, "the network is not fully connected")
+		})
+	}
+}
+
+func TestRingDialEdges_SingleNodeNeedsNoConnection(t *testing.T) {
+	require.Empty(t, ringDialEdges(1))
+	require.Empty(t, ringDialEdges(0))
+}

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -702,6 +702,32 @@ func (n *IntegrationTestNet) start() error {
 	return nil
 }
 
+// ringDialEdges returns the connections forming a ring over the given number of
+// nodes, as (dialer, target) pairs of node indexes: 0->1, 1->2, ..., n-1->0.
+// For two nodes it returns 0->1 alone, since 0->1 and 1->0 are the same pair.
+//
+// Dialing one pair from both ends can leave both nodes unconnected: each keeps
+// the connection it dialed itself and rejects the incoming one as "already
+// connected". The retry waits for the p2p dial cooldown (35s) that both nodes
+// started together, so it is equally simultaneous and can fail the same way.
+func ringDialEdges(numNodes int) [][2]int {
+	if numNodes < 2 {
+		return nil
+	}
+	edges := make([][2]int, 0, numNodes)
+	dialed := make(map[[2]int]bool, numNodes)
+	for dialer := range numNodes {
+		target := (dialer + 1) % numNodes
+		pair := [2]int{min(dialer, target), max(dialer, target)}
+		if dialed[pair] {
+			continue
+		}
+		dialed[pair] = true
+		edges = append(edges, [2]int{dialer, target})
+	}
+	return edges
+}
+
 // connectP2PNetwork connects all nodes in the network to each other.
 // The current implementation aims to keep the arity of the network low,
 // by connecting each node to the next one in the list, and the last one to the first.
@@ -713,13 +739,10 @@ func (n *IntegrationTestNet) connectP2PNetwork(enodes []string) error {
 		return nil
 	}
 
-	// First, register each node's next neighbor in the ring as trusted before
-	// waiting for any connections.
-	//
-	// - Trusted status is important because if a gossip handshake times out),
-	// 	 the gossip layer bans the peer's node ID via discfilter.Ban() and
-	//   subsequent attempts to connect with that peer are rejected in postHandshakeChecks.
-	// 	 Marking the configured ring peers as trusted prevents this rejection.
+	// First mark each node's ring neighbor as trusted, before any connection is
+	// initiated. A failed gossip handshake bans the peer's node ID via
+	// discfilter.Ban(), after which postHandshakeChecks rejects further
+	// connection attempts. Trusted peers are exempt from that check.
 	for i := range n.nodes {
 		client, err := n.GetClientConnectedToNode(i)
 		if err != nil {
@@ -727,15 +750,26 @@ func (n *IntegrationTestNet) connectP2PNetwork(enodes []string) error {
 		}
 
 		enode := enodes[(i+1)%len(n.nodes)]
-		if err := client.Client().Call(nil, "admin_addTrustedPeer", enode); err != nil {
-			client.Close()
+		err = client.Client().Call(nil, "admin_addTrustedPeer", enode)
+		client.Close()
+		if err != nil {
 			return fmt.Errorf("failed to add trusted peer on node %d: %v", i, err)
 		}
-		if err := client.Client().Call(nil, "admin_addPeer", enode); err != nil {
-			client.Close()
-			return fmt.Errorf("failed to add peer on node %d: %v", i, err)
+	}
+
+	// Then dial, once per pair of nodes, see ringDialEdges.
+	for _, edge := range ringDialEdges(len(n.nodes)) {
+		dialer, target := edge[0], edge[1]
+		client, err := n.GetClientConnectedToNode(dialer)
+		if err != nil {
+			return fmt.Errorf("failed to connect to the Ethereum client: %w", err)
 		}
+
+		err = client.Client().Call(nil, "admin_addPeer", enodes[target])
 		client.Close()
+		if err != nil {
+			return fmt.Errorf("failed to add peer on node %d: %v", dialer, err)
+		}
 	}
 
 	// Now wait for each node to have the expected number of connections.

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -714,15 +714,12 @@ func ringDialEdges(numNodes int) [][2]int {
 	if numNodes < 2 {
 		return nil
 	}
+	if numNodes == 2 {
+		return [][2]int{{0, 1}}
+	}
 	edges := make([][2]int, 0, numNodes)
-	dialed := make(map[[2]int]bool, numNodes)
 	for dialer := range numNodes {
 		target := (dialer + 1) % numNodes
-		pair := [2]int{min(dialer, target), max(dialer, target)}
-		if dialed[pair] {
-			continue
-		}
-		dialed[pair] = true
 		edges = append(edges, [2]int{dialer, target})
 	}
 	return edges


### PR DESCRIPTION
Fixes a sporadic integration test failure, seen for example on #1105:

```
--- FAIL: TestBlockParameters_BlockHeaderMatchesObservableBlockParameters/Sonic/single_proposer=false (103.76s)
    integration_test_net.go:497:
        Error: failed to connect P2P network: failed to wait for node 0 to be connected: context deadline exceeded
        Messages: failed to start the integration test network
```

## Cause

`connectP2PNetwork` dialed each node's next ring neighbor. For two nodes that means **both** nodes dial each other, as the ring edges `0->1` and `1->0` describe the same pair. When those two dials coincide, each node adds the connection it dialed itself to its peer set first and then rejects the incoming one as `already connected` — closing the connection the *other* node was keeping. Both nodes end up with no peers:

```
12:33:20.530 Adding p2p peer   peercount=1 id=c014… conn=trusted-staticdial
12:33:20.530 Adding p2p peer   peercount=1 id=c75e… conn=trusted-staticdial   <- each kept its own dial
12:33:20.530 Removing p2p peer peercount=0 id=c014… req=true err="already connected"
12:33:20.530 Removing p2p peer peercount=0 id=c75e… req=true err="already connected"
12:33:55.531 …identical double-drop 35.001s later
12:34:30.532 …resolved (one staticdial + one inbound)
```

Recovery is gated by the p2p dial cooldown (`dialHistoryExpiration = inboundThrottleTime + 5s` = 35s), and both nodes started that cooldown together — so the retry is equally simultaneous and can fail the same way. Three repeats (0s, 35s, 70s, next at 105s) exceed the 100s budget of `WaitFor`, which is the observed failure.

## Fix

Dial each *pair* of nodes from exactly one end. Trusted registration still happens for every node before any dial, unchanged. Rings over three or more nodes are unaffected, as their edges already are distinct pairs, so this only changes the two-node case.

## Validation

20 startups of a two-node network, pinned to two cores and built with coverage instrumentation to widen the race:

| | before | after |
|---|---|---|
| wall clock | 407s | 49s |
| stalled on the cooldown | 4 startups (up to 73s) | 0 |
| `already connected` drops | 12 | 0 |
| result | 1 FAIL, reproducing the CI error verbatim | pass |

Startup times before the fix were quantized on the cooldown — 1.8s, 6.5s, 36.8s, 41.3s, 73.7s — which is the fingerprint of 0, 1 or 2 double-drops.

Also passing: `TestBlockParameters_BlockHeaderMatchesObservableBlockParameters` across all hard forks and both proposer modes, plus `TestConnectP2PNetwork*`, `TestIntegrationTestNet*`, `TestRandao*` and `TestEventExtraData*`.

## Notes, not addressed here

- Integration tests run with `SONIC_VERBOSITY=1` (error only), so `Failed static peer setup` (warn) and every `Adding/Removing p2p peer` (debug) line is suppressed. None of the evidence above is visible in a CI log today; raising the level for CI would make this class of flake diagnosable from the log alone.
- `postHandshakeChecks` resolves conflicting simultaneous connections as "first to arrive wins locally", with no deterministic tie-break, so any two-node deployment with static peers configured on both ends can hit the same 35s stall. A tie-break (e.g. the lower node ID's dial always wins) would close it at the p2p layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
