### PR TITLE
Narrow the internal-tx builders to a NonceSource

### DIFF
--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -82,11 +82,11 @@ func NewDriverTxPreTransactor() *DriverTxPreTransactor {
 	return &DriverTxPreTransactor{}
 }
 
-func InternalTxBuilder(statedb state.StateDB) func(calldata []byte, addr common.Address) *types.Transaction {
+func InternalTxBuilder(nonces blockproc.NonceSource) func(calldata []byte, addr common.Address) *types.Transaction {
 	nonce := uint64(math.MaxUint64)
 	return func(calldata []byte, addr common.Address) *types.Transaction {
 		if nonce == math.MaxUint64 {
-			nonce = statedb.GetNonce(common.Address{})
+			nonce = nonces.ZeroAddressNonce()
 		}
 		tx := types.NewTransaction(nonce, addr, common.Big0, internalTransactionsGasLimit, common.Big0, calldata)
 		nonce++
@@ -101,8 +101,8 @@ func maxBlockIdx(a, b idx.Block) idx.Block {
 	return b
 }
 
-func (p *DriverTxPreTransactor) PopInternalTxs(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, sealing bool, statedb state.StateDB) types.Transactions {
-	buildTx := InternalTxBuilder(statedb)
+func (p *DriverTxPreTransactor) PopInternalTxs(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, sealing bool, nonces blockproc.NonceSource) types.Transactions {
+	buildTx := InternalTxBuilder(nonces)
 	internalTxs := make(types.Transactions, 0, 8)
 
 	// write cheaters
@@ -139,8 +139,8 @@ func (p *DriverTxPreTransactor) PopInternalTxs(block iblockproc.BlockCtx, bs ibl
 	return internalTxs
 }
 
-func (p *DriverTxTransactor) PopInternalTxs(_ iblockproc.BlockCtx, _ iblockproc.BlockState, es iblockproc.EpochState, sealing bool, statedb state.StateDB) types.Transactions {
-	buildTx := InternalTxBuilder(statedb)
+func (p *DriverTxTransactor) PopInternalTxs(_ iblockproc.BlockCtx, _ iblockproc.BlockState, es iblockproc.EpochState, sealing bool, nonces blockproc.NonceSource) types.Transactions {
+	buildTx := InternalTxBuilder(nonces)
 	internalTxs := make(types.Transactions, 0, 1)
 	// push data into Driver after epoch sealing
 	if sealing {

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -35,13 +35,10 @@ import (
 
 //go:generate mockgen -source=interface.go -package=blockproc -destination=interface_mock.go
 
-// NonceSource exposes the nonce of the zero address (0x0) — the only piece of
-// state the internal-transaction builders read. Internal-transaction sources are
-// narrowed to this interface (rather than a full state.StateDB) to make explicit,
-// at the type level, that they observe nothing else in the state.
+// NonceSource exposes the nonce of the zero address, which is all state
+// information internal-transaction builders read.
 type NonceSource interface {
-	// ZeroAddressNonce returns the current nonce of the zero address, used to
-	// sequence the internal transactions sent from it.
+	// ZeroAddressNonce returns the current nonce of the zero address.
 	ZeroAddressNonce() uint64
 }
 

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -35,6 +35,16 @@ import (
 
 //go:generate mockgen -source=interface.go -package=blockproc -destination=interface_mock.go
 
+// NonceSource exposes the nonce of the zero address (0x0) — the only piece of
+// state the internal-transaction builders read. Internal-transaction sources are
+// narrowed to this interface (rather than a full state.StateDB) to make explicit,
+// at the type level, that they observe nothing else in the state.
+type NonceSource interface {
+	// ZeroAddressNonce returns the current nonce of the zero address, used to
+	// sequence the internal transactions sent from it.
+	ZeroAddressNonce() uint64
+}
+
 type TxListener interface {
 	OnNewLog(*core_types.Log)
 	OnNewReceipt(tx *types.Transaction, r *types.Receipt, originator idx.ValidatorID, baseFee *big.Int, blobBaseFee *big.Int)
@@ -47,7 +57,7 @@ type TxListenerModule interface {
 }
 
 type TxTransactor interface {
-	PopInternalTxs(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, sealing bool, statedb state.StateDB) types.Transactions
+	PopInternalTxs(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, sealing bool, nonces NonceSource) types.Transactions
 }
 
 type SealerProcessor interface {

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -27,6 +27,44 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// MockNonceSource is a mock of NonceSource interface.
+type MockNonceSource struct {
+	ctrl     *gomock.Controller
+	recorder *MockNonceSourceMockRecorder
+	isgomock struct{}
+}
+
+// MockNonceSourceMockRecorder is the mock recorder for MockNonceSource.
+type MockNonceSourceMockRecorder struct {
+	mock *MockNonceSource
+}
+
+// NewMockNonceSource creates a new mock instance.
+func NewMockNonceSource(ctrl *gomock.Controller) *MockNonceSource {
+	mock := &MockNonceSource{ctrl: ctrl}
+	mock.recorder = &MockNonceSourceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockNonceSource) EXPECT() *MockNonceSourceMockRecorder {
+	return m.recorder
+}
+
+// ZeroAddressNonce mocks base method.
+func (m *MockNonceSource) ZeroAddressNonce() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ZeroAddressNonce")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ZeroAddressNonce indicates an expected call of ZeroAddressNonce.
+func (mr *MockNonceSourceMockRecorder) ZeroAddressNonce() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ZeroAddressNonce", reflect.TypeOf((*MockNonceSource)(nil).ZeroAddressNonce))
+}
+
 // MockTxListener is a mock of TxListener interface.
 type MockTxListener struct {
 	ctrl     *gomock.Controller
@@ -164,17 +202,17 @@ func (m *MockTxTransactor) EXPECT() *MockTxTransactorMockRecorder {
 }
 
 // PopInternalTxs mocks base method.
-func (m *MockTxTransactor) PopInternalTxs(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, sealing bool, statedb state.StateDB) types.Transactions {
+func (m *MockTxTransactor) PopInternalTxs(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, sealing bool, nonces NonceSource) types.Transactions {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PopInternalTxs", block, bs, es, sealing, statedb)
+	ret := m.ctrl.Call(m, "PopInternalTxs", block, bs, es, sealing, nonces)
 	ret0, _ := ret[0].(types.Transactions)
 	return ret0
 }
 
 // PopInternalTxs indicates an expected call of PopInternalTxs.
-func (mr *MockTxTransactorMockRecorder) PopInternalTxs(block, bs, es, sealing, statedb any) *gomock.Call {
+func (mr *MockTxTransactorMockRecorder) PopInternalTxs(block, bs, es, sealing, nonces any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopInternalTxs", reflect.TypeOf((*MockTxTransactor)(nil).PopInternalTxs), block, bs, es, sealing, statedb)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopInternalTxs", reflect.TypeOf((*MockTxTransactor)(nil).PopInternalTxs), block, bs, es, sealing, nonces)
 }
 
 // MockSealerProcessor is a mock of SealerProcessor interface.

--- a/gossip/blockproc/nonce_source.go
+++ b/gossip/blockproc/nonce_source.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package blockproc
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/0xsoniclabs/sonic/inter/state"
+)
+
+// NewNonceSource returns a NonceSource backed by the given state database. It
+// exposes only the zero-address nonce, hiding the rest of the state from the
+// internal-transaction builders.
+func NewNonceSource(statedb state.StateDB) NonceSource {
+	return stateDBNonceSource{statedb: statedb}
+}
+
+// stateDBNonceSource adapts a state.StateDB to a NonceSource.
+type stateDBNonceSource struct {
+	statedb state.StateDB
+}
+
+func (s stateDBNonceSource) ZeroAddressNonce() uint64 {
+	return s.statedb.GetNonce(common.Address{})
+}

--- a/gossip/blockproc/nonce_source_test.go
+++ b/gossip/blockproc/nonce_source_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package blockproc
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/0xsoniclabs/sonic/inter/state"
+)
+
+func TestNewNonceSource_ReturnsNonceSourceQueryingTheGivenStateDB(t *testing.T) {
+	statedb := state.NewMockStateDB(gomock.NewController(t))
+	statedb.EXPECT().GetNonce(gomock.Any()).Return(uint64(7))
+
+	require.Equal(t, uint64(7), NewNonceSource(statedb).ZeroAddressNonce())
+}
+
+func TestStateDBNonceSource_ZeroAddressNonce_ReturnsNonceOfZeroAddressFromStateDB(t *testing.T) {
+	statedb := state.NewMockStateDB(gomock.NewController(t))
+	statedb.EXPECT().GetNonce(common.Address{}).Return(uint64(42))
+
+	require.Equal(t, uint64(42), NewNonceSource(statedb).ZeroAddressNonce())
+}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -172,8 +172,6 @@ func consensusCallbackBeginBlockFn(
 		if err != nil {
 			log.Crit("Failed to open StateDB", "err", err)
 		}
-		// The internal-transaction builders only read the zero-address nonce; pass
-		// them a narrow NonceSource over the live state rather than the full statedb.
 		nonceSource := blockproc.NewNonceSource(statedb)
 		evmStateReader := &EvmStateReader{
 			ServiceFeed: feed,

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -172,6 +172,9 @@ func consensusCallbackBeginBlockFn(
 		if err != nil {
 			log.Crit("Failed to open StateDB", "err", err)
 		}
+		// The internal-transaction builders only read the zero-address nonce; pass
+		// them a narrow NonceSource over the live state rather than the full statedb.
+		nonceSource := blockproc.NewNonceSource(statedb)
 		evmStateReader := &EvmStateReader{
 			ServiceFeed: feed,
 			store:       store,
@@ -386,7 +389,7 @@ func consensusCallbackBeginBlockFn(
 				executionStart := time.Now()
 
 				// Execute pre-internal transactions
-				preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
+				preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, nonceSource)
 				preInternalProcessedTxs := evmProcessor.Execute(preInternalTxs, maxBlockGas, math.MaxUint64).ProcessedTransactions
 				bs = txListener.Finalize()
 				for _, tx := range preInternalProcessedTxs {
@@ -460,7 +463,7 @@ func consensusCallbackBeginBlockFn(
 					}
 
 					// Execute post-internal transactions
-					internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, statedb)
+					internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, sealing, nonceSource)
 					internalProcessedTxs := evmProcessor.Execute(internalTxs, maxBlockGas, math.MaxUint64).ProcessedTransactions
 					for _, tx := range internalProcessedTxs {
 						if tx.Receipt == nil || tx.Receipt.Status == 0 {

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -269,7 +269,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	bs = txListener.Finalize()
 
 	// Execute pre-internal transactions
-	preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
+	preInternalTxs := blockProc.PreTxTransactor.PopInternalTxs(blockCtx, bs, es, true, blockproc.NewNonceSource(b.tmpStateDB))
 	evmProcessor.Execute(preInternalTxs, es.Rules.Blocks.MaxBlockGas, math.MaxUint64)
 	bs = txListener.Finalize()
 
@@ -283,7 +283,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	txListener.Update(bs, es)
 
 	// Execute post-internal transactions
-	internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, true, b.tmpStateDB)
+	internalTxs := blockProc.PostTxTransactor.PopInternalTxs(blockCtx, bs, es, true, blockproc.NewNonceSource(b.tmpStateDB))
 	evmProcessor.Execute(internalTxs, es.Rules.Blocks.MaxBlockGas, math.MaxUint64)
 
 	evmBlock, numSkippedTxs, receipts := evmProcessor.Finalize()


### PR DESCRIPTION
The internal-transaction builders only ever read the zero-address nonce from the state database. This PR introduces a narrow blockproc.NonceSource interface exposing only ZeroAddressNonce() and passes it to PopInternalTxs instead of a full state.StateDB, so the type makes explicit that the builders observe nothing else in the state. No behavior change.
    
This prepares the consensus/ledger separation: the block-processing ledger can hand the consensus a NonceSource over its live state without exposing the whole state DB.