### PR TITLE
Flatten blockproc.EVM.Start to take a block number, time, and epoch

### DIFF
--- a/gossip/blockproc/evmmodule/evm.go
+++ b/gossip/blockproc/evmmodule/evm.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/Fantom-foundation/lachesis-base/inter/idx"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -30,7 +31,7 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc"
 	"github.com/0xsoniclabs/sonic/gossip/gasprice"
-	"github.com/0xsoniclabs/sonic/inter/iblockproc"
+	"github.com/0xsoniclabs/sonic/inter"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 )
@@ -44,7 +45,9 @@ func New() *EVMModule {
 }
 
 func (p *EVMModule) Start(
-	block iblockproc.BlockCtx,
+	blockNumber idx.Block,
+	blockTime inter.Timestamp,
+	epoch idx.Epoch,
 	statedb state.StateDB,
 	reader evmcore.DummyChain,
 	onNewLog func(*core_types.Log),
@@ -55,10 +58,10 @@ func (p *EVMModule) Start(
 ) blockproc.EVMProcessor {
 	var prevBlockHash common.Hash
 	var baseFee *big.Int
-	if block.Idx == 0 {
+	if blockNumber == 0 {
 		baseFee = gasprice.GetInitialBaseFee(rules.Economy)
 	} else {
-		header := reader.Header(common.Hash{}, uint64(block.Idx-1))
+		header := reader.Header(common.Hash{}, uint64(blockNumber-1))
 		prevBlockHash = header.Hash
 		baseFee = gasprice.GetBaseFeeForNextBlock(gasprice.ParentBlockInfo{
 			BaseFee:  header.BaseFee,
@@ -68,16 +71,17 @@ func (p *EVMModule) Start(
 	}
 
 	// Start block
-	statedb.BeginBlock(uint64(block.Idx))
+	statedb.BeginBlock(uint64(blockNumber))
 
 	return &OperaEVMProcessor{
-		block:            block,
+		blockTime:        blockTime,
+		epoch:            epoch,
 		reader:           reader,
 		statedb:          statedb,
 		onNewLog:         onNewLog,
 		rules:            rules,
 		evmCfg:           evmCfg,
-		blockIdx:         uint64(block.Idx),
+		blockIdx:         uint64(blockNumber),
 		prevBlockHash:    prevBlockHash,
 		prevRandao:       prevrandao,
 		gasBaseFee:       baseFee,
@@ -87,12 +91,13 @@ func (p *EVMModule) Start(
 }
 
 type OperaEVMProcessor struct {
-	block    iblockproc.BlockCtx
-	reader   evmcore.DummyChain
-	statedb  state.StateDB
-	onNewLog func(*core_types.Log)
-	rules    opera.Rules
-	evmCfg   *params.ChainConfig
+	blockTime inter.Timestamp
+	epoch     idx.Epoch
+	reader    evmcore.DummyChain
+	statedb   state.StateDB
+	onNewLog  func(*core_types.Log)
+	rules     opera.Rules
+	evmCfg    *params.ChainConfig
 
 	blockIdx      uint64
 	prevBlockHash common.Hash
@@ -132,7 +137,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 		Number:          new(big.Int).SetUint64(p.blockIdx),
 		ParentHash:      p.prevBlockHash,
 		Root:            common.Hash{}, // state root is added later
-		Time:            p.block.Time,
+		Time:            p.blockTime,
 		Coinbase:        evmcore.GetCoinbase(),
 		GasLimit:        p.rules.Blocks.MaxBlockGas,
 		GasUsed:         p.gasUsed,
@@ -140,7 +145,7 @@ func (p *OperaEVMProcessor) evmBlockWith(txs types.Transactions) *evmcore.EvmBlo
 		BlobBaseFee:     blobBaseFee.ToBig(),
 		PrevRandao:      prevRandao,
 		WithdrawalsHash: withdrawalsHash,
-		Epoch:           p.block.Atropos.Epoch(),
+		Epoch:           p.epoch,
 	}
 
 	return evmcore.NewEvmBlock(h, txs)

--- a/gossip/blockproc/evmmodule/evm_test.go
+++ b/gossip/blockproc/evmmodule/evm_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/evmcore/core_types"
 	"github.com/0xsoniclabs/sonic/inter"
-	"github.com/0xsoniclabs/sonic/inter/iblockproc"
 	"github.com/0xsoniclabs/sonic/inter/state"
 	"github.com/0xsoniclabs/sonic/opera"
 	"github.com/ethereum/go-ethereum/common"
@@ -70,7 +69,9 @@ func TestEvm_IgnoresGasPriceOfInternalTransactions(t *testing.T) {
 
 	evmModule := New()
 	processor := evmModule.Start(
-		iblockproc.BlockCtx{},
+		0,
+		0,
+		0,
 		stateDb,
 		nil,
 		nil,
@@ -153,7 +154,7 @@ func TestOperaEVMProcessor_Execute_ProducesContinuousTxIndexesInReceipts(t *test
 
 	evmModule := New()
 	processor := evmModule.Start(
-		iblockproc.BlockCtx{}, stateDb, nil, logConsumer.OnNewLog,
+		0, 0, 0, stateDb, nil, logConsumer.OnNewLog,
 		opera.Rules{}, &params.ChainConfig{}, common.Hash{}, nil,
 	)
 
@@ -410,7 +411,7 @@ func TestOperaEVMProcessor_Finalize_ReportsAggregatedNumberOfSkippedTransactions
 
 	evmModule := New()
 	processor := evmModule.Start(
-		iblockproc.BlockCtx{}, stateDb, nil, logConsumer.OnNewLog,
+		0, 0, 0, stateDb, nil, logConsumer.OnNewLog,
 		opera.Rules{}, &params.ChainConfig{}, common.Hash{}, nil,
 	)
 
@@ -475,9 +476,7 @@ func TestOperaEVMProcessor_Finalize_DoesNotBlockOnSyncChannel_WhenBlockIsOlderTh
 		evmModule := New()
 		blockTime := time.Now().Add(-1*time.Hour - time.Second)
 		processor := evmModule.Start(
-			iblockproc.BlockCtx{
-				Time: inter.FromUnix(blockTime.Unix()),
-			},
+			0, inter.FromUnix(blockTime.Unix()), 0,
 			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
 			nil,
 		)
@@ -508,9 +507,7 @@ func TestOperaEVMProcessor_Finalize_DoesNotBlockOnSyncChannel_WhenSyncChannelIsN
 		evmModule := New()
 		blockTime := time.Now().Add(-1*time.Hour + time.Second)
 		processor := evmModule.Start(
-			iblockproc.BlockCtx{
-				Time: inter.FromUnix(blockTime.Unix()),
-			},
+			0, inter.FromUnix(blockTime.Unix()), 0,
 			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
 			nil,
 		)
@@ -541,9 +538,7 @@ func TestOperaEVMProcessor_Finalize_BlockOnSyncChannel_WhenBlockIsYoungerThanOne
 		evmModule := New()
 		blockTime := time.Now().Add(-1*time.Hour + time.Second)
 		processor := evmModule.Start(
-			iblockproc.BlockCtx{
-				Time: inter.FromUnix(blockTime.Unix()),
-			},
+			0, inter.FromUnix(blockTime.Unix()), 0,
 			stateDb, nil, nil, opera.Rules{}, &params.ChainConfig{}, common.Hash{},
 			nil,
 		)

--- a/gossip/blockproc/interface.go
+++ b/gossip/blockproc/interface.go
@@ -87,7 +87,9 @@ type EVMProcessor interface {
 
 type EVM interface {
 	Start(
-		block iblockproc.BlockCtx,
+		blockNumber idx.Block,
+		blockTime inter.Timestamp,
+		epoch idx.Epoch,
 		statedb state.StateDB,
 		reader evmcore.DummyChain,
 		onNewLog func(*core_types.Log),

--- a/gossip/blockproc/interface_mock.go
+++ b/gossip/blockproc/interface_mock.go
@@ -485,15 +485,15 @@ func (m *MockEVM) EXPECT() *MockEVMMockRecorder {
 }
 
 // Start mocks base method.
-func (m *MockEVM) Start(block iblockproc.BlockCtx, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*core_types.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash, metrics evmcore.BlockExecutionMetrics) EVMProcessor {
+func (m *MockEVM) Start(blockNumber idx.Block, blockTime inter.Timestamp, epoch idx.Epoch, statedb state.StateDB, reader evmcore.DummyChain, onNewLog func(*core_types.Log), net opera.Rules, evmCfg *params.ChainConfig, prevrandao common.Hash, metrics evmcore.BlockExecutionMetrics) EVMProcessor {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", block, statedb, reader, onNewLog, net, evmCfg, prevrandao, metrics)
+	ret := m.ctrl.Call(m, "Start", blockNumber, blockTime, epoch, statedb, reader, onNewLog, net, evmCfg, prevrandao, metrics)
 	ret0, _ := ret[0].(EVMProcessor)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockEVMMockRecorder) Start(block, statedb, reader, onNewLog, net, evmCfg, prevrandao, metrics any) *gomock.Call {
+func (mr *MockEVMMockRecorder) Start(blockNumber, blockTime, epoch, statedb, reader, onNewLog, net, evmCfg, prevrandao, metrics any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockEVM)(nil).Start), block, statedb, reader, onNewLog, net, evmCfg, prevrandao, metrics)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockEVM)(nil).Start), blockNumber, blockTime, epoch, statedb, reader, onNewLog, net, evmCfg, prevrandao, metrics)
 }

--- a/gossip/c_block_callbacks.go
+++ b/gossip/c_block_callbacks.go
@@ -375,7 +375,9 @@ func consensusCallbackBeginBlockFn(
 
 				// prepare block processing
 				evmProcessor := blockProc.EVMModule.Start(
-					blockCtx,
+					blockCtx.Idx,
+					blockCtx.Time,
+					blockCtx.Atropos.Epoch(),
 					statedb,
 					evmStateReader,
 					onNewLogAll,

--- a/gossip/c_block_callbacks_test.go
+++ b/gossip/c_block_callbacks_test.go
@@ -288,9 +288,9 @@ func TestConsensusCallback_SingleProposer_HandlesBlockSkippingCorrectly(t *testi
 
 				evmModule := blockproc.NewMockEVM(ctrl)
 				evmModule.EXPECT().
-					Start(_any, _any, _any, _any, _any, _any, _any, _any).
-					DoAndReturn(func(block iblockproc.BlockCtx, _, _, _, _, _, _, _ any) blockproc.EVMProcessor {
-						require.Equal(t, test.blockTime, block.Time)
+					Start(_any, _any, _any, _any, _any, _any, _any, _any, _any, _any).
+					DoAndReturn(func(_ idx.Block, blockTime inter.Timestamp, _ idx.Epoch, _, _, _, _, _, _, _ any) blockproc.EVMProcessor {
+						require.Equal(t, test.blockTime, blockTime)
 						return evmProcessor
 					})
 
@@ -433,7 +433,7 @@ func TestConsensusCallback_UsesBlockStartRulesAcrossEpochSealing(t *testing.T) {
 		},
 	}, 0, nil)
 	evmModule := blockproc.NewMockEVM(ctrl)
-	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
+	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
 
 	// Sealer reports that this block seals the epoch and returns the sealed
 	// epoch state carrying the changed rules.
@@ -605,7 +605,7 @@ func TestConsensusCallback_UsesBlockStartRulesForReceiptOriginTracking(t *testin
 		&types.Receipt{TxHash: receiptTx.Hash(), Status: 1},
 	})
 	evmModule := blockproc.NewMockEVM(ctrl)
-	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
+	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
 
 	sealer := blockproc.NewMockSealerProcessor(ctrl)
 	sealer.EXPECT().EpochSealing().Return(true)
@@ -763,7 +763,7 @@ func TestConsensusCallback_AppliesTransactionPriorities(t *testing.T) {
 		},
 	}, 0, nil)
 	evmModule := blockproc.NewMockEVM(ctrl)
-	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
+	evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
 
 	sealer := blockproc.NewMockSealerProcessor(ctrl)
 	sealer.EXPECT().EpochSealing().Return(false)
@@ -1741,7 +1741,9 @@ func TestProcessUserTransactions_InternalTransactionsHaveNoImpactOnTheUserTransa
 
 	evmModule := evmmodule.New()
 	evmProcessor := evmModule.Start(
-		iblockproc.BlockCtx{},
+		0,
+		0,
+		0,
 		statedb,
 		&EvmStateReader{},
 		func(l *core_types.Log) {},
@@ -1794,7 +1796,9 @@ func TestProcessUserTransactions_MetricsAreForwardedToStateProcessor(t *testing.
 
 	evmModule := evmmodule.New()
 	evmProcessor := evmModule.Start(
-		iblockproc.BlockCtx{},
+		0,
+		0,
+		0,
 		statedb,
 		&EvmStateReader{},
 		func(l *core_types.Log) {},
@@ -2260,7 +2264,7 @@ func TestConsensusCallback_TxCausedBy_UsesOriginTxForCreatorLookupWithBrio(t *te
 			}, 0, types.Receipts{originReceipt, derivedReceipt})
 
 			evmModule := blockproc.NewMockEVM(ctrl)
-			evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
+			evmModule.EXPECT().Start(_any, _any, _any, _any, _any, _any, _any, _any, _any, _any).Return(evmProcessor)
 
 			txTransactor := blockproc.NewMockTxTransactor(ctrl)
 			txTransactor.EXPECT().PopInternalTxs(_any, _any, _any, _any, _any).Return(types.Transactions{}).AnyTimes()

--- a/integration/makegenesis/genesis.go
+++ b/integration/makegenesis/genesis.go
@@ -256,7 +256,7 @@ func (b *GenesisBuilder) ExecuteGenesisTxs(blockProc BlockProc, genesisTxs types
 		blockCtx.Idx,
 	)
 	evmProcessor := blockProc.EVMModule.Start(
-		blockCtx, b.tmpStateDB, dummyHeaderReturner{b.blocks},
+		blockCtx.Idx, blockCtx.Time, blockCtx.Atropos.Epoch(), b.tmpStateDB, dummyHeaderReturner{b.blocks},
 		func(l *core_types.Log) { txListener.OnNewLog(l) },
 		es.Rules,
 		chainConfig,


### PR DESCRIPTION
EVM.Start took an iblockproc.BlockCtx (a consensus type) but used only its Idx, Time, and Atropos.Epoch(). Replace the nested consensus type at the EVM module boundary with the three plain values it actually needs (block number, block time, epoch), so the EVM module no longer depends on a consensus event.

The values passed are identical to what the callers derived from the BlockCtx before (Idx, Time, Atropos.Epoch()), so block production is unchanged.