### PR TITLE
Revert failed bundles with a bare execution plan root

### DIFF
--- a/evmcore/bundle_precheck.go
+++ b/evmcore/bundle_precheck.go
@@ -25,6 +25,7 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
 	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/utils"
 	"github.com/Fantom-foundation/lachesis-base/common/bigendian"
 	"github.com/ethereum/go-ethereum/common"
@@ -147,7 +148,7 @@ func getBundleState(
 	// Next, check whether there are any nonce conflicts in the execution of
 	// the bundle. This is a quicker check than actually running the bundle in
 	// full to determine whether it can succeed or not.
-	state := checkForNonceConflicts(bundle, signer, stateDb)
+	state := checkForNonceConflicts(bundle, signer, stateDb, chain.GetCurrentNetworkRules().Upgrades)
 	if !state.Executable {
 		return state
 	}
@@ -199,6 +200,7 @@ func checkForNonceConflicts(
 	txBundle *bundle.TransactionBundle,
 	signer types.Signer,
 	nonceSource NonceSource,
+	upgrades opera.Upgrades,
 ) BundleState {
 
 	// Step 1: run with current nonces to check whether the bundle is ready to
@@ -206,8 +208,9 @@ func checkForNonceConflicts(
 	strictRunner := &dryRunner{
 		signer:       signer,
 		nonceTracker: &nonceTracker{source: nonceSource},
+		upgrades:     upgrades,
 	}
-	if bundle.RunBundle(txBundle, strictRunner) {
+	if bundle.RunBundle(txBundle, strictRunner, upgrades) {
 		return makeRunnableState(nil)
 	}
 
@@ -217,8 +220,9 @@ func checkForNonceConflicts(
 		signer:       signer,
 		nonceTracker: &nonceTracker{source: nonceSource},
 		allowGaps:    true, // for each account, a future nonce may be chosen once
+		upgrades:     upgrades,
 	}
-	if bundle.RunBundle(txBundle, looseRunner) {
+	if bundle.RunBundle(txBundle, looseRunner, upgrades) {
 		return makeTemporaryBlockedState("gapped nonce")
 	}
 
@@ -241,6 +245,7 @@ type dryRunner struct {
 	allowGaps    bool
 	nonceLocked  map[common.Address]struct{}
 	undo         []func()
+	upgrades     opera.Upgrades
 }
 
 func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
@@ -251,7 +256,7 @@ func (r *dryRunner) Run(tx *types.Transaction) core_types.TransactionResult {
 			return core_types.TransactionResultInvalid
 		}
 
-		if bundle.RunBundle(&txBundle, r) {
+		if bundle.RunBundle(&txBundle, r, r.upgrades) {
 			return core_types.TransactionResultSuccessful
 		}
 

--- a/evmcore/bundle_precheck_test.go
+++ b/evmcore/bundle_precheck_test.go
@@ -500,7 +500,7 @@ func Test_checkForNonceConflicts_DetectsNonceUsage(t *testing.T) {
 			bundle, _, err := bundle.ValidateEnvelope(signer, envelope)
 			require.NoError(t, err)
 
-			got := checkForNonceConflicts(bundle, signer, source)
+			got := checkForNonceConflicts(bundle, signer, source, opera.GetCantoUpgrades())
 			require.Equal(t, test.result, got)
 		})
 	}

--- a/evmcore/state_processor.go
+++ b/evmcore/state_processor.go
@@ -603,7 +603,7 @@ func (r *transactionRunner) runTransactionBundleInternal(
 		trueTxOffset: trueTxOffset,
 		sizeLimit:    sizeLimit,
 	}
-	if !bundle.RunBundle(txBundle, &runner) {
+	if !bundle.RunBundle(txBundle, &runner, ctxt.upgrades) {
 		// Mark the execution plan as processed in the StateDB to prevent processing
 		// another bundle with the same execution plan in the same block. Also keep
 		// track of the position of the bundle in the block.

--- a/gossip/blockproc/bundle/bundle_processor.go
+++ b/gossip/blockproc/bundle/bundle_processor.go
@@ -18,6 +18,7 @@ package bundle
 
 import (
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -27,13 +28,26 @@ import (
 // TransactionRunner. It returns true if the bundle execution is considered
 // successful, and false otherwise.
 //
+// Only groups snapshot and revert their steps. Starting with Canto, a failed
+// bundle is rolled back as a whole, which also covers an execution plan whose
+// root is a single transaction step and thus has no group to revert it.
+//
 // This is the canonical implementation of the bundle execution logic, which
 // defines the semantic of the execution flags.
 func RunBundle(
 	bundle *TransactionBundle,
 	runner TransactionRunner,
+	upgrades opera.Upgrades,
 ) bool {
-	return runStep(bundle.Plan.Root, bundle.Transactions, runner)
+	if !upgrades.Canto {
+		return runStep(bundle.Plan.Root, bundle.Transactions, runner)
+	}
+	snapshot := runner.CreateSnapshot()
+	if !runStep(bundle.Plan.Root, bundle.Transactions, runner) {
+		runner.RevertToSnapshot(snapshot)
+		return false
+	}
+	return true
 }
 
 // TransactionRunner defines an interface for running individual transactions

--- a/gossip/blockproc/bundle/bundle_processor_test.go
+++ b/gossip/blockproc/bundle/bundle_processor_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -81,7 +82,45 @@ func TestRunBundle_DelegatesToRunStep(t *testing.T) {
 		// third branch should not be executed since one of the branches already succeeded
 	)
 
-	require.True(t, RunBundle(bundle, runner))
+	require.True(t, RunBundle(bundle, runner, opera.GetBrioUpgrades()))
+}
+
+func TestRunBundle_FailedBundleWithBareRootStepIsRevertedStartingWithCanto(t *testing.T) {
+	tests := map[string]struct {
+		upgrades opera.Upgrades
+		revert   bool
+	}{
+		"pre-Canto":  {upgrades: opera.GetBrioUpgrades(), revert: false},
+		"post-Canto": {upgrades: opera.GetCantoUpgrades(), revert: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			runner := NewMockTransactionRunner(ctrl)
+
+			ref := TxReference{From: common.Address{1}}
+			tx := types.NewTx(&types.LegacyTx{})
+
+			// A bare root step has no group that would revert it.
+			bundle := &TransactionBundle{
+				Transactions: map[TxReference]*types.Transaction{ref: tx},
+				Plan:         ExecutionPlan{Root: NewTxStep(ref)},
+			}
+
+			if test.revert {
+				gomock.InOrder(
+					runner.EXPECT().CreateSnapshot().Return(1),
+					runner.EXPECT().Run(tx).Return(core_types.TransactionResultFailed),
+					runner.EXPECT().RevertToSnapshot(1),
+				)
+			} else {
+				runner.EXPECT().Run(tx).Return(core_types.TransactionResultFailed)
+			}
+
+			require.False(t, RunBundle(bundle, runner, test.upgrades))
+		})
+	}
 }
 
 func Test_runStep_DispatchesToCorrectExecutionMode(t *testing.T) {

--- a/opera/vm_config_test.go
+++ b/opera/vm_config_test.go
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with Sonic. If not, see <http://www.gnu.org/licenses/>.
 
-package opera
+// The external test package avoids an import cycle: this file needs the
+// state-DB mock, and inter/state transitively depends on opera.
+package opera_test
 
 import (
 	"fmt"
@@ -23,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/inter/state"
+	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/require"
@@ -33,13 +36,13 @@ func TestGetVmConfig_SingleProposerModeDisablesExcessGasCharging(t *testing.T) {
 	for _, singleProposerMode := range []bool{true, false} {
 		t.Run(fmt.Sprintf("SingleProposerModeEnabled=%t", singleProposerMode), func(t *testing.T) {
 			require := require.New(t)
-			rules := Rules{
-				Upgrades: Upgrades{
+			rules := opera.Rules{
+				Upgrades: opera.Upgrades{
 					SingleProposerBlockFormation: singleProposerMode,
 				},
 			}
 
-			vmConfig := GetVmConfig(rules)
+			vmConfig := opera.GetVmConfig(rules)
 
 			require.NotEqual(singleProposerMode, vmConfig.ChargeExcessGas)
 		})
@@ -48,31 +51,31 @@ func TestGetVmConfig_SingleProposerModeDisablesExcessGasCharging(t *testing.T) {
 
 func TestGetVmConfig_NonBrioUpgrade_DoesNotSetMaxTxGas(t *testing.T) {
 
-	rules := Rules{
-		Upgrades: Upgrades{
+	rules := opera.Rules{
+		Upgrades: opera.Upgrades{
 			Brio: false,
 		},
 	}
 
-	vmConfig := GetVmConfig(rules)
+	vmConfig := opera.GetVmConfig(rules)
 
 	require.Nil(t, vmConfig.MaxTxGas)
 }
 
 func TestGetVmConfig_BrioUpgrade_CopiesMaxEventGasValue(t *testing.T) {
 	want := uint64(123456)
-	rules := Rules{
-		Upgrades: Upgrades{
+	rules := opera.Rules{
+		Upgrades: opera.Upgrades{
 			Brio: true,
 		},
-		Economy: EconomyRules{
-			Gas: GasRules{
+		Economy: opera.EconomyRules{
+			Gas: opera.GasRules{
 				MaxEventGas: want,
 			},
 		},
 	}
 
-	vmConfig := GetVmConfig(rules)
+	vmConfig := opera.GetVmConfig(rules)
 
 	require.NotNil(t, vmConfig.MaxTxGas)
 	require.Equal(t, want, *vmConfig.MaxTxGas)
@@ -89,15 +92,15 @@ func TestGetVmConfig_BrioUpgradeFromLfvmToSfvmInterpreter(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			rules := Rules{
-				Upgrades: Upgrades{
+			rules := opera.Rules{
+				Upgrades: opera.Upgrades{
 					Sonic:   true,
 					Allegro: true,
 					Brio:    test.brioEnabled,
 				},
 			}
 
-			vmConfig := GetVmConfig(rules)
+			vmConfig := opera.GetVmConfig(rules)
 			require.NotNil(t, vmConfig.Interpreter)
 
 			// create a contract with code size exceeding the LFVM code size limit
@@ -149,21 +152,21 @@ func TestCodeSizeLimits_BrioSetsCustomCodeSizeLimits(t *testing.T) {
 
 	for name, brioEnabled := range tests {
 		t.Run(name, func(t *testing.T) {
-			rules := Rules{
-				Upgrades: Upgrades{
+			rules := opera.Rules{
+				Upgrades: opera.Upgrades{
 					Sonic:   true,
 					Allegro: true,
 					Brio:    brioEnabled,
 				},
 			}
 
-			vmConfig := GetVmConfig(rules)
+			vmConfig := opera.GetVmConfig(rules)
 
 			if brioEnabled {
 				require.NotNil(t, vmConfig.MaxCodeSize)
 				require.NotNil(t, vmConfig.MaxInitCodeSize)
-				require.Equal(t, SonicPostAllegroMaxCodeSize, *vmConfig.MaxCodeSize)
-				require.Equal(t, SonicPostAllegroMaxInitCodeSize, *vmConfig.MaxInitCodeSize)
+				require.Equal(t, opera.SonicPostAllegroMaxCodeSize, *vmConfig.MaxCodeSize)
+				require.Equal(t, opera.SonicPostAllegroMaxInitCodeSize, *vmConfig.MaxInitCodeSize)
 			} else {
 				require.Nil(t, vmConfig.MaxCodeSize)
 				require.Nil(t, vmConfig.MaxInitCodeSize)

--- a/tests/bundles/failing_root_step_test.go
+++ b/tests/bundles/failing_root_step_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package bundles
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/0xsoniclabs/sonic/gossip/blockproc/bundle"
+	"github.com/0xsoniclabs/sonic/opera"
+	"github.com/0xsoniclabs/sonic/tests"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundle_FailingRootStepLeavesNoStateBehind(t *testing.T) {
+	upgrades := opera.GetCantoUpgrades()
+	upgrades.TransactionBundles = true
+
+	// The transaction pool would reject a bundle failing at the head state, so
+	// the envelope is emitted directly, like a validator not pre-checking it.
+	net := NewNoIntakeAndEmissionValidationTestNet(t, upgrades)
+
+	client, err := net.GetClient()
+	require.NoError(t, err)
+	defer client.Close()
+
+	signer := types.LatestSignerForChainID(net.GetChainId())
+	revertAddress, revertInput := tests.MustDeployRevertContractAndGetMethodCallParameters(t, net)
+
+	initialBalance := big.NewInt(1e18)
+
+	cases := map[string]struct {
+		wrapInGroup bool
+	}{
+		"BareRoot":   {wrapInGroup: false},
+		"AllOfGroup": {wrapInGroup: true},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			sender := tests.MakeAccountsWithBalance(t, net, 1, initialBalance)[0]
+
+			blockNumber, err := client.BlockNumber(t.Context())
+			require.NoError(t, err)
+
+			root := Step(t, net, sender, &types.AccessListTx{
+				To:   &revertAddress,
+				Gas:  1_000_000,
+				Data: revertInput,
+			})
+			if c.wrapInGroup {
+				root = bundle.AllOf(root)
+			}
+
+			envelope, txBundle, plan := bundle.NewBuilder().
+				WithSigner(signer).
+				SetEarliest(blockNumber).
+				With(root).
+				BuildEnvelopeBundleAndPlan()
+
+			t.Log("execution plan:", plan.Root.String())
+
+			_, err = net.Send(envelope)
+			require.NoError(t, err)
+
+			info, err := WaitForBundleExecution(t.Context(), client.Client(), plan.Hash())
+			require.NoError(t, err)
+			require.Zero(t, int(info.Count))
+
+			// The failing transaction reaches no block, ...
+			block := big.NewInt(info.Block.Int64())
+			failingTx := txBundle.GetTransactionsInReferencedOrder()[0]
+			_, err = client.TransactionReceipt(t.Context(), failingTx.Hash())
+			require.ErrorIs(t, err, ethereum.NotFound)
+			require.NotContains(t, getBlockTxsHashes(t, client, block), failingTx.Hash())
+
+			// ... so the block must not account for any of its effects either.
+			nonce, err := client.NonceAt(t.Context(), sender.Address(), block)
+			require.NoError(t, err)
+			assert.Zero(t, nonce)
+
+			balance, err := client.BalanceAt(t.Context(), sender.Address(), block)
+			require.NoError(t, err)
+			assert.Equal(t, initialBalance, balance)
+		})
+	}
+}


### PR DESCRIPTION
Starting with Canto, RunBundle snapshots and reverts the bundle as a whole when it fails. (see https://github.com/0xsoniclabs/sonic-admin/issues/885)