### PR TITLE
Bump carmen version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ module github.com/0xsoniclabs/sonic
 go 1.26.0
 
 require (
-	github.com/0xsoniclabs/carmen/go v0.0.0-20260810100456-9efcad847e1b
+	github.com/0xsoniclabs/carmen/go v0.0.0-20260813124720-0f8d78893b32
 	github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42
 	github.com/Fantom-foundation/lachesis-base v0.0.0-20240116072301-a75735c4ef00
 	github.com/cespare/cp v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0xsoniclabs/carmen/go v0.0.0-20260810100456-9efcad847e1b h1:0dJ5+v6Uh794M1CUdBUma6o4VcwwNq3yzfyGuNZZryU=
-github.com/0xsoniclabs/carmen/go v0.0.0-20260810100456-9efcad847e1b/go.mod h1:hqRaE66FNXefSgAj5VU/8Lmr2YCq00/c6N7sF5HJD20=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260813124720-0f8d78893b32 h1:ptrWlW4b8f33nCYcsg/ptjbqyzVTuteBtV1WfHrtneI=
+github.com/0xsoniclabs/carmen/go v0.0.0-20260813124720-0f8d78893b32/go.mod h1:hqRaE66FNXefSgAj5VU/8Lmr2YCq00/c6N7sF5HJD20=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe h1:JPiyJPZ1oBzRwsRW0BER76wChPg7rOxKwk1W5YUkKlE=
 github.com/0xsoniclabs/go-ethereum v0.0.0-20260507120815-e9dfccd41dbe/go.mod h1:F60oMGNtPsr0hhwnGzwZv4ooj0AfnXJ1iGMGXylfjrg=
 github.com/0xsoniclabs/tosca v0.0.0-20260429071638-3f4119284c42 h1:oJMc/vekaRHmIwiRYHzfn8pofD4AwR8awgJe8DeUaDs=


### PR DESCRIPTION
Bumps the carmen version to https://github.com/0xsoniclabs/carmen/commit/0f8d78893b3218b25b5c5376ac148b06e9031703.
This commit includes the fix for the Sepolia run.