### PR TITLE
Read sponsorship funds at the receipt's block in Fund helper

### DIFF
--- a/tests/gas_subsidies/test_utils.go
+++ b/tests/gas_subsidies/test_utils.go
@@ -56,7 +56,7 @@ func Fund(
 
 	tests.WaitForProofOf(t, client, int(latestBlock.NumberU64()))
 
-	sponsorshipBefore, err := registry.Sponsorships(nil, fundId)
+	sponsorshipBefore, err := registry.Sponsorships(&bind.CallOpts{BlockNumber: latestBlock.Number()}, fundId)
 	require.NoError(t, err)
 
 	receipt, err := session.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
@@ -70,8 +70,8 @@ func Fund(
 
 	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
-	// check that the sponsorshipAfter funds got deposited
-	sponsorshipAfter, err := registry.Sponsorships(nil, fundId)
+	// Read at the receipt's block: "latest" may still lag behind it.
+	sponsorshipAfter, err := registry.Sponsorships(&bind.CallOpts{BlockNumber: receipt.BlockNumber}, fundId)
 	require.NoError(t, err)
 	require.Equal(t, sponsorshipBefore.Funds.Uint64()+donation.Uint64(), sponsorshipAfter.Funds.Uint64())
 


### PR DESCRIPTION
## Summary

`TestGasSubsidies_SubsidizedTransaction_DeductsSubsidyFunds` failed on CI with

```
test_utils.go:76: expected: 0xde0b6b3a7640000  actual: 0x0
```

The `Fund` helper waits for the Sponsor receipt and the proof of its block, then reads `Sponsorships` at "latest". The head pointer can still lag behind the receipt's block, so the read returns the pre-donation state.

Read at the receipt's block instead. The "before" read is pinned to the block it already waited a proof for. Same lagging-head mechanism as #1108, hitting the setup helper instead of the final scan.

Test-only change. Backport to v2.2 in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)