### PR TITLE
Fix enr shutdown race condition

### DIFF
--- a/gossip/discover.go
+++ b/gossip/discover.go
@@ -17,10 +17,12 @@
 package gossip
 
 import (
+	"sync"
+
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/forkid"
-	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
@@ -39,13 +41,23 @@ func (e enrEntry) ENRKey() string {
 	return "opera"
 }
 
+// nodeRecord is the part of enode.LocalNode used by the ENR updater.
+type nodeRecord interface {
+	Set(entry enr.Entry)
+}
+
 // StartENRUpdater starts the `opera` ENR updater loop, which listens for chain
 // head events and updates the requested node record whenever a fork is passed.
-func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
+// The returned function stops the loop and waits for it to terminate. It must be
+// called before the store is closed, since the loop reads from the store.
+func StartENRUpdater(svc *Service, ln nodeRecord) (stop func()) {
 	var newHead = make(chan evmcore.ChainHeadNotify, 10)
 	sub := svc.feed.SubscribeNewBlock(newHead)
 
+	quit := make(chan struct{})
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		defer sub.Unsubscribe()
 		for {
 			select {
@@ -55,13 +67,18 @@ func StartENRUpdater(svc *Service, ln *enode.LocalNode) {
 					idx.Block(head.Block.Number.Uint64()),
 					uint64(head.Block.Time.Unix()),
 				))
+			case <-quit:
+				return
 			case <-sub.Err():
-				// Would be nice to sync with Stop, but there is no
-				// good way to do that.
 				return
 			}
 		}
 	}()
+
+	return sync.OnceFunc(func() {
+		close(quit)
+		<-done
+	})
 }
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.

--- a/gossip/discover_test.go
+++ b/gossip/discover_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package gossip
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/0xsoniclabs/sonic/evmcore"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestStartENRUpdater_StopWaitsForUpdaterToFinishStoreAccess covers the
+// shutdown ordering the updater depends on: it reads from the gossip store on
+// every chain head notification, so it must be joined before the store is
+// closed. Without the join the updater would still be accessing the store while
+// Store.Close nils out its tables and caches.
+func TestStartENRUpdater_StopWaitsForUpdaterToFinishStoreAccess(t *testing.T) {
+	require := require.New(t)
+	svc := newENRUpdaterTestService(t)
+
+	record := newBlockingNodeRecord()
+	stop := StartENRUpdater(svc, record)
+
+	svc.feed.notifyAboutNewBlock(&evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{Number: big.NewInt(1)},
+	}, nil)
+
+	// Wait for the updater to be inside the handler that reads the store. The
+	// entry it delivers is the result of those reads, so by the time the record
+	// blocks, the handler is provably in the middle of its store access.
+	entry := <-record.updates
+	require.IsType(&enrEntry{}, entry)
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		stop()
+	}()
+
+	select {
+	case <-stopped:
+		require.Fail("stop returned while the updater was still accessing the store")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(record.release)
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		require.Fail("stop did not return after the updater finished")
+	}
+
+	svc.feed.Stop()
+}
+
+func TestStartENRUpdater_StopCanBeCalledRepeatedly(t *testing.T) {
+	svc := newENRUpdaterTestService(t)
+	stop := StartENRUpdater(svc, newBlockingNodeRecord())
+
+	stop()
+	stop()
+
+	svc.feed.Stop()
+}
+
+func newENRUpdaterTestService(tb testing.TB) *Service {
+	tb.Helper()
+
+	store := newInMemoryStoreWithGenesisData(tb, opera.GetSonicUpgrades(), 1, 1)
+
+	archive := NewMockArchiveBlockHeightSource(gomock.NewController(tb))
+	archive.EXPECT().GetArchiveBlockHeight().Return(^uint64(0), false, nil).AnyTimes()
+
+	svc := &Service{store: store}
+	svc.feed.Start(archive)
+
+	return svc
+}
+
+// blockingNodeRecord is a node record whose update blocks the caller until the
+// test releases it, pinning the ENR updater inside a notification handler.
+type blockingNodeRecord struct {
+	updates chan enr.Entry
+	release chan struct{}
+}
+
+func newBlockingNodeRecord() *blockingNodeRecord {
+	return &blockingNodeRecord{
+		updates: make(chan enr.Entry),
+		release: make(chan struct{}),
+	}
+}
+
+func (r *blockingNodeRecord) Set(entry enr.Entry) {
+	r.updates <- entry
+	<-r.release
+}

--- a/gossip/service.go
+++ b/gossip/service.go
@@ -259,6 +259,9 @@ type Service struct {
 	// filterAPI must be stopped during shutdown before the store is closed.
 	filterAPI *filters.PublicFilterAPI
 
+	// stopENRUpdater must be called during shutdown before the store is closed.
+	stopENRUpdater func()
+
 	procLogger *proclogger.Logger
 
 	stopped   bool
@@ -593,7 +596,7 @@ func (s *Service) Start() error {
 	s.blockProcTasks.Start(1)
 
 	// start p2p
-	StartENRUpdater(s, s.p2pServer.LocalNode())
+	s.stopENRUpdater = StartENRUpdater(s, s.p2pServer.LocalNode())
 	s.handler.Start(s.p2pServer.MaxPeers)
 
 	// start emitters
@@ -634,6 +637,9 @@ func (s *Service) Stop() error {
 	// Must stop before the store is closed to avoid reading from a closed store.
 	if s.filterAPI != nil {
 		s.filterAPI.Stop()
+	}
+	if s.stopENRUpdater != nil {
+		s.stopENRUpdater()
 	}
 	s.feed.Stop()
 	s.gpo.Stop()


### PR DESCRIPTION
A nightly race detection [run](https://scala.fantom.network/job/Sonic/job/Unit-test-race-detection/551) failed due to a race condition during node shutdown.

`Service.Stop` is strictly sequential. The concurrency is the background
goroutines started by `Service.Start`, still running alongside it. Each step
either *joins* its goroutine or merely *signals* it.

Before the fix, the ENR updater was signalled but never joined:

```
 Service.Stop()  ── one goroutine, top to bottom ──┐
                                                   │
 step                          │ feeder │ ENR updater │
 ────────────────────────────── ─────── ───────────── ┤
 txpool.Stop()                 │  ███   │     ███     │
 verWatcher.Stop()             │  ███   │     ███     │
 emitters[i].Stop()            │  ███   │     ███     │
 operaDialCandidates.Close()   │  ███   │     ███     │
 handler.Stop()                │  ███   │     ███     │
 filterAPI.Stop()              │  ███   │     ███     │
 feed.Stop():                  │        │             │
   close(stopFeeder) ─────────▶│ signal │     ███     │
   <-feederDone  ═══ JOIN ═════╡ exits  │     ███     │
   scope.Close() ──────────────────────▶ sub.Err() closes
 gpo.Stop()                    │        │     ███  ⚠  │
 tflusher.Stop()               │        │     ███  ⚠  │
 engineMu.Lock()               │        │     ███  ⚠  │
 blockProcWg.Wait()            │        │     ███  ⚠  │
 dagIndexer.Close()            │        │     ███  ⚠  │
 store.Commit()                │        │     ███  ⚠  │
 ── Stop returns ──────────────│        │     ███  ⚠  │
 p2p.Server.Stop()             │        │     ███  ⚠  │
 node.doClose()                │        │     ███  ⚠  │
 nodeClose() → Store.Close()   │        │     ███  ⚠  │
   MigrateCaches ✗WRITE ◀── DATA RACE ──▶ ✗READ GetBlock
```

The feeder gets a real join (`<-feederDone`). The ENR updater got only a signal
(`scope.Close()`), fired at the very end of `feed.Stop()`, with nothing waiting
for it afterwards. Its lifetime was unbounded — the `⚠` band was luck.

After the fix:

```
 filterAPI.Stop()              │  ███   │     ███     │
 stopENRUpdater():        ◀NEW │        │             │
   close(quit) ────────────────────────▶│   signal    │
   <-done  ═════════ JOIN ══════════════╡   exits     │
 feed.Stop()                   │  ███   │   (gone)    │
   ...                         │        │             │
 store.Commit()                │        │             │
 ── Stop returns ──────────────│        │             │
 nodeClose() → Store.Close()   │        │             │
   MigrateCaches ✗WRITE          nothing left to read ✓
```

## Why the join, not the signal

```
 BEFORE                               AFTER
 ──────                               ─────
 newHead: [b][b][b]…  cap 10          newHead: [b][b][b]…  cap 10

 select {                             select {
   case <-newHead:                      case <-newHead:
       store.GetBlock()   ⚠                 store.GetBlock()
   case <-sub.Err():                    case <-quit:     ◀ closed by Stop
       return                               return
 }                                      case <-sub.Err():
                                            return
 Both cases ready ⇒ Go picks a       }
 ready case at random. A queued
 block can win *after* sub.Err()     Still random — but Stop blocks
 closed, and nothing waits for       on <-done, so the loop is
 the loop to finish.                 provably finished before Stop
                                     moves on.
```

The select stays non-deterministic. Correctness comes from `stop()` blocking on
`<-done`, not from controlling which branch wins.