### PR TITLE
Fix eth_config precompile resolution and blobSchedule encoding

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -734,11 +734,18 @@ type configResponse struct {
 // config as described by https://eips.ethereum.org/EIPS/eip-7910
 type config struct {
 	// ActivationTime is the timestamp of the first block where this config is active.
-	ActivationTime uint64       `json:"activationTime"`
-	BlockHeight    *hexutil.Big `json:"blockHeight"`
+	ActivationTime uint64 `json:"activationTime"`
 
-	// BlobSchedule will remain nil because in Sonic this is not relevant
-	BlobSchedule *params.BlobConfig `json:"blobSchedule"`
+	// BlockHeight is the height of the block that activated this configuration.
+	// It is an extension beyond EIP-7910, which describes forks activated by
+	// time: Sonic activates an upgrade with a transaction, so the block carrying
+	// it - not a schedule - is what identifies the fork.
+	BlockHeight *hexutil.Big `json:"blockHeight"`
+
+	// BlobSchedule reports zero blob capacity: Sonic supports no blobs. EIP-7910
+	// requires the field to be an object, so it cannot be omitted or reported as
+	// null.
+	BlobSchedule params.BlobConfig `json:"blobSchedule"`
 
 	ChainId *hexutil.Big `json:"chainId"`
 
@@ -764,7 +771,11 @@ type contractRegistry map[string]common.Address
 // activation. The "Current" config corresponds to the config active at the current block,
 // and the "Last" config (if available) corresponds to the config active before the current one.
 //
-// BlobSchedule field is not relevant in Sonic, hence is always nil.
+// BlobSchedule is reported with zero target, maximum and base fee update fraction:
+// Sonic supports no blobs, and EIP-7910 requires the field to be an object.
+//
+// BlockHeight reports the block that activated the configuration, which EIP-7910
+// has no field for; see the field's comment.
 func (s *PublicBlockChainAPI) Config(ctx context.Context) (*configResponse, error) {
 
 	currentHeader := s.b.CurrentBlock().Header()

--- a/api/ethapi/config.go
+++ b/api/ethapi/config.go
@@ -21,7 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
-	"math/big"
+	"math"
 
 	priorityRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/priorities/registry"
 	subsidiesRegistry "github.com/0xsoniclabs/sonic/gossip/blockproc/subsidies/registry"
@@ -45,16 +45,17 @@ func makeConfigFromUpgrade(
 	chainID := b.ChainID()
 	chainCfg := b.ChainConfig(upgradeHeight.Height)
 
-	precompiled := make(contractRegistry)
-	chainCfgRules := chainCfg.Rules(big.NewInt(int64(upgradeHeight.Height)), true, uint64(0))
-	for addr, c := range vm.ActivePrecompiledContracts(chainCfgRules) {
-		precompiled[c.Name()] = addr
-	}
-
 	forkId, err := MakeForkId(upgradeHeight, b.GetGenesisID())
 	if err != nil {
 		// this can only fail if RLP encoding fails, which is unexpected
 		return nil, fmt.Errorf("could not make fork id, %v", err)
+	}
+
+	// rpc.BlockNumber is a signed integer whose negative values name the block
+	// tags, so a height that does not fit would not fail but silently resolve to
+	// "latest" or "pending".
+	if upgradeHeight.Height > math.MaxInt64 {
+		return nil, fmt.Errorf("upgrade height %d exceeds the largest addressable block number", upgradeHeight.Height)
 	}
 
 	block, err := b.BlockByNumber(ctx, rpc.BlockNumber(int64(upgradeHeight.Height)))
@@ -66,10 +67,21 @@ func makeConfigFromUpgrade(
 		return nil, fmt.Errorf("block %d not found to determine activation time", upgradeHeight.Height)
 	}
 
+	if block.Number == nil {
+		return nil, fmt.Errorf("block %d carries no number", upgradeHeight.Height)
+	}
+
+	activationTime := uint64(block.Time.Unix())
+
+	// The chain config resolves the upgrades active at a block from its height and its timestamp
+	precompiled := make(contractRegistry)
+	chainCfgRules := chainCfg.Rules(block.Number, true, activationTime)
+	for addr, c := range vm.ActivePrecompiledContracts(chainCfgRules) {
+		precompiled[c.Name()] = addr
+	}
+
 	return &config{
-		// block time needs to be converted to unix timestamp as it is done in
-		// evmcore/dummy_block.go in method EvmHeader.EthHeader()
-		ActivationTime:  uint64(block.Time.Unix()),
+		ActivationTime:  activationTime,
 		BlockHeight:     (*hexutil.Big)(block.Number),
 		ChainId:         (*hexutil.Big)(chainID),
 		ForkId:          forkId[:],

--- a/api/ethapi/config_test.go
+++ b/api/ethapi/config_test.go
@@ -19,6 +19,7 @@ package ethapi
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"hash/crc32"
 	"maps"
@@ -603,4 +604,50 @@ func TestEIP7910_Config_ResolvesTimeGatedForksWithTheBlockTime(t *testing.T) {
 	require.Contains(t, gotConfig.Current.Precompiles, "P256VERIFY")
 	require.Contains(t, gotConfig.Current.Precompiles, "KZG_POINT_EVALUATION")
 	require.Contains(t, gotConfig.Current.Precompiles, "BLS12_PAIRING_CHECK")
+}
+
+func TestEIP7910_Config_ReportsAZeroBlobScheduleAndTheActivatingBlockHeight(t *testing.T) {
+	// EIP-7910 requires blobSchedule to be an object, and Sonic has no blobs, so
+	// the schedule reports zero capacity. blockHeight is Sonic's extension beyond
+	// the specification: it names the block whose transaction activated the
+	// upgrade, which is how Sonic activates one.
+	chainId := big.NewInt(250)
+	upgradeHeights := []opera.UpgradeHeight{{
+		Upgrades: opera.GetSonicUpgrades(),
+		Height:   idx.Block(5),
+	}}
+
+	ctrl := gomock.NewController(t)
+	backend := NewMockBackend(ctrl)
+	backend.EXPECT().ChainID().Return(chainId)
+	backend.EXPECT().GetGenesisID().Return(common.Hash{0x42})
+	backend.EXPECT().CurrentBlock().Return(&evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{Number: big.NewInt(5)},
+	})
+	backend.EXPECT().GetUpgradeHeights().Return(upgradeHeights)
+	backend.EXPECT().ChainConfig(gomock.Any()).Return(opera.CreateTransientEvmChainConfig(
+		chainId.Uint64(), upgradeHeights, idx.Block(5),
+	))
+	backend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(&evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{
+			Number: big.NewInt(5),
+			Time:   inter.FromUnix(540),
+		},
+	}, nil)
+
+	gotConfig, err := NewPublicBlockChainAPI(backend).Config(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, params.BlobConfig{}, gotConfig.Current.BlobSchedule)
+
+	encoded, err := json.Marshal(gotConfig)
+	require.NoError(t, err)
+
+	var decoded map[string]map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.Equal(t, "0x5", decoded["current"]["blockHeight"])
+	require.Equal(t, map[string]any{
+		"target":                float64(0),
+		"max":                   float64(0),
+		"baseFeeUpdateFraction": float64(0),
+	}, decoded["current"]["blobSchedule"])
 }

--- a/api/ethapi/config_test.go
+++ b/api/ethapi/config_test.go
@@ -553,10 +553,9 @@ func TestEIP7910_Config_ReturnsConfigs(t *testing.T) {
 }
 
 func TestEIP7910_Config_ResolvesTimeGatedForksWithTheBlockTime(t *testing.T) {
-	// A chain config whose forks are gated on real timestamps -- a foreign chain
-	// replayed through the backend, unlike Sonic's own transient config, which
-	// places every time-gated fork at timestamp 0. The precompile set must follow
-	// the block's time, not a zero one.
+	// A chain config whose forks are gated on real timestamps, unlike Sonic's own
+	// transient config, which places every time-gated fork at timestamp 0. The
+	// precompile set must follow the block's time, not a zero one.
 	forkTime := uint64(480)
 	blockTime := forkTime + 60
 

--- a/api/ethapi/config_test.go
+++ b/api/ethapi/config_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"maps"
+	"math"
 	"math/big"
 	"testing"
 
@@ -258,7 +259,10 @@ func TestMakeConfigFromUpgrade_Reports_AvailableSystemContracts(t *testing.T) {
 			backend.EXPECT().ChainConfig(gomock.Any()).Return(chainCfg)
 			backend.EXPECT().GetGenesisID().Return(common.Hash{0x42})
 			backend.EXPECT().BlockByNumber(gomock.Any(), rpc.BlockNumber(int64(test.upgradeHeight.Height))).
-				Return(&evmcore.EvmBlock{EvmHeader: evmcore.EvmHeader{Time: inter.Timestamp(1)}}, nil)
+				Return(&evmcore.EvmBlock{EvmHeader: evmcore.EvmHeader{
+					Number: new(big.Int).SetUint64(uint64(test.upgradeHeight.Height)),
+					Time:   inter.Timestamp(1),
+				}}, nil)
 
 			result, err := makeConfigFromUpgrade(context.Background(), backend, test.upgradeHeight)
 			require.NoError(t, err, "unexpected error from makeConfigFromUpgrade")
@@ -309,6 +313,50 @@ func TestMakeConfigFromUpgrade_ReportsError_WhenBlockByNumberReturnsNilBlock(t *
 
 	_, err := makeConfigFromUpgrade(t.Context(), backend, opera.UpgradeHeight{})
 	require.ErrorContains(t, err, "block 0 not found")
+}
+
+func TestMakeConfigFromUpgrade_ReportsError_WhenBlockCarriesNoNumber(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	backend := NewMockBackend(ctrl)
+
+	chainId := big.NewInt(250)
+	backend.EXPECT().ChainID().Return(chainId)
+	chainCfg := opera.CreateTransientEvmChainConfig(
+		chainId.Uint64(),
+		[]opera.UpgradeHeight{{}},
+		0,
+	)
+	backend.EXPECT().ChainConfig(gomock.Any()).Return(chainCfg)
+	backend.EXPECT().GetGenesisID().Return(common.Hash{0x42})
+
+	backend.EXPECT().BlockByNumber(gomock.Any(), rpc.BlockNumber(int64(0))).
+		Return(&evmcore.EvmBlock{}, nil)
+
+	_, err := makeConfigFromUpgrade(t.Context(), backend, opera.UpgradeHeight{})
+	require.ErrorContains(t, err, "block 0 carries no number")
+}
+
+func TestMakeConfigFromUpgrade_ReportsError_WhenUpgradeHeightExceedsMaxInt64(t *testing.T) {
+	// rpc.BlockNumber is signed and its negative values name the block tags, so a
+	// height beyond MaxInt64 must be rejected rather than wrapped into a tag.
+	ctrl := gomock.NewController(t)
+	backend := NewMockBackend(ctrl)
+
+	chainId := big.NewInt(250)
+	backend.EXPECT().ChainID().Return(chainId)
+	chainCfg := opera.CreateTransientEvmChainConfig(
+		chainId.Uint64(),
+		[]opera.UpgradeHeight{{}},
+		0,
+	)
+	backend.EXPECT().ChainConfig(gomock.Any()).Return(chainCfg)
+	backend.EXPECT().GetGenesisID().Return(common.Hash{0x42})
+
+	// No BlockByNumber call is expected: the height never reaches the backend.
+	upgradeHeight := opera.UpgradeHeight{Height: idx.Block(math.MaxInt64) + 1}
+
+	_, err := makeConfigFromUpgrade(t.Context(), backend, upgradeHeight)
+	require.ErrorContains(t, err, "exceeds the largest addressable block number")
 }
 
 func TestEIP7910_Config_ReportsErrors(t *testing.T) {
@@ -410,6 +458,7 @@ func TestEIP7910_Config_ReturnsConfigs(t *testing.T) {
 				sonicId, err := MakeForkId(opera.MakeUpgradeHeight(opera.GetSonicUpgrades(), 1), common.Hash{0x42})
 				require.NoError(t, err, "makeForkId failed for sonic upgrades")
 				return configResponse{Current: &config{
+					BlockHeight:     (*hexutil.Big)(big.NewInt(1)),
 					ChainId:         (*hexutil.Big)(chainId),
 					ForkId:          sonicId[:],
 					Precompiles:     sonicPrecompiled,
@@ -455,12 +504,14 @@ func TestEIP7910_Config_ReturnsConfigs(t *testing.T) {
 
 				return configResponse{
 					Current: &config{
+						BlockHeight:     (*hexutil.Big)(big.NewInt(5)),
 						ChainId:         (*hexutil.Big)(chainId),
 						ForkId:          allegroId[:],
 						Precompiles:     allegroPrecompiled,
 						SystemContracts: activeSystemContracts(opera.GetAllegroUpgrades()),
 					},
 					Last: &config{
+						BlockHeight:     (*hexutil.Big)(big.NewInt(1)),
 						ChainId:         (*hexutil.Big)(chainId),
 						ForkId:          sonicId[:],
 						Precompiles:     sonicPrecompiled,
@@ -478,8 +529,16 @@ func TestEIP7910_Config_ReturnsConfigs(t *testing.T) {
 			backend.EXPECT().ChainID().Return(chainId).AnyTimes()
 			// could be called once or twice depending on the test case.
 			backend.EXPECT().GetGenesisID().Return(common.Hash{0x42}).AnyTimes()
+			// The block a request resolves to is the one at the requested height, so
+			// the stub echoes the number back: makeConfigFromUpgrade reads it to
+			// resolve the height-gated upgrades.
 			backend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).
-				Return(&evmcore.EvmBlock{EvmHeader: evmcore.EvmHeader{Time: inter.Timestamp(1)}}, nil).AnyTimes()
+				DoAndReturn(func(_ context.Context, number rpc.BlockNumber) (*evmcore.EvmBlock, error) {
+					return &evmcore.EvmBlock{EvmHeader: evmcore.EvmHeader{
+						Number: big.NewInt(number.Int64()),
+						Time:   inter.Timestamp(1),
+					}}, nil
+				}).AnyTimes()
 
 			test.backendSetup(backend)
 
@@ -490,4 +549,58 @@ func TestEIP7910_Config_ReturnsConfigs(t *testing.T) {
 			require.Equal(t, test.wantConfig, *gotConfig)
 		})
 	}
+}
+
+func TestEIP7910_Config_ResolvesTimeGatedForksWithTheBlockTime(t *testing.T) {
+	// A chain config whose forks are gated on real timestamps -- a foreign chain
+	// replayed through the backend, unlike Sonic's own transient config, which
+	// places every time-gated fork at timestamp 0. The precompile set must follow
+	// the block's time, not a zero one.
+	forkTime := uint64(480)
+	blockTime := forkTime + 60
+
+	chainId := big.NewInt(250)
+	upgradeHeights := []opera.UpgradeHeight{{
+		Upgrades: opera.GetBrioUpgrades(),
+		Height:   idx.Block(5),
+	}}
+	chainConfig := &params.ChainConfig{
+		ChainID:        chainId,
+		HomesteadBlock: big.NewInt(0),
+		EIP150Block:    big.NewInt(0),
+		EIP155Block:    big.NewInt(0),
+		EIP158Block:    big.NewInt(0),
+		ByzantiumBlock: big.NewInt(0),
+		BerlinBlock:    big.NewInt(0),
+		LondonBlock:    big.NewInt(0),
+		ShanghaiTime:   &forkTime,
+		CancunTime:     &forkTime,
+		PragueTime:     &forkTime,
+		OsakaTime:      &forkTime,
+	}
+
+	ctrl := gomock.NewController(t)
+	backend := NewMockBackend(ctrl)
+	backend.EXPECT().ChainID().Return(chainId).AnyTimes()
+	backend.EXPECT().GetGenesisID().Return(common.Hash{0x42}).AnyTimes()
+	backend.EXPECT().CurrentBlock().Return(&evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{Number: big.NewInt(5)},
+	})
+	backend.EXPECT().GetUpgradeHeights().Return(upgradeHeights)
+	backend.EXPECT().ChainConfig(gomock.Any()).Return(chainConfig)
+	backend.EXPECT().BlockByNumber(gomock.Any(), gomock.Any()).Return(&evmcore.EvmBlock{
+		EvmHeader: evmcore.EvmHeader{
+			Number: big.NewInt(5),
+			Time:   inter.FromUnix(int64(blockTime)),
+		},
+	}, nil)
+
+	gotConfig, err := NewPublicBlockChainAPI(backend).Config(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, blockTime, gotConfig.Current.ActivationTime)
+
+	// The Osaka precompile set: everything Prague has, plus P256VERIFY.
+	require.Contains(t, gotConfig.Current.Precompiles, "P256VERIFY")
+	require.Contains(t, gotConfig.Current.Precompiles, "KZG_POINT_EVALUATION")
+	require.Contains(t, gotConfig.Current.Precompiles, "BLS12_PAIRING_CHECK")
 }


### PR DESCRIPTION
Two eth_config (EIP-7910) fixes found by execution-apis conformance testing.

The active precompiles are now resolved from the number and time of the block that activated the upgrade, the same block whose time is reported as activationTime. Previously the height was used with a zero timestamp. For Sonic's own chain config, which activates every time-gated fork at timestamp 0, the result is unchanged. The resolution is now correct for any
config gated on real timestamps. An upgrade height above MaxInt64 is rejected instead of wrapping into a negative rpc.BlockNumber, and a block without a number is reported as an error.

blobSchedule is now encoded as an object with zero target, max and baseFeeUpdateFraction. EIP-7910 requires the field to be an object, and reporting null failed schema validation. Sonic has no blobs, so zero capacity is the accurate value.

blockHeight is documented as Sonic's extension beyond EIP-7910: an upgrade is activated by a transaction, so the block carrying it identifies the fork.