### PR TITLE
Default omitted block parameter to latest in state RPC methods

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -708,11 +708,21 @@ func (s *PublicBlockChainAPI) BlockNumber() hexutil.Uint64 {
 	return hexutil.Uint64(header.Number.Uint64())
 }
 
+// blockNrOrHashOrLatest returns the given block parameter, defaulting to the
+// latest block if the parameter was omitted by the caller.
+func blockNrOrHashOrLatest(blockNrOrHash *rpc.BlockNumberOrHash) rpc.BlockNumberOrHash {
+	if blockNrOrHash != nil {
+		return *blockNrOrHash
+	}
+	return rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+}
+
 // GetBalance returns the amount of wei for the given address in the state of the
 // given block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta
-// block numbers are also allowed.
-func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.U256, error) {
-	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHash)
+// block numbers are also allowed. When the block parameter is omitted, it
+// defaults to the latest block.
+func (s *PublicBlockChainAPI) GetBalance(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.U256, error) {
+	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHashOrLatest(blockNrOrHash))
 	if state == nil || err != nil {
 		return nil, err
 	}
@@ -815,8 +825,9 @@ type GetAccountResult struct {
 
 // GetAccount returns the information about account with given address in the state of the given block number.
 // The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block numbers are also allowed.
-func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*GetAccountResult, error) {
-	state, block, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHash)
+// When the block parameter is omitted, it defaults to the latest block.
+func (s *PublicBlockChainAPI) GetAccount(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*GetAccountResult, error) {
+	state, block, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHashOrLatest(blockNrOrHash))
 	if err != nil {
 		return nil, err
 	}
@@ -866,8 +877,9 @@ type StorageResult struct {
 }
 
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
-func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*AccountResult, error) {
-	state, block, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHash)
+// When the block parameter is omitted, it defaults to the latest block.
+func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash *rpc.BlockNumberOrHash) (*AccountResult, error) {
+	state, block, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHashOrLatest(blockNrOrHash))
 	if state == nil || err != nil {
 		return nil, err
 	}
@@ -1029,8 +1041,9 @@ func (s *PublicBlockChainAPI) GetUncleCountByBlockHash(ctx context.Context, bloc
 }
 
 // GetCode returns the code stored at the given address in the state for the given block number.
-func (s *PublicBlockChainAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHash)
+// When the block parameter is omitted, it defaults to the latest block.
+func (s *PublicBlockChainAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
+	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHashOrLatest(blockNrOrHash))
 	if state == nil || err != nil {
 		return nil, err
 	}
@@ -1041,9 +1054,10 @@ func (s *PublicBlockChainAPI) GetCode(ctx context.Context, address common.Addres
 
 // GetStorageAt returns the storage from the state at the given address, key and
 // block number. The rpc.LatestBlockNumber and rpc.PendingBlockNumber meta block
-// numbers are also allowed.
-func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, address common.Address, key string, blockNr rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
-	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNr)
+// numbers are also allowed. When the block parameter is omitted, it defaults to
+// the latest block.
+func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, address common.Address, key string, blockNr *rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
+	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHashOrLatest(blockNr))
 	if state == nil || err != nil {
 		return nil, err
 	}
@@ -1256,8 +1270,8 @@ func (e *revertError) ErrorData() interface{} {
 //
 // Note, this function doesn't make and changes in the state/blockchain and is
 // useful to execute and retrieve values.
-func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, stateOverrides *StateOverride, blockOverrides *BlockOverrides) (hexutil.Bytes, error) {
-	result, err := DoCall(ctx, s.b, args, blockNrOrHash, stateOverrides, blockOverrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap(), nil)
+func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash, stateOverrides *StateOverride, blockOverrides *BlockOverrides) (hexutil.Bytes, error) {
+	result, err := DoCall(ctx, s.b, args, blockNrOrHashOrLatest(blockNrOrHash), stateOverrides, blockOverrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1913,10 +1927,12 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockHashAndIndex(ctx cont
 	return nil
 }
 
-// GetTransactionCount returns the number of transactions the given address has sent for the given block number
-func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
+// GetTransactionCount returns the number of transactions the given address has sent for the given block number.
+// When the block parameter is omitted, it defaults to the latest block.
+func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
+	resolved := blockNrOrHashOrLatest(blockNrOrHash)
 	// Ask transaction pool for the nonce which includes pending transactions
-	if blockNr, ok := blockNrOrHash.Number(); ok && blockNr == rpc.PendingBlockNumber {
+	if blockNr, ok := resolved.Number(); ok && blockNr == rpc.PendingBlockNumber {
 		nonce, err := s.b.GetPoolNonce(ctx, address)
 		if err != nil {
 			return nil, err
@@ -1924,7 +1940,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, addr
 		return (*hexutil.Uint64)(&nonce), nil
 	}
 	// Resolve block number and use its state to ask for the nonce
-	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, blockNrOrHash)
+	state, _, err := s.b.StateAndBlockByNumberOrHash(ctx, resolved)
 	if state == nil || err != nil {
 		return nil, err
 	}

--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -1688,3 +1688,92 @@ func TestCapMaxGas_IsUpgradesAware(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockNrOrHashOrLatest_DefaultsOmittedParameterToLatest(t *testing.T) {
+	latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+	pending := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	number := rpc.BlockNumberOrHashWithNumber(42)
+	hash := rpc.BlockNumberOrHashWithHash(common.Hash{7}, true)
+
+	tests := map[string]struct {
+		given *rpc.BlockNumberOrHash
+		want  rpc.BlockNumberOrHash
+	}{
+		"omitted defaults to latest": {given: nil, want: latest},
+		"latest is kept":             {given: &latest, want: latest},
+		"pending is kept":            {given: &pending, want: pending},
+		"number is kept":             {given: &number, want: number},
+		"hash is kept":               {given: &hash, want: hash},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.want, blockNrOrHashOrLatest(test.given))
+		})
+	}
+}
+
+func TestAPI_OmittedBlockParameterResolvesLatestBlock(t *testing.T) {
+	addr := common.Address{1}
+	latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+
+	tests := map[string]struct {
+		expectState func(*state.MockStateDB)
+		call        func(*PublicBlockChainAPI, *PublicTransactionPoolAPI) error
+	}{
+		"eth_getBalance": {
+			expectState: func(s *state.MockStateDB) {
+				s.EXPECT().GetBalance(addr).Return(uint256.NewInt(1))
+			},
+			call: func(api *PublicBlockChainAPI, _ *PublicTransactionPoolAPI) error {
+				_, err := api.GetBalance(context.Background(), addr, nil)
+				return err
+			},
+		},
+		"eth_getCode": {
+			expectState: func(s *state.MockStateDB) {
+				s.EXPECT().GetCode(addr).Return([]byte{1})
+			},
+			call: func(api *PublicBlockChainAPI, _ *PublicTransactionPoolAPI) error {
+				_, err := api.GetCode(context.Background(), addr, nil)
+				return err
+			},
+		},
+		"eth_getStorageAt": {
+			expectState: func(s *state.MockStateDB) {
+				s.EXPECT().GetState(addr, common.Hash{}).Return(common.Hash{1})
+			},
+			call: func(api *PublicBlockChainAPI, _ *PublicTransactionPoolAPI) error {
+				_, err := api.GetStorageAt(context.Background(), addr, "0x0", nil)
+				return err
+			},
+		},
+		"eth_getTransactionCount": {
+			expectState: func(s *state.MockStateDB) {
+				s.EXPECT().GetNonce(addr).Return(uint64(1))
+			},
+			call: func(_ *PublicBlockChainAPI, api *PublicTransactionPoolAPI) error {
+				_, err := api.GetTransactionCount(context.Background(), addr, nil)
+				return err
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockBackend := NewMockBackend(ctrl)
+			mockState := state.NewMockStateDB(ctrl)
+			mockBackend.EXPECT().ChainID().Return(big.NewInt(1)).AnyTimes()
+
+			// The backend must be asked for the latest block, not for a zero value.
+			mockBackend.EXPECT().StateAndBlockByNumberOrHash(gomock.Any(), latest).Return(mockState, nil, nil)
+			test.expectState(mockState)
+			mockState.EXPECT().Error().Return(nil).AnyTimes()
+			mockState.EXPECT().Release()
+
+			err := test.call(NewPublicBlockChainAPI(mockBackend), NewPublicTransactionPoolAPI(mockBackend, nil))
+			require.NoError(t, err)
+		})
+	}
+}

--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -141,7 +141,7 @@ func TestAPI_GetProof(t *testing.T) {
 
 	api := NewPublicBlockChainAPI(mockBackend)
 
-	accountProof, err := api.GetProof(context.Background(), common.Address(addr), keys, blkNr)
+	accountProof, err := api.GetProof(context.Background(), common.Address(addr), keys, &blkNr)
 	require.NoError(t, err, "failed to get account")
 
 	u256Balance := balance.Uint256()
@@ -184,7 +184,7 @@ func TestAPI_GetAccount(t *testing.T) {
 
 	api := NewPublicBlockChainAPI(mockBackend)
 
-	account, err := api.GetAccount(context.Background(), common.Address(addr), blkNr)
+	account, err := api.GetAccount(context.Background(), common.Address(addr), &blkNr)
 	require.NoError(t, err, "failed to get account")
 
 	u256Balance := balance.Uint256()
@@ -459,7 +459,7 @@ func TestBlockStateOverrides(t *testing.T) {
 	// Check block overrides on eth api with eth_call and eth_estimateGas rpc function
 	apiEth := NewPublicBlockChainAPI(mockBackend)
 
-	_, err = apiEth.Call(context.Background(), getTxArgs(t), rpcBlkNr, stateOverrides, blockOverrides)
+	_, err = apiEth.Call(context.Background(), getTxArgs(t), &rpcBlkNr, stateOverrides, blockOverrides)
 	require.NoError(t, err, "debug api must be able to override block number and base fee")
 
 	_, err = apiEth.EstimateGas(context.Background(), getTxArgs(t), &rpcBlkNr, stateOverrides, blockOverrides)


### PR DESCRIPTION
The execution-apis specification marks the block parameter of the state query methods as optional, defaulting to "latest". Sonic declared it as a value type, so an omitted parameter was answered with "missing value for required argument".

This changes the block parameter of eth_getBalance, eth_getAccount, eth_getProof, eth_getCode, eth_getStorageAt, eth_call and eth_getTransactionCount to a pointer, and resolves a nil parameter to the latest block, the same way eth_estimateGas already does.

Found by execution-apis conformance testing.