### PR TITLE
config: return the unlock error after failed validator key attempts

### DIFF
--- a/config/valkeystore.go
+++ b/config/valkeystore.go
@@ -73,11 +73,13 @@ func unlockValidatorKey(sigCtx context.Context, cliCtx *cli.Context, pubKey vali
 	var err error
 	for trials := 0; trials < 3; trials++ {
 		prompt := fmt.Sprintf("Unlocking validator key %s | Attempt %d/%d", pubKey.String(), trials+1, 3)
-		passwordList, err := makeValidatorPasswordList(sigCtx, cliCtx)
+		var passwordList []string
+		passwordList, err = makeValidatorPasswordList(sigCtx, cliCtx)
 		if err != nil {
 			return err
 		}
-		password, err := GetPassPhrase(sigCtx, prompt, false, 0, passwordList)
+		var password string
+		password, err = GetPassPhrase(sigCtx, prompt, false, 0, passwordList)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Summary

`unlockValidatorKey` retries up to three times and then bails out with `return err`. That `err` is declared once, before the loop:

```go
var err error
for trials := 0; trials < 3; trials++ {
    ...
    passwordList, err := makeValidatorPasswordList(sigCtx, cliCtx)          // shadows outer err
    ...
    password, err := GetPassPhrase(sigCtx, prompt, false, 0, passwordList)  // shadows outer err
    ...
    err = valKeystore.Unlock(pubKey, password)                             // assigns the loop-scoped err
    if err == nil {
        ...
        return nil
    }
    if err.Error() != "could not decrypt key with given password" {
        return err
    }
}
return err // outer err — still nil
```

Both `:=` statements inside the loop declare a new, loop-scoped `err`, so `err = valKeystore.Unlock(...)` writes to that inner variable. When all three attempts fail with `"could not decrypt key with given password"`, the loop ends and the trailing `return err` returns the **outer** `err`, which was never assigned and is still `nil`.

### Impact

A validator started with the wrong `--validator.password` (or the wrong interactive password) receives a `nil` error from `unlockValidatorKey` once the three attempts are exhausted, so startup proceeds as though the key had been unlocked instead of failing fast. The misconfiguration then surfaces later, and less clearly, than it should.

### Fix

Pre-declare `passwordList` and `password` and assign with `=`, so the outer `err` receives the last unlock error and is returned:

```go
var passwordList []string
passwordList, err = makeValidatorPasswordList(sigCtx, cliCtx)
...
var password string
password, err = GetPassPhrase(sigCtx, prompt, false, 0, passwordList)
```

No behavior change on a successful unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
