### PR TITLE
Fix for shutdown race condition fix

### DIFF
--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -488,18 +488,13 @@ func (h *handler) Stop() {
 	// Quit the sync loop.
 	close(h.quitSync)
 
-	log.Info("Sonic protocol stopped")
-}
-
-// disconnectPeers tears down the established peer sessions and closes the gate
-// for any new registrations on the peer set. Sessions which are already
-// established but not added to h.peers yet will exit when they try to
-// register.
-//
-// The peer handler goroutines this releases belong to the p2p server, not to
-// the handler; the Service waits for them to return before calling Stop.
-func (h *handler) disconnectPeers() {
+	// Disconnect existing sessions.
+	// This also closes the gate for any new registrations on the peer set.
+	// Sessions which are already established but not added to h.peers yet
+	// will exit when they try to register.
 	h.peers.Close()
+
+	log.Info("Sonic protocol stopped")
 }
 
 func (h *handler) myProgress() PeerProgress {

--- a/gossip/handler.go
+++ b/gossip/handler.go
@@ -165,8 +165,6 @@ type handler struct {
 	// wait group is used for graceful shutdowns during downloading
 	// and processing
 	loopsWg sync.WaitGroup
-	wg      sync.WaitGroup
-	peerWG  sync.WaitGroup
 	started sync.WaitGroup
 
 	// channels for peer info collection loop
@@ -488,20 +486,20 @@ func (h *handler) Stop() {
 
 	h.msgSemaphore.Terminate()
 	// Quit the sync loop.
-	// After this send has completed, no new peers will be accepted.
 	close(h.quitSync)
 
-	// Disconnect existing sessions.
-	// This also closes the gate for any new registrations on the peer set.
-	// sessions which are already established but not added to h.peers yet
-	// will exit when they try to register.
-	h.peers.Close()
-
-	// Wait for all peer handler goroutines to come down.
-	h.wg.Wait()
-	h.peerWG.Wait()
-
 	log.Info("Sonic protocol stopped")
+}
+
+// disconnectPeers tears down the established peer sessions and closes the gate
+// for any new registrations on the peer set. Sessions which are already
+// established but not added to h.peers yet will exit when they try to
+// register.
+//
+// The peer handler goroutines this releases belong to the p2p server, not to
+// the handler; the Service waits for them to return before calling Stop.
+func (h *handler) disconnectPeers() {
+	h.peers.Close()
 }
 
 func (h *handler) myProgress() PeerProgress {
@@ -565,9 +563,6 @@ func (h *handler) handle(p *peer) (err error) {
 	if !p.Peer.Info().Network.Trusted && useless {
 		p.SetUseless()
 	}
-
-	h.peerWG.Add(1)
-	defer h.peerWG.Done()
 
 	// Execute the handshake
 	var (

--- a/gossip/peerruns.go
+++ b/gossip/peerruns.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gossip
+
+import "sync"
+
+// peerRunTracker tracks the peer handler goroutines that the p2p server starts
+// on the Service's behalf. The Service does not own these goroutines and
+// cannot stop them directly: the p2p server keeps starting them until it is
+// itself shut down, which the node only does after every service has come
+// down. The tracker lets the Service refuse the late ones and wait out the
+// running ones instead.
+//
+// The zero value is an open tracker with no runs in flight.
+type peerRunTracker struct {
+	// mu serializes closing against acquire, so that wg.Add never happens
+	// concurrently with the wg.Wait in waitForRuns. Doing the check and the
+	// increment as two separate steps would let a run observe an open tracker,
+	// be descheduled, and increment the WaitGroup after the wait had already
+	// started on a zero counter -- which sync.WaitGroup explicitly forbids,
+	// and which would let the run outlive the shutdown.
+	mu     sync.Mutex
+	closed bool
+	wg     sync.WaitGroup
+}
+
+// acquireRun registers a peer handler goroutine and reports whether it may
+// proceed. It returns false once the tracker is closed, in which case nothing
+// was registered and the caller must not call releaseRun.
+func (t *peerRunTracker) acquireRun() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.closed {
+		return false
+	}
+	t.wg.Add(1)
+	return true
+}
+
+// releaseRun reports that a goroutine registered by acquireRun has finished.
+func (t *peerRunTracker) releaseRun() {
+	t.wg.Done()
+}
+
+// refuseNewRuns makes all further acquireRun calls fail. It does not wait for
+// the runs already in flight; call waitForRuns for that, once whatever keeps
+// them running has been torn down.
+func (t *peerRunTracker) refuseNewRuns() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.closed = true
+}
+
+// waitForRuns blocks until every registered peer handler goroutine has
+// returned. Callers must have called refuseNewRuns first, otherwise a run
+// arriving concurrently races with the wait.
+func (t *peerRunTracker) waitForRuns() {
+	t.wg.Wait()
+}

--- a/gossip/peerruns_test.go
+++ b/gossip/peerruns_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gossip
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerRunTracker_AcquireIsGrantedWhileOpen(t *testing.T) {
+	var tracker peerRunTracker
+
+	require.True(t, tracker.acquireRun())
+	require.True(t, tracker.acquireRun())
+
+	tracker.releaseRun()
+	tracker.releaseRun()
+
+	tracker.refuseNewRuns()
+	tracker.waitForRuns()
+}
+
+func TestPeerRunTracker_AcquireIsRefusedAfterRefuseNewRuns(t *testing.T) {
+	var tracker peerRunTracker
+	tracker.refuseNewRuns()
+
+	require.False(t, tracker.acquireRun())
+}
+
+func TestPeerRunTracker_WaitBlocksUntilRunsReturn(t *testing.T) {
+	const runs = 5
+
+	var tracker peerRunTracker
+	for range runs {
+		require.True(t, tracker.acquireRun())
+	}
+	tracker.refuseNewRuns()
+
+	waited := make(chan struct{})
+	go func() {
+		defer close(waited)
+		tracker.waitForRuns()
+	}()
+
+	for range runs - 1 {
+		tracker.releaseRun()
+		select {
+		case <-waited:
+			t.Fatal("wait returned while peer handlers were still running")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	tracker.releaseRun()
+
+	select {
+	case <-waited:
+	case <-time.After(time.Second):
+		t.Fatal("wait did not return after all peer handlers returned")
+	}
+}
+
+// TestPeerRunTracker_NoRunOutlivesTheWait is the regression test for the
+// shutdown race: a peer handler must never register itself after the shutdown
+// has started waiting. Before the fix, the gate check and the WaitGroup
+// increment were two separate steps, so a handler could slip in between them
+// -- tripping "WaitGroup misuse: Add called concurrently with Wait" or, worse,
+// silently outliving the shutdown.
+func TestPeerRunTracker_NoRunOutlivesTheWait(t *testing.T) {
+	const attempts = 200
+
+	var tracker peerRunTracker
+
+	var running atomic.Int32
+	var done sync.WaitGroup
+	release := make(chan struct{})
+
+	for range attempts {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			if !tracker.acquireRun() {
+				return
+			}
+			running.Add(1)
+			<-release
+			running.Add(-1)
+			tracker.releaseRun()
+		}()
+	}
+
+	go func() {
+		time.Sleep(time.Millisecond)
+		close(release)
+	}()
+
+	tracker.refuseNewRuns()
+	tracker.waitForRuns()
+	require.Zero(t, running.Load())
+
+	done.Wait()
+	require.False(t, tracker.acquireRun())
+}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -236,6 +236,10 @@ type Service struct {
 	// version watcher
 	verWatcher *verwatcher.VersionWatcher
 
+	// peerRuns tracks the peer handler goroutines started by the p2p server
+	// for the protocols returned by Protocols, so Stop can wait them out.
+	peerRuns peerRunTracker
+
 	blockProcWg        sync.WaitGroup
 	blockProcTasks     *workers.Workers
 	blockProcTasksDone chan struct{}
@@ -491,14 +495,11 @@ func MakeProtocols(svc *Service, backend *handler, disc enode.Iterator) ([]p2p.P
 				peer := newPeer(version, p, rw, backend.config.Protocol.PeerCache)
 				defer peer.Close()
 
-				select {
-				case <-backend.quitSync:
+				if !svc.peerRuns.acquireRun() {
 					return p2p.DiscQuitting
-				default:
-					backend.wg.Add(1)
-					defer backend.wg.Done()
-					return backend.handle(peer)
 				}
+				defer svc.peerRuns.releaseRun()
+				return backend.handle(peer)
 			},
 			NodeInfo: func() interface{} {
 				return backend.NodeInfo()
@@ -629,6 +630,14 @@ func (s *Service) Stop() error {
 
 	// Stop all the peer-related stuff first.
 	s.operaDialCandidates.Close()
+
+	// Bring down the peer handler goroutines the p2p server started for us
+	// before tearing down the handler they run against. The order matters:
+	// refusing new runs first means the wait cannot race an arriving one, and
+	// the running ones only return once their sessions are disconnected.
+	s.peerRuns.refuseNewRuns()
+	s.handler.disconnectPeers()
+	s.peerRuns.waitForRuns()
 
 	s.handler.Stop()
 	// Must stop before the store is closed to avoid reading from a closed store.

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -631,15 +631,11 @@ func (s *Service) Stop() error {
 	// Stop all the peer-related stuff first.
 	s.operaDialCandidates.Close()
 
-	// Bring down the peer handler goroutines the p2p server started for us
-	// before tearing down the handler they run against. The order matters:
-	// refusing new runs first means the wait cannot race an arriving one, and
-	// the running ones only return once their sessions are disconnected.
+	// The wait must come after handler.Stop: it terminates everything a peer
+	// handler run can be parked on, so waiting any earlier can deadlock.
 	s.peerRuns.refuseNewRuns()
-	s.handler.disconnectPeers()
-	s.peerRuns.waitForRuns()
-
 	s.handler.Stop()
+	s.peerRuns.waitForRuns()
 	// Must stop before the store is closed to avoid reading from a closed store.
 	if s.filterAPI != nil {
 		s.filterAPI.Stop()

--- a/gossip/service_test.go
+++ b/gossip/service_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/evmstore"
+	"github.com/Fantom-foundation/lachesis-base/inter/dag"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -111,6 +113,53 @@ func TestServiceFeed_BlocksInOrder(t *testing.T) {
 	}
 
 	feed.Stop()
+}
+
+// Service.Stop must tear the handler down before waiting for the peer handler
+// runs: a run parked in DataSemaphore.Acquire is only woken by a Release or a
+// Terminate, and the Terminates live in handler.Stop.
+func TestServiceStop_ReleasesAPeerRunParkedOnTheMessageSemaphore(t *testing.T) {
+	env := newTestEnv(2, 1, t)
+	handler := env.handler
+	handler.Start(10)
+
+	require.True(t,
+		handler.msgSemaphore.TryAcquire(handler.config.Protocol.MsgsSemaphoreLimit),
+		"the message semaphore should start out empty")
+
+	// A stand-in for a p2p Protocol.Run callback, parked the way handleMsg
+	// parks when the semaphore is full.
+	parked := make(chan struct{})
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		if !env.peerRuns.acquireRun() {
+			return
+		}
+		defer env.peerRuns.releaseRun()
+		close(parked)
+		handler.msgSemaphore.Acquire(dag.Metric{Num: 1, Size: 1}, time.Hour)
+	}()
+	<-parked
+	time.Sleep(10 * time.Millisecond) // let the run park before Stop starts
+
+	stopped := make(chan error, 1)
+	go func() {
+		stopped <- env.Stop()
+	}()
+
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Minute):
+		t.Fatal("Service.Stop hangs while a peer handler run is parked on the message semaphore")
+	}
+
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the parked peer handler run did not return after Service.Stop")
+	}
 }
 
 type expectedBlockNotification struct {


### PR DESCRIPTION
ORIGINAL (main)                                      ✗ data race
═══════════════════════════════════════════════════════════════════

Service.Stop()
│
├─ txpool / verWatcher / emitters .Stop, dialCandidates.Close
│
├─ handler.Stop()
│   ├─ dagLeecher.Stop / dagSeeder.Stop
│   ├─ dagProcessor.Stop ····· terminates EVENTS semaphore,
│   │                          clears buffered events (frees held weight)
│   ├─ Heavycheck.Stop
│   ├─ txFetcher / dagFetcher .Stop ····· quit chans unblock Notify*()
│   ├─ stop broadcast loops, loopsWg.Wait
│   ├─ msgSemaphore.Terminate ····· wakes handlers parked in handleMsg
│   ├─ close(quitSync) ◄─── gate read by Run callback
│   ├─ peers.Close ········ sessions drop, reads fail
│   └─ wg.Wait + peerWG.Wait ◄── waits for peer handlers
│           ✗ Run callback checks quitSync, THEN wg.Add(1) — two steps,
│             so Add can race this Wait  (the report in data_race.log)
│
└─ filterAPI / feed / gpo / tflusher .Stop ... store.Commit


LUIS'S COMMIT (d83d9ee)                              ✗ shutdown deadlock
═══════════════════════════════════════════════════════════════════

Service.Stop()
│
├─ peerRuns.refuseNewRuns() ····· race-free gate ✓
├─ handler.disconnectPeers() ···· peers.Close only: reads fail,
│                                 but both semaphores still live
├─ peerRuns.waitForRuns() ◄────── ✗ can hang forever:
│       · handler parked in dagProcessor.Enqueue (events semaphore) —
│         weight held by buffered events whose parents, with all
│         peers now disconnected, will never arrive
│       · handler parked in handleMsg (msgSemaphore) — holders are
│         the handlers stuck above
│       · Acquire only re-checks its timeout when a Release or
│         Terminate wakes it — and the Terminates are below ↓
│
└─ handler.Stop()
    ├─ dagProcessor.Stop ···· events semaphore Terminate   ← too late
    └─ msgSemaphore.Terminate                               ← too late


CURRENT (working tree)                               ✓
═══════════════════════════════════════════════════════════════════

Service.Stop()
│
├─ peerRuns.refuseNewRuns() ····· race-free gate ✓ (mutex serializes
│                                 acquire against the wait)
│
├─ handler.Stop() ····· full teardown FIRST — same order as main
│   ├─ dagLeecher.Stop / dagSeeder.Stop
│   ├─ dagProcessor.Stop ····· terminates EVENTS semaphore,
│   │                          clears buffered events
│   ├─ Heavycheck.Stop
│   ├─ txFetcher / dagFetcher .Stop
│   ├─ stop broadcast loops, loopsWg.Wait
│   ├─ msgSemaphore.Terminate ····· wakes parked handleMsg
│   ├─ close(quitSync)
│   └─ peers.Close ········ sessions drop, reads fail
│
├─ peerRuns.waitForRuns() ✓ every park point already released,
│                           so the wait always terminates
│
└─ filterAPI / feed / gpo / tflusher .Stop ... store.Commit
