### PR TITLE
Fix data race between ENR updater and gossip store shutdown

### DIFF
--- a/gossip/discover.go
+++ b/gossip/discover.go
@@ -41,13 +41,27 @@ func (e enrEntry) ENRKey() string {
 
 // StartENRUpdater starts the `opera` ENR updater loop, which listens for chain
 // head events and updates the requested node record whenever a fork is passed.
-func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
+// The loop terminates once the subscription to the service's block feed is
+// closed by ServiceFeed.Stop. The returned function blocks until the loop has
+// terminated; it must be called before the service's store is closed, since the
+// loop reads from the store.
+func StartENRUpdater(svc *Service, ln *enode.LocalNode) (waitForShutdown func()) {
 	var newHead = make(chan evmcore.ChainHeadNotify, 10)
 	sub := svc.feed.SubscribeNewBlock(newHead)
 
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		defer sub.Unsubscribe()
 		for {
+			// The subscription error channel is checked with priority to make
+			// sure no store access happens after the shutdown was initiated,
+			// even if there are still head events buffered in newHead.
+			select {
+			case <-sub.Err():
+				return
+			default:
+			}
 			select {
 			case head := <-newHead:
 				ln.Set(currentENREntry(
@@ -56,12 +70,12 @@ func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
 					uint64(head.Block.Time.Unix()),
 				))
 			case <-sub.Err():
-				// Would be nice to sync with Stop, but there is no
-				// good way to do that.
 				return
 			}
 		}
 	}()
+
+	return func() { <-done }
 }
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.

--- a/gossip/discover_test.go
+++ b/gossip/discover_test.go
@@ -1,0 +1,97 @@
+package gossip
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/inter"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartENRUpdater_ShutdownWaitBlocksUntilLoopStoppedReadingTheStore checks
+// that the store can be safely closed once the function returned by
+// StartENRUpdater has returned. Run with -race, this test fails if the updater
+// loop is still accessing the store during or after the store is closed.
+func TestStartENRUpdater_ShutdownWaitBlocksUntilLoopStoppedReadingTheStore(t *testing.T) {
+	store := newInMemoryStoreWithGenesisData(t, opera.GetSonicUpgrades(), 1, 1)
+	svc := &Service{store: store}
+	svc.feed.Start(store.evm)
+
+	waitForShutdown := StartENRUpdater(svc, newTestLocalNode(t))
+
+	// Keep the updater busy with head notifications while the shutdown runs, so
+	// that the loop is likely to be in the middle of a store access when the
+	// feed is stopped.
+	stopFeeding := make(chan struct{})
+	feederDone := make(chan struct{})
+	go func() {
+		defer close(feederDone)
+		for i := 1; ; i++ {
+			select {
+			case <-stopFeeding:
+				return
+			default:
+			}
+			svc.feed.newBlock.Send(evmcore.ChainHeadNotify{
+				Block: &evmcore.EvmBlock{
+					EvmHeader: evmcore.EvmHeader{
+						Number: big.NewInt(int64(i)),
+						Time:   inter.Timestamp(i),
+					},
+				},
+			})
+		}
+	}()
+	time.Sleep(10 * time.Millisecond)
+
+	svc.feed.Stop() // < closes the subscription scope, terminating the updater
+	waitForShutdown()
+
+	close(stopFeeding)
+	<-feederDone
+
+	// From here on no goroutine may touch the store any more; it is closed by
+	// the clean-up registered by newInMemoryStoreWithGenesisData.
+}
+
+// TestStartENRUpdater_ShutdownWaitReturnsIfNoEventsAreProduced checks that the
+// updater loop terminates on an idle chain.
+func TestStartENRUpdater_ShutdownWaitReturnsIfNoEventsAreProduced(t *testing.T) {
+	store := newInMemoryStoreWithGenesisData(t, opera.GetSonicUpgrades(), 1, 1)
+	svc := &Service{store: store}
+	svc.feed.Start(store.evm)
+
+	waitForShutdown := StartENRUpdater(svc, newTestLocalNode(t))
+	svc.feed.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		waitForShutdown()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ENR updater did not terminate after the feed was stopped")
+	}
+}
+
+func newTestLocalNode(t *testing.T) *enode.LocalNode {
+	t.Helper()
+	db, err := enode.OpenDB("")
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+
+	var key *ecdsa.PrivateKey
+	key, err = crypto.GenerateKey()
+	require.NoError(t, err)
+
+	return enode.NewLocalNode(db, key)
+}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -253,6 +253,11 @@ type Service struct {
 
 	operaDialCandidates enode.Iterator
 
+	// waitForEnrUpdaterShutdown blocks until the ENR updater loop started by
+	// Start has terminated. It must be called during shutdown before the store
+	// is closed, since the loop reads from the store.
+	waitForEnrUpdaterShutdown func()
+
 	EthAPI        *EthAPIBackend
 	netRPCService *ethapi.PublicNetAPI
 
@@ -593,7 +598,7 @@ func (s *Service) Start() error {
 	s.blockProcTasks.Start(1)
 
 	// start p2p
-	StartENRUpdater(s, s.p2pServer.LocalNode())
+	s.waitForEnrUpdaterShutdown = StartENRUpdater(s, s.p2pServer.LocalNode())
 	s.handler.Start(s.p2pServer.MaxPeers)
 
 	// start emitters
@@ -636,6 +641,13 @@ func (s *Service) Stop() error {
 		s.filterAPI.Stop()
 	}
 	s.feed.Stop()
+	// The ENR updater is terminated by the feed's subscription scope being
+	// closed in feed.Stop above. It must be awaited before returning, since it
+	// reads from the store, which is closed once this service is stopped.
+	if s.waitForEnrUpdaterShutdown != nil {
+		s.waitForEnrUpdaterShutdown()
+		s.waitForEnrUpdaterShutdown = nil
+	}
 	s.gpo.Stop()
 	// it's safe to stop tflusher only before locking engineMu
 	s.tflusher.Stop()


### PR DESCRIPTION
Fixes the `MigrateCaches` vs `GetBlock` data race reported by the race-detection CI job.

**Cause:** the `StartENRUpdater` goroutine reads the gossip store (`GetGenesisTime` → `GetBlock`), but was never synchronized with shutdown — the old code said as much in a comment. `Service.Stop` closed the feed's subscription scope and returned without waiting, so the loop could still be reading when `MakeNode`'s cleanup closed the store.

**Fix:** `StartENRUpdater` returns a function that blocks until its goroutine has exited; `Service.Stop` awaits it right after `feed.Stop()`. The loop also checks `sub.Err()` with priority so it stops touching the store once shutdown begins, instead of draining buffered head events.

**Test:** `gossip/discover_test.go` reproduces the reported race under `-race` when the fix is reverted, and passes with it.

Note: `main` carries the same bug and needs the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)