### PR TITLE
Reduce TxPosition to {Block, BlockOffset}

### DIFF
--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -511,16 +511,12 @@ func consensusCallbackBeginBlockFn(
 					// memorize event position of each tx
 					txPositions := make(map[common.Hash]ExtendedTxPosition)
 					for _, e := range blockEvents {
-						for i, tx := range e.Transactions() {
+						for _, tx := range e.Transactions() {
 							// If tx was met in multiple events, then assign to first ordered event
 							if _, ok := txPositions[tx.Hash()]; ok {
 								continue
 							}
 							txPositions[tx.Hash()] = ExtendedTxPosition{
-								TxPosition: evmstore.TxPosition{
-									Event:       e.ID(),
-									EventOffset: uint32(i),
-								},
 								EventCreator: e.Creator(),
 							}
 						}

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -508,7 +508,7 @@ func consensusCallbackBeginBlockFn(
 						}
 					}
 
-					// memorize event position of each tx
+					// memorize the event creator of each tx
 					txPositions := make(map[common.Hash]ExtendedTxPosition)
 					for _, e := range blockEvents {
 						for _, tx := range e.Transactions() {

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -548,6 +548,13 @@ func consensusCallbackBeginBlockFn(
 					bs.FinalizedStateRoot = hash.Hash(evmBlock.Root)
 					// At this point, block state is finalized
 
+					// Store the transaction bodies before indexing their
+					// positions, such that readers finding a position always
+					// find the corresponding body as well.
+					for _, tx := range blockBuilder.GetTransactions() {
+						store.evm.SetTx(tx.Hash(), tx)
+					}
+
 					// Build index for not skipped txs
 					if txIndex {
 						for _, tx := range evmBlock.Transactions {
@@ -570,10 +577,6 @@ func consensusCallbackBeginBlockFn(
 					if sealing {
 						store.SetHistoryBlockEpochState(es.Epoch, bs, es)
 						store.SetEpochBlock(blockCtx.Idx+1, es.Epoch)
-					}
-
-					for _, tx := range blockBuilder.GetTransactions() {
-						store.evm.SetTx(tx.Hash(), tx)
 					}
 
 					store.SetBlock(blockCtx.Idx, block)

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -467,6 +467,9 @@ func (b *EthAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) 
 	}
 
 	tx := b.svc.store.evm.GetTx(txHash)
+	if tx == nil {
+		return nil, 0, 0, fmt.Errorf("transactions index is corrupted (position without body), txid=%s, block=%d", txHash, position.Block)
+	}
 	return tx, uint64(position.Block), uint64(position.BlockOffset), nil
 }
 

--- a/gossip/ethapi_backend.go
+++ b/gossip/ethapi_backend.go
@@ -466,22 +466,7 @@ func (b *EthAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) 
 		return nil, 0, 0, nil
 	}
 
-	var tx *types.Transaction
-	if position.Event.IsZero() {
-		tx = b.svc.store.evm.GetTx(txHash)
-	} else {
-		event := b.svc.store.GetEventPayload(position.Event)
-		if position.EventOffset > uint32(event.Transactions().Len()) {
-			return nil, 0, 0, fmt.Errorf("transactions index is corrupted (offset is larger than number of txs in event), event=%s, txid=%s, block=%d, offset=%d, txs_num=%d",
-				position.Event.String(),
-				txHash.String(),
-				position.Block,
-				position.EventOffset,
-				event.Transactions().Len())
-		}
-		tx = event.Transactions()[position.EventOffset]
-	}
-
+	tx := b.svc.store.evm.GetTx(txHash)
 	return tx, uint64(position.Block), uint64(position.BlockOffset), nil
 }
 

--- a/gossip/ethapi_backend_test.go
+++ b/gossip/ethapi_backend_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 
 	"github.com/0xsoniclabs/sonic/gossip/emitter"
+	"github.com/0xsoniclabs/sonic/gossip/evmstore"
 	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
@@ -98,6 +100,50 @@ func TestEthApiBackend_GetNetworkRules_MissingBlockReturnsNilRules(t *testing.T)
 	rules, err := backend.GetNetworkRules(t.Context(), blockNumber)
 	require.NoError(err)
 	require.Nil(rules)
+}
+
+func TestEthApiBackend_GetTransaction_ReturnsTransactionAtItsPosition(t *testing.T) {
+	require := require.New(t)
+
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	tx := types.NewTx(&types.LegacyTx{Nonce: 1})
+	store.evm.SetTx(tx.Hash(), tx)
+	store.evm.SetTxPosition(tx.Hash(), evmstore.TxPosition{Block: 42, BlockOffset: 7})
+
+	backend := &EthAPIBackend{
+		svc: &Service{
+			config: Config{TxIndex: true},
+			store:  store,
+		},
+	}
+
+	got, block, offset, err := backend.GetTransaction(t.Context(), tx.Hash())
+	require.NoError(err)
+	require.Equal(tx.Hash(), got.Hash())
+	require.Equal(uint64(42), block)
+	require.Equal(uint64(7), offset)
+}
+
+func TestEthApiBackend_GetTransaction_ReportsCorruptedIndexIfBodyIsMissing(t *testing.T) {
+	require := require.New(t)
+
+	store, err := NewMemStore(t)
+	require.NoError(err)
+
+	txHash := common.Hash{1}
+	store.evm.SetTxPosition(txHash, evmstore.TxPosition{Block: 42, BlockOffset: 7})
+
+	backend := &EthAPIBackend{
+		svc: &Service{
+			config: Config{TxIndex: true},
+			store:  store,
+		},
+	}
+
+	_, _, _, err = backend.GetTransaction(t.Context(), txHash)
+	require.ErrorContains(err, "index is corrupted")
 }
 
 func TestEthApiBackend_IsTestOnlyApiEnabled_ReturnsConfigFlagValue(t *testing.T) {

--- a/gossip/evmstore/store_tx_position.go
+++ b/gossip/evmstore/store_tx_position.go
@@ -21,16 +21,34 @@ package evmstore
 */
 
 import (
-	"github.com/Fantom-foundation/lachesis-base/hash"
+	"fmt"
+
 	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type TxPosition struct {
 	Block       idx.Block
-	Event       hash.Event
-	EventOffset uint32
 	BlockOffset uint32
+}
+
+// DecodeRLP decodes a TxPosition, tolerating the historical 4-element layout
+// [Block, Event, EventOffset, BlockOffset] in addition to the current
+// [Block, BlockOffset]. In both layouts Block is the first element and
+// BlockOffset is the last, so older records remain readable without a reindex.
+func (p *TxPosition) DecodeRLP(s *rlp.Stream) error {
+	var raw []rlp.RawValue
+	if err := s.Decode(&raw); err != nil {
+		return err
+	}
+	if len(raw) != 2 && len(raw) != 4 {
+		return fmt.Errorf("unexpected TxPosition arity %d", len(raw))
+	}
+	if err := rlp.DecodeBytes(raw[0], &p.Block); err != nil {
+		return err
+	}
+	return rlp.DecodeBytes(raw[len(raw)-1], &p.BlockOffset)
 }
 
 // SetTxPosition stores transaction block and position.

--- a/gossip/evmstore/store_tx_position_test.go
+++ b/gossip/evmstore/store_tx_position_test.go
@@ -17,6 +17,7 @@
 package evmstore
 
 import (
+	"math"
 	"testing"
 
 	"github.com/Fantom-foundation/lachesis-base/hash"
@@ -60,10 +61,35 @@ func TestTxPosition_DecodeRLP_ReadsLegacyFourFieldLayout(t *testing.T) {
 	require.Equal(t, TxPosition{Block: 42, BlockOffset: 7}, got)
 }
 
-func TestTxPosition_DecodeRLP_RejectsUnexpectedArity(t *testing.T) {
-	encoded, err := rlp.EncodeToBytes([]uint32{1, 2, 3})
-	require.NoError(t, err)
+func TestTxPosition_DecodeRLP_RejectsInvalidEncodings(t *testing.T) {
+	encode := func(v any) []byte {
+		encoded, err := rlp.EncodeToBytes(v)
+		require.NoError(t, err)
+		return encoded
+	}
 
-	var got TxPosition
-	require.Error(t, rlp.DecodeBytes(encoded, &got))
+	tests := map[string]struct {
+		encoded []byte
+	}{
+		"not a list":   {encode(uint32(1))},
+		"no fields":    {encode([]uint32{})},
+		"one field":    {encode([]uint32{1})},
+		"three fields": {encode([]uint32{1, 2, 3})},
+		"five fields":  {encode([]uint32{1, 2, 3, 4, 5})},
+		"block is not an integer": {encode(struct {
+			Block       []uint32
+			BlockOffset uint32
+		}{[]uint32{1}, 7})},
+		"block offset overflows uint32": {encode(struct {
+			Block       idx.Block
+			BlockOffset uint64
+		}{42, math.MaxUint32 + 1})},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got TxPosition
+			require.Error(t, rlp.DecodeBytes(test.encoded, &got))
+		})
+	}
 }

--- a/gossip/evmstore/store_tx_position_test.go
+++ b/gossip/evmstore/store_tx_position_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Sonic Operations Ltd
+// This file is part of the Sonic Client
+//
+// Sonic is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Sonic is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Sonic. If not, see <http://www.gnu.org/licenses/>.
+
+package evmstore
+
+import (
+	"testing"
+
+	"github.com/Fantom-foundation/lachesis-base/hash"
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxPosition_DecodeRLP_ReadsCurrentTwoFieldLayout(t *testing.T) {
+	want := TxPosition{Block: 42, BlockOffset: 7}
+
+	encoded, err := rlp.EncodeToBytes(&want)
+	require.NoError(t, err)
+
+	var got TxPosition
+	require.NoError(t, rlp.DecodeBytes(encoded, &got))
+	require.Equal(t, want, got)
+}
+
+func TestTxPosition_DecodeRLP_ReadsLegacyFourFieldLayout(t *testing.T) {
+	// The historical layout persisted four fields:
+	// [Block, Event, EventOffset, BlockOffset]. Such records must still decode,
+	// keeping Block (first) and BlockOffset (last) and dropping the event fields.
+	legacy := struct {
+		Block       idx.Block
+		Event       hash.Event
+		EventOffset uint32
+		BlockOffset uint32
+	}{
+		Block:       42,
+		Event:       hash.HexToEventHash("0xdeadbeef"),
+		EventOffset: 3,
+		BlockOffset: 7,
+	}
+
+	encoded, err := rlp.EncodeToBytes(&legacy)
+	require.NoError(t, err)
+
+	var got TxPosition
+	require.NoError(t, rlp.DecodeBytes(encoded, &got))
+	require.Equal(t, TxPosition{Block: 42, BlockOffset: 7}, got)
+}
+
+func TestTxPosition_DecodeRLP_RejectsUnexpectedArity(t *testing.T) {
+	encoded, err := rlp.EncodeToBytes([]uint32{1, 2, 3})
+	require.NoError(t, err)
+
+	var got TxPosition
+	require.Error(t, rlp.DecodeBytes(encoded, &got))
+}


### PR DESCRIPTION
The persisted Event/EventOffset fields fed an alternate read path in GetTransaction that loaded the tx body from the event payload. Since PR [#301](https://github.com/Fantom-foundation/Sonic/pull/301) every non-skipped block tx body is stored via SetTx, so GetTx serves all lookups and the event-payload branch is dead. Drop Event/EventOffset, shrinking TxPosition to {Block, BlockOffset}.

A custom DecodeRLP keeps existing databases readable: it accepts both the legacy 4-element layout [Block, Event, EventOffset, BlockOffset] and the new 2-element [Block, BlockOffset] (Block is first, BlockOffset is last in both), so no reindex or resync is required. GetTransaction is simplified to a single GetTx call.

The consensus callback no longer records event provenance in the position; it still tracks tx hash -> creator for OnNewReceipt. Writing the positions from the callback is unchanged here and is relocated into the ledger in a later commit.