### PR TITLE
Add the Canto hard fork flag

### DIFF
--- a/cmd/sonictool/app/app_test.go
+++ b/cmd/sonictool/app/app_test.go
@@ -168,6 +168,7 @@ func TestSonicTool_genesis_CreatesDataDirWithAllowedUpgrades(t *testing.T) {
 		"sonic",
 		"allegro",
 		"brio",
+		"canto",
 	}
 
 	for _, upgradeName := range upgrades {
@@ -190,7 +191,7 @@ func TestSonicTool_genesis_ReturnsErrorIfHardforkIsInvalid(t *testing.T) {
 		"genesis", "fake",
 		"--upgrades", "invalid",
 		"1")
-	require.ErrorContains(t, err, "invalid profile invalid - must be 'sonic', 'allegro', or 'brio'")
+	require.ErrorContains(t, err, "invalid profile invalid - must be 'sonic', 'allegro', 'brio', or 'canto'")
 }
 
 func TestSonicTool_genesis_ExportsAndSigns_WithoutErrors(t *testing.T) {

--- a/cmd/sonictool/app/genesis.go
+++ b/cmd/sonictool/app/genesis.go
@@ -182,8 +182,10 @@ func fakeGenesisImport(ctx *cli.Context) (retErr error) {
 		upgrades = opera.GetAllegroUpgrades()
 	case "brio":
 		upgrades = opera.GetBrioUpgrades()
+	case "canto":
+		upgrades = opera.GetCantoUpgrades()
 	default:
-		return fmt.Errorf("invalid profile %v - must be 'sonic', 'allegro', or 'brio'", upgradesString)
+		return fmt.Errorf("invalid profile %v - must be 'sonic', 'allegro', 'brio', or 'canto'", upgradesString)
 	}
 
 	tmpDir, err := futils.MakeTempDir(dataDir, "genesis-tmp")

--- a/opera/hardforks.go
+++ b/opera/hardforks.go
@@ -52,6 +52,19 @@ func GetBrioUpgrades() Upgrades {
 	}
 }
 
+// GetCantoUpgrades contains the feature flags for the Canto upgrade.
+func GetCantoUpgrades() Upgrades {
+	return Upgrades{
+		Berlin:  true,
+		London:  true,
+		Llr:     false,
+		Sonic:   true,
+		Allegro: true,
+		Brio:    true,
+		Canto:   true,
+	}
+}
+
 // GetAllHardForksInOrder returns an iterator over all hard forks and their
 // corresponding feature flags in order.
 // This function returns an iterator and not a map to preserve the hardfork order.
@@ -65,6 +78,7 @@ func GetAllHardForksInOrder() iter.Seq2[string, Upgrades] {
 		{"Sonic", GetSonicUpgrades()},
 		{"Allegro", GetAllegroUpgrades()},
 		{"Brio", GetBrioUpgrades()},
+		{"Canto", GetCantoUpgrades()},
 	}
 
 	return func(yield func(string, Upgrades) bool) {

--- a/opera/hardforks_test.go
+++ b/opera/hardforks_test.go
@@ -27,6 +27,7 @@ func TestGetAllHardForksInOrder_ReturnsOrderedEntries(t *testing.T) {
 		"Sonic",
 		"Allegro",
 		"Brio",
+		"Canto",
 	}
 
 	var actualOrder []string

--- a/opera/legacy_serialization.go
+++ b/opera/legacy_serialization.go
@@ -118,6 +118,9 @@ func (u Upgrades) EncodeRLP(w io.Writer) error {
 	if u.Brio {
 		bitmap.V |= brioBit
 	}
+	if u.Canto {
+		bitmap.V |= cantoBit
+	}
 	if u.SingleProposerBlockFormation {
 		bitmap.V |= singleProposerBlockFormationBit
 	}
@@ -148,6 +151,7 @@ func (u *Upgrades) DecodeRLP(s *rlp.Stream) error {
 	u.Sonic = (bitmap.V & sonicBit) != 0
 	u.Allegro = (bitmap.V & allegroBit) != 0
 	u.Brio = (bitmap.V & brioBit) != 0
+	u.Canto = (bitmap.V & cantoBit) != 0
 
 	u.SingleProposerBlockFormation = (bitmap.V & singleProposerBlockFormationBit) != 0
 	u.GasSubsidies = (bitmap.V & gasSubsidiesBit) != 0

--- a/opera/marshal.go
+++ b/opera/marshal.go
@@ -29,7 +29,7 @@ func UpdateRules(src Rules, diff []byte) (Rules, error) {
 	changed.Name = src.Name
 
 	// check validity of the new rules for all hardforks starting from Allegro
-	if changed.Upgrades.Allegro || changed.Upgrades.Brio {
+	if changed.Upgrades.Allegro || changed.Upgrades.Brio || changed.Upgrades.Canto {
 		if err := changed.Validate(src); err != nil {
 			return Rules{}, err
 		}

--- a/opera/marshal_test.go
+++ b/opera/marshal_test.go
@@ -145,6 +145,7 @@ func TestUpgradesRLP_CanBeEncodedAndDecoded(t *testing.T) {
 		func(u *Upgrades) { u.Allegro = true },
 		func(u *Upgrades) { u.SingleProposerBlockFormation = true },
 		func(u *Upgrades) { u.Brio = true },
+		func(u *Upgrades) { u.Canto = true },
 		func(u *Upgrades) { u.GasSubsidies = true },
 		func(u *Upgrades) { u.TransactionBundles = true },
 		func(u *Upgrades) { u.TransactionPriorities = true },

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -220,7 +220,7 @@ type Upgrades struct {
 	Sonic   bool // < launch version of the Sonic chain, introducing Cancun features
 	Allegro bool // < first hard fork of the Sonic chain, introducing Prague features
 	Brio    bool // < second hard fork of the Sonic chain, introducing Osaka features
-	Canto   bool // < third hard fork of the Sonic chain
+	Canto   bool // < third hard fork of the Sonic chain, introducing Amsterdam features
 
 	// -- Optional Features --
 

--- a/opera/rules.go
+++ b/opera/rules.go
@@ -44,6 +44,7 @@ const (
 	allegroBit = 1 << 4
 	_unused    = 1 << 5 // reserved, do not use
 	brioBit    = 1 << 6
+	cantoBit   = 1 << 7
 
 	// optional features
 	singleProposerBlockFormationBit = 1 << 63
@@ -219,6 +220,7 @@ type Upgrades struct {
 	Sonic   bool // < launch version of the Sonic chain, introducing Cancun features
 	Allegro bool // < first hard fork of the Sonic chain, introducing Prague features
 	Brio    bool // < second hard fork of the Sonic chain, introducing Osaka features
+	Canto   bool // < third hard fork of the Sonic chain
 
 	// -- Optional Features --
 

--- a/opera/rules_test.go
+++ b/opera/rules_test.go
@@ -195,6 +195,11 @@ func TestRules_Copy_CopiesAreDisjoint(t *testing.T) {
 				rule.Upgrades.Brio = !rule.Upgrades.Brio
 			},
 		},
+		"upgrade Upgrades.Canto": {
+			update: func(rule *Rules) {
+				rule.Upgrades.Canto = !rule.Upgrades.Canto
+			},
+		},
 		"upgrade Upgrades.GasSubsidies": {
 			update: func(rule *Rules) {
 				rule.Upgrades.GasSubsidies = !rule.Upgrades.GasSubsidies

--- a/opera/validate.go
+++ b/opera/validate.go
@@ -287,6 +287,16 @@ func validateUpgrades(old, new Upgrades) error {
 		issues = append(issues, errors.New("Brio upgrade cannot be disabled"))
 	}
 
+	if new.Canto && !new.Brio {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
+		issues = append(issues, errors.New("Canto upgrade requires Brio"))
+	}
+
+	if old.Canto && !new.Canto {
+		//nolint:staticcheck // ST1005: allow capitalized error message to preserve proper name
+		issues = append(issues, errors.New("Canto upgrade cannot be disabled"))
+	}
+
 	// The GasSubsidies feature can be freely modified.
 
 	// The TransactionPriorities feature can be freely modified.

--- a/opera/validate_test.go
+++ b/opera/validate_test.go
@@ -533,6 +533,19 @@ func TestUpgradesValidation_DetectsIssues(t *testing.T) {
 			upgrade: Upgrades{Brio: false},
 			issue:   "Brio upgrade cannot be disabled",
 		},
+		"Canto upgrade requires Brio": {
+			upgrade: Upgrades{Canto: true},
+			issue:   "Canto upgrade requires Brio",
+		},
+		"Canto upgrade cannot be disabled": {
+			previous: Upgrades{
+				Allegro: true,
+				Brio:    true,
+				Canto:   true,
+			},
+			upgrade: Upgrades{Brio: true, Canto: false},
+			issue:   "Canto upgrade cannot be disabled",
+		},
 	}
 
 	for name, test := range issues {

--- a/tests/create_skipped_test.go
+++ b/tests/create_skipped_test.go
@@ -35,7 +35,8 @@ func TestAccountCreation_CreateCallsWithInitCodesTooLargeDoNotAlterBalance(t *te
 		"Sonic":   50000,
 		"Allegro": 50000,
 		// From Brio onwards, the limit is doubled
-		"Brio": 50000 * 2,
+		"Brio":  50000 * 2,
+		"Canto": 50000 * 2,
 	}
 
 	for name, version := range opera.GetAllHardForksInOrder() {

--- a/tests/integration_test_net.go
+++ b/tests/integration_test_net.go
@@ -363,8 +363,10 @@ func StartIntegrationTestNetWithFakeGenesis(
 		upgrades = "allegro"
 	} else if *effectiveOptions.Upgrades == opera.GetBrioUpgrades() {
 		upgrades = "brio"
+	} else if *effectiveOptions.Upgrades == opera.GetCantoUpgrades() {
+		upgrades = "canto"
 	} else {
-		t.Fatal("fake genesis only supports sonic, allegro and brio feature sets")
+		t.Fatal("fake genesis only supports sonic, allegro, brio and canto feature sets")
 	}
 
 	numNodesString := fmt.Sprintf("%d", effectiveOptions.NumNodes)


### PR DESCRIPTION
Introduces Canto as the next hard fork of the Sonic chain. The upgrade requires Brio and cannot be disabled once enabled. It introduces no Ethereum revision, so it maps to no additional geth chain config.

The flag is registered in the hard fork iterator, the sonictool fake genesis profiles, and the integration test net feature sets.