### PR TITLE
Wait for the ENR updater to stop  before closing the gossip store

### DIFF
--- a/gossip/discover.go
+++ b/gossip/discover.go
@@ -45,23 +45,22 @@ func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
 	var newHead = make(chan evmcore.ChainHeadNotify, 10)
 	sub := svc.feed.SubscribeNewBlock(newHead)
 
-	go func() {
-		defer sub.Unsubscribe()
-		for {
-			select {
-			case head := <-newHead:
-				ln.Set(currentENREntry(
-					svc,
-					idx.Block(head.Block.Number.Uint64()),
-					uint64(head.Block.Time.Unix()),
-				))
-			case <-sub.Err():
-				// Would be nice to sync with Stop, but there is no
-				// good way to do that.
-				return
+	svc.storeReadersWg.Go(
+		func() {
+			defer sub.Unsubscribe()
+			for {
+				select {
+				case head := <-newHead:
+					ln.Set(currentENREntry(
+						svc,
+						idx.Block(head.Block.Number.Uint64()),
+						uint64(head.Block.Time.Unix()),
+					))
+				case <-sub.Err():
+					return
+				}
 			}
-		}
-	}()
+		})
 }
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.

--- a/gossip/discover.go
+++ b/gossip/discover.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/forkid"
-	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
@@ -39,9 +39,17 @@ func (e enrEntry) ENRKey() string {
 	return "opera"
 }
 
+// nodeRecord is the part of enode.LocalNode used by the ENR updater. It is an
+// interface to allow tests to observe and delay node record updates.
+type nodeRecord interface {
+	Set(entry enr.Entry)
+}
+
 // StartENRUpdater starts the `opera` ENR updater loop, which listens for chain
 // head events and updates the requested node record whenever a fork is passed.
-func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
+// The loop reads from the gossip store, so it is registered at the service's
+// store-reader wait group; it terminates when the service's feed is stopped.
+func StartENRUpdater(svc *Service, ln nodeRecord) {
 	var newHead = make(chan evmcore.ChainHeadNotify, 10)
 	sub := svc.feed.SubscribeNewBlock(newHead)
 

--- a/gossip/discover_test.go
+++ b/gossip/discover_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gossip
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestStartENRUpdater_UpdatesNodeRecordOnNewBlock(t *testing.T) {
+	require := require.New(t)
+	svc := newENRUpdaterTestService(t)
+
+	record := newBlockingNodeRecord()
+	close(record.release) // < do not block the updater in this test
+	StartENRUpdater(svc, record)
+
+	svc.feed.notifyAboutNewBlock(newTestBlock(1), nil)
+
+	select {
+	case entry := <-record.updates:
+		// The entry is derived from data read from the gossip store, so its
+		// delivery proves that the updater is a store reader.
+		require.IsType(&enrEntry{}, entry)
+	case <-time.After(30 * time.Second):
+		require.Fail("node record was not updated")
+	}
+
+	svc.stopStoreReaders()
+}
+
+// TestStartENRUpdater_ShutdownWaitsForRunningUpdater covers the shutdown
+// ordering the updater depends on: it reads from the gossip store on every
+// chain head notification, so it must have terminated before Service.Stop
+// closes the store. Without the join, the updater could still be accessing the
+// store while Store.Close nils out its tables and caches.
+func TestStartENRUpdater_ShutdownWaitsForRunningUpdater(t *testing.T) {
+	require := require.New(t)
+	svc := newENRUpdaterTestService(t)
+
+	record := newBlockingNodeRecord()
+	StartENRUpdater(svc, record)
+
+	svc.feed.notifyAboutNewBlock(newTestBlock(1), nil)
+
+	// Wait for the updater to enter the notification handler. It is pinned
+	// there, mid-iteration, until the test releases it.
+	<-record.updates
+
+	stopped := runAsync(svc.stopStoreReaders)
+
+	select {
+	case <-stopped:
+		require.Fail("shutdown returned while the ENR updater was still running")
+	case <-time.After(100 * time.Millisecond):
+		// all good, the shutdown is waiting for the updater
+	}
+
+	close(record.release)
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		require.Fail("shutdown did not return after the ENR updater finished")
+	}
+}
+
+// TestStartENRUpdater_ShutdownTerminatesWithBackloggedNotifications exercises
+// the shutdown path while the feed producer is blocked in a send to the
+// updater's full notification channel. Stopping the feed has to unblock the
+// producer, the producer has to unblock the feed's shutdown, and only then can
+// the updater be signaled -- a chain in which every step waits for the previous
+// one.
+func TestStartENRUpdater_ShutdownTerminatesWithBackloggedNotifications(t *testing.T) {
+	require := require.New(t)
+	svc := newENRUpdaterTestService(t)
+
+	record := newBlockingNodeRecord()
+	StartENRUpdater(svc, record)
+
+	// The updater's notification channel holds 10 events; sending more than
+	// that blocks the feed's producer goroutine inside the notification send
+	// while the updater is pinned in the handler.
+	const notifications = 25
+	for i := range notifications {
+		svc.feed.notifyAboutNewBlock(newTestBlock(int64(i+1)), nil)
+	}
+	<-record.updates
+
+	stopped := runAsync(svc.stopStoreReaders)
+
+	close(record.release)
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		require.Fail("shutdown deadlocked with backlogged notifications")
+	}
+}
+
+func TestStartENRUpdater_ShutdownIsDeadlockFreeWhileNotificationsAreInFlight(t *testing.T) {
+	require := require.New(t)
+
+	// The updater is stopped at an arbitrary point of its notification
+	// processing, covering the interleavings between an in-flight notification
+	// and the shutdown signal.
+	for _, delay := range []time.Duration{0, time.Microsecond, 10 * time.Microsecond, time.Millisecond} {
+		svc := newENRUpdaterTestService(t)
+
+		record := newBlockingNodeRecord()
+		close(record.release) // < do not block the updater in this test
+		StartENRUpdater(svc, record)
+
+		for i := range 25 {
+			svc.feed.notifyAboutNewBlock(newTestBlock(int64(i+1)), nil)
+		}
+		time.Sleep(delay)
+
+		stopped := runAsync(svc.stopStoreReaders)
+
+		select {
+		case <-stopped:
+		case <-time.After(30 * time.Second):
+			require.Failf("shutdown deadlocked", "delay: %v", delay)
+		}
+	}
+}
+
+func TestStartENRUpdater_ShutdownDoesNotBlockIfUpdaterWasNeverStarted(t *testing.T) {
+	require := require.New(t)
+	svc := newENRUpdaterTestService(t)
+
+	// Service.Stop runs the same sequence when Service.Start failed before the
+	// ENR updater was started.
+	stopped := runAsync(svc.stopStoreReaders)
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		require.Fail("shutdown blocked although no store reader was started")
+	}
+}
+
+func runAsync(f func()) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+	}()
+	return done
+}
+
+func newTestBlock(number int64) *evmcore.EvmBlock {
+	return &evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{Number: big.NewInt(number)},
+	}
+}
+
+func newENRUpdaterTestService(tb testing.TB) *Service {
+	tb.Helper()
+
+	store := newInMemoryStoreWithGenesisData(tb, opera.GetSonicUpgrades(), 1, 1)
+
+	archive := NewMockArchiveBlockHeightSource(gomock.NewController(tb))
+	archive.EXPECT().GetArchiveBlockHeight().Return(^uint64(0), false, nil).AnyTimes()
+
+	svc := &Service{store: store}
+	svc.feed.Start(archive)
+
+	return svc
+}
+
+// blockingNodeRecord is a node record whose update blocks the ENR updater
+// inside a notification handler until the test releases it.
+type blockingNodeRecord struct {
+	updates chan enr.Entry
+	release chan struct{}
+}
+
+func newBlockingNodeRecord() *blockingNodeRecord {
+	return &blockingNodeRecord{
+		updates: make(chan enr.Entry, 1024),
+		release: make(chan struct{}),
+	}
+}
+
+func (r *blockingNodeRecord) Set(entry enr.Entry) {
+	r.updates <- entry
+	<-r.release
+}

--- a/gossip/discover_test.go
+++ b/gossip/discover_test.go
@@ -162,6 +162,28 @@ func TestStartENRUpdater_ShutdownDoesNotBlockIfUpdaterWasNeverStarted(t *testing
 	}
 }
 
+// TestStartENRUpdater_ShutdownCanBeCalledRepeatedly pins a property the
+// shutdown gets for free from ServiceFeed.Stop, which is idempotent: a repeated
+// shutdown must neither panic on the already stopped feed nor block on the wait
+// group of the store readers it terminated the first time.
+func TestStartENRUpdater_ShutdownCanBeCalledRepeatedly(t *testing.T) {
+	require := require.New(t)
+	svc := newENRUpdaterTestService(t)
+
+	record := newBlockingNodeRecord()
+	close(record.release) // < do not block the updater in this test
+	StartENRUpdater(svc, record)
+
+	svc.stopStoreReaders()
+	stopped := runAsync(svc.stopStoreReaders)
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		require.Fail("repeated shutdown blocked")
+	}
+}
+
 func runAsync(f func()) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -245,6 +245,11 @@ type Service struct {
 	blockProcTasksDone chan struct{}
 	blockProcModules   BlockProc
 
+	// storeReadersWg tracks background routines reading from the store. They
+	// must have terminated before Stop returns, since the store is closed
+	// afterwards.
+	storeReadersWg sync.WaitGroup
+
 	blockBusyFlag uint32
 	eventBusyFlag uint32
 
@@ -662,6 +667,8 @@ func (s *Service) Stop() error {
 		s.filterAPI.Stop()
 	}
 	s.feed.Stop()
+	// Feed subscribers are signaled by feed.Stop, wait for them to terminate.
+	s.storeReadersWg.Wait()
 	s.gpo.Stop()
 	// it's safe to stop tflusher only before locking engineMu
 	s.tflusher.Stop()

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -247,7 +247,8 @@ type Service struct {
 
 	// storeReadersWg tracks background routines reading from the store. They
 	// must have terminated before Stop returns, since the store is closed
-	// afterwards.
+	// afterwards. Routines may only join this group if they terminate on feed
+	// shutdown.
 	storeReadersWg sync.WaitGroup
 
 	blockBusyFlag uint32
@@ -646,6 +647,13 @@ func (s *Service) stopPeerHandling() {
 	s.peerRuns.waitForRuns()
 }
 
+// stopStoreReaders stops the feed and waits for the background routines reading
+// from the store to terminate.
+func (s *Service) stopStoreReaders() {
+	s.feed.Stop()
+	s.storeReadersWg.Wait()
+}
+
 // Stop method invoked when the node terminates the service.
 func (s *Service) Stop() error {
 	defer log.Info("Sonic service stopped")
@@ -666,9 +674,7 @@ func (s *Service) Stop() error {
 	if s.filterAPI != nil {
 		s.filterAPI.Stop()
 	}
-	s.feed.Stop()
-	// Feed subscribers are signaled by feed.Stop, wait for them to terminate.
-	s.storeReadersWg.Wait()
+	s.stopStoreReaders()
 	s.gpo.Stop()
 	// it's safe to stop tflusher only before locking engineMu
 	s.tflusher.Stop()


### PR DESCRIPTION
This PR fixes a data race detected in a [CI run](https://scala.fantom.network/job/Sonic/job/Unit-test-race-detection/547/consoleFull).

`Store.Close()` nils all cache fields, and it runs from `MakeNode`'s cleanup — deferred until after `node.Wait()`, i.e. after `Service.Stop()`. The ENR updater was the one store-reading routine not joined at shutdown: `feed.Stop()` closes its subscription scope, but nobody waited for the goroutine, so it could still be reading `s.cache.Blocks` via `GetGenesisTime` → `GetBlock`:

    Write at 0x00c0168fb730 by goroutine 80395:
      kvdb/table.MigrateCaches()
      gossip.(*Store).Close()          gossip/store.go:173
      config.MakeNode.func2()          config/make_node.go:72

    Previous read at 0x00c0168fb730 by goroutine 81937:
      gossip.(*Store).GetBlock()       gossip/store_block.go:76
      gossip.(*Store).GetGenesisTime() gossip/store_block.go:171
      gossip.currentENREntry()         gossip/discover.go:69
      gossip.StartENRUpdater.func1()   gossip/discover.go:53

The goroutine is now tracked in a `storeReadersWg` on `Service`, which `Stop()` waits on right after `feed.Stop()` signals subscribers to exit.