### PR TITLE
Test that priority contract can be swapped

### DIFF
--- a/tests/contracts/magic_value_priority/gen.go
+++ b/tests/contracts/magic_value_priority/gen.go
@@ -1,0 +1,20 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package magic_value_priority
+
+//go:generate solc --bin magic_value_priority.sol --abi magic_value_priority.sol -o build --overwrite
+//go:generate abigen --bin=build/MagicValuePriority.bin --abi=build/MagicValuePriority.abi --pkg=magic_value_priority --out=magic_value_priority.go

--- a/tests/contracts/magic_value_priority/magic_value_priority.go
+++ b/tests/contracts/magic_value_priority/magic_value_priority.go
@@ -1,0 +1,329 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package magic_value_priority
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// MagicValuePriorityMetaData contains all meta data concerning the MagicValuePriority contract.
+var MagicValuePriorityMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"name\":\"MAGIC_VALUE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"getPriority\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"level\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"weight\",\"type\":\"uint64\"},{\"internalType\":\"uint128\",\"name\":\"id\",\"type\":\"uint128\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getPriorityConfig\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"maxGasPerEntityPerBlock\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPiggybackTxsPerEntityPerEvent\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f5ffd5b506103a68061001c5f395ff3fe608060405234801561000f575f5ffd5b506004361061003f575f3560e01c80632067319614610043578063928461bd14610061578063d9dceeb814610080575b5f5ffd5b61004b6100b2565b6040516100589190610118565b60405180910390f35b6100696100ba565b604051610077929190610131565b60405180910390f35b61009a60048036038101906100959190610245565b6100cc565b6040516100a99392919061033b565b60405180910390f35b63075bcd1581565b5f5f633b9aca006103e8915091509091565b5f5f5f63075bcd1588036100e95760015f5f9250925092506100f3565b5f5f5f9250925092505b9750975097945050505050565b5f819050919050565b61011281610100565b82525050565b5f60208201905061012b5f830184610109565b92915050565b5f6040820190506101445f830185610109565b6101516020830184610109565b9392505050565b5f5ffd5b5f5ffd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f61018982610160565b9050919050565b6101998161017f565b81146101a3575f5ffd5b50565b5f813590506101b481610190565b92915050565b6101c381610100565b81146101cd575f5ffd5b50565b5f813590506101de816101ba565b92915050565b5f5ffd5b5f5ffd5b5f5ffd5b5f5f83601f840112610205576102046101e4565b5b8235905067ffffffffffffffff811115610222576102216101e8565b5b60208301915083600182028301111561023e5761023d6101ec565b5b9250929050565b5f5f5f5f5f5f5f60c0888a0312156102605761025f610158565b5b5f61026d8a828b016101a6565b975050602061027e8a828b016101a6565b965050604061028f8a828b016101d0565b95505060606102a08a828b016101d0565b945050608088013567ffffffffffffffff8111156102c1576102c061015c565b5b6102cd8a828b016101f0565b935093505060a06102e08a828b016101d0565b91505092959891949750929550565b5f67ffffffffffffffff82169050919050565b61030b816102ef565b82525050565b5f6fffffffffffffffffffffffffffffffff82169050919050565b61033581610311565b82525050565b5f60608201905061034e5f830186610302565b61035b6020830185610302565b610368604083018461032c565b94935050505056fea2646970667358221220362237f8a8af3ea5b63675f225bd8693e1bdfd9daf3ffca46d166fc0cc47ca3c64736f6c634300081e0033",
+}
+
+// MagicValuePriorityABI is the input ABI used to generate the binding from.
+// Deprecated: Use MagicValuePriorityMetaData.ABI instead.
+var MagicValuePriorityABI = MagicValuePriorityMetaData.ABI
+
+// MagicValuePriorityBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use MagicValuePriorityMetaData.Bin instead.
+var MagicValuePriorityBin = MagicValuePriorityMetaData.Bin
+
+// DeployMagicValuePriority deploys a new Ethereum contract, binding an instance of MagicValuePriority to it.
+func DeployMagicValuePriority(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *MagicValuePriority, error) {
+	parsed, err := MagicValuePriorityMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(MagicValuePriorityBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &MagicValuePriority{MagicValuePriorityCaller: MagicValuePriorityCaller{contract: contract}, MagicValuePriorityTransactor: MagicValuePriorityTransactor{contract: contract}, MagicValuePriorityFilterer: MagicValuePriorityFilterer{contract: contract}}, nil
+}
+
+// MagicValuePriority is an auto generated Go binding around an Ethereum contract.
+type MagicValuePriority struct {
+	MagicValuePriorityCaller     // Read-only binding to the contract
+	MagicValuePriorityTransactor // Write-only binding to the contract
+	MagicValuePriorityFilterer   // Log filterer for contract events
+}
+
+// MagicValuePriorityCaller is an auto generated read-only Go binding around an Ethereum contract.
+type MagicValuePriorityCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MagicValuePriorityTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type MagicValuePriorityTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MagicValuePriorityFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type MagicValuePriorityFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MagicValuePrioritySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type MagicValuePrioritySession struct {
+	Contract     *MagicValuePriority // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts       // Call options to use throughout this session
+	TransactOpts bind.TransactOpts   // Transaction auth options to use throughout this session
+}
+
+// MagicValuePriorityCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type MagicValuePriorityCallerSession struct {
+	Contract *MagicValuePriorityCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts             // Call options to use throughout this session
+}
+
+// MagicValuePriorityTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type MagicValuePriorityTransactorSession struct {
+	Contract     *MagicValuePriorityTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts             // Transaction auth options to use throughout this session
+}
+
+// MagicValuePriorityRaw is an auto generated low-level Go binding around an Ethereum contract.
+type MagicValuePriorityRaw struct {
+	Contract *MagicValuePriority // Generic contract binding to access the raw methods on
+}
+
+// MagicValuePriorityCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type MagicValuePriorityCallerRaw struct {
+	Contract *MagicValuePriorityCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// MagicValuePriorityTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type MagicValuePriorityTransactorRaw struct {
+	Contract *MagicValuePriorityTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewMagicValuePriority creates a new instance of MagicValuePriority, bound to a specific deployed contract.
+func NewMagicValuePriority(address common.Address, backend bind.ContractBackend) (*MagicValuePriority, error) {
+	contract, err := bindMagicValuePriority(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &MagicValuePriority{MagicValuePriorityCaller: MagicValuePriorityCaller{contract: contract}, MagicValuePriorityTransactor: MagicValuePriorityTransactor{contract: contract}, MagicValuePriorityFilterer: MagicValuePriorityFilterer{contract: contract}}, nil
+}
+
+// NewMagicValuePriorityCaller creates a new read-only instance of MagicValuePriority, bound to a specific deployed contract.
+func NewMagicValuePriorityCaller(address common.Address, caller bind.ContractCaller) (*MagicValuePriorityCaller, error) {
+	contract, err := bindMagicValuePriority(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &MagicValuePriorityCaller{contract: contract}, nil
+}
+
+// NewMagicValuePriorityTransactor creates a new write-only instance of MagicValuePriority, bound to a specific deployed contract.
+func NewMagicValuePriorityTransactor(address common.Address, transactor bind.ContractTransactor) (*MagicValuePriorityTransactor, error) {
+	contract, err := bindMagicValuePriority(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &MagicValuePriorityTransactor{contract: contract}, nil
+}
+
+// NewMagicValuePriorityFilterer creates a new log filterer instance of MagicValuePriority, bound to a specific deployed contract.
+func NewMagicValuePriorityFilterer(address common.Address, filterer bind.ContractFilterer) (*MagicValuePriorityFilterer, error) {
+	contract, err := bindMagicValuePriority(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &MagicValuePriorityFilterer{contract: contract}, nil
+}
+
+// bindMagicValuePriority binds a generic wrapper to an already deployed contract.
+func bindMagicValuePriority(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := MagicValuePriorityMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_MagicValuePriority *MagicValuePriorityRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _MagicValuePriority.Contract.MagicValuePriorityCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_MagicValuePriority *MagicValuePriorityRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _MagicValuePriority.Contract.MagicValuePriorityTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_MagicValuePriority *MagicValuePriorityRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _MagicValuePriority.Contract.MagicValuePriorityTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_MagicValuePriority *MagicValuePriorityCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _MagicValuePriority.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_MagicValuePriority *MagicValuePriorityTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _MagicValuePriority.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_MagicValuePriority *MagicValuePriorityTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _MagicValuePriority.Contract.contract.Transact(opts, method, params...)
+}
+
+// MAGICVALUE is a free data retrieval call binding the contract method 0x20673196.
+//
+// Solidity: function MAGIC_VALUE() view returns(uint256)
+func (_MagicValuePriority *MagicValuePriorityCaller) MAGICVALUE(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _MagicValuePriority.contract.Call(opts, &out, "MAGIC_VALUE")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MAGICVALUE is a free data retrieval call binding the contract method 0x20673196.
+//
+// Solidity: function MAGIC_VALUE() view returns(uint256)
+func (_MagicValuePriority *MagicValuePrioritySession) MAGICVALUE() (*big.Int, error) {
+	return _MagicValuePriority.Contract.MAGICVALUE(&_MagicValuePriority.CallOpts)
+}
+
+// MAGICVALUE is a free data retrieval call binding the contract method 0x20673196.
+//
+// Solidity: function MAGIC_VALUE() view returns(uint256)
+func (_MagicValuePriority *MagicValuePriorityCallerSession) MAGICVALUE() (*big.Int, error) {
+	return _MagicValuePriority.Contract.MAGICVALUE(&_MagicValuePriority.CallOpts)
+}
+
+// GetPriority is a free data retrieval call binding the contract method 0xd9dceeb8.
+//
+// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) pure returns(uint64 level, uint64 weight, uint128 id)
+func (_MagicValuePriority *MagicValuePriorityCaller) GetPriority(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (struct {
+	Level  uint64
+	Weight uint64
+	Id     *big.Int
+}, error) {
+	var out []interface{}
+	err := _MagicValuePriority.contract.Call(opts, &out, "getPriority", arg0, arg1, value, arg3, arg4, arg5)
+
+	outstruct := new(struct {
+		Level  uint64
+		Weight uint64
+		Id     *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Level = *abi.ConvertType(out[0], new(uint64)).(*uint64)
+	outstruct.Weight = *abi.ConvertType(out[1], new(uint64)).(*uint64)
+	outstruct.Id = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetPriority is a free data retrieval call binding the contract method 0xd9dceeb8.
+//
+// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) pure returns(uint64 level, uint64 weight, uint128 id)
+func (_MagicValuePriority *MagicValuePrioritySession) GetPriority(arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (struct {
+	Level  uint64
+	Weight uint64
+	Id     *big.Int
+}, error) {
+	return _MagicValuePriority.Contract.GetPriority(&_MagicValuePriority.CallOpts, arg0, arg1, value, arg3, arg4, arg5)
+}
+
+// GetPriority is a free data retrieval call binding the contract method 0xd9dceeb8.
+//
+// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) pure returns(uint64 level, uint64 weight, uint128 id)
+func (_MagicValuePriority *MagicValuePriorityCallerSession) GetPriority(arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (struct {
+	Level  uint64
+	Weight uint64
+	Id     *big.Int
+}, error) {
+	return _MagicValuePriority.Contract.GetPriority(&_MagicValuePriority.CallOpts, arg0, arg1, value, arg3, arg4, arg5)
+}
+
+// GetPriorityConfig is a free data retrieval call binding the contract method 0x928461bd.
+//
+// Solidity: function getPriorityConfig() pure returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
+func (_MagicValuePriority *MagicValuePriorityCaller) GetPriorityConfig(opts *bind.CallOpts) (struct {
+	MaxGasPerEntityPerBlock          *big.Int
+	MaxPiggybackTxsPerEntityPerEvent *big.Int
+}, error) {
+	var out []interface{}
+	err := _MagicValuePriority.contract.Call(opts, &out, "getPriorityConfig")
+
+	outstruct := new(struct {
+		MaxGasPerEntityPerBlock          *big.Int
+		MaxPiggybackTxsPerEntityPerEvent *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.MaxGasPerEntityPerBlock = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.MaxPiggybackTxsPerEntityPerEvent = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// GetPriorityConfig is a free data retrieval call binding the contract method 0x928461bd.
+//
+// Solidity: function getPriorityConfig() pure returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
+func (_MagicValuePriority *MagicValuePrioritySession) GetPriorityConfig() (struct {
+	MaxGasPerEntityPerBlock          *big.Int
+	MaxPiggybackTxsPerEntityPerEvent *big.Int
+}, error) {
+	return _MagicValuePriority.Contract.GetPriorityConfig(&_MagicValuePriority.CallOpts)
+}
+
+// GetPriorityConfig is a free data retrieval call binding the contract method 0x928461bd.
+//
+// Solidity: function getPriorityConfig() pure returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
+func (_MagicValuePriority *MagicValuePriorityCallerSession) GetPriorityConfig() (struct {
+	MaxGasPerEntityPerBlock          *big.Int
+	MaxPiggybackTxsPerEntityPerEvent *big.Int
+}, error) {
+	return _MagicValuePriority.Contract.GetPriorityConfig(&_MagicValuePriority.CallOpts)
+}

--- a/tests/contracts/magic_value_priority/magic_value_priority.sol
+++ b/tests/contracts/magic_value_priority/magic_value_priority.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+// MagicValuePriority is a stand-in contract for Sonic's on-chain priority
+// registry to be used as a replacement to the development registry used in
+// integration tests. It classifies a transaction as prioritized iff its
+// `value` field equals a fixed magic constant, so tests can exercise the
+// classifier on the consensus path by submitting a mix of magic- and
+// non-magic-value transactions and observing that only the magic ones are
+// hoisted to the front of a block. Using an unlikely fixed value (rather
+// than e.g. even/odd parity) makes it very unlikely that unrelated
+// background traffic is accidentally classified as prioritized.
+contract MagicValuePriority {
+    // The exact value a tx must carry to be prioritized. Public so tests can
+    // read it instead of duplicating it.
+    uint256 public constant MAGIC_VALUE = 123456789;
+
+    // A fixed non-zero level assigned to prioritized (magic-value) txs.
+    uint64 constant PRIORITY_LEVEL = 1;
+
+    // A fixed weight assigned to prioritized txs.
+    uint64 constant PRIORITY_WEIGHT = 0;
+
+    // A large per-block gas budget so rate-limiting cannot trim any
+    // prioritized transaction during tests.
+    uint256 constant PER_BLOCK_GAS = 1_000_000_000;
+
+    // A large per-event tx budget so all prioritized events fit.
+    uint256 constant PER_EVENT_TXS = 1_000;
+
+    function getPriority(
+        address /*from*/,
+        address /*to*/,
+        uint256 value,
+        uint256 /*nonce*/,
+        bytes calldata /*data*/,
+        uint256 /*gas*/
+    ) external pure returns (uint64 level, uint64 weight, uint128 id) {
+        if (value == MAGIC_VALUE) {
+            return (PRIORITY_LEVEL, PRIORITY_WEIGHT, 0);
+        }
+        return (0, 0, 0);
+    }
+
+    function getPriorityConfig()
+        external
+        pure
+        returns (
+            uint256 maxGasPerEntityPerBlock,
+            uint256 maxPiggybackTxsPerEntityPerEvent
+        )
+    {
+        return (PER_BLOCK_GAS, PER_EVENT_TXS);
+    }
+}

--- a/tests/priorities/network_rules_test.go
+++ b/tests/priorities/network_rules_test.go
@@ -55,7 +55,7 @@ func TestPriorities_PriorityCanBeEnabledAndDisabled(t *testing.T) {
 
 				txs := make([]*types.Transaction, 5)
 				for i := range txs {
-					txs[i] = newSignedTx(t, net, prioAccount, nonce+uint64(i), 21_000, nil)
+					txs[i] = newSignedTx(t, net, prioAccount, nonce+uint64(i), 1, 21_000, nil)
 				}
 				return txs
 			}

--- a/tests/priorities/registry_update_test.go
+++ b/tests/priorities/registry_update_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package priorities
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/proxy"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/0xsoniclabs/sonic/tests/contracts/magic_value_priority"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriorities_SwapContract_PrioritizationChanges(t *testing.T) {
+	require := require.New(t)
+
+	net, client, signer := netClientSignerWithPriorities(t, nil)
+	defer client.Close()
+
+	registered := newFundedPrioritizedAccount(t, net, 1, 0, 0xaa)
+	unregistered := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+
+	// The replacement registry is deployed up front so its magic value is known.
+	// Deploying does not affect the network until the swap below.
+	impl, deployReceipt, err := tests.DeployContract(net, magic_value_priority.DeployMagicValuePriority)
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, deployReceipt.Status)
+	magicValue, err := impl.MAGICVALUE(nil)
+	require.NoError(err)
+
+	buildRegisteredSenderTxs := func() []*types.Transaction {
+		nonce, err := client.PendingNonceAt(t.Context(), registered.Address())
+		require.NoError(err)
+		txs := make([]*types.Transaction, 5)
+		for i := range txs {
+			txs[i] = newSignedTx(t, net,
+				registered, nonce+uint64(i), 1, 21_000, nil)
+		}
+		return txs
+	}
+	buildMagicValueTxs := func() []*types.Transaction {
+		nonce, err := client.PendingNonceAt(t.Context(), unregistered.Address())
+		require.NoError(err)
+		txs := make([]*types.Transaction, 5)
+		for i := range txs {
+			txs[i] = newSignedTx(t, net,
+				unregistered, nonce+uint64(i), magicValue.Uint64(), 21_000, nil)
+		}
+		return txs
+	}
+	txHasRegisteredSender := func(tx *types.Transaction) bool {
+		from, err := types.Sender(signer, tx)
+		require.NoError(err)
+		return from == registered.Address()
+	}
+	txHasMagicValue := func(tx *types.Transaction) bool { return tx.Value().Cmp(magicValue) == 0 }
+
+	// --- default registry - prioritization depends only on the sender ---
+	require.True(checkPriority(t, net, registered.Address(), 1))
+	require.True(checkPriority(t, net, registered.Address(), magicValue.Uint64()))
+	require.False(checkPriority(t, net, unregistered.Address(), 1))
+	require.False(checkPriority(t, net, unregistered.Address(), magicValue.Uint64()))
+
+	requirePriorityHasEffect(t, net, buildRegisteredSenderTxs(), true, txHasRegisteredSender)
+	requirePriorityHasEffect(t, net, buildMagicValueTxs(), false, txHasMagicValue)
+
+	// --- MagicValuePriority registry - prioritization depends only on the tx value ---
+	switchPriorityRegistry(t, net, deployReceipt.ContractAddress)
+
+	require.False(checkPriority(t, net, registered.Address(), 1))
+	require.True(checkPriority(t, net, registered.Address(), magicValue.Uint64()))
+	require.False(checkPriority(t, net, unregistered.Address(), 1))
+	require.True(checkPriority(t, net, unregistered.Address(), magicValue.Uint64()))
+
+	requirePriorityHasEffect(t, net, buildRegisteredSenderTxs(), false, txHasRegisteredSender)
+	requirePriorityHasEffect(t, net, buildMagicValueTxs(), true, txHasMagicValue)
+}
+
+// checkPriority calls the registry's `getPriority` method for a transaction
+// with the given `from` and `value`, and returns whether it is prioritized.
+func checkPriority(
+	t *testing.T,
+	net *tests.IntegrationTestNet,
+	from common.Address,
+	value uint64,
+) bool {
+	t.Helper()
+	require := require.New(t)
+
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	reg, err := registry.NewRegistry(registry.GetAddress(), client)
+	require.NoError(err)
+
+	priority, err := reg.GetPriority(nil,
+		from, common.Address{}, new(big.Int).SetUint64(value), big.NewInt(0), nil, big.NewInt(21_000))
+	require.NoError(err)
+	return priority.Level > 0
+}
+
+// switchPriorityRegistry points the priority-registry proxy at `newImpl`,
+// asserting the proxy's implementation slot changes to that address.
+func switchPriorityRegistry(
+	t *testing.T,
+	net *tests.IntegrationTestNet,
+	newImpl common.Address,
+) {
+	t.Helper()
+	require := require.New(t)
+
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	oldSlotValue, err := client.StorageAt(t.Context(), registry.GetAddress(),
+		proxy.GetSlotForImplementation(), nil)
+	require.NoError(err)
+	require.NotEqual(newImpl, common.BytesToAddress(oldSlotValue))
+
+	pxy, err := proxy.NewProxy(registry.GetAddress(), client)
+	require.NoError(err)
+	updateReceipt, err := net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return pxy.Update(opts, newImpl)
+	})
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, updateReceipt.Status)
+
+	newSlotValue, err := client.StorageAt(t.Context(), registry.GetAddress(),
+		proxy.GetSlotForImplementation(), nil)
+	require.NoError(err)
+	require.Equal(newImpl, common.BytesToAddress(newSlotValue))
+}

--- a/tests/priorities/test_assertion_utils.go
+++ b/tests/priorities/test_assertion_utils.go
@@ -91,7 +91,7 @@ func buildOrdinaryTraffic(
 	for i := 0; i < numAccounts; i++ {
 		acc := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 		for n := 0; n < txsPerAccount; n++ {
-			txs = append(txs, newSignedTx(t, net, acc, uint64(n), 21000, nil))
+			txs = append(txs, newSignedTx(t, net, acc, uint64(n), 1, 21000, nil))
 		}
 	}
 	return txs

--- a/tests/priorities/test_setup_utils.go
+++ b/tests/priorities/test_setup_utils.go
@@ -20,13 +20,64 @@ import (
 	"math/big"
 	"testing"
 
-	priorityregistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
+
+// netClientSignerWithPriorities starts a fresh integration test network with
+// the Brio hard-fork and TransactionPriorities enabled by default but
+// overridable with `configure`. It configures generous priority-registry
+// limits and returns the network together with an open client and a signer
+// bound to the network's chain ID. The caller owns the returned client and is
+// expected to Close it.
+func netClientSignerWithPriorities(
+	t *testing.T,
+	configure func(*opera.Upgrades),
+) (*tests.IntegrationTestNet, *tests.PooledEhtClient, types.Signer) {
+	t.Helper()
+	require := require.New(t)
+
+	upgrades := opera.GetBrioUpgrades()
+	upgrades.TransactionPriorities = true
+	if configure != nil {
+		configure(&upgrades)
+	}
+	net := tests.StartIntegrationTestNet(t, tests.IntegrationTestNetOptions{
+		Upgrades: &upgrades,
+	})
+
+	configureHighPriorityLimits(t, net)
+
+	client, err := net.GetClient()
+	require.NoError(err)
+
+	return net, client, types.LatestSignerForChainID(net.GetChainId())
+}
+
+// configureHighPriorityLimits configures generous priority limits in the
+// priority registry.
+func configureHighPriorityLimits(t *testing.T, net *tests.IntegrationTestNet) {
+	t.Helper()
+	require := require.New(t)
+
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	reg, err := registry.NewRegistry(registry.GetAddress(), client)
+	require.NoError(err)
+
+	receipt, err := net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
+		return reg.SetConfig(opts, big.NewInt(100_000_000), big.NewInt(1_000))
+	})
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+}
 
 // newFundedPrioritizedAccount creates a funded account and registers it in the
 // priority registry with (level, weight, id).
@@ -56,7 +107,7 @@ func setPrioritized(
 	require.NoError(err)
 	defer client.Close()
 
-	reg, err := priorityregistry.NewRegistry(priorityregistry.GetAddress(), client)
+	reg, err := registry.NewRegistry(registry.GetAddress(), client)
 	require.NoError(err)
 
 	receipt, err := net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
@@ -73,6 +124,7 @@ func newSignedTx(
 	net *tests.IntegrationTestNet,
 	account *tests.Account,
 	nonce uint64,
+	value uint64,
 	gasLimit uint64,
 	gasPrice *big.Int,
 ) *types.Transaction {
@@ -92,7 +144,7 @@ func newSignedTx(
 	return types.MustSignNewTx(account.PrivateKey, signer, &types.LegacyTx{
 		Nonce:    nonce,
 		To:       &common.Address{0x99},
-		Value:    big.NewInt(1),
+		Value:    new(big.Int).SetUint64(value),
 		Gas:      gasLimit,
 		GasPrice: gasPrice,
 	})


### PR DESCRIPTION
This PR adds a test ensuring the on-chain priority-registry implementation can be swapped out behind its proxy. The test verifies that the prioritization behavior changes accordingly.