### PR TITLE
Update carmen version 

### DIFF
--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -45,7 +45,11 @@ func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
 	if err != nil {
 		panic(fmt.Errorf("failed to create temporary dir for genesis: %v", err))
 	}
-	defer tmpDir.Cleanup(nil)
+	defer func() {
+		if err := tmpDir.Cleanup(); err != nil {
+			panic(fmt.Errorf("failed to cleanup temporary dir: %v", err))
+		}
+	}()
 
 	genesisStore, err := makefakegenesis.FakeGenesisStore(
 		validatorsNum,

--- a/cmd/sonicd/app/run_test.go
+++ b/cmd/sonicd/app/run_test.go
@@ -41,12 +41,22 @@ func tmpdir(t *testing.T) string {
 }
 
 func initFakenetDatadir(dataDir string, validatorsNum idx.Validator) {
-	genesisStore := makefakegenesis.FakeGenesisStore(
+	tmpDir, err := futils.MakeTempDir(dataDir, "genesis-tmp")
+	if err != nil {
+		panic(fmt.Errorf("failed to create temporary dir for genesis: %v", err))
+	}
+	defer tmpDir.Cleanup(nil)
+
+	genesisStore, err := makefakegenesis.FakeGenesisStore(
 		validatorsNum,
 		futils.ToFtmU256(1000000000),
 		futils.ToFtmU256(5000000),
 		opera.GetSonicUpgrades(),
+		tmpDir.Path(),
 	)
+	if err != nil {
+		panic(fmt.Errorf("failed to create genesis store: %v", err))
+	}
 	defer func() {
 		if err := genesisStore.Close(); err != nil {
 			panic(fmt.Errorf("failed to close genesis store: %v", err))

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -100,7 +100,7 @@ func gfileGenesisImport(ctx *cli.Context) (err error) {
 	})
 }
 
-func jsonGenesisImport(ctx *cli.Context) (err error) {
+func jsonGenesisImport(ctx *cli.Context) (retErr error) {
 	if len(ctx.Args()) < 1 {
 		return fmt.Errorf("this command requires an argument - the genesis file to import")
 	}
@@ -129,7 +129,9 @@ func jsonGenesisImport(ctx *cli.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temporary dir for the genesis: %w", err)
 	}
-	defer tmpDir.Cleanup(&err)
+	defer func() {
+		retErr = errors.Join(retErr, tmpDir.Cleanup())
+	}()
 
 	genesisStore, err := makefakegenesis.ApplyGenesisJson(genesisJson, tmpDir.Path())
 	if err != nil {
@@ -147,7 +149,7 @@ func jsonGenesisImport(ctx *cli.Context) (err error) {
 	})
 }
 
-func fakeGenesisImport(ctx *cli.Context) (err error) {
+func fakeGenesisImport(ctx *cli.Context) (retErr error) {
 	if len(ctx.Args()) < 1 {
 		return fmt.Errorf("this command requires an argument - the number of validators in the fake network")
 	}
@@ -188,7 +190,9 @@ func fakeGenesisImport(ctx *cli.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create temporary dir for the genesis: %w", err)
 	}
-	defer tmpDir.Cleanup(&err)
+	defer func() {
+		retErr = errors.Join(retErr, tmpDir.Cleanup())
+	}()
 
 	genesisStore, err := makefakegenesis.FakeGenesisStore(
 		idx.Validator(validatorsNumber),

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -125,7 +125,13 @@ func jsonGenesisImport(ctx *cli.Context) (err error) {
 		return fmt.Errorf("failed to load JSON genesis: %w", err)
 	}
 
-	genesisStore, err := makefakegenesis.ApplyGenesisJson(genesisJson)
+	tmpDir, err := futils.MakeTempDir(dataDir, "genesis-tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary dir for the genesis: %w", err)
+	}
+	defer tmpDir.Cleanup(&err)
+
+	genesisStore, err := makefakegenesis.ApplyGenesisJson(genesisJson, tmpDir.Path())
 	if err != nil {
 		return fmt.Errorf("failed to prepare JSON genesis: %w", err)
 	}
@@ -178,12 +184,22 @@ func fakeGenesisImport(ctx *cli.Context) (err error) {
 		return fmt.Errorf("invalid profile %v - must be 'sonic', 'allegro', or 'brio'", upgradesString)
 	}
 
-	genesisStore := makefakegenesis.FakeGenesisStore(
+	tmpDir, err := futils.MakeTempDir(dataDir, "genesis-tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary dir for the genesis: %w", err)
+	}
+	defer tmpDir.Cleanup(&err)
+
+	genesisStore, err := makefakegenesis.FakeGenesisStore(
 		idx.Validator(validatorsNumber),
 		futils.ToFtmU256(1_000_000_000),
 		futils.ToFtmU256(5_000_000),
 		upgrades,
+		tmpDir.Path(),
 	)
+	if err != nil {
+		return fmt.Errorf("failed to create genesis store: %w", err)
+	}
 	defer caution.CloseAndReportError(&err, genesisStore, "failed to close the genesis store")
 	return genesis.ImportGenesisStore(genesis.ImportParams{
 		GenesisStore:  genesisStore,

--- a/cmd/sonictool/app/heal.go
+++ b/cmd/sonictool/app/heal.go
@@ -59,11 +59,11 @@ func heal(ctx *cli.Context) (retErr error) {
 	chaindataDir := filepath.Join(dataDir, "chaindata")
 	carmenArchiveDir := filepath.Join(dataDir, "carmen", "archive")
 	carmenLiveDir := filepath.Join(dataDir, "carmen", "live")
-	carmenExportScratchDir, cleanup, err := utils.MakeTempDir(dataDir, "carmen-scratch")
+	carmenExportScratchDir, err := utils.MakeTempDir(dataDir, "carmen-scratch")
 	if err != nil {
 		return fmt.Errorf("failed to create scratch dir for carmen export; %v", err)
 	}
-	defer cleanup(&retErr)
+	defer carmenExportScratchDir.Cleanup(&retErr)
 
 	archiveInfo, err := os.Stat(carmenArchiveDir)
 	if err != nil || !archiveInfo.IsDir() {
@@ -115,7 +115,7 @@ func heal(ctx *cli.Context) (retErr error) {
 	log.Info("Archive state database reverted", "block", recoveredBlock)
 
 	log.Info("Re-creating live state from the archive...")
-	if err := healLiveFromArchive(cancelCtx, carmenLiveDir, carmenArchiveDir, carmenExportScratchDir, recoveredBlock); err != nil {
+	if err := healLiveFromArchive(cancelCtx, carmenLiveDir, carmenArchiveDir, carmenExportScratchDir.Path(), recoveredBlock); err != nil {
 		return fmt.Errorf("failed to re-create carmen live state from archive; %w", err)
 	}
 

--- a/cmd/sonictool/app/heal.go
+++ b/cmd/sonictool/app/heal.go
@@ -33,13 +33,14 @@ import (
 	"github.com/0xsoniclabs/sonic/cmd/sonictool/db"
 	"github.com/0xsoniclabs/sonic/config"
 	"github.com/0xsoniclabs/sonic/config/flags"
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/caution"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/log"
 	"gopkg.in/urfave/cli.v1"
 )
 
-func heal(ctx *cli.Context) error {
+func heal(ctx *cli.Context) (retErr error) {
 	dataDir := ctx.GlobalString(flags.DataDirFlag.Name)
 	if dataDir == "" {
 		return fmt.Errorf("--%s need to be set", flags.DataDirFlag.Name)
@@ -58,6 +59,11 @@ func heal(ctx *cli.Context) error {
 	chaindataDir := filepath.Join(dataDir, "chaindata")
 	carmenArchiveDir := filepath.Join(dataDir, "carmen", "archive")
 	carmenLiveDir := filepath.Join(dataDir, "carmen", "live")
+	carmenExportScratchDir, cleanup, err := utils.MakeTempDir(dataDir, "carmen-scratch")
+	if err != nil {
+		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
+	}
+	defer cleanup(&retErr)
 
 	archiveInfo, err := os.Stat(carmenArchiveDir)
 	if err != nil || !archiveInfo.IsDir() {
@@ -109,7 +115,7 @@ func heal(ctx *cli.Context) error {
 	log.Info("Archive state database reverted", "block", recoveredBlock)
 
 	log.Info("Re-creating live state from the archive...")
-	if err := healLiveFromArchive(cancelCtx, carmenLiveDir, carmenArchiveDir, recoveredBlock); err != nil {
+	if err := healLiveFromArchive(cancelCtx, carmenLiveDir, carmenArchiveDir, carmenExportScratchDir, recoveredBlock); err != nil {
 		return fmt.Errorf("failed to re-create carmen live state from archive; %w", err)
 	}
 
@@ -117,7 +123,7 @@ func heal(ctx *cli.Context) error {
 	return nil
 }
 
-func healLiveFromArchive(ctx context.Context, carmenLiveDir, carmenArchiveDir string, recoveredBlock idx.Block) (err error) {
+func healLiveFromArchive(ctx context.Context, carmenLiveDir, carmenArchiveDir, carmenExportScratchDir string, recoveredBlock idx.Block) (err error) {
 	if err := os.RemoveAll(carmenLiveDir); err != nil {
 		return fmt.Errorf("failed to remove broken live state: %w", err)
 	}
@@ -136,7 +142,7 @@ func healLiveFromArchive(ctx context.Context, carmenLiveDir, carmenArchiveDir st
 	go func() {
 		defer wg.Done()
 		defer caution.CloseAndReportError(&exportErr, writer, "failed to close writer")
-		exportErr = mptio.ExportBlockFromArchive(ctx, mptio.NewLog(), carmenArchiveDir, bufWriter, uint64(recoveredBlock))
+		exportErr = mptio.ExportBlockFromArchive(ctx, mptio.NewLog(), carmenArchiveDir, bufWriter, uint64(recoveredBlock), carmenExportScratchDir)
 		if exportErr == nil {
 			exportErr = bufWriter.Flush()
 		}

--- a/cmd/sonictool/app/heal.go
+++ b/cmd/sonictool/app/heal.go
@@ -63,7 +63,9 @@ func heal(ctx *cli.Context) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("failed to create scratch dir for carmen export; %v", err)
 	}
-	defer carmenExportScratchDir.Cleanup(&retErr)
+	defer func() {
+		retErr = errors.Join(retErr, carmenExportScratchDir.Cleanup())
+	}()
 
 	archiveInfo, err := os.Stat(carmenArchiveDir)
 	if err != nil || !archiveInfo.IsDir() {

--- a/cmd/sonictool/app/heal.go
+++ b/cmd/sonictool/app/heal.go
@@ -61,7 +61,7 @@ func heal(ctx *cli.Context) (retErr error) {
 	carmenLiveDir := filepath.Join(dataDir, "carmen", "live")
 	carmenExportScratchDir, cleanup, err := utils.MakeTempDir(dataDir, "carmen-scratch")
 	if err != nil {
-		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
+		return fmt.Errorf("failed to create scratch dir for carmen export; %v", err)
 	}
 	defer cleanup(&retErr)
 

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -187,12 +187,12 @@ func exportBlocksSection(ctx context.Context, gdb *gossip.Store, writer *unitWri
 
 func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) error {
 	log.Info("Exporting Sonic World State Live data")
-	liveScratchDir, _, err := utils.MakeTempDir(tmpPath, "live-scratch")
+	liveScratchDir, err := utils.MakeTempDir(tmpPath, "live-scratch")
 	if err != nil {
 		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
 	}
 
-	if err := gdb.EvmStore().ExportLiveWorldState(ctx, writer, liveScratchDir); err != nil {
+	if err := gdb.EvmStore().ExportLiveWorldState(ctx, writer, liveScratchDir.Path()); err != nil {
 		return err
 	}
 	fwsHash, err := writer.Flush()
@@ -206,12 +206,12 @@ func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter
 
 func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) error {
 	log.Info("Exporting Sonic World State Archive data")
-	archiveScratchDir, _, err := utils.MakeTempDir(tmpPath, "archive-scratch")
+	archiveScratchDir, err := utils.MakeTempDir(tmpPath, "archive-scratch")
 	if err != nil {
 		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
 	}
 
-	if err := gdb.EvmStore().ExportArchiveWorldState(ctx, writer, archiveScratchDir); err != nil {
+	if err := gdb.EvmStore().ExportArchiveWorldState(ctx, writer, archiveScratchDir.Path()); err != nil {
 		return err
 	}
 

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -185,7 +185,7 @@ func exportBlocksSection(ctx context.Context, gdb *gossip.Store, writer *unitWri
 	return nil
 }
 
-func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) (retErr error) {
+func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) error {
 	log.Info("Exporting Sonic World State Live data")
 	liveScratchDir, _, err := utils.MakeTempDir(tmpPath, "live-scratch")
 	if err != nil {
@@ -204,7 +204,7 @@ func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter
 	return nil
 }
 
-func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) (retErr error) {
+func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) error {
 	log.Info("Exporting Sonic World State Archive data")
 	archiveScratchDir, _, err := utils.MakeTempDir(tmpPath, "archive-scratch")
 	if err != nil {

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -30,6 +30,7 @@ import (
 	"github.com/0xsoniclabs/sonic/opera/genesis"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore"
 	"github.com/0xsoniclabs/sonic/opera/genesisstore/fileshash"
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/0xsoniclabs/sonic/utils/devnullfile"
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -82,7 +83,7 @@ func ExportGenesis(ctx context.Context, gdb *gossip.Store, includeArchive bool, 
 	if err := writer.Start(header, "fws", tmpPath); err != nil {
 		return err
 	}
-	if err := exportFwsSection(ctx, gdb, writer); err != nil {
+	if err := exportFwsSection(ctx, gdb, writer, tmpPath); err != nil {
 		return err
 	}
 
@@ -92,7 +93,7 @@ func ExportGenesis(ctx context.Context, gdb *gossip.Store, includeArchive bool, 
 		if err := writer.Start(header, "fwa", tmpPath); err != nil {
 			return err
 		}
-		if err := exportFwaSection(ctx, gdb, writer); err != nil {
+		if err := exportFwaSection(ctx, gdb, writer, tmpPath); err != nil {
 			return err
 		}
 	}
@@ -184,9 +185,15 @@ func exportBlocksSection(ctx context.Context, gdb *gossip.Store, writer *unitWri
 	return nil
 }
 
-func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter) error {
+func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) (retErr error) {
 	log.Info("Exporting Sonic World State Live data")
-	if err := gdb.EvmStore().ExportLiveWorldState(ctx, writer); err != nil {
+	liveScratchDir, cleanup, err := utils.MakeTempDir(tmpPath, "live-scratch")
+	if err != nil {
+		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
+	}
+	defer cleanup(&retErr)
+
+	if err := gdb.EvmStore().ExportLiveWorldState(ctx, writer, liveScratchDir); err != nil {
 		return err
 	}
 	fwsHash, err := writer.Flush()
@@ -198,9 +205,15 @@ func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter
 	return nil
 }
 
-func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter) error {
+func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) (retErr error) {
 	log.Info("Exporting Sonic World State Archive data")
-	if err := gdb.EvmStore().ExportArchiveWorldState(ctx, writer); err != nil {
+	archiveScratchDir, cleanup, err := utils.MakeTempDir(tmpPath, "archive-scratch")
+	if err != nil {
+		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
+	}
+	defer cleanup(&retErr)
+
+	if err := gdb.EvmStore().ExportArchiveWorldState(ctx, writer, archiveScratchDir); err != nil {
 		return err
 	}
 

--- a/cmd/sonictool/genesis/export.go
+++ b/cmd/sonictool/genesis/export.go
@@ -187,11 +187,10 @@ func exportBlocksSection(ctx context.Context, gdb *gossip.Store, writer *unitWri
 
 func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) (retErr error) {
 	log.Info("Exporting Sonic World State Live data")
-	liveScratchDir, cleanup, err := utils.MakeTempDir(tmpPath, "live-scratch")
+	liveScratchDir, _, err := utils.MakeTempDir(tmpPath, "live-scratch")
 	if err != nil {
 		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
 	}
-	defer cleanup(&retErr)
 
 	if err := gdb.EvmStore().ExportLiveWorldState(ctx, writer, liveScratchDir); err != nil {
 		return err
@@ -207,11 +206,10 @@ func exportFwsSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter
 
 func exportFwaSection(ctx context.Context, gdb *gossip.Store, writer *unitWriter, tmpPath string) (retErr error) {
 	log.Info("Exporting Sonic World State Archive data")
-	archiveScratchDir, cleanup, err := utils.MakeTempDir(tmpPath, "archive-scratch")
+	archiveScratchDir, _, err := utils.MakeTempDir(tmpPath, "archive-scratch")
 	if err != nil {
 		return fmt.Errorf("failed to create scratch dir for FWS export; %v", err)
 	}
-	defer cleanup(&retErr)
 
 	if err := gdb.EvmStore().ExportArchiveWorldState(ctx, writer, archiveScratchDir); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ module github.com/0xsoniclabs/sonic
 go 1.26.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4
+	github.com/0xsoniclabs/carmen/go v0.0.0-20260805094353-570a67532cc9
 	github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4 h1:HF2gKas3kyQx28LDcN4jn1yafxa4+gsy+UXUEnli2Kc=
-github.com/0xsoniclabs/carmen/go v0.0.0-20260512102324-2d892af38ce4/go.mod h1:ebS6LBL8TM3tKnRf9AHVb4FYQbb+edg3f7Gw/HnAffA=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260805094353-570a67532cc9 h1:2W+KqAw67WE6/GRH8RCdTsZiRIdp8tqZpjttGuRcY3M=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260805094353-570a67532cc9/go.mod h1:9u3EvorvPYLr24PH++pti4xBgIMLgOMHrshupYjqCB0=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe h1:JPiyJPZ1oBzRwsRW0BER76wChPg7rOxKwk1W5YUkKlE=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=

--- a/gossip/common_test.go
+++ b/gossip/common_test.go
@@ -236,14 +236,16 @@ func newInMemoryStoreWithGenesisData(
 	rules.Epochs.MaxEpochDuration = inter.Timestamp(maxEpochDuration)
 	rules.Emitter.Interval = 0
 
-	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
+	genStore, err := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
 		numValidators,
 		utils.ToFtmU256(genesisBalance),
 		utils.ToFtmU256(genesisStake),
 		rules,
 		firstEpoch,
 		2,
+		tb.TempDir(),
 	)
+	require.NoError(err)
 	genesis := genStore.Genesis()
 
 	store, err := NewMemStore(tb)

--- a/gossip/emitter_world_test.go
+++ b/gossip/emitter_world_test.go
@@ -59,14 +59,16 @@ func initStoreForTests(t *testing.T) *Store {
 	store, err := NewMemStore(t)
 	require.NoError(err)
 
-	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
+	genStore, err := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
 		2,
 		utils.ToFtmU256(genesisBalance),
 		utils.ToFtmU256(genesisStake),
 		opera.FakeNetRules(opera.GetSonicUpgrades()),
 		2,
 		2,
+		t.TempDir(),
 	)
+	require.NoError(err)
 	genesis := genStore.Genesis()
 	require.NoError(store.ApplyGenesis(genesis))
 	return store

--- a/gossip/evmstore/statedb_import.go
+++ b/gossip/evmstore/statedb_import.go
@@ -104,7 +104,7 @@ func (s *Store) InitializeArchiveWorldState(liveReader io.Reader, blockNum uint6
 
 // ExportLiveWorldState exports Sonic World State data for the live state genesis section.
 // The Store must be closed during the call.
-func (s *Store) ExportLiveWorldState(ctx context.Context, out io.Writer, scratchDir string) (retErr error) {
+func (s *Store) ExportLiveWorldState(ctx context.Context, out io.Writer, scratchDir string) error {
 	liveDir := filepath.Join(s.parameters.Directory, "live")
 	if err := mptio.Export(ctx, mptio.NewLog(), liveDir, out, scratchDir); err != nil {
 		return fmt.Errorf("failed to export Live StateDB; %v", err)
@@ -114,7 +114,7 @@ func (s *Store) ExportLiveWorldState(ctx context.Context, out io.Writer, scratch
 
 // ExportArchiveWorldState exports Sonic World State data for the archive state genesis section.
 // The Store must be closed during the call.
-func (s *Store) ExportArchiveWorldState(ctx context.Context, out io.Writer, scratchDir string) (retErr error) {
+func (s *Store) ExportArchiveWorldState(ctx context.Context, out io.Writer, scratchDir string) error {
 	archiveDir := filepath.Join(s.parameters.Directory, "archive")
 	if err := mptio.ExportArchiveWithConfig(
 		ctx,

--- a/gossip/evmstore/statedb_import.go
+++ b/gossip/evmstore/statedb_import.go
@@ -104,9 +104,9 @@ func (s *Store) InitializeArchiveWorldState(liveReader io.Reader, blockNum uint6
 
 // ExportLiveWorldState exports Sonic World State data for the live state genesis section.
 // The Store must be closed during the call.
-func (s *Store) ExportLiveWorldState(ctx context.Context, out io.Writer) error {
+func (s *Store) ExportLiveWorldState(ctx context.Context, out io.Writer, scratchDir string) (retErr error) {
 	liveDir := filepath.Join(s.parameters.Directory, "live")
-	if err := mptio.Export(ctx, mptio.NewLog(), liveDir, out); err != nil {
+	if err := mptio.Export(ctx, mptio.NewLog(), liveDir, out, scratchDir); err != nil {
 		return fmt.Errorf("failed to export Live StateDB; %v", err)
 	}
 	return nil
@@ -114,13 +114,14 @@ func (s *Store) ExportLiveWorldState(ctx context.Context, out io.Writer) error {
 
 // ExportArchiveWorldState exports Sonic World State data for the archive state genesis section.
 // The Store must be closed during the call.
-func (s *Store) ExportArchiveWorldState(ctx context.Context, out io.Writer) error {
+func (s *Store) ExportArchiveWorldState(ctx context.Context, out io.Writer, scratchDir string) (retErr error) {
 	archiveDir := filepath.Join(s.parameters.Directory, "archive")
 	if err := mptio.ExportArchiveWithConfig(
 		ctx,
 		mptio.NewLog(),
 		archiveDir,
 		out,
+		scratchDir,
 		mpt.NodeCacheConfig{Capacity: s.cfg.Cache.StateDbCapacity},
 		mpt.ArchiveConfig{},
 	); err != nil {

--- a/gossip/handler_fuzz_test.go
+++ b/gossip/handler_fuzz_test.go
@@ -104,12 +104,16 @@ func makeFuzzedHandler(t *testing.T) (*handler, error) {
 
 	upgrades := opera.GetSonicUpgrades()
 
-	genStore := makefakegenesis.FakeGenesisStore(
+	genStore, err := makefakegenesis.FakeGenesisStore(
 		genesisStakers,
 		utils.ToFtmU256(genesisBalance),
 		utils.ToFtmU256(genesisStake),
 		upgrades,
+		t.TempDir(),
 	)
+	if err != nil {
+		return nil, err
+	}
 	genesis := genStore.Genesis()
 
 	store, err := NewMemStore(t)

--- a/integration/makefakegenesis/genesis.go
+++ b/integration/makefakegenesis/genesis.go
@@ -18,6 +18,7 @@ package makefakegenesis
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -60,22 +61,31 @@ func FakeKey(n idx.ValidatorID) *ecdsa.PrivateKey {
 	return evmcore.FakeKey(uint32(n))
 }
 
-func FakeGenesisStore(num idx.Validator, balance, stake *uint256.Int, upgrades opera.Upgrades) *genesisstore.Store {
-	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules(upgrades))
+// FakeGenesisStore creates a fake genesis store. The given tmpDir is used for temporary
+// data produced while reading the resulting store, see makegenesis.NewGenesisBuilder.
+func FakeGenesisStore(num idx.Validator, balance, stake *uint256.Int, upgrades opera.Upgrades, tmpDir string) (*genesisstore.Store, error) {
+	return FakeGenesisStoreWithRules(num, balance, stake, opera.FakeNetRules(upgrades), tmpDir)
 }
 
-func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *uint256.Int, rules opera.Rules) *genesisstore.Store {
-	return FakeGenesisStoreWithRulesAndStart(num, balance, stake, rules, 2, 1)
+// FakeGenesisStoreWithRules is like FakeGenesisStore, but with explicit network rules.
+func FakeGenesisStoreWithRules(num idx.Validator, balance, stake *uint256.Int, rules opera.Rules, tmpDir string) (*genesisstore.Store, error) {
+	return FakeGenesisStoreWithRulesAndStart(num, balance, stake, rules, 2, 1, tmpDir)
 }
 
+// FakeGenesisStoreWithRulesAndStart is like FakeGenesisStoreWithRules, but with an explicit
+// start epoch and block.
 func FakeGenesisStoreWithRulesAndStart(
 	num idx.Validator,
 	balance, stake *uint256.Int,
 	rules opera.Rules,
 	epoch idx.Epoch,
 	block idx.Block,
-) *genesisstore.Store {
-	builder := makegenesis.NewGenesisBuilder()
+	tmpDir string,
+) (*genesisstore.Store, error) {
+	builder, err := makegenesis.NewGenesisBuilder(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create genesis builder: %v", err)
+	}
 
 	validators := GetFakeValidators(num)
 

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -212,8 +212,14 @@ func GenerateFakeJsonGenesis(
 	return jsonGenesis
 }
 
-func GetGenesisIdFromJson(json *GenesisJson) (common.Hash, error) {
-	store, err := ApplyGenesisJson(json)
+func GetGenesisIdFromJson(json *GenesisJson, tmpDir string) (_ common.Hash, retErr error) {
+	genesisTmpDir, err := utils.MakeTempDir(tmpDir, "sonic-tmp-genesis-json")
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to create temporary dir for genesis; %w", err)
+	}
+	defer genesisTmpDir.Cleanup(&retErr)
+
+	store, err := ApplyGenesisJson(json, genesisTmpDir.Path())
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to apply genesis json; %v", err)
 	}
@@ -221,12 +227,18 @@ func GetGenesisIdFromJson(json *GenesisJson) (common.Hash, error) {
 	return common.Hash(store.Genesis().GenesisID), nil
 }
 
-func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
+// ApplyGenesisJson builds a genesis store from the given JSON genesis definition. The given
+// tmpDir is used for temporary data produced while reading the resulting store, see
+// makegenesis.NewGenesisBuilder.
+func ApplyGenesisJson(json *GenesisJson, tmpDir string) (*genesisstore.Store, error) {
 	if json.BlockZeroTime.IsZero() {
 		return nil, fmt.Errorf("block zero time must be set")
 	}
 
-	builder := makegenesis.NewGenesisBuilder()
+	builder, err := makegenesis.NewGenesisBuilder(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create genesis builder: %v", err)
+	}
 	for _, acc := range json.Accounts {
 		if acc.Balance != nil {
 			builder.AddBalance(acc.Address, acc.Balance)
@@ -300,7 +312,7 @@ func ApplyGenesisJson(json *GenesisJson) (*genesisstore.Store, error) {
 		GenesisID:   builder.CurrentHash(),
 		NetworkID:   json.Rules.NetworkID,
 		NetworkName: json.Rules.Name,
-	}), nil
+	})
 }
 
 type VariableLenCode []byte

--- a/integration/makefakegenesis/json.go
+++ b/integration/makefakegenesis/json.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -217,7 +218,9 @@ func GetGenesisIdFromJson(json *GenesisJson, tmpDir string) (_ common.Hash, retE
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to create temporary dir for genesis; %w", err)
 	}
-	defer genesisTmpDir.Cleanup(&retErr)
+	defer func() {
+		retErr = errors.Join(retErr, genesisTmpDir.Cleanup())
+	}()
 
 	store, err := ApplyGenesisJson(json, genesisTmpDir.Path())
 	if err != nil {

--- a/integration/makefakegenesis/json_test.go
+++ b/integration/makefakegenesis/json_test.go
@@ -27,13 +27,13 @@ import (
 
 func TestJsonGenesis_CanApplyGeneratedFakeJsonGensis(t *testing.T) {
 	genesis := GenerateFakeJsonGenesis(opera.GetSonicUpgrades(), CreateEqualValidatorStake(1))
-	_, err := ApplyGenesisJson(genesis)
+	_, err := ApplyGenesisJson(genesis, t.TempDir())
 	require.NoError(t, err)
 }
 
 func TestJsonGenesis_AcceptsGenesisWithoutCommittee(t *testing.T) {
 	genesis := GenerateFakeJsonGenesis(opera.GetSonicUpgrades(), CreateEqualValidatorStake(1))
-	_, err := ApplyGenesisJson(genesis)
+	_, err := ApplyGenesisJson(genesis, t.TempDir())
 	require.NoError(t, err)
 }
 
@@ -53,7 +53,7 @@ func TestJsonGenesis_Network_RulesValidated_WithAllegroAndLater(t *testing.T) {
 
 			genesis := GenerateFakeJsonGenesis(upgrades, CreateEqualValidatorStake(1))
 			genesis.Rules.Upgrades.Llr = true // LLR is not supported in any hardfork
-			_, err := ApplyGenesisJson(genesis)
+			_, err := ApplyGenesisJson(genesis, t.TempDir())
 
 			// Validation of network rules introduced in Allegro
 			if name == "Sonic" {
@@ -68,11 +68,11 @@ func TestJsonGenesis_Network_RulesValidated_WithAllegroAndLater(t *testing.T) {
 func TestJsonGenesis_GetGenesisIdFromJson(t *testing.T) {
 	genesis := GenerateFakeJsonGenesis(opera.GetSonicUpgrades(), CreateEqualValidatorStake(1))
 
-	store, err := ApplyGenesisJson(genesis)
+	store, err := ApplyGenesisJson(genesis, t.TempDir())
 	require.NoError(t, err)
 	want := common.Hash(store.Genesis().GenesisID)
 
-	got, err := GetGenesisIdFromJson(genesis)
+	got, err := GetGenesisIdFromJson(genesis, t.TempDir())
 	require.NoError(t, err)
 	require.NotZero(t, got)
 
@@ -84,7 +84,7 @@ func TestJsonGenesis_GetGenesisIdFromJson_ReportsErrorsFromApplyGenesis(t *testi
 	genesis := GenerateFakeJsonGenesis(opera.GetSonicUpgrades(), CreateEqualValidatorStake(1))
 	genesis.BlockZeroTime = time.Time{} // invalid time
 
-	_, err := GetGenesisIdFromJson(genesis)
+	_, err := GetGenesisIdFromJson(genesis, t.TempDir())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to apply genesis json")
 }

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/holiman/uint256"
 
@@ -61,12 +62,13 @@ type GenesisBuilder struct {
 	tmpStateDB    state.StateDB
 	carmenDir     string
 	carmenStateDb carmen.StateDB
-
-	totalSupply *uint256.Int
+	totalSupply   *uint256.Int
 
 	blocks       []ibr.LlrIdxFullBlockRecord
 	epochs       []ier.LlrIdxFullEpochRecord
 	currentEpoch ier.LlrIdxFullEpochRecord
+
+	dataDir string // temporary directory for genesis data export
 }
 
 type BlockProc struct {
@@ -150,11 +152,19 @@ func NewGenesisBuilder() *GenesisBuilder {
 	// Set cache size to lowest value possible
 	carmenStateDb := carmen.CreateCustomStateDBUsing(carmenState, 1024)
 	tmpStateDB := evmstore.CreateCarmenStateDb(carmenStateDb, nil)
+
+	// Create a temporary directory for the genesis data
+	dataDir, err := os.MkdirTemp("", "opera-tmp-genesis-data")
+	if err != nil {
+		panic(fmt.Errorf("failed to create temporary dir for GenesisBuilder data: %v", err))
+	}
+
 	return &GenesisBuilder{
 		tmpStateDB:    tmpStateDB,
 		carmenDir:     carmenDir,
 		carmenStateDb: carmenStateDb,
 		totalSupply:   new(uint256.Int),
+		dataDir:       dataDir,
 	}
 }
 
@@ -353,7 +363,7 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 	if err != nil {
 		panic(fmt.Errorf("failed to close genesis carmen state; %s", err))
 	}
-	return genesisstore.NewStore(func(name string) (io.Reader, error) {
+	return genesisstore.NewStore(func(name string) (_ io.Reader, retErr error) {
 		buf := &memFile{bytes.NewBuffer(nil)}
 		if name == genesisstore.BlocksSection(0) {
 			for i := len(b.blocks) - 1; i >= 0; i-- {
@@ -368,15 +378,31 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 			return buf, nil
 		}
 		if name == genesisstore.FwsLiveSection(0) {
-			err := mptIo.Export(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "live"), buf)
-			if err != nil {
-				return nil, err
+			{
+				scratchDir, cleanup, err := utils.MakeTempDir(b.dataDir, "live-scratch")
+				if err != nil {
+					return nil, fmt.Errorf("failed to create scratch dir for FWS live export; %v", err)
+				}
+				defer cleanup(&retErr)
+
+				err = mptIo.Export(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "live"), buf, scratchDir)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		if name == genesisstore.FwsArchiveSection(0) {
-			err := mptIo.ExportArchive(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "archive"), buf)
-			if err != nil {
-				return nil, err
+			{
+				scratchDir, cleanup, err := utils.MakeTempDir(b.dataDir, "archive-scratch")
+				if err != nil {
+					return nil, fmt.Errorf("failed to create scratch dir for FWS archive export; %v", err)
+				}
+				defer cleanup(&retErr)
+
+				err = mptIo.ExportArchive(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "archive"), buf, scratchDir)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		if buf.Len() == 0 {

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -68,7 +68,7 @@ type GenesisBuilder struct {
 	epochs       []ier.LlrIdxFullEpochRecord
 	currentEpoch ier.LlrIdxFullEpochRecord
 
-	scratchPath string // temporary directory for genesis data export
+	tmpDir string // caller-owned directory for temporary genesis export data
 }
 
 type BlockProc struct {
@@ -133,10 +133,14 @@ func (b *GenesisBuilder) CurrentHash() hash.Hash {
 	return er.Hash()
 }
 
-func NewGenesisBuilder() *GenesisBuilder {
-	carmenDir, err := os.MkdirTemp("", "opera-tmp-genesis")
+// NewGenesisBuilder creates a builder for a new genesis. The given tmpDir is used as the
+// parent directory for the Carmen database and data produced while exporting the state into the genesis
+// store returned by Build. It must exist and remain available until that store has been
+// fully read; removing it is the responsibility of the caller.
+func NewGenesisBuilder(tmpDir string) (*GenesisBuilder, error) {
+	carmenDir, err := os.MkdirTemp(tmpDir, "opera-tmp-genesis")
 	if err != nil {
-		panic(fmt.Errorf("failed to create temporary dir for GenesisBuilder: %v", err))
+		return nil, fmt.Errorf("failed to create temporary dir for GenesisBuilder: %v", err)
 	}
 	carmenState, err := carmen.NewState(carmen.Parameters{
 		Variant:      "go-file",
@@ -147,25 +151,19 @@ func NewGenesisBuilder() *GenesisBuilder {
 		ArchiveCache: 1, // use minimum cache (not default)
 	})
 	if err != nil {
-		panic(fmt.Errorf("failed to create carmen state; %s", err))
+		return nil, fmt.Errorf("failed to create carmen state; %s", err)
 	}
 	// Set cache size to lowest value possible
 	carmenStateDb := carmen.CreateCustomStateDBUsing(carmenState, 1024)
 	tmpStateDB := evmstore.CreateCarmenStateDb(carmenStateDb, nil)
-
-	// Create a temporary directory for the genesis data
-	dataDir, err := os.MkdirTemp("", "opera-tmp-genesis-data")
-	if err != nil {
-		panic(fmt.Errorf("failed to create temporary dir for GenesisBuilder data: %v", err))
-	}
 
 	return &GenesisBuilder{
 		tmpStateDB:    tmpStateDB,
 		carmenDir:     carmenDir,
 		carmenStateDb: carmenStateDb,
 		totalSupply:   new(uint256.Int),
-		scratchPath:   dataDir,
-	}
+		tmpDir:        tmpDir,
+	}, nil
 }
 
 type dummyHeaderReturner struct {
@@ -358,10 +356,10 @@ func (f *memFile) Close() error {
 	return nil
 }
 
-func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
+func (b *GenesisBuilder) Build(head genesis.Header) (*genesisstore.Store, error) {
 	err := b.carmenStateDb.Close()
 	if err != nil {
-		panic(fmt.Errorf("failed to close genesis carmen state; %s", err))
+		return nil, fmt.Errorf("failed to close genesis carmen state; %s", err)
 	}
 	return genesisstore.NewStore(func(name string) (_ io.Reader, retErr error) {
 		buf := &memFile{bytes.NewBuffer(nil)}
@@ -379,13 +377,13 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 		}
 		if name == genesisstore.FwsLiveSection(0) {
 			{
-				scratchDir, cleanup, err := utils.MakeTempDir(b.scratchPath, "live-scratch")
+				scratchDir, err := utils.MakeTempDir(b.tmpDir, "live-scratch")
 				if err != nil {
 					return nil, fmt.Errorf("failed to create scratch dir for FWS live export; %v", err)
 				}
-				defer cleanup(&retErr)
+				defer scratchDir.Cleanup(&retErr)
 
-				err = mptIo.Export(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "live"), buf, scratchDir)
+				err = mptIo.Export(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "live"), buf, scratchDir.Path())
 				if err != nil {
 					return nil, err
 				}
@@ -393,13 +391,13 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 		}
 		if name == genesisstore.FwsArchiveSection(0) {
 			{
-				scratchDir, cleanup, err := utils.MakeTempDir(b.scratchPath, "archive-scratch")
+				scratchDir, err := utils.MakeTempDir(b.tmpDir, "archive-scratch")
 				if err != nil {
 					return nil, fmt.Errorf("failed to create scratch dir for FWS archive export; %v", err)
 				}
-				defer cleanup(&retErr)
+				defer scratchDir.Cleanup(&retErr)
 
-				err = mptIo.ExportArchive(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "archive"), buf, scratchDir)
+				err = mptIo.ExportArchive(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "archive"), buf, scratchDir.Path())
 				if err != nil {
 					return nil, err
 				}
@@ -413,5 +411,5 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 		err := os.RemoveAll(b.carmenDir)
 		*b = GenesisBuilder{}
 		return err
-	})
+	}), nil
 }

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -381,7 +381,9 @@ func (b *GenesisBuilder) Build(head genesis.Header) (*genesisstore.Store, error)
 				if err != nil {
 					return nil, fmt.Errorf("failed to create scratch dir for FWS live export; %v", err)
 				}
-				defer scratchDir.Cleanup(&retErr)
+				defer func() {
+					retErr = errors.Join(retErr, scratchDir.Cleanup())
+				}()
 
 				err = mptIo.Export(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "live"), buf, scratchDir.Path())
 				if err != nil {
@@ -395,7 +397,9 @@ func (b *GenesisBuilder) Build(head genesis.Header) (*genesisstore.Store, error)
 				if err != nil {
 					return nil, fmt.Errorf("failed to create scratch dir for FWS archive export; %v", err)
 				}
-				defer scratchDir.Cleanup(&retErr)
+				defer func() {
+					retErr = errors.Join(retErr, scratchDir.Cleanup())
+				}()
 
 				err = mptIo.ExportArchive(context.Background(), mptIo.NewLog(), filepath.Join(b.carmenDir, "archive"), buf, scratchDir.Path())
 				if err != nil {

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -68,7 +68,7 @@ type GenesisBuilder struct {
 	epochs       []ier.LlrIdxFullEpochRecord
 	currentEpoch ier.LlrIdxFullEpochRecord
 
-	dataDir string // temporary directory for genesis data export
+	scratchPath string // temporary directory for genesis data export
 }
 
 type BlockProc struct {
@@ -164,7 +164,7 @@ func NewGenesisBuilder() *GenesisBuilder {
 		carmenDir:     carmenDir,
 		carmenStateDb: carmenStateDb,
 		totalSupply:   new(uint256.Int),
-		dataDir:       dataDir,
+		scratchPath:   dataDir,
 	}
 }
 
@@ -379,7 +379,7 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 		}
 		if name == genesisstore.FwsLiveSection(0) {
 			{
-				scratchDir, cleanup, err := utils.MakeTempDir(b.dataDir, "live-scratch")
+				scratchDir, cleanup, err := utils.MakeTempDir(b.scratchPath, "live-scratch")
 				if err != nil {
 					return nil, fmt.Errorf("failed to create scratch dir for FWS live export; %v", err)
 				}
@@ -393,7 +393,7 @@ func (b *GenesisBuilder) Build(head genesis.Header) *genesisstore.Store {
 		}
 		if name == genesisstore.FwsArchiveSection(0) {
 			{
-				scratchDir, cleanup, err := utils.MakeTempDir(b.dataDir, "archive-scratch")
+				scratchDir, cleanup, err := utils.MakeTempDir(b.scratchPath, "archive-scratch")
 				if err != nil {
 					return nil, fmt.Errorf("failed to create scratch dir for FWS archive export; %v", err)
 				}

--- a/integration/makegenesis/genesis_test.go
+++ b/integration/makegenesis/genesis_test.go
@@ -41,9 +41,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGenesisBuilder_NewGenesisBuilder_ReturnsErrorWhenTmpDirDoesNotExist(t *testing.T) {
+	require := require.New(t)
+
+	missingDir := filepath.Join(t.TempDir(), "does-not-exist")
+	builder, err := NewGenesisBuilder(missingDir)
+
+	require.Error(err)
+	require.Nil(builder)
+	require.Contains(err.Error(), "failed to create temporary dir")
+}
+
 func TestGenesisBuilder_ExecuteGenesisTxs_ExecutesTransactionsAccordingToUpgrades(t *testing.T) {
 	rules := opera.FakeNetRules(opera.GetAllegroUpgrades())
-	builder := NewGenesisBuilder()
+	builder, err := NewGenesisBuilder(t.TempDir())
+	require.NoError(t, err)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -84,16 +96,19 @@ func TestGenesisBuilder_Build_CleansScratchDirAfterDBExport(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
-			builder := NewGenesisBuilder()
+			tmpDir := t.TempDir()
+			builder, err := NewGenesisBuilder(tmpDir)
+			require.NoError(err)
 			rules := opera.FakeNetRules(opera.GetAllegroUpgrades())
 
-			store := builder.Build(genesis.Header{
+			store, err := builder.Build(genesis.Header{
 				GenesisID:   hash.Zero,
 				NetworkID:   rules.NetworkID,
 				NetworkName: rules.Name,
 			})
+			require.NoError(err)
 
-			scratchDir := filepath.Join(builder.scratchPath, tc.dirName)
+			scratchDir := filepath.Join(tmpDir, tc.dirName)
 
 			reader, err := tc.runExport(store)
 			require.NoError(err)

--- a/integration/makegenesis/genesis_test.go
+++ b/integration/makegenesis/genesis_test.go
@@ -93,7 +93,7 @@ func TestGenesisBuilder_Build_CleansScratchDirAfterDBExport(t *testing.T) {
 				NetworkName: rules.Name,
 			})
 
-			scratchDir := filepath.Join(builder.dataDir, tc.dirName)
+			scratchDir := filepath.Join(builder.scratchPath, tc.dirName)
 
 			reader, err := tc.runExport(store)
 			require.NoError(err)

--- a/integration/makegenesis/genesis_test.go
+++ b/integration/makegenesis/genesis_test.go
@@ -18,7 +18,9 @@ package makegenesis
 
 import (
 	"crypto/ecdsa"
+	"io"
 	"math/big"
+	"path/filepath"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/inter"
@@ -26,6 +28,8 @@ import (
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/ier"
 	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/opera/genesis"
+	"github.com/0xsoniclabs/sonic/opera/genesisstore"
 	"github.com/Fantom-foundation/lachesis-base/hash"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/Fantom-foundation/lachesis-base/inter/pos"
@@ -56,6 +60,53 @@ func TestGenesisBuilder_ExecuteGenesisTxs_ExecutesTransactionsAccordingToUpgrade
 	// TODO: investigate the suitability of containing log.Crit inside of block processing
 	err = builder.ExecuteGenesisTxs(blockProc, []*types.Transaction{setCodeTx})
 	require.NoError(t, err)
+}
+
+func TestGenesisBuilder_Build_CleansScratchDirAfterDBExport(t *testing.T) {
+	testCases := map[string]struct {
+		runExport func(s *genesisstore.Store) (io.Reader, error)
+		dirName   string
+	}{
+		"live": {
+			runExport: func(s *genesisstore.Store) (io.Reader, error) {
+				return s.FwsLiveSection().GetReader()
+			},
+			dirName: "live-scratch",
+		},
+		"archive": {
+			runExport: func(s *genesisstore.Store) (io.Reader, error) {
+				return s.FwsArchiveSection().GetReader()
+			},
+			dirName: "archive-scratch",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			builder := NewGenesisBuilder()
+			rules := opera.FakeNetRules(opera.GetAllegroUpgrades())
+
+			store := builder.Build(genesis.Header{
+				GenesisID:   hash.Zero,
+				NetworkID:   rules.NetworkID,
+				NetworkName: rules.Name,
+			})
+
+			scratchDir := filepath.Join(builder.dataDir, tc.dirName)
+
+			reader, err := tc.runExport(store)
+			require.NoError(err)
+
+			// read a single byte to ensure the reader is used and the export is complete
+			singleByte := make([]byte, 1)
+			n, err := reader.Read(singleByte)
+			require.Equal(n, 1)
+			require.NoError(err)
+
+			require.NoDirExists(scratchDir)
+		})
+	}
 }
 
 func finalizeBlockZero(t *testing.T, builder *GenesisBuilder, rules opera.Rules) {

--- a/tests/eth_rpc_api_functions_test.go
+++ b/tests/eth_rpc_api_functions_test.go
@@ -99,14 +99,16 @@ func getNodeService(t *testing.T) *gossip.Service {
 	rules.Epochs.MaxEpochDuration = inter.Timestamp(maxEpochDuration)
 	rules.Emitter.Interval = 0
 
-	genStore := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
+	genStore, err := makefakegenesis.FakeGenesisStoreWithRulesAndStart(
 		1,
 		utils.ToFtmU256(genesisBalance),
 		utils.ToFtmU256(genesisStake),
 		rules,
 		1,
 		2,
+		t.TempDir(),
 	)
+	require.NoError(t, err)
 	genesis := genStore.Genesis()
 
 	err = store.ApplyGenesis(genesis)

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -432,8 +432,7 @@ func StartIntegrationTestNetWithJsonGenesis(
 	err = os.WriteFile(jsonFile, encoded, 0644)
 	require.NoError(t, err, "failed to write genesis json file")
 
-	genesisTmpDir, err := os.MkdirTemp(directory, "sonic-tmp-genesis-json")
-	require.NoError(t, err, "failed to create temporary dir for genesis")
+	genesisTmpDir := t.TempDir()
 
 	net, err := startIntegrationTestNet(
 		t,

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -432,6 +432,9 @@ func StartIntegrationTestNetWithJsonGenesis(
 	err = os.WriteFile(jsonFile, encoded, 0644)
 	require.NoError(t, err, "failed to write genesis json file")
 
+	genesisTmpDir, err := os.MkdirTemp(directory, "sonic-tmp-genesis-json")
+	require.NoError(t, err, "failed to create temporary dir for genesis")
+
 	net, err := startIntegrationTestNet(
 		t,
 		directory,
@@ -441,7 +444,7 @@ func StartIntegrationTestNetWithJsonGenesis(
 	require.NoError(t, err, "failed to start integration test network with json genesis")
 
 	net.genesis = jsonGenesis
-	net.genesisId, err = makefakegenesis.GetGenesisIdFromJson(jsonGenesis)
+	net.genesisId, err = makefakegenesis.GetGenesisIdFromJson(jsonGenesis, genesisTmpDir)
 	require.NoError(t, err, "failed to get genesis ID from json genesis")
 
 	return net

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -50,9 +49,6 @@ func (td TempDir) Path() string {
 	return string(td)
 }
 
-func (td TempDir) Cleanup(retErr *error) {
-	if retErr == nil {
-		retErr = new(error)
-	}
-	*retErr = errors.Join(*retErr, os.RemoveAll(string(td)))
+func (td TempDir) Cleanup() error {
+	return os.RemoveAll(string(td))
 }

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -27,7 +28,12 @@ type TempDir string
 // MakeTempDir creates a temporary directory at the specified path with the given name.
 // Everything in the directory is removed before creation. The function returns the path to the created directory,
 // a cleanup function to remove the directory, and an error if any occurred during the process.
+// The name must be a plain basename (no path separators, not "." or ".."); otherwise, an
+// error is returned.
 func MakeTempDir(path string, name string) (TempDir, error) {
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return "", fmt.Errorf("invalid directory name %q: must be a basename with no path separators", name)
+	}
 	dir := filepath.Join(path, name)
 	err := os.RemoveAll(dir)
 	if err != nil {

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// MakeTempDir creates a temporary directory at the specified path with the given name.
+// Everything in the directory is removed before creation. The function returns the path to the created directory,
+// a cleanup function to remove the directory, and an error if any occurred during the process.
+func MakeTempDir(path string, name string) (string, func(*error), error) {
+	dir := filepath.Join(path, name)
+	err := os.RemoveAll(dir)
+	if err != nil {
+		return "", nil, err
+	}
+	err = os.MkdirAll(dir, 0700)
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func(retErr *error) {
+		if retErr == nil {
+			retErr = new(error)
+		}
+		*retErr = errors.Join(*retErr, os.RemoveAll(dir))
+	}
+	return dir, cleanup, nil
+}

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -22,24 +22,31 @@ import (
 	"path/filepath"
 )
 
+type TempDir string
+
 // MakeTempDir creates a temporary directory at the specified path with the given name.
 // Everything in the directory is removed before creation. The function returns the path to the created directory,
 // a cleanup function to remove the directory, and an error if any occurred during the process.
-func MakeTempDir(path string, name string) (string, func(*error), error) {
+func MakeTempDir(path string, name string) (TempDir, error) {
 	dir := filepath.Join(path, name)
 	err := os.RemoveAll(dir)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 	err = os.MkdirAll(dir, 0700)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
-	cleanup := func(retErr *error) {
-		if retErr == nil {
-			retErr = new(error)
-		}
-		*retErr = errors.Join(*retErr, os.RemoveAll(dir))
+	return TempDir(dir), nil
+}
+
+func (td TempDir) Path() string {
+	return string(td)
+}
+
+func (td TempDir) Cleanup(retErr *error) {
+	if retErr == nil {
+		retErr = new(error)
 	}
-	return dir, cleanup, nil
+	*retErr = errors.Join(*retErr, os.RemoveAll(string(td)))
 }

--- a/utils/directory_test.go
+++ b/utils/directory_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMakeTempDir_CreatesEmptyDirectoryWipingPreexistingContent(t *testing.T) {
+func TestTempDir_MakeTempDir_CreatesEmptyDirectoryWipingPreexistingContent(t *testing.T) {
 	require := require.New(t)
 	parent := t.TempDir()
 
@@ -33,76 +33,83 @@ func TestMakeTempDir_CreatesEmptyDirectoryWipingPreexistingContent(t *testing.T)
 	require.NoError(os.MkdirAll(filepath.Dir(stale), 0700))
 	require.NoError(os.WriteFile(stale, []byte("old"), 0600))
 
-	dir, cleanup, err := MakeTempDir(parent, "scratch")
+	dir, err := MakeTempDir(parent, "scratch")
 	require.NoError(err)
-	require.Equal(filepath.Join(parent, "scratch"), dir)
-	require.NotNil(cleanup)
+	require.Equal(filepath.Join(parent, "scratch"), dir.Path())
 
-	entries, err := os.ReadDir(dir)
+	entries, err := os.ReadDir(dir.Path())
 	require.NoError(err)
 	require.Empty(entries)
 
-	info, err := os.Stat(dir)
+	info, err := os.Stat(dir.Path())
 	require.NoError(err)
 	require.True(info.IsDir())
 }
 
-func TestMakeTempDir_ReturnsErrorWhenParentIsNotADirectory(t *testing.T) {
+func TestTempDir_MakeTempDir_ReturnsErrorWhenParentIsNotADirectory(t *testing.T) {
 	require := require.New(t)
 	parent := t.TempDir()
 	notADir := filepath.Join(parent, "file")
 	require.NoError(os.WriteFile(notADir, []byte(""), 0600))
 
-	dir, cleanup, err := MakeTempDir(notADir, "scratch")
+	dir, err := MakeTempDir(notADir, "scratch")
 	require.Error(err)
-	require.Empty(dir)
-	require.Nil(cleanup)
+	require.Empty(dir.Path())
 }
 
-func TestMakeTempDir_CleanupRemovesDirectoryAndLeavesErrorNilOnSuccess(t *testing.T) {
+func TestTempDir_Path_ReturnsCorrectPath(t *testing.T) {
 	require := require.New(t)
 	parent := t.TempDir()
 
-	dir, cleanup, err := MakeTempDir(parent, "scratch")
+	dir, err := MakeTempDir(parent, "scratch")
+	require.NoError(err)
+	require.Equal(filepath.Join(parent, "scratch"), dir.Path())
+}
+
+func TestTempDir_Cleanup_RemovesDirectoryAndLeavesErrorNilOnSuccess(t *testing.T) {
+	require := require.New(t)
+	parent := t.TempDir()
+
+	dir, err := MakeTempDir(parent, "scratch")
 	require.NoError(err)
 
 	var retErr error
-	cleanup(&retErr)
+	dir.Cleanup(&retErr)
 	require.NoError(retErr)
 
-	_, err = os.Stat(dir)
+	_, err = os.Stat(dir.Path())
 	require.True(os.IsNotExist(err))
 }
 
-func TestMakeTempDir_CleanupJoinsWithExistingError(t *testing.T) {
+func TestTempDir_Cleanup_JoinsWithExistingError(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("permission checks are bypassed when running as root")
 	}
 	require := require.New(t)
 	parent := t.TempDir()
 
-	dir, cleanup, err := MakeTempDir(parent, "scratch")
+	dir, err := MakeTempDir(parent, "scratch")
 	require.NoError(err)
 
-	require.NoError(os.WriteFile(filepath.Join(dir, "child"), []byte("x"), 0600))
-	require.NoError(os.Chmod(dir, 0500))
+	require.NoError(os.WriteFile(filepath.Join(dir.Path(), "child"), []byte("x"), 0600))
+	require.NoError(os.Chmod(dir.Path(), 0500))
 	defer func() {
-		require.NoError(os.Chmod(dir, 0700))
+		require.NoError(os.Chmod(dir.Path(), 0700))
 	}()
 
 	original := errors.New("boom")
 	retErr := original
-	cleanup(&retErr)
+	dir.Cleanup(&retErr)
 	require.ErrorIs(retErr, original)
 	require.ErrorIs(retErr, os.ErrPermission)
 }
 
-func TestMakeTempDir_CleanupWithNilPointerDoesNotPanic(t *testing.T) {
+func TestTempDir_Cleanup_WithNilPointerDoesNotPanic(t *testing.T) {
 	require := require.New(t)
 	parent := t.TempDir()
 
-	_, cleanup, err := MakeTempDir(parent, "scratch")
+	dir, err := MakeTempDir(parent, "scratch")
 	require.NoError(err)
 
-	require.NotPanics(func() { cleanup(nil) })
+	require.NotPanics(func() { dir.Cleanup(nil) })
 }

--- a/utils/directory_test.go
+++ b/utils/directory_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeTempDir_CreatesEmptyDirectoryWipingPreexistingContent(t *testing.T) {
+	require := require.New(t)
+	parent := t.TempDir()
+
+	stale := filepath.Join(parent, "scratch", "stale.txt")
+	require.NoError(os.MkdirAll(filepath.Dir(stale), 0700))
+	require.NoError(os.WriteFile(stale, []byte("old"), 0600))
+
+	dir, cleanup, err := MakeTempDir(parent, "scratch")
+	require.NoError(err)
+	require.Equal(filepath.Join(parent, "scratch"), dir)
+	require.NotNil(cleanup)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(err)
+	require.Empty(entries)
+
+	info, err := os.Stat(dir)
+	require.NoError(err)
+	require.True(info.IsDir())
+}
+
+func TestMakeTempDir_ReturnsErrorWhenParentIsNotADirectory(t *testing.T) {
+	require := require.New(t)
+	parent := t.TempDir()
+	notADir := filepath.Join(parent, "file")
+	require.NoError(os.WriteFile(notADir, []byte(""), 0600))
+
+	dir, cleanup, err := MakeTempDir(notADir, "scratch")
+	require.Error(err)
+	require.Empty(dir)
+	require.Nil(cleanup)
+}
+
+func TestMakeTempDir_CleanupRemovesDirectoryAndLeavesErrorNilOnSuccess(t *testing.T) {
+	require := require.New(t)
+	parent := t.TempDir()
+
+	dir, cleanup, err := MakeTempDir(parent, "scratch")
+	require.NoError(err)
+
+	var retErr error
+	cleanup(&retErr)
+	require.NoError(retErr)
+
+	_, err = os.Stat(dir)
+	require.True(os.IsNotExist(err))
+}
+
+func TestMakeTempDir_CleanupJoinsWithExistingError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission checks are bypassed when running as root")
+	}
+	require := require.New(t)
+	parent := t.TempDir()
+
+	dir, cleanup, err := MakeTempDir(parent, "scratch")
+	require.NoError(err)
+
+	require.NoError(os.WriteFile(filepath.Join(dir, "child"), []byte("x"), 0600))
+	require.NoError(os.Chmod(dir, 0500))
+	defer func() {
+		require.NoError(os.Chmod(dir, 0700))
+	}()
+
+	original := errors.New("boom")
+	retErr := original
+	cleanup(&retErr)
+	require.ErrorIs(retErr, original)
+	require.ErrorIs(retErr, os.ErrPermission)
+}
+
+func TestMakeTempDir_CleanupWithNilPointerDoesNotPanic(t *testing.T) {
+	require := require.New(t)
+	parent := t.TempDir()
+
+	_, cleanup, err := MakeTempDir(parent, "scratch")
+	require.NoError(err)
+
+	require.NotPanics(func() { cleanup(nil) })
+}

--- a/utils/directory_test.go
+++ b/utils/directory_test.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,50 +106,16 @@ func TestTempDir_Path_ReturnsCorrectPath(t *testing.T) {
 	require.Equal(filepath.Join(parent, "scratch"), dir.Path())
 }
 
-func TestTempDir_Cleanup_RemovesDirectoryAndLeavesErrorNilOnSuccess(t *testing.T) {
+func TestTempDir_Cleanup_RemovesDirectory(t *testing.T) {
 	require := require.New(t)
 	parent := t.TempDir()
 
 	dir, err := MakeTempDir(parent, "scratch")
 	require.NoError(err)
 
-	var retErr error
-	dir.Cleanup(&retErr)
-	require.NoError(retErr)
+	err = dir.Cleanup()
+	require.NoError(err)
 
 	_, err = os.Stat(dir.Path())
 	require.True(os.IsNotExist(err))
-}
-
-func TestTempDir_Cleanup_JoinsWithExistingError(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("permission checks are bypassed when running as root")
-	}
-	require := require.New(t)
-	parent := t.TempDir()
-
-	dir, err := MakeTempDir(parent, "scratch")
-	require.NoError(err)
-
-	require.NoError(os.WriteFile(filepath.Join(dir.Path(), "child"), []byte("x"), 0600))
-	require.NoError(os.Chmod(dir.Path(), 0500))
-	defer func() {
-		require.NoError(os.Chmod(dir.Path(), 0700))
-	}()
-
-	original := errors.New("boom")
-	retErr := original
-	dir.Cleanup(&retErr)
-	require.ErrorIs(retErr, original)
-	require.ErrorIs(retErr, os.ErrPermission)
-}
-
-func TestTempDir_Cleanup_WithNilPointerDoesNotPanic(t *testing.T) {
-	require := require.New(t)
-	parent := t.TempDir()
-
-	dir, err := MakeTempDir(parent, "scratch")
-	require.NoError(err)
-
-	require.NotPanics(func() { dir.Cleanup(nil) })
 }

--- a/utils/directory_test.go
+++ b/utils/directory_test.go
@@ -57,6 +57,47 @@ func TestTempDir_MakeTempDir_ReturnsErrorWhenParentIsNotADirectory(t *testing.T)
 	require.Empty(dir.Path())
 }
 
+func TestTempDir_MakeTempDir_RejectsNonBasenameNames(t *testing.T) {
+	parent := t.TempDir()
+
+	// Create a sibling directory that must not be touched by MakeTempDir when
+	// a caller attempts to escape the intended parent via a relative name.
+	sibling := filepath.Join(parent, "sibling")
+	require.NoError(t, os.MkdirAll(sibling, 0700))
+	sentinel := filepath.Join(sibling, "keep.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("keep"), 0600))
+
+	testCases := map[string]string{
+		"empty":            "",
+		"dot":              ".",
+		"double-dot":       "..",
+		"parent-traversal": "../sibling",
+		"nested":           "foo/bar",
+		"absolute":         "/tmp/attack",
+		"leading-slash":    "/scratch",
+		"trailing-slash":   "scratch/",
+	}
+
+	scratchParent := filepath.Join(parent, "scratch-parent")
+	require.NoError(t, os.MkdirAll(scratchParent, 0700))
+
+	for name, invalidName := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			dir, err := MakeTempDir(scratchParent, invalidName)
+			require.Error(err)
+			require.Empty(dir.Path())
+			require.Contains(err.Error(), "invalid directory name")
+
+			// Sibling directory and its sentinel file must still exist:
+			// MakeTempDir must not have escaped the intended parent.
+			_, statErr := os.Stat(sentinel)
+			require.NoError(statErr)
+		})
+	}
+}
+
 func TestTempDir_Path_ReturnsCorrectPath(t *testing.T) {
 	require := require.New(t)
 	parent := t.TempDir()


### PR DESCRIPTION
This updates the Carmen version to the latest release 2.2 release candidate (https://github.com/0xsoniclabs/carmen/commit/570a67532cc9c4721d213783d309a6c64c64501f).

This commit changed the interface to the `Export` functionality, which now requires a writable scratch folder in input. 
The Sonic interface has been updated to instantiate temporary directories in the top level user of the fuctions.

Notable changes:
- `NewGenesisBuilder(tmpDir string)` now returns an error and takes a `tmpDir` parameter. All the temporary files are instantiated there