### PR TITLE
Fix lagging-head flakes in gas subsidies DeductsSubsidyFunds test [v2.2]

### DIFF
--- a/tests/gas_subsidies/deducts_funds_test.go
+++ b/tests/gas_subsidies/deducts_funds_test.go
@@ -19,6 +19,7 @@ package gas_subsidies
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/0xsoniclabs/sonic/evmcore"
 	"github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies"
@@ -252,49 +253,81 @@ func testGasSubsidies_SubsidizedTransaction_DeductsSubsidyFunds(t *testing.T, ne
 
 			// Scenarios may produce multiple blocks, so we need to
 			// iterate through all of them to find all sponsored transactions.
+			// The "latest" block can lag the blocks the scenario just produced,
+			// since the scenario only waits for a receipt, not for the head
+			// pointer to catch up. The scan window is therefore extended while
+			// no sponsorship request has been observed.
 			var fundsDelta uint64
+			var sponsorshipRequests int
 
-			// For every block created during test scenario
-			for blockNumber := blockBefore.NumberU64() + 1; blockNumber <= blockAfter.NumberU64(); blockNumber++ {
+			const maxWindowExtensions = 10
+			windowExtensions := 0
+			// Cursor across window extensions: each scan resumes where the
+			// previous one stopped, so no block is counted twice.
+			nextBlock := blockBefore.NumberU64() + 1
+			lastBlock := blockAfter.NumberU64()
 
-				tests.WaitForProofOf(t, client, int(blockNumber))
+			for {
+				// For every block created during test scenario
+				for ; nextBlock <= lastBlock; nextBlock++ {
 
-				block, err := client.BlockByNumber(t.Context(), big.NewInt(int64(blockNumber)))
-				require.NoError(t, err)
+					tests.WaitForProofOf(t, client, int(nextBlock))
 
-				var totalGasUsed uint64
-
-				for i, tx := range block.Transactions() {
-					receipt, err := net.GetReceipt(tx.Hash())
+					block, err := client.BlockByNumber(t.Context(), big.NewInt(int64(nextBlock)))
 					require.NoError(t, err)
 
-					totalGasUsed += receipt.GasUsed
-					require.EqualValues(t, totalGasUsed, receipt.CumulativeGasUsed)
+					var totalGasUsed uint64
 
-					if subsidies.IsSponsorshipRequest(tx) {
-						fundsUsed := (receipt.GasUsed +
-							config.OverheadChargeForFundBackedSponsorships.Uint64()) * block.BaseFee().Uint64()
-						require.Greater(t, fundsUsed, uint64(0),
-							"sponsored tx must have a non-zero funds cost",
-						)
-						fundsDelta += fundsUsed
-
-						require.Less(t, i, len(block.Transactions())-1,
-							"sponsored tx should not be the last tx in the block")
-						internalTx := block.Transactions()[i+1]
-
-						deduceFundsReceipt, err := net.GetReceipt(internalTx.Hash())
+					for i, tx := range block.Transactions() {
+						receipt, err := net.GetReceipt(tx.Hash())
 						require.NoError(t, err)
-						require.Equal(t, types.ReceiptStatusSuccessful, deduceFundsReceipt.Status)
 
-						validateSponsoredTxInBlock(t, net, tx.Hash())
+						totalGasUsed += receipt.GasUsed
+						require.EqualValues(t, totalGasUsed, receipt.CumulativeGasUsed)
+
+						if subsidies.IsSponsorshipRequest(tx) {
+							sponsorshipRequests++
+							fundsUsed := (receipt.GasUsed +
+								config.OverheadChargeForFundBackedSponsorships.Uint64()) * block.BaseFee().Uint64()
+							require.Greater(t, fundsUsed, uint64(0),
+								"sponsored tx must have a non-zero funds cost",
+							)
+							fundsDelta += fundsUsed
+
+							require.Less(t, i, len(block.Transactions())-1,
+								"sponsored tx should not be the last tx in the block")
+							internalTx := block.Transactions()[i+1]
+
+							deduceFundsReceipt, err := net.GetReceipt(internalTx.Hash())
+							require.NoError(t, err)
+							require.Equal(t, types.ReceiptStatusSuccessful, deduceFundsReceipt.Status)
+
+							validateSponsoredTxInBlock(t, net, tx.Hash())
+
+						}
 
 					}
-
 				}
+
+				// Window exhausted without a sponsored transaction: re-read the
+				// head and keep scanning.
+				if sponsorshipRequests > 0 || windowExtensions >= maxWindowExtensions {
+					break
+				}
+				windowExtensions++
+				time.Sleep(100 * time.Millisecond)
+				latest, err := client.BlockByNumber(t.Context(), nil)
+				require.NoError(t, err)
+				lastBlock = latest.NumberU64()
 			}
 
-			tests.WaitForProofOf(t, client, int(blockAfter.NumberU64()))
+			// Every scenario sponsors at least one transaction.
+			require.Greater(t, sponsorshipRequests, 0,
+				"no sponsorship request observed in blocks %d..%d after %d window extension(s)",
+				blockBefore.NumberU64()+1, lastBlock, windowExtensions,
+			)
+
+			tests.WaitForProofOf(t, client, int(lastBlock))
 
 			_, fundId, err := sponsorshipRegistry.AccountSponsorshipFundId(nil, sponsoredSender.Address())
 			require.NoError(t, err)

--- a/tests/gas_subsidies/test_utils.go
+++ b/tests/gas_subsidies/test_utils.go
@@ -56,7 +56,7 @@ func Fund(
 
 	tests.WaitForProofOf(t, client, int(latestBlock.NumberU64()))
 
-	sponsorshipBefore, err := registry.Sponsorships(nil, fundId)
+	sponsorshipBefore, err := registry.Sponsorships(&bind.CallOpts{BlockNumber: latestBlock.Number()}, fundId)
 	require.NoError(t, err)
 
 	receipt, err := session.Apply(func(opts *bind.TransactOpts) (*types.Transaction, error) {
@@ -70,8 +70,8 @@ func Fund(
 
 	tests.WaitForProofOf(t, client, int(receipt.BlockNumber.Int64()))
 
-	// check that the sponsorshipAfter funds got deposited
-	sponsorshipAfter, err := registry.Sponsorships(nil, fundId)
+	// Read at the receipt's block: "latest" may still lag behind it.
+	sponsorshipAfter, err := registry.Sponsorships(&bind.CallOpts{BlockNumber: receipt.BlockNumber}, fundId)
 	require.NoError(t, err)
 	require.Equal(t, sponsorshipBefore.Funds.Uint64()+donation.Uint64(), sponsorshipAfter.Funds.Uint64())
 


### PR DESCRIPTION
## Summary

Backport of two test-only fixes for `TestGasSubsidies_SubsidizedTransaction_DeductsSubsidyFunds`, both caused by "latest" lagging behind the block a scenario just waited a receipt for:

- #1108: extend the final scan window until a sponsorship request is observed, and assert one was seen.
- #1158: `Fund` helper reads `Sponsorships` at the receipt's block instead of "latest". This is the failure seen on #1155 CI (`test_utils.go:76: expected 0xde0b6b3a7640000, actual 0x0`).

Both cherry-picked cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)