### PR TITLE
Drop the dead statedb argument from TxListenerModule.Start

### DIFF
--- a/gossip/blockproc/drivermodule/driver_txs.go
+++ b/gossip/blockproc/drivermodule/driver_txs.go
@@ -34,7 +34,6 @@ import (
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/drivertype"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
-	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/inter/validatorpk"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/0xsoniclabs/sonic/opera/contracts/driver"
@@ -54,20 +53,18 @@ func NewDriverTxListenerModule() *DriverTxListenerModule {
 	return &DriverTxListenerModule{}
 }
 
-func (m *DriverTxListenerModule) Start(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, statedb state.StateDB) blockproc.TxListener {
+func (m *DriverTxListenerModule) Start(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState) blockproc.TxListener {
 	return &DriverTxListener{
-		block:   block,
-		es:      es,
-		bs:      bs,
-		statedb: statedb,
+		block: block,
+		es:    es,
+		bs:    bs,
 	}
 }
 
 type DriverTxListener struct {
-	block   iblockproc.BlockCtx
-	es      iblockproc.EpochState
-	bs      iblockproc.BlockState
-	statedb state.StateDB
+	block iblockproc.BlockCtx
+	es    iblockproc.EpochState
+	bs    iblockproc.BlockState
 }
 
 type DriverTxTransactor struct{}

--- a/gossip/blockproc/drivermodule/driver_txs_test.go
+++ b/gossip/blockproc/drivermodule/driver_txs_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
-	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/logger"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
@@ -69,8 +68,7 @@ func TestReceiptRewardWithoutFixEnabled(t *testing.T) {
 		Validators: valsBuilder.Build(),
 		Rules:      rules,
 	}
-	stateDb := state.NewMockStateDB(ctrl)
-	listener := module.Start(blockCtx, bs, es, stateDb)
+	listener := module.Start(blockCtx, bs, es)
 
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: big.NewInt(GasTip),
@@ -110,8 +108,7 @@ func TestReceiptRewardWithFixEnabled(t *testing.T) {
 		Validators: valsBuilder.Build(),
 		Rules:      rules,
 	}
-	stateDb := state.NewMockStateDB(ctrl)
-	listener := module.Start(blockCtx, bs, es, stateDb)
+	listener := module.Start(blockCtx, bs, es)
 
 	tx := types.NewTx(&types.DynamicFeeTx{
 		GasTipCap: big.NewInt(GasTip),
@@ -151,8 +148,7 @@ func TestReceiptRewardWithBlobsAndFixEnabled(t *testing.T) {
 		Validators: valsBuilder.Build(),
 		Rules:      rules,
 	}
-	stateDb := state.NewMockStateDB(ctrl)
-	listener := module.Start(blockCtx, bs, es, stateDb)
+	listener := module.Start(blockCtx, bs, es)
 
 	tx := types.NewTx(&types.BlobTx{
 		GasTipCap:  uint256.NewInt(GasTip),

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -50,7 +50,7 @@ type TxListener interface {
 }
 
 type TxListenerModule interface {
-	Start(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, statedb state.StateDB) TxListener
+	Start(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState) TxListener
 }
 
 type TxTransactor interface {

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -164,17 +164,17 @@ func (m *MockTxListenerModule) EXPECT() *MockTxListenerModuleMockRecorder {
 }
 
 // Start mocks base method.
-func (m *MockTxListenerModule) Start(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState, statedb state.StateDB) TxListener {
+func (m *MockTxListenerModule) Start(block iblockproc.BlockCtx, bs iblockproc.BlockState, es iblockproc.EpochState) TxListener {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", block, bs, es, statedb)
+	ret := m.ctrl.Call(m, "Start", block, bs, es)
 	ret0, _ := ret[0].(TxListener)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockTxListenerModuleMockRecorder) Start(block, bs, es, statedb any) *gomock.Call {
+func (mr *MockTxListenerModuleMockRecorder) Start(block, bs, es any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockTxListenerModule)(nil).Start), block, bs, es, statedb)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockTxListenerModule)(nil).Start), block, bs, es)
 }
 
 // MockTxTransactor is a mock of TxTransactor interface.

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -364,7 +364,7 @@ func consensusCallbackBeginBlockFn(
 
 				sealer := blockProc.SealerModule.Start(blockCtx, bs, es)
 				sealing := sealer.EpochSealing()
-				txListener := blockProc.TxListenerModule.Start(blockCtx, bs, es, statedb)
+				txListener := blockProc.TxListenerModule.Start(blockCtx, bs, es)
 				onNewLogAll := func(l *core_types.Log) {
 					txListener.OnNewLog(l)
 					// Note: it's possible for logs to get indexed twice by BR and block processing

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -275,7 +275,7 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 				txListener.EXPECT().Finalize().Return(iblockproc.BlockState{}).AnyTimes()
 
 				txListenerModule := blockproc.NewMockTxListenerModule(ctrl)
-				txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
+				txListenerModule.EXPECT().Start(_any, _any, _any).Return(txListener)
 
 				evmProcessor := blockproc.NewMockEVMProcessor(ctrl)
 				evmProcessor.EXPECT().Execute(_any, _any, _any).MinTimes(1)
@@ -450,7 +450,7 @@ func TestConsensusCallback_UsesBlockStartRulesAcrossEpochSealing(t *testing.T) {
 	txListener.EXPECT().Update(_any, _any).AnyTimes()
 	txListener.EXPECT().OnNewReceipt(_any, _any, _any, _any, _any).AnyTimes()
 	txListenerModule := blockproc.NewMockTxListenerModule(ctrl)
-	txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
+	txListenerModule.EXPECT().Start(_any, _any, _any).Return(txListener)
 
 	txTransactor := blockproc.NewMockTxTransactor(ctrl)
 	txTransactor.EXPECT().PopInternalTxs(_any, _any, _any, _any, _any).
@@ -628,7 +628,7 @@ func TestConsensusCallback_UsesBlockStartRulesForReceiptOriginTracking(t *testin
 			reportedOriginators = append(reportedOriginators, originator)
 		}).AnyTimes()
 	txListenerModule := blockproc.NewMockTxListenerModule(ctrl)
-	txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
+	txListenerModule.EXPECT().Start(_any, _any, _any).Return(txListener)
 
 	txTransactor := blockproc.NewMockTxTransactor(ctrl)
 	txTransactor.EXPECT().PopInternalTxs(_any, _any, _any, _any, _any).
@@ -773,7 +773,7 @@ func TestConsensusCallback_AppliesTransactionPriorities(t *testing.T) {
 	txListener := blockproc.NewMockTxListener(ctrl)
 	txListener.EXPECT().Finalize().Return(iblockproc.BlockState{}).AnyTimes()
 	txListenerModule := blockproc.NewMockTxListenerModule(ctrl)
-	txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
+	txListenerModule.EXPECT().Start(_any, _any, _any).Return(txListener)
 
 	txTransactor := blockproc.NewMockTxTransactor(ctrl)
 	txTransactor.EXPECT().PopInternalTxs(_any, _any, _any, _any, _any).
@@ -2235,7 +2235,7 @@ func TestConsensusCallback_TxCausedBy_UsesOriginTxForCreatorLookupWithBrio(t *te
 				}).Times(2)
 
 			txListenerModule := blockproc.NewMockTxListenerModule(ctrl)
-			txListenerModule.EXPECT().Start(_any, _any, _any, _any).Return(txListener)
+			txListenerModule.EXPECT().Start(_any, _any, _any).Return(txListener)
 
 			// EVM processor: 3 Execute calls in order (pre-internal, post-internal, user txs).
 			evmProcessor := blockproc.NewMockEVMProcessor(ctrl)

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -245,7 +245,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 	}
 
 	sealer := blockProc.SealerModule.Start(blockCtx, bs, es)
-	txListener := blockProc.TxListenerModule.Start(blockCtx, bs, es, b.tmpStateDB)
+	txListener := blockProc.TxListenerModule.Start(blockCtx, bs, es)
 	chainConfig := opera.CreateTransientEvmChainConfig(
 		es.Rules.NetworkID,
 		// apply upgrades described in genesis rules, effect immediately


### PR DESCRIPTION
DriverTxListenerModule.Start stored the state database but never read it, so removing the argument from the interface, its mock, the implementation, and all callers is behavior-preserving.