### PR TITLE
Give the PR pipeline queue priority 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
     }
 
     options {
+        basicJobPriority priority: 2
         timestamps()
         timeout(time: 1, unit: 'HOURS')
         disableConcurrentBuilds(abortPrevious: true)


### PR DESCRIPTION
## Why

We installed the [Simple Priority Sorter](https://plugins.jenkins.io/simple-priority-sorter/) plugin on Jenkins. It replaces the default FIFO build queue with a queue sorted by job priority: **lower number runs first**, and any job that does not declare a priority keeps the **default 10**.

Until now a pull request build could sit behind a 24-hour nightly or a release-testing run that happened to be queued a minute earlier. Declaring a priority in the pipeline fixes the ordering once, instead of us reshuffling the queue by hand.

## What

One line in the `options` block of the PR pipeline:

```groovy
options {
    basicJobPriority priority: 2
    ...
}
```

## The scheme

| Priority | Jobs |
|---|---|
| 2 | PR CI in `sonic`, `carmen`, `tosca` — the builds that gate merging |
| 8 | The long-running suites: every pipeline in `lascala` (nightlies, release testing, validation) and Norma's PR pipeline |
| 10 | Default — everything these PRs do not touch, including this repo's `CI/fuzzing.jenkinsfile` and `CI/eth-exec-spec-tests.jenkinsfile` |

Only the queue *order* changes. Nothing is preempted, no running build is cancelled, and a job at 10 still starts immediately whenever an executor is free.

## Companion PRs

- `sonic` — PR CI -> 2
- `carmen` — PR CI -> 2
- `tosca` — PR CI -> 2
- `lascala` — all 65 pipelines -> 8
- `norma` — PR pipeline -> 8
