### PR TITLE
Build with debug symbols by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ sonicd:
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/version.gitCommit=$${GIT_COMMIT} \
-	                    -X github.com/0xsoniclabs/sonic/version.gitDate=$${GIT_DATE}" \
+	    -ldflags "-X github.com/0xsoniclabs/sonic/version.gitCommit=$${GIT_COMMIT} \
+	              -X github.com/0xsoniclabs/sonic/version.gitDate=$${GIT_DATE}" \
 	    -o build/sonicd \
 	    ./cmd/sonicd && \
 	    ./build/sonicd version
@@ -19,8 +19,8 @@ sonictool:
 	GIT_DATE=`git log -1 --date=short --pretty=format:%ct 2>/dev/null || echo ""` && \
 	GOPROXY=$(GOPROXY) \
 	go build \
-	    -ldflags "-s -w -X github.com/0xsoniclabs/sonic/version.gitCommit=$${GIT_COMMIT} \
-	                    -X github.com/0xsoniclabs/sonic/version.gitDate=$${GIT_DATE}" \
+	    -ldflags "-X github.com/0xsoniclabs/sonic/version.gitCommit=$${GIT_COMMIT} \
+	              -X github.com/0xsoniclabs/sonic/version.gitDate=$${GIT_DATE}" \
 	    -o build/sonictool \
 	    ./cmd/sonictool && \
 	    ./build/sonictool --version


### PR DESCRIPTION
Removes `-s -w` from the `sonicd` and `sonictool` link flags, so the binaries we
build and ship keep their symbol table and DWARF debug information.

## Binary size

Measured on this branch (linux/amd64):

| binary | stripped (`-s -w`) | with symbols | delta |
|---|---|---|---|
| `sonicd` | 47.6 MB | 69.2 MB | +21.7 MB (+46%) |
| `sonictool` | 46.5 MB | 67.7 MB | +21.2 MB (+46%) |

The extra ~21 MB is metadata only: the symbol table and DWARF sections sit
alongside the code, they are not loaded into resident memory at run time and
they do not affect the generated machine code. Runtime performance is
unchanged; only the artifact on disk (and in the container image layer) grows.

## What this buys us

- **Readable stack traces.** `-w` strips DWARF, `-s` strips the symbol table.
  Without them, a crash dump or a core file from a node in the field gives us
  addresses instead of function names, and we cannot map them back without
  reproducing the exact build.
- **Working debuggers.** `dlv attach` / `dlv core` and `gdb` on a running or
  crashed node become useful: real frames, arguments, and local variables
  instead of `??`.
- **Usable profiles and traces.** `pprof` and the execution tracer resolve
  symbols from the binary, so CPU, heap, mutex and block profiles taken from a
  production node come back with function and line attribution rather than raw
  addresses. This is the difference between a profile we can act on and one we
  have to guess at.
- **Post-mortem on the machine that failed.** For an incident on a validator we
  do not control, being able to symbolize whatever the operator sends us,
  without asking them to rebuild, shortens diagnosis considerably.

Given that a node binary is deployed once and runs for weeks, trading ~21 MB of
disk for symbolized traces and attachable debuggers is worth it.
