### PR TITLE
Test that priority can be revoked

### DIFF
--- a/tests/priorities/grant_revoke_test.go
+++ b/tests/priorities/grant_revoke_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package priorities
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriorities_SenderPriorityCanBeGrantedAndRevoked(t *testing.T) {
+	require := require.New(t)
+
+	net, client, signer := netClientSignerWithPriorities(t, nil)
+	defer client.Close()
+
+	account := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+
+	buildTxs := func() []*types.Transaction {
+		nonce, err := client.PendingNonceAt(t.Context(), account.Address())
+		require.NoError(err)
+		txs := make([]*types.Transaction, 5)
+		for i := range txs {
+			txs[i] = newSignedTx(t, net, account, nonce+uint64(i), 1, 21_000, nil)
+		}
+		return txs
+	}
+	txHasRegisteredSender := func(tx *types.Transaction) bool {
+		from, err := types.Sender(signer, tx)
+		require.NoError(err)
+		return from == account.Address()
+	}
+
+	// --- unregistered ---
+	requirePrioritized(t, net, account.Address(), 1, false)
+	requirePriorityHasEffect(t, net, buildTxs(), false, txHasRegisteredSender)
+
+	// --- granted ---
+	setPrioritized(t, net, account.Address(), 1, 1, 1)
+	requirePrioritized(t, net, account.Address(), 1, true)
+	requirePriorityHasEffect(t, net, buildTxs(), true, txHasRegisteredSender)
+
+	// --- revoked ---
+	setPrioritized(t, net, account.Address(), 0, 0, 0)
+	requirePrioritized(t, net, account.Address(), 1, false)
+	requirePriorityHasEffect(t, net, buildTxs(), false, txHasRegisteredSender)
+}

--- a/tests/priorities/registry_update_test.go
+++ b/tests/priorities/registry_update_test.go
@@ -76,10 +76,10 @@ func TestPriorities_SwapContract_PrioritizationChanges(t *testing.T) {
 	txHasMagicValue := func(tx *types.Transaction) bool { return tx.Value().Cmp(magicValue) == 0 }
 
 	// --- default registry - prioritization depends only on the sender ---
-	require.True(checkPriority(t, net, registered.Address(), 1))
-	require.True(checkPriority(t, net, registered.Address(), magicValue.Uint64()))
-	require.False(checkPriority(t, net, unregistered.Address(), 1))
-	require.False(checkPriority(t, net, unregistered.Address(), magicValue.Uint64()))
+	requirePrioritized(t, net, registered.Address(), 1, true)
+	requirePrioritized(t, net, registered.Address(), magicValue.Uint64(), true)
+	requirePrioritized(t, net, unregistered.Address(), 1, false)
+	requirePrioritized(t, net, unregistered.Address(), magicValue.Uint64(), false)
 
 	requirePriorityHasEffect(t, net, buildRegisteredSenderTxs(), true, txHasRegisteredSender)
 	requirePriorityHasEffect(t, net, buildMagicValueTxs(), false, txHasMagicValue)
@@ -87,37 +87,13 @@ func TestPriorities_SwapContract_PrioritizationChanges(t *testing.T) {
 	// --- MagicValuePriority registry - prioritization depends only on the tx value ---
 	switchPriorityRegistry(t, net, deployReceipt.ContractAddress)
 
-	require.False(checkPriority(t, net, registered.Address(), 1))
-	require.True(checkPriority(t, net, registered.Address(), magicValue.Uint64()))
-	require.False(checkPriority(t, net, unregistered.Address(), 1))
-	require.True(checkPriority(t, net, unregistered.Address(), magicValue.Uint64()))
+	requirePrioritized(t, net, registered.Address(), 1, false)
+	requirePrioritized(t, net, registered.Address(), magicValue.Uint64(), true)
+	requirePrioritized(t, net, unregistered.Address(), 1, false)
+	requirePrioritized(t, net, unregistered.Address(), magicValue.Uint64(), true)
 
 	requirePriorityHasEffect(t, net, buildRegisteredSenderTxs(), false, txHasRegisteredSender)
 	requirePriorityHasEffect(t, net, buildMagicValueTxs(), true, txHasMagicValue)
-}
-
-// checkPriority calls the registry's `getPriority` method for a transaction
-// with the given `from` and `value`, and returns whether it is prioritized.
-func checkPriority(
-	t *testing.T,
-	net *tests.IntegrationTestNet,
-	from common.Address,
-	value uint64,
-) bool {
-	t.Helper()
-	require := require.New(t)
-
-	client, err := net.GetClient()
-	require.NoError(err)
-	defer client.Close()
-
-	reg, err := registry.NewRegistry(registry.GetAddress(), client)
-	require.NoError(err)
-
-	priority, err := reg.GetPriority(nil,
-		from, common.Address{}, new(big.Int).SetUint64(value), big.NewInt(0), nil, big.NewInt(21_000))
-	require.NoError(err)
-	return priority.Level > 0
 }
 
 // switchPriorityRegistry points the priority-registry proxy at `newImpl`,

--- a/tests/priorities/test_assertion_utils.go
+++ b/tests/priorities/test_assertion_utils.go
@@ -23,12 +23,39 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
 	"github.com/0xsoniclabs/sonic/tests"
 	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
 )
+
+// requirePrioritized calls the registry's `getPriority` method for a
+// transaction with the given `from` and `value`, and checks that it is
+// prioritized iff `expectPrioritized`.
+func requirePrioritized(
+	t *testing.T,
+	net *tests.IntegrationTestNet,
+	from common.Address,
+	value uint64,
+	expectPrioritized bool,
+) {
+	t.Helper()
+	require := require.New(t)
+
+	client, err := net.GetClient()
+	require.NoError(err)
+	defer client.Close()
+
+	reg, err := registry.NewRegistry(registry.GetAddress(), client)
+	require.NoError(err)
+
+	priority, err := reg.GetPriority(nil,
+		from, common.Address{}, new(big.Int).SetUint64(value), big.NewInt(0), nil, big.NewInt(21_000))
+	require.NoError(err)
+	require.Equal(expectPrioritized, priority.Level > 0)
+}
 
 // requirePriorityHasEffect proves that the currently installed priority
 // classifier is (or isn't, per `expectPrioritized`) consulted on the


### PR DESCRIPTION
This PR adds a test ensuring that an account registered for priority usage can be unregistered and afterward its transactions are no longer prioritized.