### PR TITLE
Improve misbehaving registry test

### DIFF
--- a/tests/contracts/misbehaving_priority_registry/misbehaving_priority_registry.go
+++ b/tests/contracts/misbehaving_priority_registry/misbehaving_priority_registry.go
@@ -31,8 +31,8 @@ var (
 
 // MisbehavingPriorityRegistryMetaData contains all meta data concerning the MisbehavingPriorityRegistry contract.
 var MisbehavingPriorityRegistryMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[],\"name\":\"MAGIC_VALUE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"getPriority\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"},{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getPriorityConfig\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"maxGasPerEntityPerBlock\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPiggybackTxsPerEntityPerEvent\",\"type\":\"uint256\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"mode\",\"outputs\":[{\"internalType\":\"enumMisbehavingPriorityRegistry.Mode\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"enumMisbehavingPriorityRegistry.Mode\",\"name\":\"newMode\",\"type\":\"uint8\"}],\"name\":\"setMode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
-	Bin: "0x6080604052348015600e575f5ffd5b506107a08061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610055575f3560e01c8063206731961461005957806321175b4a14610077578063295a521214610093578063928461bd146100b1578063d9dceeb8146100d0575b5f5ffd5b610061610102565b60405161006e919061034c565b60405180910390f35b610091600480360381019061008c9190610390565b61010a565b005b61009b610135565b6040516100a8919061042e565b60405180910390f35b6100b9610146565b6040516100c7929190610447565b60405180910390f35b6100ea60048036038101906100e59190610553565b610158565b6040516100f993929190610649565b60405180910390f35b63075bcd1581565b805f5f6101000a81548160ff0219169083600481111561012d5761012c6103bb565b5b021790555050565b5f5f9054906101000a900460ff1681565b5f5f633b9aca006103e8915091509091565b5f5f5f5f5f5f9054906101000a900460ff16905060048081111561017f5761017e6103bb565b5b816004811115610192576101916103bb565b5b036101d2576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016101c9906106d8565b60405180910390fd5b600160048111156101e6576101e56103bb565b5b8160048111156101f9576101f86103bb565b5b03610262575f5f5f90505b61271081101561024657818160405160200161022192919061073f565b6040516020818303038152906040528051906020012091508080600101915050610204565b505f5f1b8103610260575f5f5f94509450945050506102f9565b505b5f5f5f61026e8c610306565b92509250925060026004811115610288576102876103bb565b5b84600481111561029b5761029a6103bb565b5b036102b3575f195f525f196020525f1960405260605ff35b600360048111156102c7576102c66103bb565b5b8460048111156102da576102d96103bb565b5b036102eb57825f528160205260405ff35b828282965096509650505050505b9750975097945050505050565b5f5f5f63075bcd1584036103235760015f5f92509250925061032d565b5f5f5f9250925092505b9193909250565b5f819050919050565b61034681610334565b82525050565b5f60208201905061035f5f83018461033d565b92915050565b5f5ffd5b5f5ffd5b60058110610379575f5ffd5b50565b5f8135905061038a8161036d565b92915050565b5f602082840312156103a5576103a4610365565b5b5f6103b28482850161037c565b91505092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b600581106103f9576103f86103bb565b5b50565b5f819050610409826103e8565b919050565b5f610418826103fc565b9050919050565b6104288161040e565b82525050565b5f6020820190506104415f83018461041f565b92915050565b5f60408201905061045a5f83018561033d565b610467602083018461033d565b9392505050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6104978261046e565b9050919050565b6104a78161048d565b81146104b1575f5ffd5b50565b5f813590506104c28161049e565b92915050565b6104d181610334565b81146104db575f5ffd5b50565b5f813590506104ec816104c8565b92915050565b5f5ffd5b5f5ffd5b5f5ffd5b5f5f83601f840112610513576105126104f2565b5b8235905067ffffffffffffffff8111156105305761052f6104f6565b5b60208301915083600182028301111561054c5761054b6104fa565b5b9250929050565b5f5f5f5f5f5f5f60c0888a03121561056e5761056d610365565b5b5f61057b8a828b016104b4565b975050602061058c8a828b016104b4565b965050604061059d8a828b016104de565b95505060606105ae8a828b016104de565b945050608088013567ffffffffffffffff8111156105cf576105ce610369565b5b6105db8a828b016104fe565b935093505060a06105ee8a828b016104de565b91505092959891949750929550565b5f67ffffffffffffffff82169050919050565b610619816105fd565b82525050565b5f6fffffffffffffffffffffffffffffffff82169050919050565b6106438161061f565b82525050565b5f60608201905061065c5f830186610610565b6106696020830185610610565b610676604083018461063a565b949350505050565b5f82825260208201905092915050565b7f6765745072696f7269747920616c77617973206661696c7300000000000000005f82015250565b5f6106c260188361067e565b91506106cd8261068e565b602082019050919050565b5f6020820190508181035f8301526106ef816106b6565b9050919050565b5f819050919050565b5f819050919050565b610719610714826106f6565b6106ff565b82525050565b5f819050919050565b61073961073482610334565b61071f565b82525050565b5f61074a8285610708565b60208201915061075a8284610728565b602082019150819050939250505056fea26469706673582212202c00b87bde81176beb241af51a5df37a8321cf25c63c69d3284aeba9a2d8760064736f6c634300081e0033",
+	ABI: "[{\"inputs\":[],\"name\":\"MAGIC_VALUE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"configMode\",\"outputs\":[{\"internalType\":\"enumMisbehavingPriorityRegistry.Mode\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"getPriority\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"},{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getPriorityConfig\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"maxGasPerEntityPerBlock\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxPiggybackTxsPerEntityPerEvent\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"mode\",\"outputs\":[{\"internalType\":\"enumMisbehavingPriorityRegistry.Mode\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"mutated\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"enumMisbehavingPriorityRegistry.Mode\",\"name\":\"newMode\",\"type\":\"uint8\"}],\"name\":\"setConfigMode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"enumMisbehavingPriorityRegistry.Mode\",\"name\":\"newMode\",\"type\":\"uint8\"}],\"name\":\"setMode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f5ffd5b50610abf8061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610086575f3560e01c8063928461bd11610059578063928461bd146101005780639a2941031461011f578063d9dceeb81461013d578063ff8fe2601461016f57610086565b8063206731961461008a57806321175b4a146100a8578063295a5212146100c457806391056cdf146100e2575b5f5ffd5b61009261018b565b60405161009f91906105d0565b60405180910390f35b6100c260048036038101906100bd9190610614565b610193565b005b6100cc6101be565b6040516100d991906106b2565b60405180910390f35b6100ea6101cf565b6040516100f791906106b2565b60405180910390f35b6101086101e1565b6040516101169291906106cb565b60405180910390f35b61012761035a565b604051610134919061070c565b60405180910390f35b6101576004803603810190610152919061080a565b61036c565b60405161016693929190610900565b60405180910390f35b61018960048036038101906101849190610614565b610505565b005b63075bcd1581565b805f5f6101000a81548160ff021916908360058111156101b6576101b561063f565b5b021790555050565b5f5f9054906101000a900460ff1681565b5f60019054906101000a900460ff1681565b5f5f5f5f60019054906101000a900460ff169050600460058111156102095761020861063f565b5b81600581111561021c5761021b61063f565b5b0361025c576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016102539061098f565b60405180910390fd5b600160058111156102705761026f61063f565b5b8160058111156102835761028261063f565b5b0361029157610290610531565b5b6005808111156102a4576102a361063f565b5b8160058111156102b7576102b661063f565b5b036102d75760015f60026101000a81548160ff0219169083151502179055505b600260058111156102eb576102ea61063f565b5b8160058111156102fe576102fd61063f565b5b03610311575f195f525f1960205260405ff35b600360058111156103255761032461063f565b5b8160058111156103385761033761063f565b5b0361034957633b9aca005f5260205ff35b633b9aca006103e892509250509091565b5f60029054906101000a900460ff1681565b5f5f5f5f5f5f9054906101000a900460ff169050600460058111156103945761039361063f565b5b8160058111156103a7576103a661063f565b5b036103e7576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016103de906109f7565b60405180910390fd5b600160058111156103fb576103fa61063f565b5b81600581111561040e5761040d61063f565b5b0361041c5761041b610531565b5b60058081111561042f5761042e61063f565b5b8160058111156104425761044161063f565b5b036104625760015f60026101000a81548160ff0219169083151502179055505b5f5f5f61046e8c61058a565b925092509250600260058111156104885761048761063f565b5b84600581111561049b5761049a61063f565b5b036104b3575f195f525f196020525f1960405260605ff35b600360058111156104c7576104c661063f565b5b8460058111156104da576104d961063f565b5b036104eb57825f528160205260405ff35b828282965096509650505050509750975097945050505050565b805f60016101000a81548160ff021916908360058111156105295761052861063f565b5b021790555050565b5f5f5f90505b612710811015610579578181604051602001610554929190610a5e565b6040516020818303038152906040528051906020012091508080600101915050610537565b505f5f1b8103610587575f5ffd5b50565b5f5f5f63075bcd1584036105a75760015f5f9250925092506105b1565b5f5f5f9250925092505b9193909250565b5f819050919050565b6105ca816105b8565b82525050565b5f6020820190506105e35f8301846105c1565b92915050565b5f5ffd5b5f5ffd5b600681106105fd575f5ffd5b50565b5f8135905061060e816105f1565b92915050565b5f60208284031215610629576106286105e9565b5b5f61063684828501610600565b91505092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b6006811061067d5761067c61063f565b5b50565b5f81905061068d8261066c565b919050565b5f61069c82610680565b9050919050565b6106ac81610692565b82525050565b5f6020820190506106c55f8301846106a3565b92915050565b5f6040820190506106de5f8301856105c1565b6106eb60208301846105c1565b9392505050565b5f8115159050919050565b610706816106f2565b82525050565b5f60208201905061071f5f8301846106fd565b92915050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f61074e82610725565b9050919050565b61075e81610744565b8114610768575f5ffd5b50565b5f8135905061077981610755565b92915050565b610788816105b8565b8114610792575f5ffd5b50565b5f813590506107a38161077f565b92915050565b5f5ffd5b5f5ffd5b5f5ffd5b5f5f83601f8401126107ca576107c96107a9565b5b8235905067ffffffffffffffff8111156107e7576107e66107ad565b5b602083019150836001820283011115610803576108026107b1565b5b9250929050565b5f5f5f5f5f5f5f60c0888a031215610825576108246105e9565b5b5f6108328a828b0161076b565b97505060206108438a828b0161076b565b96505060406108548a828b01610795565b95505060606108658a828b01610795565b945050608088013567ffffffffffffffff811115610886576108856105ed565b5b6108928a828b016107b5565b935093505060a06108a58a828b01610795565b91505092959891949750929550565b5f67ffffffffffffffff82169050919050565b6108d0816108b4565b82525050565b5f6fffffffffffffffffffffffffffffffff82169050919050565b6108fa816108d6565b82525050565b5f6060820190506109135f8301866108c7565b61092060208301856108c7565b61092d60408301846108f1565b949350505050565b5f82825260208201905092915050565b7f6765745072696f72697479436f6e66696720616c77617973206661696c7300005f82015250565b5f610979601e83610935565b915061098482610945565b602082019050919050565b5f6020820190508181035f8301526109a68161096d565b9050919050565b7f6765745072696f7269747920616c77617973206661696c7300000000000000005f82015250565b5f6109e1601883610935565b91506109ec826109ad565b602082019050919050565b5f6020820190508181035f830152610a0e816109d5565b9050919050565b5f819050919050565b5f819050919050565b610a38610a3382610a15565b610a1e565b82525050565b5f819050919050565b610a58610a53826105b8565b610a3e565b82525050565b5f610a698285610a27565b602082019150610a798284610a47565b602082019150819050939250505056fea2646970667358221220fd2732d2a01e2330c666f398edc6686d934a9a3b6f8fe026842db4394094228a64736f6c634300081e0033",
 }
 
 // MisbehavingPriorityRegistryABI is the input ABI used to generate the binding from.
@@ -233,82 +233,35 @@ func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCallerSession) MA
 	return _MisbehavingPriorityRegistry.Contract.MAGICVALUE(&_MisbehavingPriorityRegistry.CallOpts)
 }
 
-// GetPriority is a free data retrieval call binding the contract method 0xd9dceeb8.
+// ConfigMode is a free data retrieval call binding the contract method 0x91056cdf.
 //
-// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) view returns(uint64, uint64, uint128)
-func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCaller) GetPriority(opts *bind.CallOpts, arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (uint64, uint64, *big.Int, error) {
+// Solidity: function configMode() view returns(uint8)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCaller) ConfigMode(opts *bind.CallOpts) (uint8, error) {
 	var out []interface{}
-	err := _MisbehavingPriorityRegistry.contract.Call(opts, &out, "getPriority", arg0, arg1, value, arg3, arg4, arg5)
+	err := _MisbehavingPriorityRegistry.contract.Call(opts, &out, "configMode")
 
 	if err != nil {
-		return *new(uint64), *new(uint64), *new(*big.Int), err
+		return *new(uint8), err
 	}
 
-	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
-	out1 := *abi.ConvertType(out[1], new(uint64)).(*uint64)
-	out2 := *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
 
-	return out0, out1, out2, err
+	return out0, err
 
 }
 
-// GetPriority is a free data retrieval call binding the contract method 0xd9dceeb8.
+// ConfigMode is a free data retrieval call binding the contract method 0x91056cdf.
 //
-// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) view returns(uint64, uint64, uint128)
-func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) GetPriority(arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (uint64, uint64, *big.Int, error) {
-	return _MisbehavingPriorityRegistry.Contract.GetPriority(&_MisbehavingPriorityRegistry.CallOpts, arg0, arg1, value, arg3, arg4, arg5)
+// Solidity: function configMode() view returns(uint8)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) ConfigMode() (uint8, error) {
+	return _MisbehavingPriorityRegistry.Contract.ConfigMode(&_MisbehavingPriorityRegistry.CallOpts)
 }
 
-// GetPriority is a free data retrieval call binding the contract method 0xd9dceeb8.
+// ConfigMode is a free data retrieval call binding the contract method 0x91056cdf.
 //
-// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) view returns(uint64, uint64, uint128)
-func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCallerSession) GetPriority(arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (uint64, uint64, *big.Int, error) {
-	return _MisbehavingPriorityRegistry.Contract.GetPriority(&_MisbehavingPriorityRegistry.CallOpts, arg0, arg1, value, arg3, arg4, arg5)
-}
-
-// GetPriorityConfig is a free data retrieval call binding the contract method 0x928461bd.
-//
-// Solidity: function getPriorityConfig() pure returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
-func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCaller) GetPriorityConfig(opts *bind.CallOpts) (struct {
-	MaxGasPerEntityPerBlock          *big.Int
-	MaxPiggybackTxsPerEntityPerEvent *big.Int
-}, error) {
-	var out []interface{}
-	err := _MisbehavingPriorityRegistry.contract.Call(opts, &out, "getPriorityConfig")
-
-	outstruct := new(struct {
-		MaxGasPerEntityPerBlock          *big.Int
-		MaxPiggybackTxsPerEntityPerEvent *big.Int
-	})
-	if err != nil {
-		return *outstruct, err
-	}
-
-	outstruct.MaxGasPerEntityPerBlock = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
-	outstruct.MaxPiggybackTxsPerEntityPerEvent = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
-
-	return *outstruct, err
-
-}
-
-// GetPriorityConfig is a free data retrieval call binding the contract method 0x928461bd.
-//
-// Solidity: function getPriorityConfig() pure returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
-func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) GetPriorityConfig() (struct {
-	MaxGasPerEntityPerBlock          *big.Int
-	MaxPiggybackTxsPerEntityPerEvent *big.Int
-}, error) {
-	return _MisbehavingPriorityRegistry.Contract.GetPriorityConfig(&_MisbehavingPriorityRegistry.CallOpts)
-}
-
-// GetPriorityConfig is a free data retrieval call binding the contract method 0x928461bd.
-//
-// Solidity: function getPriorityConfig() pure returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
-func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCallerSession) GetPriorityConfig() (struct {
-	MaxGasPerEntityPerBlock          *big.Int
-	MaxPiggybackTxsPerEntityPerEvent *big.Int
-}, error) {
-	return _MisbehavingPriorityRegistry.Contract.GetPriorityConfig(&_MisbehavingPriorityRegistry.CallOpts)
+// Solidity: function configMode() view returns(uint8)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCallerSession) ConfigMode() (uint8, error) {
+	return _MisbehavingPriorityRegistry.Contract.ConfigMode(&_MisbehavingPriorityRegistry.CallOpts)
 }
 
 // Mode is a free data retrieval call binding the contract method 0x295a5212.
@@ -340,6 +293,100 @@ func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) Mode() (
 // Solidity: function mode() view returns(uint8)
 func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCallerSession) Mode() (uint8, error) {
 	return _MisbehavingPriorityRegistry.Contract.Mode(&_MisbehavingPriorityRegistry.CallOpts)
+}
+
+// Mutated is a free data retrieval call binding the contract method 0x9a294103.
+//
+// Solidity: function mutated() view returns(bool)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCaller) Mutated(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _MisbehavingPriorityRegistry.contract.Call(opts, &out, "mutated")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Mutated is a free data retrieval call binding the contract method 0x9a294103.
+//
+// Solidity: function mutated() view returns(bool)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) Mutated() (bool, error) {
+	return _MisbehavingPriorityRegistry.Contract.Mutated(&_MisbehavingPriorityRegistry.CallOpts)
+}
+
+// Mutated is a free data retrieval call binding the contract method 0x9a294103.
+//
+// Solidity: function mutated() view returns(bool)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryCallerSession) Mutated() (bool, error) {
+	return _MisbehavingPriorityRegistry.Contract.Mutated(&_MisbehavingPriorityRegistry.CallOpts)
+}
+
+// GetPriority is a paid mutator transaction binding the contract method 0xd9dceeb8.
+//
+// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) returns(uint64, uint64, uint128)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryTransactor) GetPriority(opts *bind.TransactOpts, arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.contract.Transact(opts, "getPriority", arg0, arg1, value, arg3, arg4, arg5)
+}
+
+// GetPriority is a paid mutator transaction binding the contract method 0xd9dceeb8.
+//
+// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) returns(uint64, uint64, uint128)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) GetPriority(arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.Contract.GetPriority(&_MisbehavingPriorityRegistry.TransactOpts, arg0, arg1, value, arg3, arg4, arg5)
+}
+
+// GetPriority is a paid mutator transaction binding the contract method 0xd9dceeb8.
+//
+// Solidity: function getPriority(address , address , uint256 value, uint256 , bytes , uint256 ) returns(uint64, uint64, uint128)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryTransactorSession) GetPriority(arg0 common.Address, arg1 common.Address, value *big.Int, arg3 *big.Int, arg4 []byte, arg5 *big.Int) (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.Contract.GetPriority(&_MisbehavingPriorityRegistry.TransactOpts, arg0, arg1, value, arg3, arg4, arg5)
+}
+
+// GetPriorityConfig is a paid mutator transaction binding the contract method 0x928461bd.
+//
+// Solidity: function getPriorityConfig() returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryTransactor) GetPriorityConfig(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.contract.Transact(opts, "getPriorityConfig")
+}
+
+// GetPriorityConfig is a paid mutator transaction binding the contract method 0x928461bd.
+//
+// Solidity: function getPriorityConfig() returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) GetPriorityConfig() (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.Contract.GetPriorityConfig(&_MisbehavingPriorityRegistry.TransactOpts)
+}
+
+// GetPriorityConfig is a paid mutator transaction binding the contract method 0x928461bd.
+//
+// Solidity: function getPriorityConfig() returns(uint256 maxGasPerEntityPerBlock, uint256 maxPiggybackTxsPerEntityPerEvent)
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryTransactorSession) GetPriorityConfig() (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.Contract.GetPriorityConfig(&_MisbehavingPriorityRegistry.TransactOpts)
+}
+
+// SetConfigMode is a paid mutator transaction binding the contract method 0xff8fe260.
+//
+// Solidity: function setConfigMode(uint8 newMode) returns()
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryTransactor) SetConfigMode(opts *bind.TransactOpts, newMode uint8) (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.contract.Transact(opts, "setConfigMode", newMode)
+}
+
+// SetConfigMode is a paid mutator transaction binding the contract method 0xff8fe260.
+//
+// Solidity: function setConfigMode(uint8 newMode) returns()
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistrySession) SetConfigMode(newMode uint8) (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.Contract.SetConfigMode(&_MisbehavingPriorityRegistry.TransactOpts, newMode)
+}
+
+// SetConfigMode is a paid mutator transaction binding the contract method 0xff8fe260.
+//
+// Solidity: function setConfigMode(uint8 newMode) returns()
+func (_MisbehavingPriorityRegistry *MisbehavingPriorityRegistryTransactorSession) SetConfigMode(newMode uint8) (*types.Transaction, error) {
+	return _MisbehavingPriorityRegistry.Contract.SetConfigMode(&_MisbehavingPriorityRegistry.TransactOpts, newMode)
 }
 
 // SetMode is a paid mutator transaction binding the contract method 0x21175b4a.

--- a/tests/contracts/misbehaving_priority_registry/misbehaving_priority_registry.sol
+++ b/tests/contracts/misbehaving_priority_registry/misbehaving_priority_registry.sol
@@ -5,19 +5,28 @@ pragma solidity ^0.8.24;
 // priority registry to be used as a replacement to the development registry
 // used in integration tests. Like MagicValuePriority it classifies a
 // transaction as prioritized iff its `value` field equals a fixed magic
-// constant, but it can be told with setMode to fail delivering that
-// classification to the node in the ways a real registry might.
+// constant and reports generous rate limits, but each of its two query entry
+// points can be told with setMode and setConfigMode to answer the node in the
+// ways a real registry might misbehave.
 contract MisbehavingPriorityRegistry {
     enum Mode {
-        Correct, // delivers the classification as expected
+        Correct, // answers as expected
         OutOfGas, // needs more gas than the node grants the call
         OutOfRange, // returns values exceeding the expected types
         Truncated, // returns fewer values than expected
-        Reverting // does not return at all
+        Reverting, // does not return at all
+        Mutating // answers as expected, but writes to its storage first
     }
 
-    // The current mode. Defaults to Mode.Correct.
+    // The mode of getPriority. Defaults to Mode.Correct.
     Mode public mode;
+
+    // The mode of getPriorityConfig. Defaults to Mode.Correct.
+    Mode public configMode;
+
+    // Set by every Mutating query so tests can observe whether that write
+    // survived.
+    bool public mutated;
 
     // The exact value a tx must carry to be prioritized. Public so tests can
     // read it instead of duplicating it.
@@ -40,6 +49,10 @@ contract MisbehavingPriorityRegistry {
         mode = newMode;
     }
 
+    function setConfigMode(Mode newMode) external {
+        configMode = newMode;
+    }
+
     function getPriority(
         address /*from*/,
         address /*to*/,
@@ -47,7 +60,7 @@ contract MisbehavingPriorityRegistry {
         uint256 /*nonce*/,
         bytes calldata /*data*/,
         uint256 /*gas*/
-    ) external view returns (uint64, uint64, uint128) {
+    ) external returns (uint64, uint64, uint128) {
         Mode current = mode;
 
         if (current == Mode.Reverting) {
@@ -55,14 +68,11 @@ contract MisbehavingPriorityRegistry {
         }
 
         if (current == Mode.OutOfGas) {
-            bytes32 burner;
-            for (uint256 i = 0; i < 10_000; i++) {
-                burner = keccak256(abi.encodePacked(burner, i));
-            }
-            // Reading the result keeps the loop from being optimized away.
-            if (burner == bytes32(0)) {
-                return (0, 0, 0);
-            }
+            burnGas();
+        }
+
+        if (current == Mode.Mutating) {
+            mutated = true;
         }
 
         (uint64 level, uint64 weight, uint128 id) = classify(value);
@@ -92,12 +102,42 @@ contract MisbehavingPriorityRegistry {
 
     function getPriorityConfig()
         external
-        pure
         returns (
             uint256 maxGasPerEntityPerBlock,
             uint256 maxPiggybackTxsPerEntityPerEvent
         )
     {
+        Mode current = configMode;
+
+        if (current == Mode.Reverting) {
+            revert("getPriorityConfig always fails");
+        }
+
+        if (current == Mode.OutOfGas) {
+            burnGas();
+        }
+
+        if (current == Mode.Mutating) {
+            mutated = true;
+        }
+
+        if (current == Mode.OutOfRange) {
+            // Both limits exceed the uint64 the node expects.
+            assembly {
+                mstore(0x00, not(0))
+                mstore(0x20, not(0))
+                return(0x00, 0x40)
+            }
+        }
+
+        if (current == Mode.Truncated) {
+            // The per-event tx limit is missing from the response.
+            assembly {
+                mstore(0x00, PER_BLOCK_GAS)
+                return(0x00, 0x20)
+            }
+        }
+
         return (PER_BLOCK_GAS, PER_EVENT_TXS);
     }
 
@@ -108,5 +148,15 @@ contract MisbehavingPriorityRegistry {
             return (PRIORITY_LEVEL, PRIORITY_WEIGHT, 0);
         }
         return (0, 0, 0);
+    }
+
+    // burnGas consumes far more gas than the node grants either query. Its
+    // result is read so the loop cannot be optimized away.
+    function burnGas() private pure {
+        bytes32 burner;
+        for (uint256 i = 0; i < 10_000; i++) {
+            burner = keccak256(abi.encodePacked(burner, i));
+        }
+        require(burner != bytes32(0));
     }
 }

--- a/tests/priorities/misbehaving_registry_test.go
+++ b/tests/priorities/misbehaving_registry_test.go
@@ -34,44 +34,35 @@ const (
 	modeOutOfRange
 	modeTruncated
 	modeReverting
+	modeMutating
 )
 
-func TestPriorities_MisbehavingRegistryLeavesTransactionsUnprioritized(t *testing.T) {
+func TestPriorities_MisbehavingRegistry_LeavesTransactionsUnprioritized(t *testing.T) {
 	cases := map[string]struct {
-		mode              uint8
+		mode, configMode  uint8
 		expectPrioritized bool
 	}{
-		"correct":                            {modeCorrect, true},
-		"needs more gas than it is granted":  {modeOutOfGas, false},
-		"returns values out of range":        {modeOutOfRange, false},
-		"returns fewer values than expected": {modeTruncated, false},
-		"reverts":                            {modeReverting, false},
+		"getPriority and getPriorityConfig correct":            {modeCorrect, modeCorrect, true},
+		"getPriority needs more gas than it is granted":        {modeOutOfGas, modeCorrect, false},
+		"getPriority returns values out of range":              {modeOutOfRange, modeCorrect, false},
+		"getPriority returns fewer values than expected":       {modeTruncated, modeCorrect, false},
+		"getPriority reverts":                                  {modeReverting, modeCorrect, false},
+		"getPriorityConfig needs more gas than it is granted":  {modeCorrect, modeOutOfGas, false},
+		"getPriorityConfig returns values out of range":        {modeCorrect, modeOutOfRange, false},
+		"getPriorityConfig returns fewer values than expected": {modeCorrect, modeTruncated, false},
+		"getPriorityConfig reverts":                            {modeCorrect, modeReverting, false},
 	}
 
 	net, client, _ := netClientSignerWithPriorities(t, nil)
 	defer client.Close()
 
-	_, deployReceipt, err := tests.DeployContract(net,
-		misbehaving_priority_registry.DeployMisbehavingPriorityRegistry)
-	require.NoError(t, err)
-	require.Equal(t, types.ReceiptStatusSuccessful, deployReceipt.Status)
-	switchPriorityRegistry(t, net, deployReceipt.ContractAddress)
-
-	reg, err := misbehaving_priority_registry.NewMisbehavingPriorityRegistry(
-		registry.GetAddress(), client)
-	require.NoError(t, err)
+	reg := installMisbehavingRegistry(t, net, client)
 	magicValue, err := reg.MAGICVALUE(nil)
 	require.NoError(t, err)
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			require := require.New(t)
-
-			receipt, err := net.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
-				return reg.SetMode(opts, tc.mode)
-			})
-			require.NoError(err)
-			require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+			setModes(t, net, reg, tc.mode, tc.configMode)
 
 			sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
 			txs := make([]*types.Transaction, 5)
@@ -84,5 +75,84 @@ func TestPriorities_MisbehavingRegistryLeavesTransactionsUnprioritized(t *testin
 			// transactions are executed successfully.
 			requirePriorityHasEffect(t, net, txs, tc.expectPrioritized, txHasMagicValue)
 		})
+	}
+}
+
+func TestPriorities_RegistryMutatesState_ChangesDoNotPersist(t *testing.T) {
+	require := require.New(t)
+
+	net, client, _ := netClientSignerWithPriorities(t, nil)
+	defer client.Close()
+
+	reg := installMisbehavingRegistry(t, net, client)
+	setModes(t, net, reg, modeMutating, modeMutating)
+
+	magicValue, err := reg.MAGICVALUE(nil)
+	require.NoError(err)
+
+	sender := tests.MakeAccountWithBalance(t, net, big.NewInt(1e18))
+	txs := make([]*types.Transaction, 5)
+	for i := range txs {
+		txs[i] = newSignedTx(t, net, sender, uint64(i), magicValue.Uint64(), 21_000, nil)
+	}
+
+	txHasMagicValue := func(tx *types.Transaction) bool { return tx.Value().Cmp(magicValue) == 0 }
+	requirePriorityHasEffect(t, net, txs, true, txHasMagicValue)
+
+	// The writes were discarded with the snapshot wrapping each query.
+	mutated, err := reg.Mutated(nil)
+	require.NoError(err)
+	require.False(mutated)
+
+	// Running the very same query as a transaction does persist the write, so
+	// the check above observes the rollback and not a registry that never wrote.
+	receipt, err := net.Apply(reg.GetPriorityConfig)
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
+	mutated, err = reg.Mutated(nil)
+	require.NoError(err)
+	require.True(mutated)
+}
+
+// installMisbehavingRegistry deploys a MisbehavingPriorityRegistry and points
+// the priority-registry proxy at it, returning a binding to the proxy.
+func installMisbehavingRegistry(
+	t *testing.T,
+	net *tests.IntegrationTestNet,
+	client *tests.PooledEhtClient,
+) *misbehaving_priority_registry.MisbehavingPriorityRegistry {
+	t.Helper()
+	require := require.New(t)
+
+	_, deployReceipt, err := tests.DeployContract(net,
+		misbehaving_priority_registry.DeployMisbehavingPriorityRegistry)
+	require.NoError(err)
+	require.Equal(types.ReceiptStatusSuccessful, deployReceipt.Status)
+	switchPriorityRegistry(t, net, deployReceipt.ContractAddress)
+
+	reg, err := misbehaving_priority_registry.NewMisbehavingPriorityRegistry(
+		registry.GetAddress(), client)
+	require.NoError(err)
+	return reg
+}
+
+// setModes selects how the registry answers the node's getPriority and
+// getPriorityConfig queries.
+func setModes(
+	t *testing.T,
+	net *tests.IntegrationTestNet,
+	reg *misbehaving_priority_registry.MisbehavingPriorityRegistry,
+	mode, configMode uint8,
+) {
+	t.Helper()
+	require := require.New(t)
+
+	for _, set := range []func(*bind.TransactOpts) (*types.Transaction, error){
+		func(opts *bind.TransactOpts) (*types.Transaction, error) { return reg.SetMode(opts, mode) },
+		func(opts *bind.TransactOpts) (*types.Transaction, error) { return reg.SetConfigMode(opts, configMode) },
+	} {
+		receipt, err := net.Apply(set)
+		require.NoError(err)
+		require.Equal(types.ReceiptStatusSuccessful, receipt.Status)
 	}
 }


### PR DESCRIPTION
This PR improves the misbehaving registry test. The old version only checked what happens if the `getPriority` function misbehaves. Now also a misbehaving `getconfig` is tested. Additionally, it is tested that if the registry queries mutate the state, those changes do not persist, because the queries run inside of snapshots which get rolled back.