### PR TITLE
Test that entity gas limit gets applied

### DIFF
--- a/tests/priorities/entity_gas_limit_test.go
+++ b/tests/priorities/entity_gas_limit_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package priorities
+
+import (
+	"encoding/binary"
+	"math/big"
+	"slices"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/priorities"
+	"github.com/0xsoniclabs/sonic/utils/signers/internaltx"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPriorities_PerEntityGasLimitCapsThePrioritizedPrefixOfEveryBlock(t *testing.T) {
+	const (
+		gasPerTx    = 21_000
+		txsInBudget = 5
+
+		numEntities  = 5
+		txsPerEntity = txsInBudget + 1
+	)
+
+	require := require.New(t)
+
+	net, client, signer := netClientSignerWithPriorities(t, nil)
+	defer client.Close()
+
+	setPriorityConfig(t, net, txsInBudget*gasPerTx, 1_000)
+
+	// One sender per (entity, weight) with a single transaction each, so the
+	// selection is decided by the gas budget alone and is fully determined: of
+	// an entity's transactions in a block, the txsInBudget ones with the highest
+	// weight fit its budget, the rest is demoted.
+	prioBySender := map[common.Address]priorities.Priority{}
+	prioritized := make(types.Transactions, 0, numEntities*txsPerEntity)
+	for entity := uint64(1); entity <= numEntities; entity++ {
+		for weight := uint64(1); weight <= txsPerEntity; weight++ {
+			account := newFundedPrioritizedAccount(t, net, 1, weight, entity)
+			prio := priorities.Priority{Level: 1, Weight: weight}
+			binary.BigEndian.PutUint64(prio.ID[8:], entity)
+			prioBySender[account.Address()] = prio
+			prioritized = append(prioritized, newSignedTx(t, net, account, 0, 1, gasPerTx, nil))
+		}
+	}
+
+	ordinary := buildOrdinaryTraffic(t, net, 20, 5)
+
+	hashes := sendShuffledToPool(t, net, slices.Concat(ordinary, prioritized))
+	receipts, err := net.GetReceipts(hashes)
+	require.NoError(err)
+
+	first, last := receipts[0].BlockNumber.Uint64(), receipts[0].BlockNumber.Uint64()
+	for _, receipt := range receipts {
+		require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+		first = min(first, receipt.BlockNumber.Uint64())
+		last = max(last, receipt.BlockNumber.Uint64())
+	}
+
+	demotedAfterOrdinary := false
+	for number := first; number <= last; number++ {
+		block, err := client.BlockByNumber(t.Context(), new(big.Int).SetUint64(number))
+		require.NoError(err)
+
+		seenOfEntity := map[priorities.PriorityID]uint64{}
+		lastFittingWeightOfEntity := map[priorities.PriorityID]uint64{}
+		seenOrdinary := false
+		for _, tx := range block.Transactions() {
+			if internaltx.IsInternal(tx) {
+				continue
+			}
+			from, err := types.Sender(signer, tx)
+			require.NoError(err)
+			prio := prioBySender[from]
+			if !prio.IsPrioritized() {
+				seenOrdinary = true
+				continue
+			}
+			if lastFitting, ok := lastFittingWeightOfEntity[prio.ID]; ok {
+				require.Less(prio.Weight, lastFitting)
+			}
+			if seenOfEntity[prio.ID] < txsInBudget {
+				require.False(seenOrdinary)
+				lastFittingWeightOfEntity[prio.ID] = prio.Weight
+			} else {
+				demotedAfterOrdinary = demotedAfterOrdinary || seenOrdinary
+			}
+			seenOfEntity[prio.ID]++
+		}
+	}
+
+	require.True(demotedAfterOrdinary)
+}

--- a/tests/priorities/test_setup_utils.go
+++ b/tests/priorities/test_setup_utils.go
@@ -51,7 +51,7 @@ func netClientSignerWithPriorities(
 		Upgrades: &upgrades,
 	})
 
-	configureHighPriorityLimits(t, net)
+	setPriorityConfig(t, net, 100_000_000, 1_000)
 
 	client, err := net.GetClient()
 	require.NoError(err)
@@ -59,9 +59,12 @@ func netClientSignerWithPriorities(
 	return net, client, types.LatestSignerForChainID(net.GetChainId())
 }
 
-// configureHighPriorityLimits configures generous priority limits in the
-// priority registry.
-func configureHighPriorityLimits(t *testing.T, net *tests.IntegrationTestNet) {
+// setPriorityConfig sets the per-entity rate limits of the priority registry.
+func setPriorityConfig(
+	t *testing.T,
+	net *tests.IntegrationTestNet,
+	maxGasPerEntityPerBlock, maxPiggybackTxsPerEntityPerEvent uint64,
+) {
 	t.Helper()
 	require := require.New(t)
 
@@ -73,7 +76,9 @@ func configureHighPriorityLimits(t *testing.T, net *tests.IntegrationTestNet) {
 	require.NoError(err)
 
 	receipt, err := net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
-		return reg.SetConfig(opts, big.NewInt(100_000_000), big.NewInt(1_000))
+		return reg.SetConfig(opts,
+			new(big.Int).SetUint64(maxGasPerEntityPerBlock),
+			new(big.Int).SetUint64(maxPiggybackTxsPerEntityPerEvent))
 	})
 	require.NoError(err)
 	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)


### PR DESCRIPTION
This PR adds a test ensuring that the per entity per block gas budget gets applied. It submits one more prioritized transactions that fit into this budget, and checks that only the highest priority ones actually get the priority, and the lowest priority one is demoted and treated as non-prioritized.