### PR TITLE
Fix struct log limit units and error text in debug_traceTransaction

### DIFF
--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2509,7 +2509,7 @@ func (api *PublicDebugAPI) TraceTransaction(ctx context.Context, hash common.Has
 		return nil, err
 	}
 	if tx == nil {
-		return nil, fmt.Errorf("transaction %s not found", hash.Hex())
+		return nil, errors.New("transaction not found")
 	}
 	// It shouldn't happen in practice.
 	if blockNumber == 0 {

--- a/api/ethapi/api.go
+++ b/api/ethapi/api.go
@@ -2535,6 +2535,26 @@ func (api *PublicDebugAPI) TraceTransaction(ctx context.Context, hash common.Has
 	return api.traceTx(ctx, tx, msg, txctx, block.Header(), statedb, config, nil)
 }
 
+// limitStructLogs wraps the given opcode hook such that it is called at most
+// limit times. A zero limit means unlimited, a negative limit suppresses the
+// hook entirely -- the semantics documented for the --rpc.structloglimit flag.
+func limitStructLogs(onOpcode tracing.OpcodeHook, limit int) tracing.OpcodeHook {
+	if onOpcode == nil || limit == 0 {
+		return onOpcode
+	}
+	if limit < 0 {
+		return func(uint64, byte, uint64, uint64, tracing.OpContext, []byte, int, error) {}
+	}
+	reported := 0
+	return func(pc uint64, op byte, gas, cost uint64, scope tracing.OpContext, rData []byte, depth int, err error) {
+		if reported >= limit {
+			return
+		}
+		reported++
+		onOpcode(pc, op, gas, cost, scope, rData, depth, err)
+	}
+}
+
 // traceTx configures a new tracer according to the provided configuration, and
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
@@ -2563,19 +2583,20 @@ func (api *PublicDebugAPI) traceTx(
 	// Default tracer is the struct logger
 	if config.Tracer == nil {
 		if config.Config == nil {
-			config.Config = &logger.Config{Limit: api.structLogLimit}
-		} else {
-			if api.structLogLimit > 0 &&
-				(config.Limit == 0 || config.Limit > api.structLogLimit) {
-
-				config.Limit = api.structLogLimit
-			}
+			config.Config = &logger.Config{}
 		}
-		logger := logger.NewStructLogger(config.Config)
+		structLogger := logger.NewStructLogger(config.Config)
+		hooks := structLogger.Hooks()
+		// The struct logger's own config.Limit is a limit on the size of the
+		// produced output in bytes, while api.structLogLimit is a limit on the
+		// number of produced log entries. The latter has to be enforced here.
+		// The total response size is capped independently, see maxResponseSize
+		// below.
+		hooks.OnOpcode = limitStructLogs(hooks.OnOpcode, api.structLogLimit)
 		tracer = &tracers.Tracer{
-			Hooks:     logger.Hooks(),
-			GetResult: logger.GetResult,
-			Stop:      logger.Stop,
+			Hooks:     hooks,
+			GetResult: structLogger.GetResult,
+			Stop:      structLogger.Stop,
 		}
 	} else {
 		tracer, err = tracers.DefaultDirectory.New(*config.Tracer, txctx, config.TracerConfig, chainConfig)

--- a/api/ethapi/api_test.go
+++ b/api/ethapi/api_test.go
@@ -39,6 +39,7 @@ import (
 	geth_math "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
@@ -1687,4 +1688,62 @@ func TestCapMaxGas_IsUpgradesAware(t *testing.T) {
 			require.Equal(t, uint64(test.wantEstimation), got)
 		})
 	}
+}
+
+func TestLimitStructLogs_ReportsAtMostLimitOpcodes(t *testing.T) {
+	tests := map[string]struct {
+		limit int
+		calls int
+		want  int
+	}{
+		"zero limit is unlimited":       {limit: 0, calls: 10, want: 10},
+		"negative limit reports none":   {limit: -1, calls: 10, want: 0},
+		"limit above the call count":    {limit: 10, calls: 3, want: 3},
+		"limit below the call count":    {limit: 3, calls: 10, want: 3},
+		"limit equal to the call count": {limit: 5, calls: 5, want: 5},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			reported := 0
+			hook := limitStructLogs(func(uint64, byte, uint64, uint64, tracing.OpContext, []byte, int, error) {
+				reported++
+			}, test.limit)
+
+			for i := 0; i < test.calls; i++ {
+				hook(uint64(i), 0, 0, 0, nil, nil, 0, nil)
+			}
+
+			require.Equal(t, test.want, reported)
+		})
+	}
+}
+
+func TestLimitStructLogs_KeepsTheOpcodeArguments(t *testing.T) {
+	var got struct {
+		pc        uint64
+		op        byte
+		gas, cost uint64
+		rData     []byte
+		depth     int
+		err       error
+	}
+	wantErr := errors.New("some error")
+	hook := limitStructLogs(func(pc uint64, op byte, gas, cost uint64, _ tracing.OpContext, rData []byte, depth int, err error) {
+		got.pc, got.op, got.gas, got.cost, got.rData, got.depth, got.err = pc, op, gas, cost, rData, depth, err
+	}, 1)
+
+	hook(1, 2, 3, 4, nil, []byte{5}, 6, wantErr)
+
+	require.Equal(t, uint64(1), got.pc)
+	require.Equal(t, byte(2), got.op)
+	require.Equal(t, uint64(3), got.gas)
+	require.Equal(t, uint64(4), got.cost)
+	require.Equal(t, []byte{5}, got.rData)
+	require.Equal(t, 6, got.depth)
+	require.Equal(t, wantErr, got.err)
+}
+
+func TestLimitStructLogs_KeepsANilHookNil(t *testing.T) {
+	require.Nil(t, limitStructLogs(nil, 100))
 }


### PR DESCRIPTION
Two debug_traceTransaction fixes found by execution-apis conformance testing.

The `--rpc.structloglimit` flag is documented as the maximum number of structured EVM log entries, with zero meaning unlimited and a negative value meaning no entries. The value was passed to the go-ethereum struct logger as Config.Limit, which limits the output size in bytes, so the default of 2000 entries was applied as roughly 2000 bytes. The node limit is now enforced by wrapping the struct logger's OnOpcode hook so it is called at most that many times. A byte limit a caller passes in the trace config is left to the struct logger, unchanged.

An unknown transaction hash is now answered with `"transaction not found"`, the message go-ethereum uses and conformance tests match against, instead of one embedding the hash.