### PR TITLE
evmcore: skip invalid authorizations in txpool authority index

### DIFF
--- a/evmcore/tx_pool.go
+++ b/evmcore/tx_pool.go
@@ -2098,7 +2098,15 @@ func (t *txLookup) Add(tx *types.Transaction, local bool) {
 func (t *txLookup) addAuthorities(tx *types.Transaction) {
 	// FIXME: later geth uses new signature: SetCodeAuthorizers returning addresses
 	for _, auth := range tx.SetCodeAuthorizations() {
-		addr, _ := auth.Authority()
+		addr, err := auth.Authority()
+		if err != nil {
+			// Skip authorizations whose signature does not recover to an
+			// authority. removeAuthorities iterates tx.SetCodeAuthorities(),
+			// which recovers valid authorities only, so an entry tracked here
+			// under the zero address would never be removed and would remain in
+			// t.auths for the lifetime of the pool.
+			continue
+		}
 		list, ok := t.auths[addr]
 		if !ok {
 			list = []common.Hash{}


### PR DESCRIPTION
### Summary

`txLookup.addAuthorities` and `txLookup.removeAuthorities` track EIP-7702 `SetCode` transactions against the authorities they reference, but they iterate two different lists:

- `addAuthorities` ranges over `tx.SetCodeAuthorizations()` (the raw authorization list) and calls `addr, _ := auth.Authority()`, discarding the error.
- `removeAuthorities` ranges over `tx.SetCodeAuthorities()`, which recovers **valid** authorities only.

An authorization whose signature does not recover to an authority yields the **zero address** from `auth.Authority()`, so `addAuthorities` records the tx hash under `t.auths[common.Address{}]`. Because `removeAuthorities` only ever visits recovered (valid) authorities, that zero-address entry is **never removed** when the transaction is later mined, replaced, evicted or dropped.

### Impact

The zero-address bucket accumulates hashes for the lifetime of the pool — it is not bounded by the pool's slot accounting, and nothing reads it back, so it is a pure leak. In addition, `addAuthorities` runs `slices.Contains(t.auths[zeroAddr], …)` on every insert, so the per-insert cost of tracking such transactions grows with the size of that bucket.

This is not reachable on mainnet today (no `SetCode` transactions are accepted yet); it becomes reachable once EIP-7702 is enabled, which is why I'm flagging and fixing it ahead of that.

For reference, upstream go-ethereum uses `SetCodeAuthorities()` symmetrically in both the add and remove paths; the divergence is in this rewrite of the add path (there is a `FIXME` on that loop).

### Fix

Skip authorizations that do not recover to an authority, so `addAuthorities` tracks exactly the set `removeAuthorities` untracks:

```go
addr, err := auth.Authority()
if err != nil {
    continue
}
```

No functional change for valid authorizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
