### PR TITLE
Test interaction between priority lanes and sponsorship and bundles

### DIFF
--- a/tests/priorities/feature_combinations_test.go
+++ b/tests/priorities/feature_combinations_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package priorities
+
+import (
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	testbundles "github.com/0xsoniclabs/sonic/tests/bundles"
+	"github.com/0xsoniclabs/sonic/tests/gas_subsidies"
+	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriorities_PriorityOfBundlesIsThePriorityOfTheirEnvelope(t *testing.T) {
+	const numBundles = 5
+	const txsPerBundle = 2
+
+	cases := map[string]struct {
+		prioritizeEnvelopeSender bool
+		expectPrioritized        bool
+	}{
+		"prioritized envelope sender": {prioritizeEnvelopeSender: true, expectPrioritized: true},
+		"prioritized bundle senders":  {prioritizeEnvelopeSender: false, expectPrioritized: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			net, client, signer := netClientSignerWithPriorities(t, func(u *opera.Upgrades) {
+				u.TransactionBundles = true
+			})
+			defer client.Close()
+
+			envelopeSenders := tests.MakeAccountsWithBalance(t, net, numBundles, big.NewInt(1e18))
+			bundleSenders := tests.MakeAccountsWithBalance(t, net, numBundles, big.NewInt(1e18))
+
+			prioritizedSenders := bundleSenders
+			if tc.prioritizeEnvelopeSender {
+				prioritizedSenders = envelopeSenders
+			}
+			for i, sender := range prioritizedSenders {
+				setPrioritized(t, net, sender.Address(), 1, 1, uint64(i)+1)
+			}
+
+			block, err := client.BlockNumber(t.Context())
+			require.NoError(err)
+
+			envelopes := make([]*types.Transaction, numBundles)
+			planHashes := make([]common.Hash, numBundles)
+			bundled := map[common.Hash]bool{}
+			for i, sender := range bundleSenders {
+				steps := make([]bundle.BuilderStep, txsPerBundle)
+				for n := range steps {
+					steps[n] = testbundles.Step(t, net, sender, &types.AccessListTx{
+						Nonce: uint64(n),
+						To:    &common.Address{},
+						Value: big.NewInt(1),
+						Gas:   21_000,
+					})
+				}
+
+				envelope, txBundle, plan := bundle.NewBuilder().
+					WithSigner(signer).
+					SetEarliest(block).
+					SetEnvelopeSenderKey(envelopeSenders[i].PrivateKey).
+					AllOf(steps...).
+					BuildEnvelopeBundleAndPlan()
+
+				envelopes[i] = envelope
+				planHashes[i] = plan.Hash()
+				for _, tx := range txBundle.Transactions {
+					bundled[tx.Hash()] = true
+				}
+			}
+
+			ordinaryTxs := buildOrdinaryTraffic(t, net, 20, 5)
+
+			afterBlock, err := client.BlockNumber(t.Context())
+			require.NoError(err)
+
+			sendShuffledToPool(t, net, slices.Concat(envelopes, ordinaryTxs))
+
+			infos, err := testbundles.WaitForBundleExecutions(t.Context(), client.Client(), planHashes)
+			require.NoError(err)
+			for _, info := range infos {
+				require.EqualValues(txsPerBundle, info.Count)
+			}
+
+			requirePriorityAppliedSince(t, net, afterBlock, tc.expectPrioritized,
+				func(tx *types.Transaction) bool {
+					return bundled[tx.Hash()]
+				})
+		})
+	}
+}
+
+func TestPriorities_PrioritizedSponsoredTransactionsAlsoPrioritizesPaymentTransaction(t *testing.T) {
+	const numTxs = 5
+
+	require := require.New(t)
+
+	net, client, signer := netClientSignerWithPriorities(t, func(u *opera.Upgrades) {
+		u.GasSubsidies = true
+	})
+	defer client.Close()
+
+	sponsee := tests.NewAccount()
+	gas_subsidies.Fund(t, net, sponsee.Address(), big.NewInt(1e18))
+	setPrioritized(t, net, sponsee.Address(), 1, 1, 1)
+
+	sponsoredTxs := make([]*types.Transaction, numTxs)
+	for i := range sponsoredTxs {
+		sponsoredTxs[i] = types.MustSignNewTx(sponsee.PrivateKey, signer, &types.LegacyTx{
+			Nonce:    uint64(i),
+			To:       &common.Address{},
+			Value:    big.NewInt(0),
+			Gas:      21_000,
+			GasPrice: big.NewInt(0),
+		})
+		require.True(subsidies.IsSponsorshipRequest(sponsoredTxs[i]))
+	}
+
+	ordinaryTxs := buildOrdinaryTraffic(t, net, 20, 5)
+
+	afterBlock, err := client.BlockNumber(t.Context())
+	require.NoError(err)
+
+	hashes := sendShuffledToPool(t, net, slices.Concat(sponsoredTxs, ordinaryTxs))
+
+	receipts, err := net.GetReceipts(hashes)
+	require.NoError(err)
+	receiptByHash := make(map[common.Hash]*types.Receipt, len(receipts))
+	for _, receipt := range receipts {
+		require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+		receiptByHash[receipt.TxHash] = receipt
+	}
+
+	// Verify that each sponsored tx is followed by its payment tx.
+	for _, tx := range sponsoredTxs {
+		receipt := receiptByHash[tx.Hash()]
+		block, err := client.BlockByNumber(t.Context(), receipt.BlockNumber)
+		require.NoError(err)
+		txs := block.Transactions()
+		require.Less(int(receipt.TransactionIndex)+1, len(txs))
+
+		payment := txs[receipt.TransactionIndex+1]
+		require.True(internaltx.IsInternal(payment))
+		paymentReceipt, err := net.GetReceipt(payment.Hash())
+		require.NoError(err)
+		require.Equal(types.ReceiptStatusSuccessful, paymentReceipt.Status)
+	}
+
+	// Payment txs are internal and therefore skipped by requirePriorityAppliedSince.
+	requirePriorityAppliedSince(t, net, afterBlock, true,
+		func(tx *types.Transaction) bool {
+			from, err := types.Sender(signer, tx)
+			require.NoError(err)
+			return from == sponsee.Address()
+		})
+}

--- a/tests/priorities/feature_combinations_test.go
+++ b/tests/priorities/feature_combinations_test.go
@@ -38,11 +38,19 @@ func TestPriorities_PriorityOfBundlesIsThePriorityOfTheirEnvelope(t *testing.T) 
 	const txsPerBundle = 2
 
 	cases := map[string]struct {
+		// true => the envelope sender is prioritized
+		// false => the bundle sender is prioritized
 		prioritizeEnvelopeSender bool
 		expectPrioritized        bool
 	}{
-		"prioritized envelope sender": {prioritizeEnvelopeSender: true, expectPrioritized: true},
-		"prioritized bundle senders":  {prioritizeEnvelopeSender: false, expectPrioritized: false},
+		"prioritized envelope sender prioritized all txs in bundle": {
+			prioritizeEnvelopeSender: true,
+			expectPrioritized:        true,
+		},
+		"prioritized bundled txs sender does not prioritize txs in bundle": {
+			prioritizeEnvelopeSender: false,
+			expectPrioritized:        false,
+		},
 	}
 
 	for name, tc := range cases {

--- a/tests/priorities/priority_test.go
+++ b/tests/priorities/priority_test.go
@@ -20,7 +20,6 @@ import (
 	"cmp"
 	"encoding/binary"
 	"math/big"
-	"math/rand/v2"
 	"slices"
 	"testing"
 
@@ -74,15 +73,7 @@ func TestPriorities_TransactionsAreScheduledInPriorityOrder(t *testing.T) {
 				}
 			}
 
-			batch := slices.Concat(ordinary, prioritized)
-			rand.Shuffle(len(batch), func(i, j int) {
-				batch[i], batch[j] = batch[j], batch[i]
-			})
-
-			// Add the whole batch to the pool in a single call so every transaction is
-			// available before the emitter builds its first event.
-			hashes, err := net.SendAllToPool(t.Context(), batch)
-			require.NoError(err)
+			hashes := sendShuffledToPool(t, net, slices.Concat(ordinary, prioritized))
 
 			receipts, err := net.GetReceipts(hashes)
 			require.NoError(err)
@@ -156,10 +147,7 @@ func TestPriorities_PriorityOrderingPreservesNonceOrdering(t *testing.T) {
 				txs[i] = newSignedTx(t, net, sender, uint64(i), value, 21_000, nil)
 			}
 
-			// Add the whole batch to the pool in a single call so every
-			// transaction is available before the emitter builds its first event.
-			hashes, err := net.SendAllToPool(t.Context(), txs)
-			require.NoError(err)
+			hashes := sendShuffledToPool(t, net, txs)
 
 			receipts, err := net.GetReceipts(hashes)
 			require.NoError(err)

--- a/tests/priorities/registry_update_test.go
+++ b/tests/priorities/registry_update_test.go
@@ -39,8 +39,9 @@ func TestPriorities_SwapContract_PrioritizationChanges(t *testing.T) {
 	registered := newFundedPrioritizedAccount(t, net, 1, 0, 0xaa)
 	unregistered := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 
-	// The replacement registry is deployed up front so its magic value is known.
-	// Deploying does not affect the network until the swap below.
+	// MagicValuePriority classifies a transaction as prioritized iff its value
+	// equals a fixed magic constant. It is deployed up front so its magic value
+	// is known; deploying does not affect the network until the swap below.
 	impl, deployReceipt, err := tests.DeployContract(net, magic_value_priority.DeployMagicValuePriority)
 	require.NoError(err)
 	require.Equal(types.ReceiptStatusSuccessful, deployReceipt.Status)

--- a/tests/priorities/test_assertion_utils.go
+++ b/tests/priorities/test_assertion_utils.go
@@ -101,8 +101,11 @@ func sendShuffledToPool(
 ) []common.Hash {
 	t.Helper()
 
+	const seed = 7
+	rng := rand.New(rand.NewPCG(seed, seed))
+
 	batch := slices.Clone(txs)
-	rand.Shuffle(len(batch), func(i, j int) {
+	rng.Shuffle(len(batch), func(i, j int) {
 		batch[i], batch[j] = batch[j], batch[i]
 	})
 

--- a/tests/priorities/test_assertion_utils.go
+++ b/tests/priorities/test_assertion_utils.go
@@ -19,6 +19,8 @@ package priorities
 import (
 	"math"
 	"math/big"
+	"math/rand/v2"
+	"slices"
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/tests"
@@ -50,22 +52,12 @@ func requirePriorityHasEffect(
 	require.NoError(err)
 	defer client.Close()
 
-	// Pre-build ordinary background traffic (fresh accounts are funded now
-	// so their funding txs don't compete for block space with the actual
-	// test batch).
 	ordinaryTxs := buildOrdinaryTraffic(t, net, 20, 5)
 
 	afterBlock, err := client.BlockNumber(t.Context())
 	require.NoError(err)
 
-	// Add prioritized + ordinary txs to the pool in a single batch so they all
-	// become available before the emitter builds its first event, making their
-	// relative ordering deterministic.
-	batch := append([]*types.Transaction{}, ordinaryTxs...)
-	batch = append(batch, prioritizedTxs...)
-
-	hashes, err := net.SendAllToPool(t.Context(), batch)
-	require.NoError(err)
+	hashes := sendShuffledToPool(t, net, slices.Concat(ordinaryTxs, prioritizedTxs))
 
 	receipts, err := net.GetReceipts(hashes)
 	require.NoError(err)
@@ -97,6 +89,33 @@ func buildOrdinaryTraffic(
 	return txs
 }
 
+// sendShuffledToPool adds all given transactions to the pool in a single batch
+// and in random order, so they all become available before the emitter builds
+// its first event and their relative ordering depends neither on the order they
+// were built in nor on their arrival times in the pool. It returns their hashes
+// in the order given.
+func sendShuffledToPool(
+	t *testing.T,
+	net *tests.IntegrationTestNet,
+	txs []*types.Transaction,
+) []common.Hash {
+	t.Helper()
+
+	batch := slices.Clone(txs)
+	rand.Shuffle(len(batch), func(i, j int) {
+		batch[i], batch[j] = batch[j], batch[i]
+	})
+
+	_, err := net.SendAllToPool(t.Context(), batch)
+	require.NoError(t, err)
+
+	hashes := make([]common.Hash, len(txs))
+	for i, tx := range txs {
+		hashes[i] = tx.Hash()
+	}
+	return hashes
+}
+
 // requirePriorityAppliedSince scans the user transactions of every block after
 // `afterBlock`, in block-then-index order, and asserts on the global ordering of
 // prioritized (per `isPrioritized`) vs ordinary transactions. Both classes must
@@ -110,9 +129,10 @@ func buildOrdinaryTraffic(
 //   - expectPrioritized == false: at least one ordinary tx precedes a
 //     prioritized one (proof that no reordering ran).
 //
-// Callers should submit the whole batch via SendAllToPool, so this global
-// ordering is deterministic and does not depend on arrival times of individual
-// transactions in the pool and whether emission ran between those or not.
+// Callers should submit the whole batch via sendShuffledToPool, so the observed
+// ordering is decided by prioritization alone: it depends neither on the order
+// the transactions were built in nor on their arrival times in the pool and
+// whether emission ran between those or not.
 func requirePriorityAppliedSince(
 	t *testing.T,
 	net *tests.IntegrationTestNet,


### PR DESCRIPTION
This PR adds 2 tests for the interacting between priority lanes and sponsorship and bundles.
- ensure a bundle inherits the priority of its envelope sender, not of the senders it encloses.
- ensure prioritizing a sponsee keeps each sponsored transaction paired with the internal transaction that settles its gas fee.

Alongside, the shared batch submission is extracted into `sendShuffledToPool`, which now shuffles before submitting so the observed ordering cannot depend on the order transactions were built in.